### PR TITLE
Portable escape syntax for asterisk, add cpp to code samples

### DIFF
--- a/docs/cpp/partial-ordering-of-function-templates-cpp.md
+++ b/docs/cpp/partial-ordering-of-function-templates-cpp.md
@@ -35,63 +35,65 @@ translation.priority.ht:
 
 # Partial Ordering of Function Templates (C++)
 
-Multiple function templates that match the argument list of a function call can be available. C++ defines a partial ordering of function templates to specify which function should be called. The ordering is partial because there can be some templates that are considered equally specialized.  
-  
- The compiler chooses the most specialized template function available from the possible matches. For example, if a function template takes a type **T**, and another function template taking **T&#x2a;** is available, the **T&#x2a;** version is said to be more specialized and is preferred over the generic **T** version whenever the argument is a pointer type, even though both would be allowable matches.  
-  
- Use the following process to determine if one function template candidate is more specialized:  
-  
-1.  Consider two function templates, T1 and T2.  
-  
-2.  Replace the parameters in T1 with a hypothetical unique type X.  
-  
-3.  With the parameter list in T1, see if T2 is a valid template for that parameter list. Ignore any implicit conversions.  
-  
-4.  Repeat the same process with T1 and T2 reversed.  
-  
-5.  If one template is a valid template argument list for the other template, but the converse is not true, then that template is considered to be less specialized than the other template. If both templates using the previous step form valid arguments for each other, then they are considered to be equally specialized, and an ambiguous call will result when attempting to use them.  
-  
-6.  Using these rules:  
-  
-    1.  A template specialization for a specific type is more specialized than one taking a generic type argument.  
-  
-    2.  A template taking only **T&#x2a;** is more specialized than one taking only **T**, because a hypothetical type **X&#x2a;** is a valid argument for a **T** template argument, but **X** is not a valid argument for a **T&#x2a;** template argument.  
-  
-    3.  **const T** is more specialized than **T**, because **const X** is a valid argument for a **T** template argument, but **X** is not a valid argument for a **const T** template argument.  
-  
-    4.  **const T&#x2a;** is more specialized than **T&#x2a;**, because **const X&#x2a;** is a valid argument for a **T&#x2a;** template argument, but **X&#x2a;** is not a valid argument for a **const T&#x2a;** template argument.  
-  
-7.  The following sample works in Visual C++ .NET 2003 as specified in the standard:  
-  
+Multiple function templates that match the argument list of a function call can be available. C++ defines a partial ordering of function templates to specify which function should be called. The ordering is partial because there can be some templates that are considered equally specialized.
+
+The compiler chooses the most specialized template function available from the possible matches. For example, if a function template takes a type __T__, and another function template taking __T\*__ is available, the __T\*__ version is said to be more specialized and is preferred over the generic __T__ version whenever the argument is a pointer type, even though both would be allowable matches.
+
+Use the following process to determine if one function template candidate is more specialized:
+
+1. Consider two function templates, T1 and T2.
+
+2. Replace the parameters in T1 with a hypothetical unique type X.
+
+3. With the parameter list in T1, see if T2 is a valid template for that parameter list. Ignore any implicit conversions.
+
+4. Repeat the same process with T1 and T2 reversed.
+
+5. If one template is a valid template argument list for the other template, but the converse is not true, then that template is considered to be less specialized than the other template. If both templates using the previous step form valid arguments for each other, then they are considered to be equally specialized, and an ambiguous call results when you attempt to use them.
+
+6. Using these rules:
+
+     1. A template specialization for a specific type is more specialized than one taking a generic type argument.
+
+     2. A template taking only __T\*__ is more specialized than one taking only __T__, because a hypothetical type __X\*__ is a valid argument for a __T__ template argument, but __X__ is not a valid argument for a __T\*__ template argument.
+
+     3. __const T__ is more specialized than __T__, because __const X__ is a valid argument for a __T__ template argument, but __X__ is not a valid argument for a __const T__ template argument.
+
+     4. __const T\*__ is more specialized than __T\*__, because __const X\*__ is a valid argument for a __T\*__ template argument, but __X\*__ is not a valid argument for a __const T\*__ template argument.
+
+## Example
+
+The following sample works as specified in the standard:
+
 ```cpp
-// partial_ordering_of_function_templates.cpp  
-// compile with: /EHsc  
-#include <iostream>  
-  
-extern "C" int printf(const char*,...);  
-template <class T> void f(T) {  
-   printf_s("Less specialized function called\n");  
-}  
-  
-template <class T> void f(T*) {  
-   printf_s("More specialized function called\n");  
-}  
-  
-template <class T> void f(const T*) {  
-   printf_s("Even more specialized function for const T*\n");  
-}  
-  
-int main() {  
-   int i =0;  
-   const int j = 0;  
-   int *pi = &i;  
-   const int *cpi = &j;  
-  
-   f(i);   // Calls less specialized function.  
-   f(pi);  // Calls more specialized function.  
-   f(cpi); // Calls even more specialized function.  
-   // Without partial ordering, these calls would be ambiguous.  
-}  
+// partial_ordering_of_function_templates.cpp
+// compile with: /EHsc
+#include <iostream>
+
+extern "C" int printf(const char*,...);
+template <class T> void f(T) {
+   printf_s("Less specialized function called\n");
+}
+
+template <class T> void f(T*) {
+   printf_s("More specialized function called\n");
+}
+
+template <class T> void f(const T*) {
+   printf_s("Even more specialized function for const T*\n");
+}
+
+int main() {
+   int i =0;
+   const int j = 0;
+   int *pi = &i;
+   const int *cpi = &j;
+
+   f(i);   // Calls less specialized function.
+   f(pi);  // Calls more specialized function.
+   f(cpi); // Calls even more specialized function.
+   // Without partial ordering, these calls would be ambiguous.
+}
 ```  
   
 ### Output  
