### PR TITLE
Add possible workaround to compiler-error-c2603.md

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
@@ -53,7 +53,9 @@ extern inline void f1() {
 
 ### Possible workarounds:
 
-If you require the statics to be accessible within their block scope, one potential way to avoid this issue may be to enclose the statics in a lambda that is immediately invoked. 
+*Visual Studio 2013:*
+
+In Visual Studio 2013, if you require the statics to be accessible within their block scope, one potential way to avoid this issue may be to enclose the statics in a lambda that is immediately invoked. 
 
 For example:
 
@@ -67,3 +69,12 @@ extern inline void f1() {
    }(); 
 }
 ```
+
+*Visual Studio 2015 and newer:*
+
+In C++11, a static local variable initialization is guaranteed to be thread-safe; a feature sometimes called "magic statics". This is the default starting with Visual Studio 2015. The thread-safe statics feature can be disabled by using the  flag to avoid taking a 
+
+One potential cause for this error in Visual Studio 2015 and newer versions is the disabling of thread safe static initialization via the /Zc:threadSafeInit- compiler flag. If you are encountering this error, consider whether or not this flag is necessary for your application.
+
+
+

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
@@ -50,3 +50,20 @@ extern inline void f1() {
    static C C33;   // C2603 Comment this line out to avoid error  
 }  
 ```
+
+### Possible workarounds:
+
+If you require the statics to be accessible within their block scope, one potential way to avoid this issue may be to enclose the statics in a lambda that is immediately invoked. 
+
+For example:
+
+```
+struct C { C() {} };  
+extern inline void f1() {  
+   [&]() {
+      static C C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C14,C15,C16;  
+      static C C17,C18,C19,C20,C21,C22,C23,C24,C25,C26,C27,C28,C29,C30,C31,C32;  
+      static C C33;  
+   }(); 
+}
+```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
@@ -72,9 +72,9 @@ extern inline void f1() {
 
 *Visual Studio 2015 and newer:*
 
-In C++11, a static local variable initialization is guaranteed to be thread-safe; a feature sometimes called "magic statics". This is the default starting with Visual Studio 2015. The thread-safe statics feature can be disabled by using the  flag to avoid taking a 
+In C++11, a static local variable initialization is guaranteed to be thread-safe; a feature sometimes called "magic statics". This is the default starting with Visual Studio 2015. The thread-safe statics feature can be disabled by using the /Zc:threadSafeInit- compielr flag.
 
-One potential cause for this error in Visual Studio 2015 and newer versions is the disabling of thread safe static initialization via the /Zc:threadSafeInit- compiler flag. If you are encountering this error, consider whether or not this flag is necessary for your application.
+One potential cause for this error in Visual Studio 2015 and newer versions is the disabling of thread safe static initialization via the /Zc:threadSafeInit- compiler flag. If you are encountering this error, consider whether or not this flag is necessary for your application, and remove it if possible.
 
 
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2603.md
@@ -72,7 +72,7 @@ extern inline void f1() {
 
 *Visual Studio 2015 and newer:*
 
-In C++11, a static local variable initialization is guaranteed to be thread-safe; a feature sometimes called "magic statics". This is the default starting with Visual Studio 2015. The thread-safe statics feature can be disabled by using the /Zc:threadSafeInit- compielr flag.
+In C++11, a static local variable initialization is guaranteed to be thread-safe; a feature sometimes called "magic statics". This is the default starting with Visual Studio 2015. The thread-safe statics feature can be disabled by using the /Zc:threadSafeInit- compiler flag.
 
 One potential cause for this error in Visual Studio 2015 and newer versions is the disabling of thread safe static initialization via the /Zc:threadSafeInit- compiler flag. If you are encountering this error, consider whether or not this flag is necessary for your application, and remove it if possible.
 


### PR DESCRIPTION
Added information about a possible workaround for compiler error c2603. This workaround was tested in Visual Studio 2013.