### PR TITLE
Update linker-support-for-delay-loaded-dlls.md

### DIFF
--- a/docs/build/reference/linker-support-for-delay-loaded-dlls.md
+++ b/docs/build/reference/linker-support-for-delay-loaded-dlls.md
@@ -10,7 +10,7 @@ The Visual C++ linker now supports the delayed loading of DLLs. This relieves yo
 
 Before Visual C++ 6.0, the only way to load a DLL at run time was by using **LoadLibrary** and **GetProcAddress**; the operating system would load the DLL when the executable or DLL using it was loaded.
 
-Beginning with Visual C++ 6.0, when statically linking with a DLL, the linker provides options to delay load the DLL until the program calls a function in that DLL.
+Beginning with Visual C++ 6.0, when implicitly linking with a DLL, the linker provides options to delay load the DLL until the program calls a function in that DLL.
 
 An application can delay load a DLL using the [/DELAYLOAD (Delay Load Import)](../../build/reference/delayload-delay-load-import.md) linker option with a helper function (default implementation provided by Visual C++). The helper function will load the DLL at run time by calling **LoadLibrary** and **GetProcAddress** for you.
 


### PR DESCRIPTION
"Statically linking with DLL" is not a correct terminology. "Implicit linking" should be used to describe linking via lib-file, such as in this topic: https://docs.microsoft.com/en-us/cpp/build/linking-an-executable-to-a-dll?view=vs-2017#implicit-linking