### PR TITLE
umul128: Only available on x64

### DIFF
--- a/docs/intrinsics/umul128.md
+++ b/docs/intrinsics/umul128.md
@@ -40,13 +40,13 @@ The low 64 bits of the product.
 
 |Intrinsic|Architecture|Header|
 |---------------|------------------|------------|
-|`_umul128`|ARM, x64|\<intrin.h>|
+|`_umul128`|x64|\<intrin.h>|
 
 ## Example
 
 ```
 // umul128.c
-// processor: IPF, x64
+// processor: x64
 
 #include <stdio.h>
 #include <intrin.h>


### PR DESCRIPTION
Remove ARM from the supported architectures list. Also remove IPF.