### PR TITLE
Clean up README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ This repository was moved from Microsoft/vcppdocs to MicrosoftDocs/cpp-docs-pr o
 
 The documentation for Visual Basic and Visual C# are located in a separate repository at [http://github.com/dotnet/core-docs](http://github.com/dotnet/core-docs), and the Visual Studio 2017 documentation is located in the repository located at [http://github.com/Microsoft/visualstudio-docs](http://github.com/Microsoft/visualstudio-docs).
 
-## Microsoft Open Source Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 ## Contributing to the documentation
 
 To contribute to this documentation, please see the [Contributing guide](CONTRIBUTING.md).
 We welcome your contributions to help us improve the Visual C++ docs. All the articles in this repository use GitHub flavored markdown.
 
 Several feature areas of Visual Studio have their own folders in this repository, such as `standard-library` for topics on the C++ Standard Library, `ide` for topics on the Visual Studio interactive development environment (IDE), and so forth. The `/media` subfolder in each folder contains art files for the topics. The [Contributing guide](CONTRIBUTING.md) has more information.
+
+## Microsoft Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
- ## Microsoft Open Source Code of Conduct
+# Visual Studio 2017 documentation for Visual C++
+
+Welcome! This repository contains source files for the work-in-progress Visual C++ technical documentation. The topics are published on the [Visual C++ documentation site](https://docs.microsoft.com/cpp).
+
+This repository was moved from Microsoft/vcppdocs to MicrosoftDocs/cpp-docs-pr on June 23, 2017.
+
+The documentation for Visual Basic and Visual C# are located in a separate repository at [http://github.com/dotnet/core-docs](http://github.com/dotnet/core-docs), and the Visual Studio 2017 documentation is located in the repository located at [http://github.com/Microsoft/visualstudio-docs](http://github.com/Microsoft/visualstudio-docs).
+
+## Microsoft Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-# Visual Studio 2017 documentation for Visual C++
-
-Welcome! This repo contains source files for the work-in-progress Visual C++ technical documentation. The topics are published on the [Visual C++ documentation site](https://docs.microsoft.com/cpp).
-
-This repo was moved from Microsoft/vcppdocs to MicrosoftDocs/cpp-docs-pr on June 23, 2017.
-
-The documentation for Visual Basic and Visual C# are located in a separate repo at [http://github.com/dotnet/core-docs](http://github.com/dotnet/core-docs), and the Visual Studio 2017 documentation is located in the repo located at [http://github.com/Microsoft/visualstudio-docs](http://github.com/Microsoft/visualstudio-docs).
 
 ## Contributing to the documentation
 
 To contribute to this documentation, please see the [Contributing guide](CONTRIBUTING.md).
 We welcome your contributions to help us improve the Visual C++ docs. All the articles in this repository use GitHub flavored markdown.
 
-Several feature areas of Visual Studio have their own folders in this repo, such as **standard-library** for topics on the C++ Standard Library, **ide** for topics on the Visual Studio interactive development environment (IDE), and so forth. The **/media** subfolder in each folder contains art files for the topics. The [Contributing guide](CONTRIBUTING.md) has more information.
+Several feature areas of Visual Studio have their own folders in this repository, such as `standard-library` for topics on the C++ Standard Library, `ide` for topics on the Visual Studio interactive development environment (IDE), and so forth. The `/media` subfolder in each folder contains art files for the topics. The [Contributing guide](CONTRIBUTING.md) has more information.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Edit summary:

- Move **Microsoft Open Source Code of Conduct** from first to second section.
- Fix Markdown lint issues
- Correct "repo" to "repository"