### PR TITLE
Update localtime_s syntax to match time.h header

### DIFF
--- a/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
+++ b/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
@@ -23,16 +23,16 @@ Converts a **time_t** time value to a **tm** structure, and corrects for the loc
 
 ```C
 errno_t localtime_s(
-   struct tm* tmDest,
-   const time_t *sourceTime
+   struct tm* const tmDest,
+   time_t const* const sourceTime
 );
 errno_t _localtime32_s(
    struct tm* tmDest,
-   const time32_t *sourceTime
+   __time32_t const* sourceTime
 );
 errno_t _localtime64_s(
    struct tm* tmDest,
-   const _time64_t *sourceTime
+   __time64_t const* sourceTime
 );
 ```
 


### PR DESCRIPTION
Fix prototypes in the syntax block to use the correct types and qualifiers, according to \<time.h>.
Fixes #229 