### PR TITLE
Fix the display of underscore characters

### DIFF
--- a/docs/build/reference/link-environment-variables.md
+++ b/docs/build/reference/link-environment-variables.md
@@ -20,7 +20,7 @@ manager: "ghogen"
 
 The LINK tool uses the following environment variables:  
   
--   LINK and _LINK\_, if defined. The LINK tool prepends the options and arguments defined in the LINK environment variable and appends the options and arguments defined in the _LINK\_ environment variable to the command line arguments before processing.  
+-   LINK and \_LINK\_, if defined. The LINK tool prepends the options and arguments defined in the LINK environment variable and appends the options and arguments defined in the \_LINK\_ environment variable to the command line arguments before processing.  
   
 -   LIB, if defined. The LINK tools uses the LIB path when searching for an object, library, or other file specified on the command line or by the [/BASE](../../build/reference/base-base-address.md) option. It also uses the LIB path to find a .pdb file named in an object. The LIB variable can contain one or more path specifications, separated by semicolons. One path must point to the \lib subdirectory of your Visual C++ installation.  
   


### PR DESCRIPTION
The underscore parameters around `LINK` were not properly escaped, and so it was displayed `LINK\` in italic instead of `_LINK_`.