### PR TITLE
Fix odd indentation in _popen/_wpopen

### DIFF
--- a/docs/c-runtime-library/reference/popen-wpopen.md
+++ b/docs/c-runtime-library/reference/popen-wpopen.md
@@ -69,16 +69,15 @@ Creates a pipe and executes a command.
   
 ## Syntax  
   
-```  
-  
-      FILE *_popen(  
-const char *command,  
-const char *mode   
-);  
-FILE *_wpopen(  
-const wchar_t *command,  
-const wchar_t *mode   
-);  
+```
+FILE *_popen(
+const char *command,
+const char *mode
+);
+FILE *_wpopen(
+const wchar_t *command,
+const wchar_t *mode
+);
 ```  
   
 #### Parameters  


### PR DESCRIPTION
If you'd rather I not also fix the trailing whitespace errors, I can remove that commit. Let me know.