### PR TITLE
Adding __fastfail encoding for Windows ARM64

### DIFF
--- a/docs/intrinsics/fastfail.md
+++ b/docs/intrinsics/fastfail.md
@@ -35,6 +35,7 @@ Internally, `__fastfail` is implemented by using several architecture-specific m
 |x86|int 0x29|ecx|
 |x64|int 0x29|rcx|
 |ARM|Opcode 0xDEFB|r0|
+|ARM64|Opcode 0xF003|x0|
 
 A fast fail request is self-contained and typically requires just two instructions to execute. Once a fast fail request has been executed the kernel then takes the appropriate action. In user-mode code, there are no memory dependencies beyond the instruction pointer itself when a fast fail event is raised. This maximizes its reliability even if there is severe memory corruption.
 
@@ -50,7 +51,7 @@ Support for the native fast fail mechanism began in Windows 8. Windows operating
 
 |Intrinsic|Architecture|
 |---------------|------------------|
-|`__fastfail`|x86, x64, ARM|
+|`__fastfail`|x86, x64, ARM, ARM64|
 
 **Header file** \<intrin.h>
 


### PR DESCRIPTION
__fastfail is encoded as `brk #0xF0003` on Windows ARM64.