### PR TITLE
Correct build working directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ The content inside the **docs** folder is organized into sections that are organ
 
 You can skip this first step for small changes.
 
-**Step 2:** Fork the `Microsoft/cpp-docs` repo.
+**Step 2:** Fork the `MicrosoftDocs/cpp-docs` repo.
 
 **Step 3:** Create a `branch` for your article.
 
@@ -42,7 +42,7 @@ Be sure to follow the proper Markdown syntax. See the [style guide](./styleguide
           /media
               wstring-conversion.png
 
-**Step 5:** Submit a Pull Request (PR) from your branch to `Microsoft/cpp-docs/master`.
+**Step 5:** Submit a Pull Request (PR) from your branch to `MicrosoftDocs/cpp-docs/master`.
 
 If your PR is addressing an existing issue, add the `Fixes #Issue_Number` keyword to the commit message or PR description, so the issue can be automatically closed when the PR is merged. For more information, see [Closing issues via commit messages](https://help.github.com/articles/closing-issues-via-commit-messages/).
 
@@ -52,7 +52,7 @@ The Visual Studio team will review your PR and let you know if the change looks 
 
 The maintainers will merge your PR into the master branch once feedback has been applied and your change looks good.
 
-On a certain cadence, we push all commits from master branch into the live branch and then you'll be able to see your contribution live at https://docs.microsoft.com/cpp-docs/.
+On a certain cadence, we push all commits from master branch into the live branch and then you'll be able to see your contribution live at https://docs.microsoft.com/en-us/cpp/.
 
 ## DOs and DON'Ts
 
@@ -70,7 +70,7 @@ Below is a short list of guiding rules that you should keep in mind when you are
 
 ## Building the docs
 
-The documentation is written in [GitHub Flavored Markdown](https://help.github.com/categories/writing-on-github/) and built using [DocFX](http://dotnet.github.io/docfx/) and other internal publishing/building tools. It is hosted at [docs.microsoft.com](https://docs.microsoft.com/dotnet).
+The documentation is written in [GitHub Flavored Markdown](https://help.github.com/categories/writing-on-github/) and built using [DocFX](http://dotnet.github.io/docfx/) and other internal publishing/building tools. It is hosted at [docs.microsoft.com](https://docs.microsoft.com/).
 
 If you want to build the docs locally, you need to install [DocFX](https://dotnet.github.io/docfx/); latest versions are the best.
 
@@ -86,7 +86,7 @@ You can build and preview the resulting site locally using a built-in web server
 docfx -t default --serve
 ```
 
-This starts the local preview on [localhost:8080](http://localhost:8080). You can then view the changes by going to `http://localhost:8080/[path]`, such as http://localhost:8080/articles/welcome.html.
+This starts the local preview on [localhost:8080](http://localhost:8080). You can then view the changes by going to `http://localhost:8080/[path]`, such as http://localhost:8080/cpp/visual-cpp-in-visual-studio.html.
 
 **Note:** the local preview currently doesn't contain any themes at the moment so the look and feel won't be the same as in the documentation site. We're working towards fixing that experience.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ If you are comfortable with other ways listed on the link above, feel free to us
 
 **Note:** Currently DocFX requires the .NET Framework on Windows or Mono (for Linux or macOS). We hope to port it to .NET Core in the future.
 
-You can build and preview the resulting site locally using a built-in web server. Navigate to the core-docs folder on your machine and type the following command:
+You can build and preview the resulting site locally using a built-in web server. Navigate to the `cpp-docs\docs` folder on your machine and type the following command:
 
 ```
 docfx -t default --serve


### PR DESCRIPTION
Corrects the working directory for building the docs given in the contributing guide.

Fixes #78.