### PR TITLE
Remove VS2015 mentions

### DIFF
--- a/docs/build/vscpp-step-0-installation.md
+++ b/docs/build/vscpp-step-0-installation.md
@@ -26,12 +26,6 @@ If you haven't downloaded and installed Visual Studio 2017 and the Visual C++ to
 
 For details on the disk space and operating system requirements, see [Visual Studio Product Family System Requirements](/visualstudio/productinfo/vs2017-system-requirements-vs). The installer reports how much disk space is required for the options you select.
 
-## Visual Studio 2015 Installation
-
-To install Visual Studio 2015, go to [Download older versions of Visual Studio](https://www.visualstudio.com/vs/older-downloads/). Run the setup program and choose **Custom installation** and then choose the C++ component. To add C++ support to an existing Visual Studio 2015 installation, click on the Windows Start button and type **Add Remove Programs**. Open the program from the results list and then find your Visual Studio 2015 installation in the list of installed programs. Double-click it, then choose **Modify** and select the Visual C++ components to install.
-
-In general, we highly recommend that you use Visual Studio 2017 even if you need to compile your code using the Visual Studio 2015 compiler. For more information, see [Use native multi-targeting in Visual Studio to build old projects](../porting/use-native-multi-targeting.md).
-
 ## Visual Studio 2017 Installation
 
 1. Download the latest Visual Studio 2017 installer for Windows.


### PR DESCRIPTION
This is the very first page someone hits when they follow VS -> C++ in the documentation hierarchy. Mentioning VS2015 for legacy scenarios is a distraction from this content and shouldn't be here.