### PR TITLE
Update clistbox-class_23.cpp: example code has insufficient buffer size

### DIFF
--- a/docs/mfc/codesnippet/CPP/clistbox-class_23.cpp
+++ b/docs/mfc/codesnippet/CPP/clistbox-class_23.cpp
@@ -1,6 +1,6 @@
    // Initialize the storage of the list box to be 256 strings with
    // about 10 characters per string, performance improvement.
-   int n = m_myListBox.InitStorage(256, 10);
+   int n = m_myListBox.InitStorage(256, 16*sizeof(TCHAR));
    ASSERT(n != LB_ERRSPACE);
 
    // Add 256 items to the list box.


### PR DESCRIPTION
the buffer required by later code would be 16 bytes in ANSI and 32 bytes in Unicode, preallocating 10 bytes is useless.