### PR TITLE
Mention restriction for accessing pgmptr

### DIFF
--- a/docs/c-runtime-library/reference/get-pgmptr.md
+++ b/docs/c-runtime-library/reference/get-pgmptr.md
@@ -38,7 +38,7 @@ errno_t _get_pgmptr( 
  Returns zero if successful; an error code on failure. If `pValue` is `NULL`, the invalid parameter handler is invoked as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, this function sets `errno` to `EINVAL` and returns `EINVAL`.  
   
 ## Remarks  
- The `_pgmptr` global variable contains the full path to the executable associated with the process. For more information, see [_pgmptr, _wpgmptr](../../c-runtime-library/pgmptr-wpgmptr.md).  
+ Only call `_get_pgmptr` if your program has a narrow entry point, like `main()` or `WinMain()`. The `_pgmptr` global variable contains the full path to the executable associated with the process. For more information, see [_pgmptr, _wpgmptr](../../c-runtime-library/pgmptr-wpgmptr.md).  
   
 ## Requirements  
   

--- a/docs/c-runtime-library/reference/get-wpgmptr.md
+++ b/docs/c-runtime-library/reference/get-wpgmptr.md
@@ -38,7 +38,7 @@ errno_t _get_wpgmptr( 
  Returns zero if successful; an error code on failure. If `pValue` is `NULL`, the invalid parameter handler is invoked as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, this function sets `errno` to `EINVAL` and returns `EINVAL`.  
   
 ## Remarks  
- The `_wpgmptr` global variable contains the full path to the executable associated with the process as a wide-character string. For more information, see [_pgmptr, _wpgmptr](../../c-runtime-library/pgmptr-wpgmptr.md).  
+ Only call `_get_wpgmptr` if your program has a wide entry point, like `wmain()` or `wWinMain()`. The `_wpgmptr` global variable contains the full path to the executable associated with the process as a wide-character string. For more information, see [_pgmptr, _wpgmptr](../../c-runtime-library/pgmptr-wpgmptr.md).  
   
 ## Requirements  
   


### PR DESCRIPTION
The exports _get_pgmptr and _get_wpgmptr are only correct to use when a narrow or wide entry point is used, respectively. This is because the entry point determines whether the narrow or wide global variables are initialized. Adding this detail to the Remarks section of these two functions.