### PR TITLE
Update cricheditctrl-class.md: LineLength returns length in characters not bytes

### DIFF
--- a/docs/mfc/reference/cricheditctrl-class.md
+++ b/docs/mfc/reference/cricheditctrl-class.md
@@ -1057,7 +1057,7 @@ int LineLength(int nLine = -1) const;
  Specifies the character index of a character in the line whose length is to be retrieved. If this parameter is -1, the length of the current line (the line that contains the caret) is returned, not including the length of any selected text within the line. When `LineLength` is called for a single-line edit control, this parameter is ignored.  
   
 ### Return Value  
- When `LineLength` is called for a multiple-line edit control, the return value is the length (in charactors) of the line specified by `nLine`. When `LineLength` is called for a single-line edit control, the return value is the length (in charactors) of the text in the edit control.  
+ When `LineLength` is called for a multiple-line edit control, the return value is the length (in `TCHAR`) of the line specified by `nLine`.  It does not include the carriage-return character at the end of the line. When `LineLength` is called for a single-line edit control, the return value is the length (in `TCHAR`) of the text in the edit control. If nLine is greater than the number of characters in the control, the return value is zero.
   
 ### Remarks  
  Use the [LineIndex](#lineindex) member function to retrieve a character index for a given line number within this `CRichEditCtrl` object.  

--- a/docs/mfc/reference/cricheditctrl-class.md
+++ b/docs/mfc/reference/cricheditctrl-class.md
@@ -1057,7 +1057,7 @@ int LineLength(int nLine = -1) const;
  Specifies the character index of a character in the line whose length is to be retrieved. If this parameter is -1, the length of the current line (the line that contains the caret) is returned, not including the length of any selected text within the line. When `LineLength` is called for a single-line edit control, this parameter is ignored.  
   
 ### Return Value  
- When `LineLength` is called for a multiple-line edit control, the return value is the length (in bytes) of the line specified by `nLine`. When `LineLength` is called for a single-line edit control, the return value is the length (in bytes) of the text in the edit control.  
+ When `LineLength` is called for a multiple-line edit control, the return value is the length (in charactors) of the line specified by `nLine`. When `LineLength` is called for a single-line edit control, the return value is the length (in charactors) of the text in the edit control.  
   
 ### Remarks  
  Use the [LineIndex](#lineindex) member function to retrieve a character index for a given line number within this `CRichEditCtrl` object.  


### PR DESCRIPTION
LineLength is a wrapper of [EM_LINELENGTH](https://msdn.microsoft.com/en-us/library/windows/desktop/bb761613%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396), which returns length in characters not bytes.