### PR TITLE
Fixed typo in codecvt.md

### DIFF
--- a/docs/standard-library/codecvt.md
+++ b/docs/standard-library/codecvt.md
@@ -51,7 +51,7 @@ For byte streams (stored in a file, transmitted as a byte sequence, or stored wi
 
 **Header:** \<codecvt>
 
-**Namespace:** stdt
+**Namespace:** std
 
 ## See also
 


### PR DESCRIPTION
codecvt should be in namespace std, not stdt