### PR TITLE
__[read/write/inc/add]gsqword intrinsics are not kernel specific.

### DIFF
--- a/docs/intrinsics/addgsbyte-addgsword-addgsdword-addgsqword.md
+++ b/docs/intrinsics/addgsbyte-addgsword-addgsdword-addgsqword.md
@@ -49,10 +49,6 @@ void __addgsqword(
 |`__addgsdword`|x64|
 |`__addgsqword`|x64|
 
-## Remarks
-
-These intrinsics are available in kernel mode only, and these routines are only available as intrinsics.
-
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/addgsbyte-addgsword-addgsdword-addgsqword.md
+++ b/docs/intrinsics/addgsbyte-addgsword-addgsdword-addgsqword.md
@@ -49,6 +49,10 @@ void __addgsqword(
 |`__addgsdword`|x64|
 |`__addgsqword`|x64|
 
+## Remarks
+
+These routines are only available as an intrinsic.
+
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/incgsbyte-incgsword-incgsdword-incgsqword.md
+++ b/docs/intrinsics/incgsbyte-incgsword-incgsdword-incgsqword.md
@@ -42,6 +42,10 @@ void __incgsqword(
 |`__incgsdword`|x64|
 |`__incgsqword`|x64|
 
+## Remarks
+
+These routines are only available as an intrinsic.
+
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/incgsbyte-incgsword-incgsdword-incgsqword.md
+++ b/docs/intrinsics/incgsbyte-incgsword-incgsdword-incgsqword.md
@@ -42,10 +42,6 @@ void __incgsqword(
 |`__incgsdword`|x64|
 |`__incgsqword`|x64|
 
-## Remarks
-
-These intrinsics are only available in kernel mode, and the routines are only available as intrinsics.
-
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/readgsbyte-readgsdword-readgsqword-readgsword.md
+++ b/docs/intrinsics/readgsbyte-readgsdword-readgsqword-readgsword.md
@@ -48,10 +48,6 @@ The memory contents of the byte, word, double word, or quadword (as indicated by
 
 **Header file** \<intrin.h>
 
-## Remarks
-
-These intrinsics are only available in kernel mode, and the routines are only available as intrinsics.
-
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/readgsbyte-readgsdword-readgsqword-readgsword.md
+++ b/docs/intrinsics/readgsbyte-readgsdword-readgsqword-readgsword.md
@@ -48,6 +48,10 @@ The memory contents of the byte, word, double word, or quadword (as indicated by
 
 **Header file** \<intrin.h>
 
+## Remarks
+
+These routines are only available as an intrinsic.
+
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/writegsbyte-writegsdword-writegsqword-writegsword.md
+++ b/docs/intrinsics/writegsbyte-writegsdword-writegsqword-writegsword.md
@@ -51,6 +51,10 @@ void __writegsqword(
 
 **Header file** \<intrin.h>
 
+## Remarks
+
+These routines are only available as an intrinsic.
+
 **END Microsoft Specific**
 
 ## See Also

--- a/docs/intrinsics/writegsbyte-writegsdword-writegsqword-writegsword.md
+++ b/docs/intrinsics/writegsbyte-writegsdword-writegsqword-writegsword.md
@@ -51,10 +51,6 @@ void __writegsqword(
 
 **Header file** \<intrin.h>
 
-## Remarks
-
-These intrinsics are available in kernel mode only, and these routines are only available as intrinsics.
-
 **END Microsoft Specific**
 
 ## See Also


### PR DESCRIPTION
The documentation for the gs: intrinsics (e.g. __readgsqword) incorrectly states that
these functions are only available in kernel mode. In fact, these functions are available
in any mode of compilation and will work for code running in any mode (kernel or user).