### PR TITLE
Update csettingsstore-class.md: self contradiction

### DIFF
--- a/docs/mfc/reference/csettingsstore-class.md
+++ b/docs/mfc/reference/csettingsstore-class.md
@@ -105,7 +105,7 @@ CSettingsStore(
  Boolean parameter that specifies whether the `CSettingsStore` object is created in read-only mode.  
   
 ### Remarks  
- If `bAdmin` is set to `false`, the `m_hKey` member variable is set to `HKEY_LOCAL_MACHINE`. If you set `bAdmin` to `true`, `m_hKey` is set to `HKEY_CURRENT_USER`.  
+ If `bAdmin` is set to `true`, the `m_hKey` member variable is set to `HKEY_LOCAL_MACHINE`. If you set `bAdmin` to `false`, `m_hKey` is set to `HKEY_CURRENT_USER`.  
   
  The security access depends on the `bReadOnly` parameter. If `bReadonly` is `false`, the security access will be set to `KEY_ALL_ACCESS`. If `bReadyOnly` is `true`, the security access will be set to a combination of `KEY_QUERY_VALUE, KEY_NOTIFY` and `KEY_ENUMERATE_SUB_KEYS`. For more information about security access together with the registry, see [Registry Key Security and Access Rights](http://msdn.microsoft.com/library/windows/desktop/ms724878).  
   


### PR DESCRIPTION
contradiction between the meaning of bAdmin in the parameters and remarks section of CSettingsStore::CSettingsStore