### PR TITLE
Correct .ERRDIF[[I]] title

### DIFF
--- a/docs/assembler/masm/TOC.md
+++ b/docs/assembler/masm/TOC.md
@@ -54,7 +54,7 @@
 ### [.ERR2](dot-err2.md)
 ### [.ERRB](dot-errb.md)
 ### [.ERRDEF](dot-errdef.md)
-### [.ERRDIF]]](dot-errdif.md)
+### [.ERRDIF[[I]]](dot-errdif.md)
 ### [.ERRE](dot-erre.md)
 ### [.ERRIDN]](dot-erridn.md)
 ### [.ERRNB](dot-errnb.md)

--- a/docs/assembler/masm/dot-errdif.md
+++ b/docs/assembler/masm/dot-errdif.md
@@ -1,5 +1,5 @@
 ---
-title: ".ERRDIF]] | Microsoft Docs"
+title: ".ERRDIF[[I]] | Microsoft Docs"
 ms.custom: ""
 ms.date: "11/04/2016"
 ms.reviewer: ""
@@ -9,11 +9,11 @@ ms.technology:
 ms.tgt_pltfrm: ""
 ms.topic: "article"
 f1_keywords: 
-  - ".ERRDIF[[I]]]"
+  - ".ERRDIF[[I]]"
 dev_langs: 
   - "C++"
 helpviewer_keywords: 
-  - ".ERRDIF[[I]]] directive"
+  - ".ERRDIF[[I]] directive"
 ms.assetid: af7cb441-0373-4c7e-af9c-06bcb9ed2b0a
 caps.latest.revision: 7
 author: "corob-msft"
@@ -34,7 +34,7 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
-# .ERRDIF]]
+# .ERRDIF[[I]]
 Generates an error if the text items are different.  
   
 ## Syntax  


### PR DESCRIPTION
Corrects the title of the MASM directive `.ERRDIF[[I]]` material.

Fixes #73.