### PR TITLE
chore: Remove generated Markdown title for PNGs

### DIFF
--- a/docs/build/examples-of-structure-alignment.md
+++ b/docs/build/examples-of-structure-alignment.md
@@ -18,7 +18,7 @@ _declspec(align(2)) struct {
 }
 ```
 
-![AMD conversion example](../build/media/vcamd_conv_ex_1_block.png "vcAmd_conv_ex_1")
+![AMD conversion example](../build/media/vcamd_conv_ex_1_block.png)
 
 ## Example 2
 
@@ -32,7 +32,7 @@ _declspec(align(8)) struct {
 }
 ```
 
-![AMD conversion example](../build/media/vcamd_conv_ex_2_block.png "vcAmd_conv_ex_2")
+![AMD conversion example](../build/media/vcamd_conv_ex_2_block.png)
 
 ## Example 3
 
@@ -47,7 +47,7 @@ _declspec(align(4)) struct {
 }
 ```
 
-![AMD conversion example](../build/media/vcamd_conv_ex_3_block.png "vcAmd_conv_ex_3")
+![AMD conversion example](../build/media/vcamd_conv_ex_3_block.png)
 
 ## Example 4
 
@@ -61,7 +61,7 @@ _declspec(align(8)) union {
 }
 ```
 
-![AMD conversion example](../build/media/vcamd_conv_ex_4_block.png "vcAmd_conv_ex_4")
+![AMD conversion example](../build/media/vcamd_conv_ex_4_block.png)
 
 ## See also
 

--- a/docs/build/reference/profile-guided-optimization-in-the-performance-and-diagnostics-hub.md
+++ b/docs/build/reference/profile-guided-optimization-in-the-performance-and-diagnostics-hub.md
@@ -39,21 +39,21 @@ Next, set the build configuration of your app to Release to ready it for the PGO
 
 Open the Performance and Diagnostics Hub—on the menu bar, choose **Analyze**, **Performance and Diagnostics**. This opens a diagnostics session page that has the analysis tools that are available for your project type.
 
-![PGO in the Performance and Diagnostics Hub](../../build/reference/media/pgofig0hub.png "PGOFig0Hub")
+![PGO in the Performance and Diagnostics Hub](../../build/reference/media/pgofig0hub.png)
 
 In **Available Tools**, select the **Profile Guided Optimization** check box. Choose the **Start** button to start the PGO plug-in.
 
-![PGO introduction page](../../build/reference/media/pgofig1start.png "PGOFig1Start")
+![PGO introduction page](../../build/reference/media/pgofig1start.png)
 
 The **Profile Guided Optimization** page describes the steps the plug-in uses to improve the performance of your app. Choose the **Start** button.
 
-![PGO instrumentation page](../../build/reference/media/pgofig2instrument.png "PGOFig2Instrument")
+![PGO instrumentation page](../../build/reference/media/pgofig2instrument.png)
 
 In the **Instrumentation** section, you use the **Training is initially enabled** option to choose whether to include the startup phase of your app as part of the training. If this option is not selected, training data is not recorded in a running instrumented app until you explicitly enable training.
 
 Choose the **Instrument** button to build your app with a special set of compiler options. The compiler inserts probe instructions in the generated code. These instructions record profiling data during the training phase.
 
-![PGO instrumented build page](../../build/reference/media/pgofig3build.PNG "PGOFig3Build")
+![PGO instrumented build page](../../build/reference/media/pgofig3build.PNG)
 
 When the instrumented build of your app is complete, the app is started automatically.
 
@@ -61,22 +61,22 @@ If any errors or warnings occur during the build, correct them and then choose *
 
 When your app is started, you can use the **Start Training** and **Pause Training** links in the **Training** section to control when profiling information is recorded. You can use the **Stop Application** and **Start Application** links to stop and restart the app.
 
-![PGO training page](../../build/reference/media/pgofig4training.PNG "PGOFig4Training")
+![PGO training page](../../build/reference/media/pgofig4training.PNG)
 
 During training, go through your user scenarios to capture the profiling information that the PGO plug-in needs to optimize the code. When you have completed the training, close your app or choose the **Stop Application** link. Choose the **Analyze** button to start the analysis step.
 
 When the analysis is complete, the **Analysis** section shows a report of the profiling information that was captured during the user-scenario training phase. You can use this report to examine which functions your app called the most and spent the most time in. The PGO plug-in uses the information to determine which app functions to optimize for speed and which to optimize for size. The PGO plug-in configures build optimizations to create the smallest, fastest app for the user scenarios that you recorded during training.
 
-![PGO analysis page](../../build/reference/media/pgofig5analyze.png "PGOFig5Analyze")
+![PGO analysis page](../../build/reference/media/pgofig5analyze.png)
 
 If the training captured the expected profiling information, you can choose **Save Changes** to save the analyzed profile data in your project to optimize future builds. To discard the profile data and start the training over from the beginning, choose **Redo Training**.
 
 The profile data file is saved in your project in a **PGO Training Data** folder. This data is used to control the compiler build optimization settings in your app.
 
-![PGO data file in Solution Explorer](../../build/reference/media/pgofig6data.png "PGOFig6Data")
+![PGO data file in Solution Explorer](../../build/reference/media/pgofig6data.png)
 
 After analysis, the PGO plug-in sets build options in your project to use the profile data to selectively optimize your app during compilation. You can continue to modify and build your app with the same profile data. When the app is built, the build output reports how many functions and instructions were optimized by using profile data.
 
-![PGO output diagnostics](../../build/reference/media/pgofig7diagnostics.png "PGOFig7Diagnostics")
+![PGO output diagnostics](../../build/reference/media/pgofig7diagnostics.png)
 
 If you make significant code changes during development, you may have to retrain your app to get the best optimizations. We recommend that you retrain your app when the build output reports that less than 80 percent of functions or instructions were optimized by using profile data.

--- a/docs/c-runtime-library/reference/erf-erff-erfl-erfc-erfcf-erfcl.md
+++ b/docs/c-runtime-library/reference/erf-erff-erfl-erfc-erfcf-erfcl.md
@@ -60,7 +60,7 @@ The **erf** functions return the Gauss error function of *x*. The **erfc** funct
 
 The **erf** functions calculate the Gauss error function of *x*, which is defined as:
 
-![The error function of x](media/crt_erf_formula.PNG "CRT_erf_formula")
+![The error function of x](media/crt_erf_formula.PNG)
 
 The complementary Gauss error function is defined as 1 - erf(x). The **erf** functions return a value in the range -1.0 to 1.0. There is no error return. The **erfc** functions return a value in the range 0 to 2. If *x* is too large for **erfc**, the **errno** variable is set to **ERANGE**.
 

