### PR TITLE
Removing std namespace before shuffle()

### DIFF
--- a/docs/standard-library/algorithm-functions.md
+++ b/docs/standard-library/algorithm-functions.md
@@ -7403,7 +7403,7 @@ int main()
 }
 ```
 
-## <a name="shuffle"></a>  std::shuffle
+## <a name="shuffle"></a>  shuffle
 
 Shuffles (rearranges) elements for a given range by using a random number generator.
 


### PR DESCRIPTION
to be similar to the other <algorithm> functions documentation.