### PR TITLE
Example cannot be compiled

### DIFF
--- a/docs/c-language/pointer-declarations.md
+++ b/docs/c-language/pointer-declarations.md
@@ -81,7 +81,7 @@ int const *x;      /* Declares a pointer variable, x,
 const int some_object = 5 ;  
 int other_object = 37;  
 int *const y = &fixed_object;  
-int volatile *const z = &some_object;  
+const int volatile *z = &some_object;  
 int *const volatile w = &some_object;  
 ```  
   


### PR DESCRIPTION
There are some errors of the doc. The code cannot be compiled:

$ cat error.cpp
const int some_object = 5 ;
int volatile *const z = &some_object;

$ gcc -c error.cpp
error.cpp:2:26: error: invalid conversion from ‘const int*’ to ‘volatile int*’ [-fpermissive]
 int volatile *const z = &some_object;
                          ^