--- a/docs/cpp/cpp-bit-fields.md
+++ b/docs/cpp/cpp-bit-fields.md
@@ -34,7 +34,7 @@ struct Date {
 
 The conceptual memory layout of an object of type `Date` is shown in the following figure.
 
-![Memory layout of a date object](../cpp/media/vc38uq1.png "vc38UQ1")
+![Memory layout of a date object](../cpp/media/vc38uq1.png)
 Memory Layout of Date Object
 
 Note that `nYear` is 8 bits long and would overflow the word boundary of the declared type, **unsigned** **short**. Therefore, it is begun at the beginning of a new **unsigned** **short**. It is not necessary that all bit fields fit in one object of the underlying type; new units of storage are allocated, according to the number of bits requested in the declaration.
@@ -61,7 +61,7 @@ struct Date {
 
 then the memory layout is as shown in the following figure:
 
-![Layout of Date object with zero&#45;length bit field](../cpp/media/vc38uq2.png "vc38UQ2")
+![Layout of Date object with zero&#45;length bit field](../cpp/media/vc38uq2.png)
 Layout of Date Object with Zero-Length Bit Field
 
 The underlying type of a bit field must be an integral type, as described in [Fundamental Types](../cpp/fundamental-types-cpp.md).

--- a/docs/cpp/how-to-create-and-use-shared-ptr-instances.md
+++ b/docs/cpp/how-to-create-and-use-shared-ptr-instances.md
@@ -11,7 +11,7 @@ The `shared_ptr` type is a smart pointer in the C++ standard library that is des
 
 The following illustration shows several `shared_ptr` instances that point to one memory location.
 
-[![Shared pointer](../cpp/media/shared_ptr.png "shared_ptr")]
+[![Shared pointer](../cpp/media/shared_ptr.png)]
 
 ## Example
 

--- a/docs/cpp/how-to-create-and-use-unique-ptr-instances.md
+++ b/docs/cpp/how-to-create-and-use-unique-ptr-instances.md
@@ -11,7 +11,7 @@ A [unique_ptr](../standard-library/unique-ptr-class.md) does not share its point
 
 The following diagram illustrates the transfer of ownership between two `unique_ptr` instances.
 
-![Moving the ownership of a unique&#95;ptr](../cpp/media/unique_ptr.png "unique_ptr")
+![Moving the ownership of a unique&#95;ptr](../cpp/media/unique_ptr.png)
 
 `unique_ptr` is defined in the `<memory>` header in the C++ Standard Library. It is exactly as efficient as a raw pointer and can be used in C++ Standard Library containers. The addition of `unique_ptr` instances to C++ Standard Library containers is efficient because the move constructor of the `unique_ptr` eliminates the need for a copy operation.
 

--- a/docs/cpp/lambda-expressions-in-cpp.md
+++ b/docs/cpp/lambda-expressions-in-cpp.md
@@ -34,7 +34,7 @@ void abssort(float* x, unsigned n) {
 
 This illustration shows the parts of a lambda:
 
-![Structural elements of a lambda expression](../cpp/media/lambdaexpsyntax.png "LambdaExpSyntax")
+![Structural elements of a lambda expression](../cpp/media/lambdaexpsyntax.png)
 
 1. *capture clause* (Also known as the *lambda-introducer* in the C++ specification.)
 

--- a/docs/cpp/scope-visual-cpp.md
+++ b/docs/cpp/scope-visual-cpp.md
@@ -28,7 +28,7 @@ There are six kinds of scope:
 
 You can hide a name by declaring it in an enclosed block. In the following figure, `i` is redeclared within the inner block, thereby hiding the variable associated with `i` in the outer block scope.
 
-![Block&#45;scope name hiding](../cpp/media/vc38sf1.png "vc38SF1")
+![Block&#45;scope name hiding](../cpp/media/vc38sf1.png)
 Block Scope and Name Hiding
 
 The output from the program shown in the figure is:

--- a/docs/cpp/unions.md
+++ b/docs/cpp/unions.md
@@ -622,7 +622,7 @@ int main()
 
 The `NumericType` union is arranged in memory (conceptually) as shown in the following figure.
 
-![Storage of data in a numeric type union](../cpp/media/vc38ul1.png "vc38UL1")
+![Storage of data in a numeric type union](../cpp/media/vc38ul1.png)
 Storage of Data in NumericType Union
 
 ## <a name="anonymous_unions"></a> Anonymous unions

--- a/docs/cppcx/collections-c-cx.md
+++ b/docs/cppcx/collections-c-cx.md
@@ -9,7 +9,7 @@ In a C++/CX program, you can make free use of Standard Template Library (STL) co
 
 The Windows Runtime defines the interfaces for collections and related types, and C++/CX provides the concrete C++ implementations in the collection.h header file. This illustration shows the relationships between the collection types:
 
-![C&#43;&#43;&#47;CX inheritance tree for collection types](../cppcx/media/cppcxcollectionsinheritancetree.png "CPPCXCollectionsInheritanceTree")
+![C&#43;&#43;&#47;CX inheritance tree for collection types](../cppcx/media/cppcxcollectionsinheritancetree.png)
 
 - The [Platform::Collections::Vector class](../cppcx/platform-collections-vector-class.md) resembles the [std::vector class](../standard-library/vector-class.md).
 
@@ -57,7 +57,7 @@ When you use a `range for` loop over `IVector` containers, use `auto&&` to enabl
 
 The following illustration shows a `range for` loop over an `IVector<Person^>`. Notice that execution is stopped on the breakpoint on line 64. The **QuickWatch** window shows that the iterator variable `p` is in fact a `VectorProxy<Person^>` that has `m_v` and `m_i` member variables. However, when you call `GetType` on this variable, it returns the identical type to the `Person` instance `p2`. The takeaway is that although `VectorProxy` and `ArrowProxy` might appear in **QuickWatch**, the debugger certain compiler errors, or other places, you typically don't have to explicitly code for them.
 
-![VectorProxy in range&#45;based for loop](../cppcx/media/vectorproxy-1.png "VectorProxy_1")
+![VectorProxy in range&#45;based for loop](../cppcx/media/vectorproxy-1.png)
 
 One scenario in which you have to code around the proxy object is when you have to perform a `dynamic_cast` on the elements—for example, when you are looking for XAML objects of a particular type in a `UIElement` element collection. In this case, you must first cast the element to [Platform::Object](../cppcx/platform-object-class.md)^ and then perform the dynamic cast:
 

--- a/docs/cppcx/obtaining-pointers-to-data-buffers-c-cx.md
+++ b/docs/cppcx/obtaining-pointers-to-data-buffers-c-cx.md
@@ -9,7 +9,7 @@ In the Windows Runtime the [Windows::Storage::Streams::IBuffer](https://msdn.mic
 
 The following diagram shows a XAML image element, whose source is a [Windows::UI::Xaml::Media::Imaging WriteableBitmap](https://msdn.microsoft.com/%20library/windows/apps/windows.ui.xaml.media.imaging.writeablebitmap.aspx). A client app that's written in any language can pass a reference to the `WriteableBitmap` to C++ code and then C++ can use the reference to get at the underlying buffer. In a Universal Windows Platform app that's written in C++, you can use the function in the following example directly in the source code without packaging it in a Windows Runtime component.
 
-![C&#43;&#43; code accessing pixel data directly](../cppcx/media/ibufferbyteaccessdiagram.png "IBufferByteAccessDiagram")
+![C&#43;&#43; code accessing pixel data directly](../cppcx/media/ibufferbyteaccessdiagram.png)
 
 ## GetPointerToPixelData
 

--- a/docs/ide/hint-files.md
+++ b/docs/ide/hint-files.md
@@ -231,7 +231,7 @@ The following illustration depicts some of the physical directories in a Visual 
 
 ### Hint File Directories
 
-![Common and project&#45;specific hint file directories.](../ide/media/hintfile.png "HintFile")
+![Common and project&#45;specific hint file directories.](../ide/media/hintfile.png)
 
 ### Directories and Hint File Contents
 

--- a/docs/ide/working-with-project-properties.md
+++ b/docs/ide/working-with-project-properties.md
@@ -51,7 +51,7 @@ As stated earlier, the Visual C++ project system is based on [MSBuild](/visualst
 
 The following illustration shows the property pages for a Visual C++ project. In the left pane, the **VC++ Directories** *rule* is selected, and the right pane lists the properties that are associated with that rule. The `$(...)` values are unfortunately called *macros*. These are *not* C/C++ macros but simply compile-time constants. Macros are discussed in the [Property page macros](#bkmkPropertiesVersusMacros) section later in this article.)
 
-![Project property pages](../ide/media/project_property_pages_vc.png "Project_Property_Pages_VC")
+![Project property pages](../ide/media/project_property_pages_vc.png)
 
 > [!WARNING]
 > The **Common Properties** configurations in earlier versions of Visual Studio have been removed. To add a reference to a project, you now use the **Add Reference** dialog in the same way as for managed languages. See [Managing references in a project](/visualstudio/ide/managing-references-in-a-project).
@@ -131,11 +131,11 @@ A user-defined macro is stored in a property sheet. If your project does not alr
 
 You can use the Property Editor to modify certain string properties and select macros as values. To access the Property Editor, select a property on a property page and then choose the down arrow button on the right. If the drop-down list contains **\<Edit>**, then you can choose it to display the Property Editor for that property.
 
-![Property&#95;Editor&#95;Dropdown](../ide/media/property_editor_dropdown.png "Property_Editor_Dropdown")
+![Property&#95;Editor&#95;Dropdown](../ide/media/property_editor_dropdown.png)
 
 In the Property Editor, you can choose the **Macros** button to view the available macros and their current values. The following illustration shows the Property Editor for the **Additional Include Directories** property after the **Macros** button was chosen. When the **Inherit from parent or project defaults** check box is selected and you add a new value, it is appended to any values that are currently being inherited. If you clear the check box, your new value replaces the inherited values. In most cases, leave the check box selected.
 
-![Property editor, Visual C&#43;&#43;](../ide/media/propertyeditorvc.png "PropertyEditorVC")
+![Property editor, Visual C&#43;&#43;](../ide/media/propertyeditorvc.png)
 
 ##  <a name="bkmkPropertySheets"></a> Creating reusable property configurations
 
@@ -152,7 +152,7 @@ To display **Property Manager**, on the menu bar, choose **View**, **Other Windo
 
 If you have a common, frequently used set of properties that you want to apply to multiple projects, you can use **Property Manager** to capture them in a reusable *property sheet* file, which by convention has a .props file name extension. You can apply the sheet (or sheets) to new projects so that you don't have to set its properties from scratch. To access **Property Manager**, on the menu bar, choose **View**, **Property Manager**.
 
-![Property Manager shortcut menu](../ide/media/sharingnew.png "SharingNew")
+![Property Manager shortcut menu](../ide/media/sharingnew.png)
 
 Under each configuration node, you see nodes for each property sheet that applies to that configuration. The system adds property sheets that set values based on options you choose in the app wizard when you create the project. Right-click any node and choose Properties to see the properties that apply to that node. All the property sheets are imported automatically into the project's "master" property sheet (ms.cpp.props) and are evaluated in the order they appear in Property Manager. You can move them to change the evaluation order. Property sheets that are evaluated later will override the values in previously-evaluated sheets.
 

--- a/docs/ide/writing-and-refactoring-code-cpp.md
+++ b/docs/ide/writing-and-refactoring-code-cpp.md
@@ -23,7 +23,7 @@ To set formatting options such as indents, brace completion, and colorization, t
 
 IntelliSense is the name for a set of features that provide inline information about members, types, and function overloads. The following illustration shows the member list drop-down that appears as you type. You can press the tab key to enter the selected item text into your code file.
 
-![C&#43;&#43; member list drop down](../ide/media/vs2015_cpp_statement_completion.png "vs2015_cpp_statement_completion")
+![C&#43;&#43; member list drop down](../ide/media/vs2015_cpp_statement_completion.png)
 
 For complete information see [Visual C++ IntelliSense](/visualstudio/ide/visual-cpp-intellisense).
 
@@ -31,17 +31,17 @@ For complete information see [Visual C++ IntelliSense](/visualstudio/ide/visual-
 
 A snippet is a predefined piece of source code. Right-click on a single point or on selected text to either insert a snippet or surround the selected text with the snippet. The following illustration shows the three steps to surround a selected statement with a for loop. The yellow highlights in the final image are editable fields that you access with the tab key. For more information, see [Code Snippets](/visualstudio/ide/code-snippets).
 
-![Visual C&#43;&#43; Insert Snippet Drop&#45;down](../ide/media/vs2015_cpp_surround_with.png "vs2015_cpp_surround_with")
+![Visual C&#43;&#43; Insert Snippet Drop&#45;down](../ide/media/vs2015_cpp_surround_with.png)
 
 ## Add Class
 
 Add a new class from the **Project** menu by using the Class Wizard.
 
-![Add New Class in Visual C&#43;&#43;](../ide/media/vs2015_cpp_add_class.png "vs2015_cpp_add_class")
+![Add New Class in Visual C&#43;&#43;](../ide/media/vs2015_cpp_add_class.png)
 
 You can also use Class Wizard to modify or examine an existing class.
 
-![Visual C&#43;&#43; Class Wizard](../ide/media/vs2015_cpp_class_wizard.png "vs2015_cpp_class_wizard")
+![Visual C&#43;&#43; Class Wizard](../ide/media/vs2015_cpp_class_wizard.png)
 
 For more information, see [Adding Functionality with Code Wizards (C++)](../ide/adding-functionality-with-code-wizards-cpp.md).
 
@@ -65,19 +65,19 @@ Visual C++ shares many code navigation features with other languages. For more i
 
 Hover over a variable to see its type information.
 
-![Visual C&#43;&#43; QuickInfo](../ide/media/vs2015_cpp_quickinfo.png "vs2015_cpp_quickInfo")
+![Visual C&#43;&#43; QuickInfo](../ide/media/vs2015_cpp_quickinfo.png)
 
 ## Open document (Navigate to header)
 
 Right click on the header name in an `#include` directive and open the header file.
 
-![Visual C&#43;&#43; Open Document menu option](../ide/media/vs2015_cpp_open_document.png "vs2015_cpp_open_document")
+![Visual C&#43;&#43; Open Document menu option](../ide/media/vs2015_cpp_open_document.png)
 
 ## Peek Definition
 
 Hover over a variable or function declaration, right-click, then choose **Peek Definition** to see an inline view of its definition. For more information, see [Peek Definition (Alt+F12)](/visualstudio/ide/how-to-view-and-edit-code-by-using-peek-definition-alt-plus-f12).
 
-![Visual C&#43;&#43; Peek Definition](../ide/media/vs2015_cpp_peek_definition.png "vs2015_cpp_peek_definition")
+![Visual C&#43;&#43; Peek Definition](../ide/media/vs2015_cpp_peek_definition.png)
 
 ## Go To Definition
 
@@ -87,7 +87,7 @@ Hover over a variable or function declaration, right-click, then choose **Go To 
 
 Right click on any function call and view a resursive list of all the functions that it calls, and all the functions that call it. Each function in the list can be expanded in the same way. For more information, see [Call Hierarchy](/visualstudio/ide/reference/call-hierarchy).
 
-![Visual C&#43;&#43; Call Hierarchy](../ide/media/vs2015_cpp_call_hierarchy.png "vs2015_cpp_call_hierarchy")
+![Visual C&#43;&#43; Call Hierarchy](../ide/media/vs2015_cpp_call_hierarchy.png)
 
 ## Toggle Header / Code File
 
@@ -97,19 +97,19 @@ Right-click and choose **Toggle Header / Code File** to switch back and forth be
 
 Right-click anywhere in a source code file and choose **Outlining** to collapse or expand definitions and/or custom regions to make it easier to browse only the parts you are interested in. For more information, see [Outlining](/visualstudio/ide/outlining).
 
-![Visual C&#43;&#43; Outlining](../ide/media/vs2015_cpp_outlining.png "vs2015_cpp_outlining")
+![Visual C&#43;&#43; Outlining](../ide/media/vs2015_cpp_outlining.png)
 
 ## Scrollbar map mode
 
 Scrollbar map mode enables you to quickly scroll and browse through a code file without actually leaving your current location. Or click anywhere on the code map to go directly to that location. For more information, see [How to: Track your code by customizing the scrollbar](/visualstudio/ide/how-to-track-your-code-by-customizing-the-scrollbar).
 
-![Code Map in Visual C&#43;&#43;](../ide/media/vs2015_cpp_code_map.png "vs2015_cpp_code_map")
+![Code Map in Visual C&#43;&#43;](../ide/media/vs2015_cpp_code_map.png)
 
 ## Generate graph of include files
 
 Right click on a code file in your project and choose **Generate graph of include files** to see a graph of which files are included by other files.
 
-![Visual C&#43;&#43; graph of include files](../ide/media/vs2015_cpp_include_graph.png "vs2015_cpp_include_graph")
+![Visual C&#43;&#43; graph of include files](../ide/media/vs2015_cpp_include_graph.png)
 
 ## F1 Help
 
@@ -119,4 +119,4 @@ Place the cursor on or just after any type, keyword or function and press F1 to 
 
 To easily navigate to any window or tool in Visual Studio, simply type its name in the Quick Launch window in the upper right corner of the UI. The auto-completion list will filter as you type.
 
-![Visual Studio Quick Launch](../ide/media/vs2015_cpp_quick_launch.png "vs2015_cpp_quick_launch")
+![Visual Studio Quick Launch](../ide/media/vs2015_cpp_quick_launch.png)

--- a/docs/mfc/creating-new-documents-windows-and-views.md
+++ b/docs/mfc/creating-new-documents-windows-and-views.md
@@ -13,7 +13,7 @@ Upon completion of this process, the cooperating objects exist and store pointer
 ![Sequence for creating a document](../mfc/media/vc387l1.gif "vc387l1")
 Sequence in Creating a Document
 
-![Frame Window Creation Sequence](../mfc/media/vc387l2.png "vc387l2")
+![Frame Window Creation Sequence](../mfc/media/vc387l2.png)
 Sequence in Creating a Frame Window
 
 ![Sequence for creating a view](../mfc/media/vc387l3.gif "vc387l3")

--- a/docs/mfc/dynamic-layout.md
+++ b/docs/mfc/dynamic-layout.md
@@ -11,11 +11,11 @@ With MFC in Visual Studio 2015, you can create dialogs that the user can resize,
 
 When the user resizes a dialog, the controls in the dialog can resize or move in the X and Y directions. The change in size or position of a control when the user resizes a dialog is called dynamic layout. For example, the following is a dialog before being resized:
 
-![Dialog before being resized.](../mfc/media/mfcdynamiclayout4.png "mfcdynamiclayout4")
+![Dialog before being resized.](../mfc/media/mfcdynamiclayout4.png)
 
 After being resized, the listbox area is increased to show more items, and the buttons are moved along with the bottom right corner:
 
-![Dialog after being resized.](../mfc/media/mfcdynamiclayout5.png "mfcdynamiclayout5")
+![Dialog after being resized.](../mfc/media/mfcdynamiclayout5.png)
 
 You can control dynamic layout by specifying the details for each control in the Resource Editor in the IDE, or you can do so programmatically by accessing the `CMFCDynamicLayout` object for a particular control and setting the properties.
 
@@ -27,17 +27,17 @@ You can set the dynamic layout behavior for a dialog box without having to write
 
 1. With an MFC project open, open the dialog you want to work with in the dialog editor.
 
-     ![Open the dialog in the resource editor.](../mfc/media/mfcdynamiclayout3.png "mfcdynamiclayout3")
+     ![Open the dialog in the resource editor.](../mfc/media/mfcdynamiclayout3.png)
 
 2. Select a control and in the properties window, set its dynamic layout properties. The **Dynamic Layout** section in the properties window contains the properties **Moving Type**, **Sizing Type**, and, depending on the values selected for those properties, specific properties that define how much controls move or change size. **Moving Type** determines how a control is moved as the size of the dialog is changed; **Sizing Type** determines how a control is resized as the size of the dialog is changed. **Moving Type** and **Sizing Type** may be **Horizontal**, **Vertical**, **Both**, or **None** depending on the dimensions that you want to change dynamically. Horizontal is the X dimension; Vertical is the Y direction.
 
 3. If you want a control such as a button to be at a fixed size and stay in place at the bottom right, as is common for the **OK** or **Cancel** buttons, set the **Sizing Type** to **None**, and set the **Moving Type** to **Both**. For the **Moving X** and **Moving Y** values under **Moving Type**, set 100% to cause the control to stay a fixed distance from the bottom right corner.
 
-     ![Dynamic Layout](../mfc/media/mfcdynamiclayout1.png "mfcdynamiclayout1")
+     ![Dynamic Layout](../mfc/media/mfcdynamiclayout1.png)
 
 4. Suppose you also have a control that you want to expand as the dialog expands. Typically, a user might expand a dialog in order to expand a multiline editbox to increase the size of the text area, or they might expand a list control to see more data. For this case, set the **Sizing Type** to Both, and set the **Moving Type** to none. Then, set the **Sizing X** and **Sizing Y** values to 100.
 
-     ![Dynamic Layout Settings](../mfc/media/mfcdynamiclayout2.png "mfcdynamiclayout2")
+     ![Dynamic Layout Settings](../mfc/media/mfcdynamiclayout2.png)
 
 5. Experiment with other values that might make sense for your controls. A dialog with a one-line textbox might have the **Sizing Type** set to **Horizontal** only, for example.
 

--- a/docs/mfc/hierarchy-chart-categories.md
+++ b/docs/mfc/hierarchy-chart-categories.md
@@ -7,7 +7,7 @@ ms.assetid: 1f109428-4b84-4f7c-90a9-e71fe071311e
 ---
 # Hierarchy Chart Categories
 
-![MFC hierarchy chart categories](../mfc/media/vc369r1.png "vc369r1")
+![MFC hierarchy chart categories](../mfc/media/vc369r1.png)
 
 ## See Also
 

--- a/docs/mfc/hierarchy-chart.md
+++ b/docs/mfc/hierarchy-chart.md
@@ -9,15 +9,15 @@ ms.assetid: 19d70341-e391-4a72-94c6-35755ce975d4
 
 The following illustration represents the MFC classes derived from `CObject`:
 
-![Classes Derived From CObject](../mfc/media/mfc_heirarchy_chart1of3.png "mfc_heirarchy_chart1of3")
+![Classes Derived From CObject](../mfc/media/mfc_heirarchy_chart1of3.png)
 
 The following illustration represents the MFC classes derived from `CWnd` and `CCmdTarget`:
 
-![Classes Derived From CCmdTarget or CWnd](../mfc/media/mfc_heirarchy_chart2of3.png "mfc_heirarchy_chart2of3")
+![Classes Derived From CCmdTarget or CWnd](../mfc/media/mfc_heirarchy_chart2of3.png)
 
 The following illustration represents the MFC classes not derived from `CObject`:
 
-![Classes Not Derived From CObject](../mfc/media/mfc_heirarchy_chart3of3.png "mfc_heirarchy_chart3of3")
+![Classes Not Derived From CObject](../mfc/media/mfc_heirarchy_chart3of3.png)
 
 You can download the complete chart from the following location: [MFC Hierarchy Charts Download](https://aka.ms/hxgg8e).
 

--- a/docs/mfc/how-to-customize-the-application-button.md
+++ b/docs/mfc/how-to-customize-the-application-button.md
@@ -8,7 +8,7 @@ ms.assetid: ebb11180-ab20-43df-a234-801feca9eb38
 
 When you click the Application button, a menu of commands is displayed. Typically, the menu contains file-related commands such as **Open**, **Save**, **Print**, and **Exit**.
 
-![MFC Ribbon Application Button](../mfc/media/application_button.png "application_button")
+![MFC Ribbon Application Button](../mfc/media/application_button.png)
 
 To customize the Application button, open it in the **Properties** window, modify its properties, and then preview the ribbon control.
 

--- a/docs/mfc/how-to-customize-the-quick-access-toolbar.md
+++ b/docs/mfc/how-to-customize-the-quick-access-toolbar.md
@@ -8,7 +8,7 @@ ms.assetid: 2554099b-0c89-4605-9249-31bf9cbcefe0
 
 The Quick Access Toolbar (QAT) is a customizable toolbar that contains a set of commands that are either displayed next to the Application button or under the category tabs. The following illustration shows a typical Quick Access Toolbar.
 
-![MFC Ribbon Quick Access Toolbar](../mfc/media/quick_access_toolbar.png "quick_access_toolbar")
+![MFC Ribbon Quick Access Toolbar](../mfc/media/quick_access_toolbar.png)
 
 To customize the Quick Access Toolbar, open it in the **Properties** window, modify its commands, and then preview the ribbon control.
 

--- a/docs/mfc/interface-elements.md
+++ b/docs/mfc/interface-elements.md
@@ -10,7 +10,7 @@ This document describes interface elements that were introduced in Visual Studio
 
 The following illustration shows an application that was built by using the new interface elements.
 
-![MFC Feature Pack example application](../mfc/media/mfc_featurepack.png "mfc_featurepack")
+![MFC Feature Pack example application](../mfc/media/mfc_featurepack.png)
 
 ## Window Docking
 

--- a/docs/mfc/keyboard-and-mouse-customization.md
+++ b/docs/mfc/keyboard-and-mouse-customization.md
@@ -14,7 +14,7 @@ In the **Customization** dialog box, the user can change the custom controls for
 
 The following illustration shows the **Keyboard** tab of the **Customization** dialog box.
 
-![Keyboard tab in the Customize dialog box](../mfc/media/mfcnextkeyboardtab.png "mfcnextkeyboardtab")
+![Keyboard tab in the Customize dialog box](../mfc/media/mfcnextkeyboardtab.png)
 Keyboard Customization Tab
 
 The user interacts with the keyboard tab to assign one or more keyboard shortcuts to a command. The available commands are listed on the left side of the tab. The user can select any available command from the menu. Only menu commands can be associated with a keyboard shortcut. After the user enters a new shortcut, the **Assign** button becomes enabled. When the user clicks this button, the application associates the selected command with that shortcut.
@@ -29,7 +29,7 @@ If you use the Wizard to create your application, the Wizard will initialize the
 
 The following illustration shows the **Mouse** tab of the **Customization** dialog box.
 
-![Mouse tab in the Customize dialog box](../mfc/media/mfcnextmousetab.png "mfcnextmousetab")
+![Mouse tab in the Customize dialog box](../mfc/media/mfcnextmousetab.png)
 Mouse Customization Tab
 
 The user interacts with this tab to assign a menu command to the mouse double-click action. The user selects a view from the left side of the window and then uses the controls on the right side to associate a command with the double-click action. After the user clicks **Close**, the application executes the associated command whenever the user double-clicks anywhere in the view.

--- a/docs/mfc/reference/cmfccolorpickerctrl-class.md
+++ b/docs/mfc/reference/cmfccolorpickerctrl-class.md
@@ -55,7 +55,7 @@ Standard colors are selected from a hexagonal color palette, and custom colors a
 
 The following illustration depicts several `CMFCColorPickerCtrl` objects.
 
-![CMFCColorPickerCtrl dialog box](../../mfc/reference/media/colorpicker.png "colorpicker")
+![CMFCColorPickerCtrl dialog box](../../mfc/reference/media/colorpicker.png)
 
 The `CMFCColorPickerCtrl` supports two pairs of styles. The HEX and HEX_GREYSCALE styles are appropriate for standard color selection. The PICKER and LUMINANCE styles are appropriate for custom color selection.
 

--- a/docs/mfc/reference/cmfcdropdowntoolbar-class.md
+++ b/docs/mfc/reference/cmfcdropdowntoolbar-class.md
@@ -38,7 +38,7 @@ A drop-down toolbar cannot be customized or docked, and it does not have a tear-
 
 The following illustration shows a `CMFCDropDownToolBar` object:
 
-![Example of CMFCDropDownToolbar](../../mfc/reference/media/cmfcdropdown.png "cmfcdropdown")
+![Example of CMFCDropDownToolbar](../../mfc/reference/media/cmfcdropdown.png)
 
 You create a `CMFCDropDownToolBar` object the same way you create an ordinary toolbar (see [CMFCToolBar Class](../../mfc/reference/cmfctoolbar-class.md)).
 

--- a/docs/mfc/reference/cmfcimageeditordialog-class.md
+++ b/docs/mfc/reference/cmfcimageeditordialog-class.md
@@ -37,7 +37,7 @@ The `CMFCImageEditorDialog` class provides a dialog box that includes:
 
 The following illustration shows an image editor dialog box.
 
-![CMFCImageEditorDialog dialog box](../../mfc/reference/media/imageedit.png "imageedit")
+![CMFCImageEditorDialog dialog box](../../mfc/reference/media/imageedit.png)
 
 One way to use a `CMFCImageEditorDialog` object is to pass it a `CBitmap` image to be edited. Do not create a large image because the image editing area has a limited size and the logical pixel size is adjusted to fit the area. Call the `DoModal` method to start a modal dialog box.
 

--- a/docs/mfc/reference/cmfcpropertygridctrl-class.md
+++ b/docs/mfc/reference/cmfcpropertygridctrl-class.md
@@ -141,7 +141,7 @@ The following table lists four selection property types:
 
 The following illustrations depict a property grid control that displays properties in two ways. The first illustration displays properties hierarchically and the second displays properties alphabetically.
 
-![Property List PropertySheet](../../mfc/reference/media/proplist.png "proplist")
+![Property List PropertySheet](../../mfc/reference/media/proplist.png)
 
 ## Example
 

--- a/docs/mfc/reference/cmfcpropertysheet-class.md
+++ b/docs/mfc/reference/cmfcpropertysheet-class.md
@@ -70,15 +70,15 @@ Perform the following steps to use the `CMFCPropertySheet` class in your applica
 
 The following illustration depicts a property sheet that is in the style of an embedded Microsoft Outlook toolbar. The Outlook toolbar appears on the left side of the property sheet.
 
-![CMFCPropertySheet color controls](../../mfc/reference/media/cmfcpropertysheet_color.png "cmfcpropertysheet_color")
+![CMFCPropertySheet color controls](../../mfc/reference/media/cmfcpropertysheet_color.png)
 
 The following illustration depicts a property sheet that contains a [CMFCPropertyGridCtrl Class](../../mfc/reference/cmfcpropertygridctrl-class.md) object. That object is a property sheet in the style of a standard common controls property sheet.
 
-![CMFCPropertySheet list and property controls](../../mfc/reference/media/cmfcpropertysheet_list.png "cmfcpropertysheet_list")
+![CMFCPropertySheet list and property controls](../../mfc/reference/media/cmfcpropertysheet_list.png)
 
 The following illustration depicts a property sheet that is in the style of a tree control.
 
-![Peroperty Tree](../../mfc/reference/media/proptree.png "proptree")
+![Peroperty Tree](../../mfc/reference/media/proptree.png)
 
 ## Inheritance Hierarchy
 

--- a/docs/mfc/reference/cmfcribboncategory-class.md
+++ b/docs/mfc/reference/cmfcribboncategory-class.md
@@ -112,7 +112,7 @@ CMFCRibbonPanel* pPanel = pCategory->AddPanel (
 
 The following diagram shows a figure of the Home category from the RibbonApp sample application.
 
-![CMFCRibbonCategory image](../../mfc/reference/media/cmfcribboncategory.png "cmfcribboncategory")
+![CMFCRibbonCategory image](../../mfc/reference/media/cmfcribboncategory.png)
 
 ## Inheritance Hierarchy
 

--- a/docs/mfc/reference/cmfcstatusbar-class.md
+++ b/docs/mfc/reference/cmfcstatusbar-class.md
@@ -66,7 +66,7 @@ class CMFCStatusBar : public CPane
 
 The following diagram shows a figure of the status bar from [Status Bar Demo sample](../../visual-cpp-samples.md) application.
 
-![Example of CMFCStatusBar](../../mfc/reference/media/cmfcstatusbar.png "cmfcstatusbar")
+![Example of CMFCStatusBar](../../mfc/reference/media/cmfcstatusbar.png)
 
 ## Example
 

--- a/docs/mfc/reference/cmfctaskspane-class.md
+++ b/docs/mfc/reference/cmfctaskspane-class.md
@@ -154,11 +154,11 @@ To use the `CMFCTasksPane` control in your application, follow these steps:
 
 The following illustration shows a typical task pane control. The first group is a *special* group and its caption is a darker color. The third group is collapsed. The last group is aligned to the bottom of the task pane and has no caption, and the last task in the group is a simple label:
 
-![Example of Task Pane](../../mfc/reference/media/nexttaskpane.png "nexttaskpane")
+![Example of Task Pane](../../mfc/reference/media/nexttaskpane.png)
 
 You can customize the appearance of the task pane by adjusting various margins and offsets. The following illustration clarifies the meaning of these variables:
 
-![Custom task group](../../mfc/reference/media/nexttaskgrpcustom.png "nexttaskgrpcustom")
+![Custom task group](../../mfc/reference/media/nexttaskgrpcustom.png)
 
 ## Example
 

--- a/docs/mfc/reference/cmfctaskspanetask-class.md
+++ b/docs/mfc/reference/cmfctaskspanetask-class.md
@@ -49,7 +49,7 @@ class CMFCTasksPaneTask : public CObject
 
 The following illustration shows a task group that contains three tasks:
 
-![Task group, expanded](../../mfc/reference/media/nexttaskgrpexpand.png "nexttaskgrpexpand")
+![Task group, expanded](../../mfc/reference/media/nexttaskgrpexpand.png)
 
 > [!NOTE]
 >  If a task does not have a valid command ID, it is treated as a simple label.

--- a/docs/mfc/reference/cmfctaskspanetaskgroup-class.md
+++ b/docs/mfc/reference/cmfctaskspanetaskgroup-class.md
@@ -46,19 +46,19 @@ class CMFCTasksPaneTaskGroup : public CObject
 
 The following illustration shows an expanded task group:
 
-![Task group, expanded](../../mfc/reference/media/nexttaskgrpexpand.png "nexttaskgrpexpand")
+![Task group, expanded](../../mfc/reference/media/nexttaskgrpexpand.png)
 
 The following illustration shows a collapsed task group:
 
-![Collapsed task group](../../mfc/reference/media/nexttaskgrpcollapse.png "nexttaskgrpcollapse")
+![Collapsed task group](../../mfc/reference/media/nexttaskgrpcollapse.png)
 
 The following illustration shows a task group without a caption:
 
-![Task group without a caption](../../mfc/reference/media/nexttaskgrpnocapt.png "nexttaskgrpnocapt")
+![Task group without a caption](../../mfc/reference/media/nexttaskgrpnocapt.png)
 
 The following illustration shows two task groups. The first task group is marked as special by setting the `m_bIsSpecial` flag to TRUE, while the second task group is not special. Note how the caption for the first task group is darker than the second task group:
 
-![Special task group](../../mfc/reference/media/nexttaskgrpspecial.png "nexttaskgrpspecial")
+![Special task group](../../mfc/reference/media/nexttaskgrpspecial.png)
 
 ## Inheritance Hierarchy
 

--- a/docs/mfc/reference/cnetaddressctrl-class.md
+++ b/docs/mfc/reference/cnetaddressctrl-class.md
@@ -42,7 +42,7 @@ The `CNetAddressCtrl` class is derived from the [CEdit](../../mfc/reference/cedi
 
 The following figure depicts a dialog that contains a network address control. The text box (1) for the network address control contains an invalid network address. The infotip message (2) is displayed if the network address is invalid.
 
-![Dialog with a network address control and infotip.](../../mfc/reference/media/cnetaddctrl.png "cnetaddctrl")
+![Dialog with a network address control and infotip.](../../mfc/reference/media/cnetaddctrl.png)
 
 ## Example
 

--- a/docs/mfc/reference/csmartdockinginfo-class.md
+++ b/docs/mfc/reference/csmartdockinginfo-class.md
@@ -47,7 +47,7 @@ class CSmartDockingInfo : public CObject
 
 The framework handles smart docking markers internally. The following illustration shows the standard smart docking markers:
 
-![Standard markers for smart docking](../../mfc/reference/media/nextsdmarkers.png "nextsdmarkers")
+![Standard markers for smart docking](../../mfc/reference/media/nextsdmarkers.png)
 
 In this figure, the image on the left shows a central group smart docking marker that does not have docking to a tab enabled. The image in the middle shows a right edge smart docking marker. The image on the right shows a central group smart docking marker that does have docking to a tab enabled. The central group smart docking marker has a main bitmap and five smart docking marker bitmaps.
 
@@ -65,7 +65,7 @@ You can customize the following parameters of smart docking markers:
 
 The following illustration shows an example of smart docking markers that have been customized:
 
-![Custom markers for smart docking](../../mfc/reference/media/nextsdmarkerscustom.png "nextsdmarkerscustom")
+![Custom markers for smart docking](../../mfc/reference/media/nextsdmarkerscustom.png)
 
 ## Inheritance Hierarchy
 

--- a/docs/mfc/reference/csplitbutton-class.md
+++ b/docs/mfc/reference/csplitbutton-class.md
@@ -42,7 +42,7 @@ The `CSplitButton` class is derived from the [CButton](../../mfc/reference/cbutt
 
 The following figure depicts a dialog box that contains a pager control and a (1) split button control. The (2) drop-down arrow has already been clicked and the (3) submenu is displayed.
 
-![Dialog with a splitbutton and pager control.](../../mfc/reference/media/splitbutton_pager.png "splitbutton_pager")
+![Dialog with a splitbutton and pager control.](../../mfc/reference/media/splitbutton_pager.png)
 
 ## Inheritance Hierarchy
 
@@ -172,7 +172,7 @@ The *nMenuId* parameter identifies a menu bar, which is a horizontal list of men
 
 The following figure depicts a dialog box that contains a pager control and a (1) split button control. The (2) drop-down arrow has already been clicked and the (3) submenu is displayed.
 
-![Dialog with a splitbutton and pager control.](../../mfc/reference/media/splitbutton_pager.png "splitbutton_pager")
+![Dialog with a splitbutton and pager control.](../../mfc/reference/media/splitbutton_pager.png)
 
 ### Example
 

--- a/docs/mfc/reference/ctaskdialog-class.md
+++ b/docs/mfc/reference/ctaskdialog-class.md
@@ -124,7 +124,7 @@ The `CTaskDialog` has two different constructors. One constructor enables you to
 
 The following image shows a sample `CTaskDialog` to illustrate the location of some of the controls.
 
-![Example of CTaskDialog](../../mfc/reference/media/ctaskdialogsample.png "ctaskdialogsample")
+![Example of CTaskDialog](../../mfc/reference/media/ctaskdialogsample.png)
 CTaskDialog Sample
 
 ## Requirements

--- a/docs/mfc/reference/cvslistbox-class.md
+++ b/docs/mfc/reference/cvslistbox-class.md
@@ -51,7 +51,7 @@ The `CVSListBox` class provides a set of edit buttons that enable the user to cr
 
 The following is a picture of the editable list control. The second list entry, which is titled "Item2", is selected for editing.
 
-![CVSListBox control](../../mfc/reference/media/cvslistbox.png "cvslistbox")
+![CVSListBox control](../../mfc/reference/media/cvslistbox.png)
 
 If you use the resource editor to add an editable list control, notice that the **Toolbox** pane of the editor does not provide a predefined editable list control. Instead, add a static control such as the **Group Box** control. The framework uses the static control as a placeholder to specify the size and position of the editable list control.
 

--- a/docs/mfc/ribbon-designer-mfc.md
+++ b/docs/mfc/ribbon-designer-mfc.md
@@ -9,7 +9,7 @@ ms.assetid: 0806dfd6-7d11-471a-99e1-4072852231f9
 
 The Ribbon Designer lets you create and customize ribbons in MFC applications. A ribbon is a user interface (UI) element that organizes commands into logical groups. These groups appear on separate tabs in a strip across the top of the window. The ribbon replaces the menu bar and toolbars. A ribbon can significantly improve application usability. For more information, see [Ribbons](/windows/desktop/uxguide/cmd-ribbons). The following illustration shows a ribbon.
 
-![MFC Ribbon Resource Control](../mfc/media/ribbon_no_callouts.png "ribbon_no_callouts")
+![MFC Ribbon Resource Control](../mfc/media/ribbon_no_callouts.png)
 
 In earlier versions of Visual Studio, ribbons had to be created by writing code that uses the MFC ribbon classes such as [CMFCRibbonBar Class](../mfc/reference/cmfcribbonbar-class.md). In Visual Studio 2010 and later, the ribbon designer provides an alternative method for building ribbons. First, create and customize a ribbon as a resource. Then load the ribbon resource from code in the MFC application. You can even use ribbon resources and MFC ribbon classes together. For example, you can create a ribbon resource, and then programmatically add more elements to it at runtime by using code.
 
@@ -62,7 +62,7 @@ To open a ribbon in the ribbon designer, double-click the ribbon resource in Res
 
 The following illustration shows the various components in the ribbon designer.
 
-![MFC Ribbon Designer](../mfc/media/ribbon_designer.png "ribbon_designer")
+![MFC Ribbon Designer](../mfc/media/ribbon_designer.png)
 
 - **Toolbox:** Contains controls that can be dragged to the designer surface.
 
@@ -86,7 +86,7 @@ The following topics describe how to use the features in the ribbon designer:
 
 ## Definitions of Ribbon Elements
 
-![MFC Ribbon](../mfc/media/ribbon.png "ribbon")
+![MFC Ribbon](../mfc/media/ribbon.png)
 
 - **Application button:** The button that appears on the upper-left corner of a ribbon. The Application button replaces the File menu and is visible even when the ribbon is minimized. When the button is clicked, a menu that has a list of commands is displayed.
 

--- a/docs/mfc/user-defined-tools.md
+++ b/docs/mfc/user-defined-tools.md
@@ -10,7 +10,7 @@ MFC supports user-defined tools. A user-defined tool is a special command that e
 
 If you enabled user-defined tools support, the customization dialog box automatically includes the **Tools** tab. The following illustration shows the **Tools** page.
 
-![Tools tab in the Customize dialog box](../mfc/media/custdialogboxtoolstab.png "custdialogboxtoolstab")
+![Tools tab in the Customize dialog box](../mfc/media/custdialogboxtoolstab.png)
 Customization dialog box Tools tab
 
 ## Enabling user-defined tools support

--- a/docs/mfc/user-interface-objects-and-command-ids.md
+++ b/docs/mfc/user-interface-objects-and-command-ids.md
@@ -13,7 +13,7 @@ Commands in the Framework
 
 The figure "Command Updating in the Framework" below shows how MFC updates user-interface objects such as menu items and toolbar buttons. Before a menu drops down, or during the idle loop in the case of toolbar buttons, MFC routes an update command. In the figure below, the document object calls its update command handler, `OnUpdateEditClearAll`, to enable or disable the user-interface object.
 
-![Command updating in the Framework](../mfc/media/vc385p2.png "vc385p2")
+![Command updating in the Framework](../mfc/media/vc385p2.png)
 Command Updating in the Framework
 
 ## See Also

--- a/docs/mfc/visualization-manager.md
+++ b/docs/mfc/visualization-manager.md
@@ -8,19 +8,19 @@ ms.assetid: c9dd1365-27ac-42e5-8caa-1004525b4129
 
 The visual manager is an object that controls the appearance of a whole application. It acts as a single class where you can put all the drawing code for your application. The MFC Library includes several visual managers. You can also create your own visual manager if you want to create a custom view for your application. The following images show the same application when different visual managers are enabled:
 
-![MyApp as rendered by CMFCVisualManagerWindows](../mfc/media/vmwindows.png "vmwindows")
+![MyApp as rendered by CMFCVisualManagerWindows](../mfc/media/vmwindows.png)
 MyApp that uses the CMFCVisualManagerWindows visual manager
 
-![MyApp as rendered by CMFCVisualManagerVS2005](../mfc/media/vmvs2005.png "vmvs2005")
+![MyApp as rendered by CMFCVisualManagerVS2005](../mfc/media/vmvs2005.png)
 MyApp that uses the CMFCVisualManagerVS2005 visual manager
 
-![MyApp as rendered by CMFCVisualManagerOfficeXP](../mfc/media/vmofficexp.png "vmofficexp")
+![MyApp as rendered by CMFCVisualManagerOfficeXP](../mfc/media/vmofficexp.png)
 MyApp that uses the CMFCVisualManagerOfficeXP visual manager
 
-![MyApp as rendered by CMFCVisualManagerOffice2003](../mfc/media/vmoffice2003.png "vmoffice2003")
+![MyApp as rendered by CMFCVisualManagerOffice2003](../mfc/media/vmoffice2003.png)
 MyApp that uses the CMFCVisualManagerOffice2003 visual manager
 
-![MyApp as rendered by CMFCVisualManagerOffice2007](../mfc/media/msoffice2007.png "msoffice2007")
+![MyApp as rendered by CMFCVisualManagerOffice2007](../mfc/media/msoffice2007.png)
 MyApp that uses the CMFCVisualManagerOffice2007 visual manager
 
 By default, the visual manager maintains the drawing code for several GUI elements. To provide custom UI elements, you need to override the related drawing methods of the visual manager. For the list of these methods, see [CMFCVisualManager Class](../mfc/reference/cmfcvisualmanager-class.md). The methods that you can override to provide a custom appearance are all the methods that start with `OnDraw`.

--- a/docs/parallel/amp/cpp-amp-overview.md
+++ b/docs/parallel/amp/cpp-amp-overview.md
@@ -351,7 +351,7 @@ In typical applications, the elements in a tile are related in some way, and the
 
 The following diagram represents a two-dimensional array of sampling data that is arranged in tiles.
 
-![Index values in a tiled extent](../../parallel/amp/media/camptiledgridexample.png "camptiledgridexample")
+![Index values in a tiled extent](../../parallel/amp/media/camptiledgridexample.png)
 
 The following code example uses the sampling data from the previous diagram. The code replaces each value in the tile by the average of the values in the tile.
 

--- a/docs/parallel/amp/using-tiles.md
+++ b/docs/parallel/amp/using-tiles.md
@@ -21,7 +21,7 @@ To take advantage of tiling, your algorithm must partition the compute domain in
 
 The following diagram represents an 8x9 matrix of data that is arranged in 2x3 tiles.
 
-![8&#45;by&#45;9 matrix divided into 2&#45;by&#45;3 tiles](../../parallel/amp/media/usingtilesmatrix.png "usingtilesmatrix")
+![8&#45;by&#45;9 matrix divided into 2&#45;by&#45;3 tiles](../../parallel/amp/media/usingtilesmatrix.png)
 
 The following example displays the global, tile, and local indices of this tiled matrix. An `array_view` object is created by using elements of type `Description`. The `Description` holds the global, tile, and local indices of the element in the matrix. The code in the call to `parallel_for_each` sets the values of the global, tile, and local indices of each element. The output displays the values in the `Description` structures.
 

--- a/docs/parallel/amp/walkthrough-debugging-a-cpp-amp-application.md
+++ b/docs/parallel/amp/walkthrough-debugging-a-cpp-amp-application.md
@@ -191,7 +191,7 @@ In this procedure, you will use the Local Windows Debugger to make sure that the
 
 4. Set breakpoints on the lines of code shown in the following illustration (approximately lines 67 line 70).
 
-     ![CPU breakpoints](../../parallel/amp/media/campcpubreakpoints.png "campcpubreakpoints")
+     ![CPU breakpoints](../../parallel/amp/media/campcpubreakpoints.png)
 CPU breakpoints
 
 5. On the menu bar, choose **Debug** > **Start Debugging**.
@@ -220,7 +220,7 @@ This section shows how to debug the GPU code, which is the code contained in the
 
 6. Set a breakpoint at line 30, as shown in the following illustration.
 
-     ![GPU breakpoints](../../parallel/amp/media/campgpubreakpoints.png "campgpubreakpoints")
+     ![GPU breakpoints](../../parallel/amp/media/campgpubreakpoints.png)
 GPU breakpoint
 
 7. On the menu bar, choose **Debug** > **Start Debugging**. The breakpoints in the CPU code at lines 67 and 70 are not executed during GPU debugging because those lines of code are executed on the CPU.
@@ -233,7 +233,7 @@ GPU breakpoint
 
 2. Dock the **GPU Threads** window at the bottom of Visual Studio. Choose the **Expand Thread Switch** button to display the tile and thread text boxes. The **GPU Threads** window shows the total number of active and blocked GPU threads, as shown in the following illustration.
 
-     ![GPU Threads window with 4 active threads](../../parallel/amp/media/campc.png "campc")
+     ![GPU Threads window with 4 active threads](../../parallel/amp/media/campc.png)
 GPU Threads window
 
    There are 313 tiles allocated for this computation. Each tile contains 32 threads. Because local GPU debugging occurs on a software emulator, there are four active GPU threads. The four threads execute the instructions simultaneously and then move on together to the next instruction.
@@ -256,14 +256,14 @@ GPU Threads window
 
 3. Make sure that **Threads** is selected in the list in the upper-left corner. In the following illustration, the **Parallel Stacks** window shows a call-stack focused view of the GPU threads that you saw in the **GPU Threads** window.
 
-     ![Parallel Stacks window with 4 active threads](../../parallel/amp/media/campd.png "campd")
+     ![Parallel Stacks window with 4 active threads](../../parallel/amp/media/campd.png)
 Parallel Stacks window
 
    32 threads went from `_kernel_stub` to the lambda statement in the `parallel_for_each` function call and then to the `sum_kernel_tiled` function, where the parallel reduction occurs. 28 out of the 32 threads have progressed to the [tile_barrier::wait](reference/tile-barrier-class.md#wait) statement and remain blocked at line 22, whereas the other 4 threads remain active in the `sum_kernel_tiled` function at line 30.
 
    You can inspect the properties of a GPU thread that are available in the **GPU Threads** window in the rich DataTip of the **Parallel Stacks** window. To do this, rest the mouse pointer on the stack frame of **sum_kernel_tiled**. The following illustration shows the DataTip.
 
-     ![DataTip for Parallel Stacks window](../../parallel/amp/media/campe.png "campe")
+     ![DataTip for Parallel Stacks window](../../parallel/amp/media/campe.png)
 GPU thread DataTip
 
    For more information about the **Parallel Stacks** window, see [Using the Parallel Stacks Window](/visualstudio/debugger/using-the-parallel-stacks-window).
@@ -286,7 +286,7 @@ GPU thread DataTip
 
    Select the **localA[localIdx[0]]** column header to sort the column. The following illustration shows the results of sorting by **localA[localIdx[0]]**.
 
-     ![Parallel Watch window with sorted results](../../parallel/amp/media/campf.png "campf")
+     ![Parallel Watch window with sorted results](../../parallel/amp/media/campf.png)
 Results of sort
 
    You can export the content in the **Parallel Watch** window to Excel by choosing the **Excel** button and then choosing **Open in Excel**. If you have Excel installed on your development computer, this opens an Excel worksheet that contains the content.
@@ -309,7 +309,7 @@ You can mark specific GPU threads by flagging them in the **GPU Threads** window
 
    The following illustration shows the four active flagged threads in the **GPU Threads** window.
 
-     ![GPU Threads window with flagged threads](../../parallel/amp/media/campg.png "campg")
+     ![GPU Threads window with flagged threads](../../parallel/amp/media/campg.png)
 Active threads in the GPU Threads window
 
    The **Parallel Watch** window and the DataTip of the **Parallel Stacks** window both indicate the flagged threads.
@@ -318,7 +318,7 @@ Active threads in the GPU Threads window
 
    Choose the **Show Flagged Only** button on any of the windows or on the **Debug Location** toolbar. The following illustration shows the **Show Flagged Only** button on the **Debug Location** toolbar.
 
-     ![Debug Location toolbar with Show Only Flagged icon](../../parallel/amp/media/camph.png "camph")
+     ![Debug Location toolbar with Show Only Flagged icon](../../parallel/amp/media/camph.png)
 **Show Flagged Only** button
 
    Now the **GPU Threads**, **Parallel Watch**, and **Parallel Stacks** windows display only the flagged threads.
@@ -337,7 +337,7 @@ You can freeze (suspend) and thaw (resume) GPU threads from either the **GPU Thr
 
    The following illustration of the **GPU Threads** window shows that all four threads are frozen.
 
-     ![GPU Threads windows showing frozen threads](../../parallel/amp/media/campk.png "campk")
+     ![GPU Threads windows showing frozen threads](../../parallel/amp/media/campk.png)
 Frozen threads in the **GPU Threads** window
 
    Similarly, the **Parallel Watch** window shows that all four threads are frozen.
@@ -354,7 +354,7 @@ Frozen threads in the **GPU Threads** window
 
    The threads in the **GPU Threads** window are grouped by address. The address corresponds to the instruction in disassembly where each group of threads is located. 24 threads are at line 22 where the [tile_barrier::wait Method](reference/tile-barrier-class.md#wait) is executed. 12 threads are at the instruction for the barrier at line 32. Four of these threads are flagged. Eight threads are at the breakpoint at line 30. Four of these threads are frozen. The following illustration shows the grouped threads in the **GPU Threads** window.
 
-     ![GPU Threads window with threads grouped by Address](../../parallel/amp/media/campl.png "campl")
+     ![GPU Threads window with threads grouped by Address](../../parallel/amp/media/campl.png)
 Grouped threads in the **GPU Threads** window
 
 2. You can also perform the **Group By** operation by opening the shortcut menu for the data grid of the **Parallel Watch** window, choosing **Group By**, and then choosing the menu item that corresponds to how you want to group the threads.

--- a/docs/parallel/amp/walkthrough-matrix-multiplication.md
+++ b/docs/parallel/amp/walkthrough-matrix-multiplication.md
@@ -35,9 +35,9 @@ Before you start:
 
 In this section, consider the multiplication of two matrices, A and B, which are defined as follows:
 
-![3&#45;by&#45;2 matrix](../../parallel/amp/media/campmatrixanontiled.png "campmatrixanontiled")
+![3&#45;by&#45;2 matrix](../../parallel/amp/media/campmatrixanontiled.png)
 
-![2&#45;by&#45;3 matrix](../../parallel/amp/media/campmatrixbnontiled.png "campmatrixbnontiled")
+![2&#45;by&#45;3 matrix](../../parallel/amp/media/campmatrixbnontiled.png)
 
 A is a 3-by-2 matrix and B is a 2-by-3 matrix. The product of multiplying A by B is the following 3-by-3 matrix. The product is calculated by multiplying the rows of A by the columns of B element by element.
 

--- a/docs/parallel/concrt/asynchronous-agents-library.md
+++ b/docs/parallel/concrt/asynchronous-agents-library.md
@@ -18,7 +18,7 @@ The Agents Library is composed of three components: *asynchronous agents*, *asyn
 
 The following illustration shows how two agents use message blocks and message-passing functions to communicate. In this illustration, `agent1` sends a message to `agent2` by using the [concurrency::send](reference/concurrency-namespace-functions.md#send) function and a [concurrency::unbounded_buffer](reference/unbounded-buffer-class.md) object. `agent2` uses the [concurrency::receive](reference/concurrency-namespace-functions.md#receive) function to read the message. `agent2` uses the same method to send a message to `agent1`. Dashed arrows represent the flow of data between agents. Solid arrows connect the agents to the message blocks that they write to or read from.
 
-![The components of the Agents Library](../../parallel/concrt/media/agent_librarycomp.png "agent_librarycomp")
+![The components of the Agents Library](../../parallel/concrt/media/agent_librarycomp.png)
 
 A code example that implements this illustration is shown later in this topic.
 

--- a/docs/parallel/concrt/asynchronous-agents.md
+++ b/docs/parallel/concrt/asynchronous-agents.md
@@ -14,7 +14,7 @@ The Agents Library defines the [concurrency::agent](../../parallel/concrt/refere
 
 Agents have a set life cycle. The [concurrency::agent_status](reference/concurrency-namespace-enums.md#agent_status) enumeration defines the various states of an agent. The following illustration is a state diagram that shows how agents progress from one state to another. In this illustration, solid lines represent methods that you call from your application; dotted lines represent methods that are called from the runtime.
 
-![Agent State Diagram](../../parallel/concrt/media/agentstate.png "agentstate")
+![Agent State Diagram](../../parallel/concrt/media/agentstate.png)
 
 The following table describes each state in the `agent_status` enumeration.
 

--- a/docs/parallel/concrt/cancellation-in-the-ppl.md
+++ b/docs/parallel/concrt/cancellation-in-the-ppl.md
@@ -45,7 +45,7 @@ This document explains the role of cancellation in the Parallel Patterns Library
 
 The PPL uses tasks and task groups to manage fine-grained tasks and computations. You can nest task groups to form *trees* of parallel work. The following illustration shows a parallel work tree. In this illustration, `tg1` and `tg2` represent task groups; `t1`, `t2`, `t3`, `t4`, and `t5` represent the work that the task groups perform.
 
-![A parallel work tree](../../parallel/concrt/media/parallelwork_trees.png "parallelwork_trees")
+![A parallel work tree](../../parallel/concrt/media/parallelwork_trees.png)
 
 The following example shows the code that is required to create the tree in the illustration. In this example, `tg1` and `tg2` are [concurrency::structured_task_group](../../parallel/concrt/reference/structured-task-group-class.md) objects; `t1`, `t2`, `t3`, `t4`, and `t5` are [concurrency::task_handle](../../parallel/concrt/reference/task-handle-class.md) objects.
 

--- a/docs/parallel/concrt/creating-asynchronous-operations-in-cpp-for-windows-store-apps.md
+++ b/docs/parallel/concrt/creating-asynchronous-operations-in-cpp-for-windows-store-apps.md
@@ -116,7 +116,7 @@ The `getPrimesCancellation` and `cancelGetPrimes` methods work together to enabl
 
 The following illustration shows the `Primes` app after each option has been chosen.
 
-![Windows Runtime Primes app](../../parallel/concrt/media/concrt_windows_primes.png "concrt_windows_primes")
+![Windows Runtime Primes app](../../parallel/concrt/media/concrt_windows_primes.png)
 
 For examples that use `create_async` to create asynchronous tasks that can be consumed by other languages, see [Using C++ in the Bing Maps Trip Optimizer sample](https://msdn.microsoft.com/library/windows/apps/hh699891.aspx) and [Windows 8 Asynchronous Operations in C++ with PPL](http://code.msdn.microsoft.com/windowsapps/windows-8-asynchronous-08009a0d).
 
@@ -178,7 +178,7 @@ Modify the `MainPage` constructor to create a chain of continuation tasks that d
 
 The following illustration shows the results of the `CommonWords` app.
 
-![Windows Runtime CommonWords app](../../parallel/concrt/media/concrt_windows_common_words.png "concrt_windows_common_words")
+![Windows Runtime CommonWords app](../../parallel/concrt/media/concrt_windows_common_words.png)
 
 In this example, it’s possible to support cancellation because the `task` objects that support `create_async` use an implicit cancellation token. Define your work function to take a `cancellation_token` object if your tasks need to respond to cancellation in a cooperative manner. For more info about cancellation in the PPL, see [Cancellation in the PPL](cancellation-in-the-ppl.md)
 

--- a/docs/parallel/concrt/overview-of-the-concurrency-runtime.md
+++ b/docs/parallel/concrt/overview-of-the-concurrency-runtime.md
@@ -50,7 +50,7 @@ The Concurrency Runtime is divided into four components: the Parallel Patterns L
 
 **Concurrency Runtime Architecture**
 
-![The Concurrency Runtime Architecture](../../parallel/concrt/media/concurrencyrun.png "concurrencyrun")
+![The Concurrency Runtime Architecture](../../parallel/concrt/media/concurrencyrun.png)
 
 > [!IMPORTANT]
 >  The Task Scheduler and Resource Manager components are not available from a Universal Windows Platform (UWP) app or when you use the task class or other types in ppltasks.h.

--- a/docs/parallel/concrt/parallel-algorithms.md
+++ b/docs/parallel/concrt/parallel-algorithms.md
@@ -240,7 +240,7 @@ The following table summarizes the important properties of the three parallel so
 
 The following illustration  shows the important properties of the three parallel sorting algorithms more graphically.
 
-![Comparison of the sorting algorithms](../../parallel/concrt/media/concrt_parallel_sorting.png "concrt_parallel_sorting")
+![Comparison of the sorting algorithms](../../parallel/concrt/media/concrt_parallel_sorting.png)
 
 These parallel sorting algorithms follow the rules of cancellation and exception handling. For more information about cancellation and exception handling in the Concurrency Runtime, see [Canceling Parallel Algorithms](../../parallel/concrt/cancellation-in-the-ppl.md#algorithms) and [Exception Handling](../../parallel/concrt/exception-handling-in-the-concurrency-runtime.md).
 

--- a/docs/parallel/concrt/walkthrough-connecting-using-tasks-and-xml-http-requests.md
+++ b/docs/parallel/concrt/walkthrough-connecting-using-tasks-and-xml-http-requests.md
@@ -91,7 +91,7 @@ This section demonstrates how to use the `HttpRequest` class in a UWP app. The a
 
 Here is the running app:
 
-![The running Windows Runtime app](../../parallel/concrt/media/concrt_usingixhr2.png "concrt_usingixhr2")
+![The running Windows Runtime app](../../parallel/concrt/media/concrt_usingixhr2.png)
 
 ## Next Steps
 

--- a/docs/parallel/concrt/walkthrough-creating-a-dataflow-agent.md
+++ b/docs/parallel/concrt/walkthrough-creating-a-dataflow-agent.md
@@ -76,7 +76,7 @@ The dataflow agent works by creating a network of message buffers, each of which
 
 The following diagram shows the complete dataflow network for the `dataflow_agent` class:
 
-![The dataflow network](../../parallel/concrt/media/concrt_dataflow.png "concrt_dataflow")
+![The dataflow network](../../parallel/concrt/media/concrt_dataflow.png)
 
 The following table describes the members of the network.
 

--- a/docs/parallel/concrt/walkthrough-creating-an-image-processing-network.md
+++ b/docs/parallel/concrt/walkthrough-creating-an-image-processing-network.md
@@ -126,7 +126,7 @@ If your application requires that multiple message blocks process the message, i
 
 The following illustration shows the image processing network:
 
-![Image processing network](../../parallel/concrt/media/concrt_imageproc.png "concrt_imageproc")
+![Image processing network](../../parallel/concrt/media/concrt_imageproc.png)
 
 The `countdown_event` object in this example enables the image processing network to inform the main application when all images have been processed. The `countdown_event` class uses a [concurrency::event](../../parallel/concrt/reference/event-class.md) object to signal when a counter value reaches zero. The main application increments the counter every time that it sends a file name to the network. The terminal node of the network decrements the counter after each image has been processed. After the main application traverses the specified directory, it waits for the `countdown_event` object to signal that its counter has reached zero.
 
@@ -144,7 +144,7 @@ The following code shows the complete example. The `wmain` function manages the 
 
 The following illustration shows sample output. Each source image is above its corresponding modified image.
 
-![Sample output for the example](../../parallel/concrt/media/concrt_imageout.png "concrt_imageout")
+![Sample output for the example](../../parallel/concrt/media/concrt_imageout.png)
 
 `Lighthouse` is authored by Tom Alphin and therefore is converted to grayscale. `Chrysanthemum`, `Desert`, `Koala`, and `Tulips` have red as the dominant color and therefore have the blue and green color components removed and are darkened. `Hydrangeas`, `Jellyfish`, and `Penguins` match the default criteria and therefore are sepia toned.
 

--- a/docs/parallel/concrt/walkthrough-removing-work-from-a-user-interface-thread.md
+++ b/docs/parallel/concrt/walkthrough-removing-work-from-a-user-interface-thread.md
@@ -100,7 +100,7 @@ This section describes how to draw the Mandelbrot fractal. This version draws th
 
 The following illustration shows the results of the Mandelbrot application.
 
-![The Mandelbrot Application](../../parallel/concrt/media/mandelbrot.png "mandelbrot")
+![The Mandelbrot Application](../../parallel/concrt/media/mandelbrot.png)
 
 Because the computation for each pixel is computationally expensive, the UI thread cannot process additional messages until the overall computation finishes. This could decrease responsiveness in the application. However, you can relieve this problem by removing work from the UI thread.
 

--- a/docs/parallel/concrt/walkthrough-using-join-to-prevent-deadlock.md
+++ b/docs/parallel/concrt/walkthrough-using-join-to-prevent-deadlock.md
@@ -38,7 +38,7 @@ This walkthrough contains the following sections:
 
 The dining philosophers problem illustrates how deadlock occurs in an application. In this problem, five philosophers sit at a round table. Every philosopher alternates between thinking and eating. Every philosopher must share a chopstick with the neighbor to the left and another chopstick with the neighbor to the right. The following illustration shows this layout.
 
-![The Dining Philosophers Problem](../../parallel/concrt/media/dining_philosophersproblem.png "dining_philosophersproblem")
+![The Dining Philosophers Problem](../../parallel/concrt/media/dining_philosophersproblem.png)
 
 To eat, a philosopher must hold two chopsticks. If every philosopher holds just one chopstick and is waiting for another one, then no philosopher can eat and all starve.
 

--- a/docs/porting/porting-guide-mfc-scribble.md
+++ b/docs/porting/porting-guide-mfc-scribble.md
@@ -25,7 +25,7 @@ Note that you can also run devenv at the command line, using the `/Upgrade` opti
 
 When you open an old project file in Visual Studio 2017, Visual Studio offers to convert the project file to the most recent version, which we accepted. The following dialog box appeared:
 
-![Review Project and Solution Changes](../porting/media/scribbleprojectupgrade.PNG "ScribbleProjectUpgrade")
+![Review Project and Solution Changes](../porting/media/scribbleprojectupgrade.PNG)
 
 An error occurred notifying us that the Itanium target is not available and won't be converted.
 
@@ -37,7 +37,7 @@ At the time the previous Scribble project was created, Itanium was an important 
 
 Visual Studio then displayed a migration report listing all of the issues with the old project file.
 
-![Upgrade Report](../porting/media/scribblemigrationreport.PNG "ScribbleMigrationReport")
+![Upgrade Report](../porting/media/scribblemigrationreport.PNG)
 
 In this case, the issues were all warnings, and Visual Studio made the appropriate changes in the project file. The big difference as far as the project is concerned is that the build tool changed from vcbuild to msbuild. This change was first introduced in Visual Studio 2010. Other changes include some rearrangement of the sequence of elements in the project file itself. None of the issues required further attention for this simple project.
 

--- a/docs/porting/porting-guide-spy-increment.md
+++ b/docs/porting/porting-guide-spy-increment.md
@@ -19,7 +19,7 @@ The project file, two old .dsw files from Visual C++ 6.0, converted easily with 
 
 After upgrading the two projects, our solution looked like this:
 
-![The Spy&#43;&#43; Solution](../porting/media/spyxxsolution.PNG "SpyxxSolution")
+![The Spy&#43;&#43; Solution](../porting/media/spyxxsolution.PNG)
 
 We have two projects, one with a large number of C++ files, and another a DLL that's written in C.
 

--- a/docs/security/how-user-account-control-uac-affects-your-application.md
+++ b/docs/security/how-user-account-control-uac-affects-your-application.md
@@ -24,7 +24,7 @@ The second option is to not embed a UAC fragment into the manifest by specifying
 
 The following flowchart describes how your application will run depending on whether UAC is enabled and whether the application has a UAC manifest:
 
-![Windows Vista Loader behavior](media/uacflowchart.png "UACflowchart")
+![Windows Vista Loader behavior](media/uacflowchart.png)
 
 ## See Also
 

--- a/docs/windows/how-to-use-the-windows-10-sdk-in-a-windows-desktop-application.md
+++ b/docs/windows/how-to-use-the-windows-10-sdk-in-a-windows-desktop-application.md
@@ -18,11 +18,11 @@ Starting with Visual Studio 2015 and the Windows 10 SDK, the CRT library was sep
 
 2. Open the shortcut menu for the project node, and choose **Retarget SDK Version**.
 
-   ![Retarget SDK Version](../windows/media/retargetingwindowssdk1.PNG "RetargetingWindowsSDK1")
+   ![Retarget SDK Version](../windows/media/retargetingwindowssdk1.PNG)
 
    The **Review Solution Actions** dialog appears.
 
-   ![Review Solution Actions](../windows/media/retargetingwindowssdk2.PNG "RetargetingWindowsSDK2")
+   ![Review Solution Actions](../windows/media/retargetingwindowssdk2.PNG)
 
 3. In the **Target Platform Version** dropdown list, choose the version of the Windows 10 SDK you want to target. Choose the OK button to apply the change.
 
@@ -34,15 +34,15 @@ Starting with Visual Studio 2015 and the Windows 10 SDK, the CRT library was sep
 
 4. Open the project properties, and in the **Configuration Properties, General** section, notice the values of **Windows Target Platform Version**. Changing the value here has the same effect as following this procedure. See [General Property Page (Project)](../ide/general-property-page-project.md).
 
-   ![Target Platform Version](../windows/media/retargetingwindowssdk3.PNG "RetargetingWindowsSDK3")
+   ![Target Platform Version](../windows/media/retargetingwindowssdk3.PNG)
 
    This action changes the values of project macros that include paths to header files and library files. To see what changed, in the **Visual C++ Directories** section of the **Project Properties** dialog, choose one of the properties such as the **Include Directories**, choose to open the dropdown list, and choose \<Edit>. The **Include Directories** dialog appears.
 
-   ![Include Directories dialog box](../windows/media/retargetingwindowssdk4.PNG "RetargetingWindowsSDK4")
+   ![Include Directories dialog box](../windows/media/retargetingwindowssdk4.PNG)
 
    Choose the **Macros >>** button, and scroll down the list of macros to the Windows SDK macros to see all the new values.
 
-   ![Windows SDK Macros](../windows/media/retargetingwindowssdk5.PNG "RetargetingWindowsSDK5")
+   ![Windows SDK Macros](../windows/media/retargetingwindowssdk5.PNG)
 
 5. Repeat for other projects, as needed, and rebuild the solution.
 

--- a/docs/windows/showing-or-hiding-the-dialog-editor-toolbar.md
+++ b/docs/windows/showing-or-hiding-the-dialog-editor-toolbar.md
@@ -12,13 +12,13 @@ When you open the **Dialog** editor in a C++ project, the **Dialog Editor** tool
 
 |Icon|Meaning|Icon|Meaning|
 |----------|-------------|----------|-------------|
-|![Test Dialog button](../mfc/media/vcdialogeditortestdialog.png "vcDialogEditorTestDialog")|Test Dialog|![Space Across button](../mfc/media/vcdialogeditoracross.png "vcDialogEditorAcross")|Across|
-|![Align Lefts button](../mfc/media/vcdialogeditoralignlefts.png "vcDialogEditorAlignLefts")|Align Lefts|![Space Down button](../mfc/media/vcdialogeditordown.png "vcDialogEditorDown")|Down|
-|![Align Rights button](../mfc/media/vcdialogeditoralignrights.png "vcDialogEditorAlignRights")|Align Rights|![Make Same Width button](../mfc/media/vcdialogeditorsamewidth.png "vcDialogEditorSameWidth")|Make Same Width|
-|![Align Tops button](../mfc/media/vcdialogeditoraligntops.png "vcDialogEditorAlignTops")|Align Tops|![Make Same Height button](../mfc/media/vcdialogeditormakesameheight.png "vcDialogEditorMakeSameHeight")|Make Same Height|
-|![Align Bottoms button](../mfc/media/vcdialogeditoralignbottoms.png "vcDialogEditorAlignBottoms")|Align Bottoms|![Make Same Size button](../mfc/media/vcdialogeditorsamesize.png "vcDialogEditorSameSize")|Make Same Size|
-|![Center Vertical button](../mfc/media/vcdialogeditorvertical.png "vcDialogEditorVertical")|Vertical|![Toggle Grid button](../mfc/media/vcdialogeditortogglegrid.png "vcDialogEditorToggleGrid")|Toggle Grid|
-|![Center Horizontal button](../mfc/media/vcdialogeditorhorizontal.png "vcDialogEditorHorizontal")|Horizontal|![Toggle Guides button](../mfc/media/vcdialogeditortoggleguides.png "vcDialogEditorToggleGuides")|Toggle Guides|
+|![Test Dialog button](../mfc/media/vcdialogeditortestdialog.png)|Test Dialog|![Space Across button](../mfc/media/vcdialogeditoracross.png)|Across|
+|![Align Lefts button](../mfc/media/vcdialogeditoralignlefts.png)|Align Lefts|![Space Down button](../mfc/media/vcdialogeditordown.png)|Down|
+|![Align Rights button](../mfc/media/vcdialogeditoralignrights.png)|Align Rights|![Make Same Width button](../mfc/media/vcdialogeditorsamewidth.png)|Make Same Width|
+|![Align Tops button](../mfc/media/vcdialogeditoraligntops.png)|Align Tops|![Make Same Height button](../mfc/media/vcdialogeditormakesameheight.png)|Make Same Height|
+|![Align Bottoms button](../mfc/media/vcdialogeditoralignbottoms.png)|Align Bottoms|![Make Same Size button](../mfc/media/vcdialogeditorsamesize.png)|Make Same Size|
+|![Center Vertical button](../mfc/media/vcdialogeditorvertical.png)|Vertical|![Toggle Grid button](../mfc/media/vcdialogeditortogglegrid.png)|Toggle Grid|
+|![Center Horizontal button](../mfc/media/vcdialogeditorhorizontal.png)|Horizontal|![Toggle Guides button](../mfc/media/vcdialogeditortoggleguides.png)|Toggle Guides|
 
 The **Dialog Editor** toolbar contains buttons for arranging the layout of controls on the dialog box, for example size and alignment. **Dialog Editor** toolbar buttons correspond to commands on the **Format** menu. For details, see [Accelerator Keys for the Dialog Editor](../windows/accelerator-keys-for-the-dialog-editor.md).
 

--- a/docs/windows/walkthrough-creating-a-windows-store-app-using-wrl-and-media-foundation.md
+++ b/docs/windows/walkthrough-creating-a-windows-store-app-using-wrl-and-media-foundation.md
@@ -107,7 +107,7 @@ In most cases, you can use C++/CX to create Windows Runtime. However, sometimes 
 
 The following illustration shows the `MediaCapture app`.
 
-![MediaCapture app capturing a photo](../windows/media/wrl_media_capture.png "WRL_Media_Capture")
+![MediaCapture app capturing a photo](../windows/media/wrl_media_capture.png)
 
 ## Next Steps
 


### PR DESCRIPTION
Used a regex `\.png\s+"\w*"\)` to find/replace the placeholder `title` values. Since these are the same as the image file name, they don't add value