### PR TITLE
Update single-inheritance.md

### DIFF
--- a/docs/cpp/single-inheritance.md
+++ b/docs/cpp/single-inheritance.md
@@ -140,8 +140,10 @@ class PaperbackBook : public Document {};
   
 int main() {  
    Document * DocLib[10];   // Library of ten documents.  
-   for (int i = 0 ; i < 10 ; i++)  
+   for (int i = 0 ; i < 5 ; i++)  
       DocLib[i] = new Document;  
+   for (int i = 5 ; i < 10 ; i++)  
+      DocLib[i] = new PaperbackBook;  
 }  
 ```  
   


### PR DESCRIPTION
The original code doesn't demonstrate "Pointers and references to derived classes can be implicitly converted to pointers and references to their base classes if there is an accessible, unambiguous base class". The new code can show that.