### PR TITLE
add cpp to C++ code samples, md lint headers

### DIFF
--- a/docs/cpp/member-function-templates.md
+++ b/docs/cpp/member-function-templates.md
@@ -33,14 +33,16 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # Member Function Templates
+
 The term member template refers to both member function templates and nested class templates. Member function templates are template functions that are members of a class or class template.  
   
  Member functions can be function templates in several contexts. All functions of class templates are generic but are not referred to as member templates or member function templates. If these member functions take their own template arguments, they are considered to be member function templates.  
   
-## Example  
+## Example
+
  Member function templates of nontemplate or template classes are declared as function templates with their template parameters.  
   
-```  
+```cpp
 // member_function_templates.cpp  
 struct X  
 {  
@@ -55,10 +57,11 @@ int main()
 }  
 ```  
   
-## Example  
+## Example
+
  The following example shows a member function template of a template class.  
   
-```  
+```cpp
 // member_function_templates2.cpp  
 template<typename T>  
 class X  
@@ -75,10 +78,11 @@ int main()
 }  
 ```  
   
-## Example  
+## Example
+
  Additionally, in Visual Studio .NET 2003 and later, member templates can also be defined outside of a class.  
   
-```  
+```cpp
 // defining_member_templates_outside_class.cpp  
 template<typename T>  
 class X  
@@ -98,14 +102,15 @@ int main()
 }  
 ```  
   
-## Example  
+## Example
+
  Local classes are not allowed to have member templates.  
   
  Member template functions cannot be virtual functions and cannot override virtual functions from a base class when they are declared with the same name as a base class virtual function.  
   
  Visual C++ .NET 2003 introduced support for templated user-defined conversions. The following sample works in Visual C++ .NET 2003 as specified in the standard.  
   
-```  
+```cpp
 // templated_user_defined_conversions.cpp  
 template <class T>  
 struct S  
@@ -123,5 +128,6 @@ int main()
 }  
 ```  
   
-## See Also  
+## See Also
+
  [Function Templates](../cpp/function-templates.md)


### PR DESCRIPTION
markdown lint says to use blank lines around headers