### PR TITLE
Cut unnecessary variables

### DIFF
--- a/docs/cpp/template-specialization-cpp.md
+++ b/docs/cpp/template-specialization-cpp.md
@@ -42,8 +42,6 @@ struct S{};
 extern "C" int printf_s(const char*,...);
 
 int main() {
-   S s, *pS;
-   int S::*ptm;
    printf_s("PTS<S>::IsPointer == %d PTS<S>::IsPointerToDataMember == %d\n",
            PTS<S>::IsPointer, PTS<S>:: IsPointerToDataMember);
    printf_s("PTS<S*>::IsPointer == %d PTS<S*>::IsPointerToDataMember ==%d\n"


### PR DESCRIPTION
In main:
 S s, *pS;
 int S::*ptm;
seem to serve no function.

(In case there is some hidden functionality I would be very interested to learn about it.)

Best Regards, 
Johannes