### PR TITLE
Update wording for _close in _open_osfhandle and _get_osfhandle

### DIFF
--- a/docs/c-runtime-library/reference/get-osfhandle.md
+++ b/docs/c-runtime-library/reference/get-osfhandle.md
@@ -42,7 +42,7 @@ Returns an operating-system file handle if *fd* is valid. Otherwise, the invalid
   
 ## Remarks
 
-To close a file whose operating system (OS) file handle is obtained by `_get_osfhandle`, call [\_close](../../c-runtime-library/reference/close.md) on the file descriptor *fd*. Do not call `CloseHandle` on the return value of this function. The underlying OS file handle is owned by the *fd* file descriptor, and is closed when `_close` is called on *fd*. If the file descriptor is owned by a `FILE *` stream, then calling [fclose](../../c-runtime-library/reference/fclose-fcloseall.md) on that `FILE *` stream closes both the file descriptor and the underlying OS file handle. In this case, you do not need to call `_close` on the file descriptor.  
+To close a file whose operating system (OS) file handle is obtained by `_get_osfhandle`, call [\_close](../../c-runtime-library/reference/close.md) on the file descriptor *fd*. Do not call `CloseHandle` on the return value of this function. The underlying OS file handle is owned by the *fd* file descriptor, and is closed when `_close` is called on *fd*. If the file descriptor is owned by a `FILE *` stream, then calling [fclose](../../c-runtime-library/reference/fclose-fcloseall.md) on that `FILE *` stream closes both the file descriptor and the underlying OS file handle. In this case, do not call `_close` on the file descriptor.
   
 ## Requirements  
   

--- a/docs/c-runtime-library/reference/open-osfhandle.md
+++ b/docs/c-runtime-library/reference/open-osfhandle.md
@@ -62,7 +62,7 @@ Opens the file in text (translated) mode.
 **\_O\_WTEXT**  
 Opens the file in Unicode (translated UTF-16) mode.
 
-To close a file opened with `_open_osfhandle`, call [\_close](../../c-runtime-library/reference/close.md). The underlying OS file handle is also closed by a call to `_close`, so it is not necessary to call the Win32 function `CloseHandle` on the original handle. If the file descriptor is owned by a `FILE *` stream, then calling [fclose](../../c-runtime-library/reference/fclose-fcloseall.md) on that `FILE *` stream also closes both the file descriptor and the underlying handle. In this case, `_close` does not need to be called.
+To close a file opened with `_open_osfhandle`, call [\_close](../../c-runtime-library/reference/close.md). The underlying OS file handle is also closed by a call to `_close`, so it is not necessary to call the Win32 function `CloseHandle` on the original handle. If the file descriptor is owned by a `FILE *` stream, then calling [fclose](../../c-runtime-library/reference/fclose-fcloseall.md) on that `FILE *` stream also closes both the file descriptor and the underlying handle. In this case, do not call `_close` on the file descriptor.
 
 ## Requirements
 


### PR DESCRIPTION
Aligning the wording with what is in _fdopen regarding calling _close on file descriptors owned by FILE*s.