### PR TITLE
Update compiler-error-c3533.md

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
@@ -22,21 +22,21 @@ ms.workload: ["cplusplus"]
 1.  Remove the `auto` keyword from the parameter declaration.  
   
 ## Example  
- The following example yields C3535 because it declares a function parameter with the `auto` keyword and it is compiled with **/Zc:auto**.  
+ The following example yields C3533 because it declares a function parameter with the `auto` keyword and it is compiled with **/Zc:auto**.  
   
 ```  
 // C3533a.cpp  
 // Compile with /Zc:auto  
-void f(auto j){} // C3533  
+void f(auto j) {} // C3533  
 ```  
   
 ## Example  
- The following example yields C3535 because it declares a template parameter with the `auto` keyword and it is compiled with **/Zc:auto**.  
+ The following example yields C3533 in C++14 mode because it declares a template parameter with the `auto` keyword and it is compiled with **/Zc:auto**. (In C++17, this is a valid definition of a class template with a single non-type template parameter whose type is deduced.)
   
 ```  
 // C3533b.cpp  
 // Compile with /Zc:auto  
-template<auto T> class C{}; // C3533  
+template<auto T> class C {}; // C3533  
 ```  
   
 ## See Also  


### PR DESCRIPTION
Fix number typos in the text, and clarify that the second example is a valid template definition in C++17.