### PR TITLE
Update oy-frame-pointer-omission.md

### DIFF
--- a/docs/build/reference/oy-frame-pointer-omission.md
+++ b/docs/build/reference/oy-frame-pointer-omission.md
@@ -1,6 +1,6 @@
 ---
 title: "/Oy (Frame-Pointer Omission)"
-ms.date: "09/22/2017"
+ms.date: "11/19/2018"
 f1_keywords: ["VC.Project.VCCLCompilerTool.OmitFramePointers", "/oy"]
 helpviewer_keywords: ["omit frame pointer", "Oy compiler option [C++]", "stack frame pointer compiler option [C++]", "-Oy compiler option [C++]", "frame pointer omission compiler option [C++]", "suppress frame pointer creation", "/Oy compiler option [C++]"]
 ms.assetid: c451da86-5297-4c5a-92bc-561d41379853
@@ -17,9 +17,9 @@ Suppresses creation of frame pointers on the call stack.
 
 This option speeds function calls, because no frame pointers need to be set up and removed. It also frees one more register for general usage.
 
-**/Oy** enables frame-pointer omission and **/Oy-** disables omission. **/Oy** is available only in x86 compilers.
+**/Oy** enables frame-pointer omission and **/Oy-** disables omission. In x64 compilers, **/Oy** and **/Oy-** are not available.
 
-If your code requires EBP-based addressing, you can specify the **/Oy-** option after the **/Ox** option or use [optimize](../../preprocessor/optimize.md) with the "**y**" and **off** arguments to gain maximum optimization with EBP-based addressing. The compiler detects most situations where EBP-based addressing is required (for instance, with the `_alloca` and `setjmp` functions and with structured exception handling).
+If your code requires frame-based addressing, you can specify the **/Oy-** option after the **/Ox** option or use [optimize](../../preprocessor/optimize.md) with the "**y**" and **off** arguments to gain maximum optimization with frame-based addressing. The compiler detects most situations where frame-based addressing is required (for instance, with the `_alloca` and `setjmp` functions and with structured exception handling).
 
 The [/Ox (Enable Most Speed Optimizations)](../../build/reference/ox-full-optimization.md) and [/O1, /O2 (Minimize Size, Maximize Speed)](../../build/reference/o1-o2-minimize-size-maximize-speed.md) options imply **/Oy**. Specifying **/Oy-** after the **/Ox**, **/O1**, or **/O2** option disables **/Oy**, whether it is explicit or implied.
 
@@ -29,11 +29,9 @@ The **/Oy** compiler option makes using the debugger more difficult because the 
 
 1. Open the project's **Property Pages** dialog box. For details, see [Working with Project Properties](../../ide/working-with-project-properties.md).
 
-1. Click the **C/C++** folder.
+1. Select the **Configuration Properties** > **C/C++** > **Optimization** property page.
 
-1. Click the **Optimization** property page.
-
-1. Modify the **Omit Frame Pointers** property. This property adds or removes only the **/Oy** option. If you want to add the **/Oy-** option, click **Command Line** and modify **Additional options**.
+1. Modify the **Omit Frame Pointers** property. This property adds or removes only the **/Oy** option. If you want to add the **/Oy-** option, select the **Command Line** property page and modify **Additional options**.
 
 ### To set this compiler option programmatically
 
@@ -41,8 +39,6 @@ The **/Oy** compiler option makes using the debugger more difficult because the 
 
 ## See Also
 
-[/O Options (Optimize Code)](../../build/reference/o-options-optimize-code.md)
-
-[Compiler Options](../../build/reference/compiler-options.md)
-
-[Setting Compiler Options](../../build/reference/setting-compiler-options.md)
+[/O Options (Optimize Code)](../../build/reference/o-options-optimize-code.md)<br/>
+[Compiler Options](../../build/reference/compiler-options.md)<br/>
+[Setting Compiler Options](../../build/reference/setting-compiler-options.md)<br/>


### PR DESCRIPTION
Address issue #560 to include ARM and ARM64 by implication. Only the x64 ABI does not normally include frame pointers.