### PR TITLE
Fix C lexical grammar docs about string-literal

### DIFF
--- a/docs/c-language/summary-of-string-literals.md
+++ b/docs/c-language/summary-of-string-literals.md
@@ -6,8 +6,8 @@ ms.assetid: d2693900-f4e2-4820-b7de-085d51827aee
 # Summary of String Literals
 
 *string-literal*:<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;**'** *s-char-sequence*<sub>opt</sub> **'**<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;**L'** *s-char-sequence*sub>opt</sub> **'**
+&nbsp;&nbsp;&nbsp;&nbsp;**"** *s-char-sequence*<sub>opt</sub> **"**<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;**L"** *s-char-sequence*sub>opt</sub> **"**
 
 *s-char-sequence*:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;*s-char*<br/>

--- a/docs/c-language/summary-of-string-literals.md
+++ b/docs/c-language/summary-of-string-literals.md
@@ -7,7 +7,7 @@ ms.assetid: d2693900-f4e2-4820-b7de-085d51827aee
 
 *string-literal*:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;**"** *s-char-sequence*<sub>opt</sub> **"**<br/>
-&nbsp;&nbsp;&nbsp;&nbsp;**L"** *s-char-sequence*sub>opt</sub> **"**
+&nbsp;&nbsp;&nbsp;&nbsp;**L"** *s-char-sequence*<sub>opt</sub> **"**
 
 *s-char-sequence*:<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;*s-char*<br/>


### PR DESCRIPTION
C string literal's delimiter is not a single quotation ('), but a double quotation (").

> string-literal:
>      ' s-char-sequence opt '
>      L' s-char-sequence opt '

https://docs.microsoft.com/en-us/cpp/c-language/summary-of-string-literals?view=vs-2017