### PR TITLE
Correct format anomaly that docs.microsoft.com does not handle

### DIFF
--- a/docs/windows/desktop-applications-visual-cpp.md
+++ b/docs/windows/desktop-applications-visual-cpp.md
@@ -18,7 +18,7 @@ manager: "ghogen"
 translation.priority.ht: 
   - "de-de"
   - "es-es"
-   - "fr-fr"
+  - "fr-fr"
   - "it-it"
   - "ja-jp"
   - "ko-kr"


### PR DESCRIPTION
In the case of a space being included the Microsoft site renders the meta data section as text.
For fixing Issue #48 