### PR TITLE
Removed wrong sentence about high_resolution_clock

### DIFF
--- a/docs/standard-library/system-clock-structure.md
+++ b/docs/standard-library/system-clock-structure.md
@@ -29,8 +29,6 @@ A clock is *monotonic* if the value that is returned by a first call to `now()` 
 
 A clock is *steady* if it is *monotonic* and if the time between clock ticks is constant.
 
-In this implementation, a `system_clock` is synonymous with a `high_resolution_clock`.
-
 ## Members
 
 ### Public Typedefs


### PR DESCRIPTION
Because high_resolution_clock is typedef for steady_clock as is also writen in this documentation.