### PR TITLE
Correct unnecessary '\<' escape

### DIFF
--- a/docs/cpp/containers-modern-cpp.md
+++ b/docs/cpp/containers-modern-cpp.md
@@ -33,7 +33,7 @@ translation.priority.mt:
 ---
 # Containers (Modern C++)  
   
-By default, use [vector](../standard-library/vector-class.md) as the preferred sequential container in C++. This is equivalent to `List\<T>` in .NET languages.  
+By default, use [vector](../standard-library/vector-class.md) as the preferred sequential container in C++. This is equivalent to `List<T>` in .NET languages.  
   
 ```cpp  
 vector<string> apples;  


### PR DESCRIPTION
The markdown processor changed a couple of sprints ago, and '<' escaping is no longer required in backtick code literals, and also generates incorrect backslash iont he viewed content