### PR TITLE
Wrong Error Specified in unlink/remove

### DIFF
--- a/docs/c-runtime-library/reference/remove-wremove.md
+++ b/docs/c-runtime-library/reference/remove-wremove.md
@@ -30,7 +30,7 @@ Path of file to be removed.
 
 ## Return Value
 
-Each of these functions returns 0 if the file is successfully deleted. Otherwise, it returns -1 and sets **errno** either to **EACCES** to indicate that the path specifies a read-only file or the file is open, or to **ENOENT** to indicate that the filename or path was not found or that the path specifies a directory.
+Each of these functions returns 0 if the file is successfully deleted. Otherwise, it returns -1 and sets **errno** either to **EACCES** to indicate that the path specifies a read-only file, specifies a directory, or the file is open, or to **ENOENT** to indicate that the filename or path was not found.
 
 See [_doserrno, errno, _sys_errlist, and _sys_nerr](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md) for more information on these and other return codes.
 

--- a/docs/c-runtime-library/reference/unlink-wunlink.md
+++ b/docs/c-runtime-library/reference/unlink-wunlink.md
@@ -30,7 +30,7 @@ Name of file to remove.
 
 ## Return Value
 
-Each of these functions returns 0 if successful. Otherwise, the function returns -1 and sets **errno** to **EACCES**, which means the path specifies a read-only file, or to **ENOENT**, which means the file or path is not found or the path specified a directory.
+Each of these functions returns 0 if successful. Otherwise, the function returns -1 and sets **errno** to **EACCES**, which means the path specifies a read-only file or a directory, or to **ENOENT**, which means the file or path is not found.
 
 See [_doserrno, errno, _sys_errlist, and _sys_nerr](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md) for more information on these, and other, return codes.
 


### PR DESCRIPTION
_unlink, _wulink, _remove, and _wremove in the docs all specify that if used on a directory, they set errno "to ENOENT, which means the file or path is not found or the path specified a directory."

However, actually using them on a directory gives EACCES, which makes sense given that they all seem to call through to DeleteFileW which gives ERROR_ACCESS_DENIED when used on a directory.

This can be reproduced using something like 

```
#include <stdio.h>
#include <windows.h>

int main() {
  if (!DeleteFileA("testDir")) {
    printf("GetLastError %d\n", GetLastError());
  }

  if (_unlink("testDir") != 0) {
    printf(_strerror(NULL));
    printf("Errno: %d\n", errno);
  }
}
```
```
C:\Users\jmittertreiner\tmp\testRm> mkdir testDir
C:\Users\jmittertreiner\tmp\testRm>cl .\testrm.cpp  && .\testrm.exe
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27024.1 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

testrm.cpp
Microsoft (R) Incremental Linker Version 14.16.27024.1
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:testrm.exe
testrm.obj
GetLastError 5
Permission denied
Errno: 13
```