### PR TITLE
Clarify naming confusion "_mul128" vs. "__mul128"

### DIFF
--- a/docs/intrinsics/mul128.md
+++ b/docs/intrinsics/mul128.md
@@ -1,6 +1,6 @@
 ---
 title: "_mul128"
-ms.date: "11/04/2016"
+ms.date: "03/27/2019"
 f1_keywords: ["_mul128"]
 helpviewer_keywords: ["mul128 intrinsic", "_mul128 intrinsic"]
 ms.assetid: f68914b9-bffb-4e46-b1ba-4c249f7b4ecc
@@ -21,7 +21,7 @@ __int64 _mul128(
 );
 ```
 
-#### Parameters
+### Parameters
 
 *Multiplier*<br/>
 [in] The first 64-bit integer to multiply.
@@ -46,7 +46,7 @@ The low 64 bits of the product.
 
 ## Example
 
-```
+```C
 // mul128.c
 // processor: x64
 #include <stdio.h>

--- a/docs/intrinsics/mul128.md
+++ b/docs/intrinsics/mul128.md
@@ -1,11 +1,11 @@
 ---
-title: "__mul128"
+title: "_mul128"
 ms.date: "11/04/2016"
-f1_keywords: ["__mul128"]
-helpviewer_keywords: ["mul128 intrinsic", "__mul128 intrinsic"]
+f1_keywords: ["_mul128"]
+helpviewer_keywords: ["mul128 intrinsic", "_mul128 intrinsic"]
 ms.assetid: f68914b9-bffb-4e46-b1ba-4c249f7b4ecc
 ---
-# __mul128
+# _mul128
 
 **Microsoft Specific**
 
@@ -40,7 +40,7 @@ The low 64 bits of the product.
 
 |Intrinsic|Architecture|
 |---------------|------------------|
-|`__mul128`|x64|
+|`_mul128`|x64|
 
 **Header file** \<intrin.h>
 


### PR DESCRIPTION
The proper name is `_mul128`.

Verified with VS2019 Preview 4.4 that `__mul128` is not recognized as an intrinsic even if properly declared and `#pragma intrinsic`-ed.