### PR TITLE
main-program-startup.md: Add missing linebreak

### DIFF
--- a/docs/cpp/main-program-startup.md
+++ b/docs/cpp/main-program-startup.md
@@ -52,5 +52,5 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[]);
 ## See Also  
  [Keywords](../cpp/keywords-cpp.md)   
  [Using wmain Instead of main](../cpp/using-wmain-instead-of-main.md)   
- [main Function Restrictions](../cpp/main-function-restrictions.md)
+ [main Function Restrictions](../cpp/main-function-restrictions.md)   
  [Parsing C++ Command-Line Arguments](../cpp/parsing-cpp-command-line-arguments.md)


### PR DESCRIPTION
I just noticed, that I didn't add the trailing spaces to get a correct linebreak in https://github.com/MicrosoftDocs/cpp-docs/pull/328 because spaces are invisible in the webeditor, sorry.