### PR TITLE
Undesired indentation in CFile.

### DIFF
--- a/docs/mfc/reference/cfile-class.md
+++ b/docs/mfc/reference/cfile-class.md
@@ -123,7 +123,7 @@ virtual void Abort();
 ```  
 CFile();  
 CFile(CAtlTransactionManager* pTM);  
-  CFile(HANDLE hFile);
+CFile(HANDLE hFile);
 
  
 CFile(


### PR DESCRIPTION
Fix for undesired indentation in CFile constructor documentation.