### PR TITLE
Update string-and-i-o-formatting-modern-cpp.md

### DIFF
--- a/docs/cpp/string-and-i-o-formatting-modern-cpp.md
+++ b/docs/cpp/string-and-i-o-formatting-modern-cpp.md
@@ -33,7 +33,7 @@ translation.priority.ht:
 # String and I/O Formatting (Modern C++)
 C++ [iostreams](../standard-library/iostream.md) are capable of formatted string I/O. For example, the following code shows how to set cout to format an integer to output in hexadecimal, first saving off the current state and re-setting afterwards, because once state formatting is passed to cout, it stays that way until changed, not just for the one line of code.  
   
-```fortran  
+```cpp  
 #include <iostream>  
 #include <iomanip>  
   


### PR DESCRIPTION
Change Syntax Highlighting of Code Block to C++ (Was Previously Fortran)