@@ -102,5 +104,6 @@ More specialized function called
 Even more specialized function for const T*  
 ```  
   
-## See Also  
- [Function Templates](../cpp/function-templates.md)
+## See Also
+
+[Function Templates](../cpp/function-templates.md)

--- a/docs/cpp/partial-ordering-of-function-templates-cpp.md
+++ b/docs/cpp/partial-ordering-of-function-templates-cpp.md
@@ -32,10 +32,12 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
+
 # Partial Ordering of Function Templates (C++)
+
 Multiple function templates that match the argument list of a function call can be available. C++ defines a partial ordering of function templates to specify which function should be called. The ordering is partial because there can be some templates that are considered equally specialized.  
   
- The compiler chooses the most specialized template function available from the possible matches. For example, if a function template takes a type **T**, and another function template taking **T\*** is available, the **T\*** version is said to be more specialized and is preferred over the generic **T** version whenever the argument is a pointer type, even though both would be allowable matches.  
+ The compiler chooses the most specialized template function available from the possible matches. For example, if a function template takes a type **T**, and another function template taking **T&#x2a;** is available, the **T&#x2a;** version is said to be more specialized and is preferred over the generic **T** version whenever the argument is a pointer type, even though both would be allowable matches.  
   
  Use the following process to determine if one function template candidate is more specialized:  
   
@@ -53,15 +55,15 @@ Multiple function templates that match the argument list of a function call can 
   
     1.  A template specialization for a specific type is more specialized than one taking a generic type argument.  
   
-    2.  A template taking only **T\*** is more specialized than one taking only **T**, because a hypothetical type **X\*** is a valid argument for a **T** template argument, but **X** is not a valid argument for a **T\*** template argument.  
+    2.  A template taking only **T&#x2a;** is more specialized than one taking only **T**, because a hypothetical type **X&#x2a;** is a valid argument for a **T** template argument, but **X** is not a valid argument for a **T&#x2a;** template argument.  
   
     3.  **const T** is more specialized than **T**, because **const X** is a valid argument for a **T** template argument, but **X** is not a valid argument for a **const T** template argument.  
   
-    4.  **const T\*** is more specialized than **T\***, because **const X\*** is a valid argument for a **T\*** template argument, but **X\*** is not a valid argument for a **const T\*** template argument.  
+    4.  **const T&#x2a;** is more specialized than **T&#x2a;**, because **const X&#x2a;** is a valid argument for a **T&#x2a;** template argument, but **X&#x2a;** is not a valid argument for a **const T&#x2a;** template argument.  
   
 7.  The following sample works in Visual C++ .NET 2003 as specified in the standard:  
   
-```  
+```cpp
 // partial_ordering_of_function_templates.cpp  
 // compile with: /EHsc  
 #include <iostream>  


### PR DESCRIPTION
- Different md processors handle character escapes differently. In particular, the OPS markdown processor is in some places different than the GitHub/VSTS/etc previewers. A recent sprint changed the markdown processor, so this topic doesn't render the escaped asterisks properly.  Changed these to use html character references, which render properly in all processors/viewers.
- add cpp to c++ code samples