### PR TITLE
Update support-for-multibyte-character-sets-mbcss.md

### DIFF
--- a/docs/text/support-for-multibyte-character-sets-mbcss.md
+++ b/docs/text/support-for-multibyte-character-sets-mbcss.md
@@ -36,7 +36,7 @@ The C run-time library and MFC support single-byte, MBCS, and Unicode programmin
 
 ### MBCS/Unicode portability
 
-Using the Tchar.h header file, you can build single-byte, MBCS, and Unicode applications from the same sources. Tchar.h defines macros prefixed with *_tcs* , which map to `str`, `_mbs`, or `wcs` functions, as appropriate. To build MBCS, define the symbol `_MBCS`. To build Unicode, define the symbol `_UNICODE`. By default, `_MBCS` is defined for MFC applications. For more information, see [Generic-Text Mappings in Tchar.h](../text/generic-text-mappings-in-tchar-h.md).
+Using the Tchar.h header file, you can build single-byte, MBCS, and Unicode applications from the same sources. Tchar.h defines macros prefixed with *_tcs* , which map to `str`, `_mbs`, or `wcs` functions, as appropriate. To build MBCS, define the symbol `_MBCS`. To build Unicode, define the symbol `_UNICODE`. By default, `_UNICODE` is defined for MFC applications. For more information, see [Generic-Text Mappings in Tchar.h](../text/generic-text-mappings-in-tchar-h.md).
 
 > [!NOTE]
 >  Behavior is undefined if you define both `_UNICODE` and `_MBCS`.


### PR DESCRIPTION
Default symbol is the '_UNICODE' not '_MBCS'.