### PR TITLE
Add documentation for extended division intrinsics

### DIFF
--- a/docs/intrinsics/div128.md
+++ b/docs/intrinsics/div128.md
@@ -1,9 +1,8 @@
 ---
 title: "_div128"
-ms.date: "03/27/2019"
+ms.date: "04/17/2019"
 f1_keywords: ["_div128"]
 helpviewer_keywords: ["div128 intrinsic", "_div128 intrinsic"]
-ms.assetid: f68914b9-bffb-4e46-b1ba-4c249f7b4ecc
 ---
 # _div128
 

--- a/docs/intrinsics/div128.md
+++ b/docs/intrinsics/div128.md
@@ -1,0 +1,54 @@
+---
+title: "_div128"
+ms.date: "03/27/2019"
+f1_keywords: ["_div128"]
+helpviewer_keywords: ["div128 intrinsic", "_div128 intrinsic"]
+ms.assetid: f68914b9-bffb-4e46-b1ba-4c249f7b4ecc
+---
+# _div128
+
+**Microsoft Specific**
+
+Divides a 128-bit integer with the upper 64 bits in `HighDividend` and lower 64 bits in `LowDividend` by a 64-bit integer and stores the remainder in the 64-bit integer pointed to by `Remainder` and returns the 64 bits of the quotient.
+
+## Syntax
+
+```
+__int64 _div128(
+   __int64 HighDividend,
+   __int64 LowDividend,
+   __int64 Divisor,
+   __int64 *Remainder
+);
+```
+
+### Parameters
+
+*HighDividend*<br/>
+[in] The high 64 bits of the dividend.
+
+*LowDividend*<br/>
+[in] The low 64 bits of the dividend.
+
+*Multiplicand*<br/>
+[in] The 64-bit integer to divide by.
+
+*Remainder*<br/>
+[out] The 64-bit integer bits of the remainder.
+
+## Return Value
+
+The 64 bits of the quotient.
+
+## Requirements
+
+|Intrinsic|Architecture|Header|
+|---------------|------------------|------------|
+|`_div128`|x64|\<immintrin.h>|
+
+**END Microsoft Specific**
+
+## See also
+
+[_udiv128](../intrinsics/udiv128.md)
+[Compiler Intrinsics](../intrinsics/compiler-intrinsics.md)

--- a/docs/intrinsics/div64.md
+++ b/docs/intrinsics/div64.md
@@ -1,0 +1,50 @@
+---
+title: "_div64"
+ms.date: "11/04/2016"
+f1_keywords: ["_div64"]
+helpviewer_keywords: ["_div64 intrinsic"]
+ms.assetid: cd2ab093-9ef6-404d-ac34-0bee033882f3
+---
+# _div64
+
+**Microsoft Specific**
+
+Divides a 64-bit integer by a 32-bit integer and stores the remainder in the 32-bit integer pointed to by `Remainder` and returns the 32 bits of the quotient.
+
+## Syntax
+
+```
+int _div64(
+   __int64 Dividend,
+   int Divisor,
+   int* Remainder
+);
+```
+
+#### Parameters
+
+*Dividend*<br/>
+[in] The 64-bit integer to divide.
+
+*Divisor*<br/>
+[in] The 32-bit integer to divide by.
+
+*Remainder*<br/>
+[out] The 32-bit integer bits of the remainder.
+
+## Return Value
+
+The high 64 bits of the 128-bit result of the multiplication.
+
+## Requirements
+
+|Intrinsic|Architecture|Header|
+|---------------|------------------|------------|
+|`_div64`|x86, x64|\<immintrin.h>|
+
+**END Microsoft Specific**
+
+## See also
+
+[_udiv64](../intrinsics/udiv64.md)
+[Compiler Intrinsics](../intrinsics/compiler-intrinsics.md)

--- a/docs/intrinsics/div64.md
+++ b/docs/intrinsics/div64.md
@@ -1,9 +1,8 @@
 ---
 title: "_div64"
-ms.date: "11/04/2016"
+ms.date: "04/17/2019"
 f1_keywords: ["_div64"]
 helpviewer_keywords: ["_div64 intrinsic"]
-ms.assetid: cd2ab093-9ef6-404d-ac34-0bee033882f3
 ---
 # _div64
 

--- a/docs/intrinsics/udiv128.md
+++ b/docs/intrinsics/udiv128.md
@@ -1,0 +1,54 @@
+---
+title: "_udiv128"
+ms.date: "11/04/2016"
+f1_keywords: ["_udiv128"]
+helpviewer_keywords: ["_udiv128 intrinsic"]
+ms.assetid: 13684df3-3ac7-467c-b258-a0e93bc490b5
+---
+# _udiv128
+
+**Microsoft Specific**
+
+Divides a 128-bit unsigned integer with the upper 64 bits in `HighDividend` and lower 64 bits in `LowDividend` by a 64-bit unsigned integer and stores the remainder in the 64-bit unsigned integer pointed to by `Remainder` and returns the 64 bits of the quotient.
+
+## Syntax
+
+```
+unsigned __int64 _udiv128(
+   unsigned __int64 HighDividend,
+   unsigned __int64 LowDividend,
+   unsigned __int64 Divisor,
+   unsigned __int64 *Remainder
+);
+```
+
+#### Parameters
+
+*HighDividend*<br/>
+[in] The high 64 bits of the dividend.
+
+*LowDividend*<br/>
+[in] The low 64 bits of the dividend.
+
+*Multiplicand*<br/>
+[in] The 64-bit integer to divide by.
+
+*Remainder*<br/>
+[out] The 64-bit integer bits of the remainder.
+
+## Return Value
+
+The 64 bits of the quotient.
+
+## Requirements
+
+|Intrinsic|Architecture|Header|
+|---------------|------------------|------------|
+|`_udiv128`|x64|\<immintrin.h>|
+
+**END Microsoft Specific**
+
+## See also
+
+[_div128](../intrinsics/div128.md)
+[Compiler Intrinsics](../intrinsics/compiler-intrinsics.md)

--- a/docs/intrinsics/udiv128.md
+++ b/docs/intrinsics/udiv128.md
@@ -1,9 +1,8 @@
 ---
 title: "_udiv128"
-ms.date: "11/04/2016"
+ms.date: "04/17/2019"
 f1_keywords: ["_udiv128"]
 helpviewer_keywords: ["_udiv128 intrinsic"]
-ms.assetid: 13684df3-3ac7-467c-b258-a0e93bc490b5
 ---
 # _udiv128
 

--- a/docs/intrinsics/udiv64.md
+++ b/docs/intrinsics/udiv64.md
@@ -1,0 +1,50 @@
+---
+title: "_udiv64"
+ms.date: "11/04/2016"
+f1_keywords: ["_udiv64"]
+helpviewer_keywords: ["_udiv64 intrinsic"]
+ms.assetid: d241b53a-e6f7-4af1-9f6e-84e149158f03
+---
+# _udiv64
+
+**Microsoft Specific**
+
+Divides a 64-bit unsigned integer by a 32-bit unsigned integer and stores the remainder in the 32-bit unsigned integer pointed to by `Remainder` and returns the 32 bits of the quotient.
+
+## Syntax
+
+```
+unsigned int _umul64(
+   unsigned __int64 Dividend,
+   unsigned int Divisor,
+   unsigned int* Remainder
+);
+```
+
+#### Parameters
+
+*Dividend*<br/>
+[in] The 64-bit integer to divide.
+
+*Divisor*<br/>
+[in] The 32-bit integer to divide by.
+
+*Remainder*<br/>
+[out] The 32-bit integer bits of the remainder.
+
+## Return Value
+
+The high 64 bits of the 128-bit result of the multiplication.
+
+## Requirements
+
+|Intrinsic|Architecture|Header|
+|---------------|------------------|------------|
+|`_udiv64`|x86, x64|\<immintrin.h>|
+
+**END Microsoft Specific**
+
+## See also
+
+[_div64](../intrinsics/div64.md)
+[Compiler Intrinsics](../intrinsics/compiler-intrinsics.md)

--- a/docs/intrinsics/udiv64.md
+++ b/docs/intrinsics/udiv64.md
@@ -1,9 +1,8 @@
 ---
 title: "_udiv64"
-ms.date: "11/04/2016"
+ms.date: "04/17/2019"
 f1_keywords: ["_udiv64"]
 helpviewer_keywords: ["_udiv64 intrinsic"]
-ms.assetid: d241b53a-e6f7-4af1-9f6e-84e149158f03
 ---
 # _udiv64
 

--- a/docs/intrinsics/x64-amd64-intrinsics-list.md
+++ b/docs/intrinsics/x64-amd64-intrinsics-list.md
@@ -81,6 +81,8 @@ The following table lists the intrinsics available on x64 processors. The Techno
 |[__cpuidex](../intrinsics/cpuid-cpuidex.md)||intrin.h|void __cpuidex(int \*a,int b,int c)|
 |[__debugbreak](../intrinsics/debugbreak.md)||intrin.h|void __debugbreak(void)|
 |[_disable](../intrinsics/disable.md)||intrin.h|void _disable(void)|
+|[_div128](../intrinsics/div128.md)||intrin.h|unsigned __int64 _div128(unsigned \__int64 highpart,unsigned \__int64 lowpart,unsigned \__int64 quotient,unsigned \__int64 \*remainder)|
+|[_div64](../intrinsics/div64.md)||intrin.h|unsigned int \_div64(unsigned \__int64 dividend,unsigned int divisor,unsigned int* remainder)|
 |[__emul](../intrinsics/emul-emulu.md)||intrin.h|__int64 [pascal/cdecl] \__emul(int,int)|
 |[__emulu](../intrinsics/emul-emulu.md)||intrin.h|unsigned __int64 [pascal/cdecl]\__emulu(unsigned int,unsigned int)|
 |[_enable](../intrinsics/enable.md)||intrin.h|void _enable(void)|
@@ -1219,6 +1221,8 @@ The following table lists the intrinsics available on x64 processors. The Techno
 |_tzmsk_u32|ABM [1]|ammintrin.h|unsigned int _tzmsk_u32(unsigned int)|
 |_tzmsk_u64|ABM [1]|ammintrin.h|unsigned __int64 _tzmsk_u64(unsigned \__int64)|
 |[__ud2](../intrinsics/ud2.md)||intrin.h|void __ud2(void)|
+|[_udiv128](../intrinsics/udiv128.md)||intrin.h|unsigned __int64 _udiv128(unsigned \__int64 highpart,unsigned \__int64 lowpart,unsigned \__int64 quotient,unsigned \__int64 \*remainder)|
+|[_udiv64](../intrinsics/udiv64.md)||intrin.h|unsigned int \_udiv64(unsigned \__int64 dividend,unsigned int divisor,unsigned int* remainder)|
 |[__ull_rshift](../intrinsics/ull-rshift.md)||intrin.h|unsigned __int64 [pascal/cdecl] \__ull_rshift(unsigned \__int64,int)|
 |[_umul128](../intrinsics/umul128.md)||intrin.h|unsigned __int64 _umul128(unsigned \__int64 multiplier,unsigned \__int64 multiplicand,unsigned \__int64 \*highproduct)|
 |[__umulh](../intrinsics/umulh.md)||intrin.h|unsigned __int64 \__umulh(unsigned \__int64,unsigned \__int64)|

--- a/docs/intrinsics/x86-intrinsics-list.md
+++ b/docs/intrinsics/x86-intrinsics-list.md
@@ -58,6 +58,7 @@ The following table lists the intrinsics available on x86 processors. The Techno
 |[__cpuidex](../intrinsics/cpuid-cpuidex.md)||intrin.h|void __cpuidex(int \*a,int b,int c)|
 |[__debugbreak](../intrinsics/debugbreak.md)||intrin.h|void __debugbreak(void)|
 |[_disable](../intrinsics/disable.md)||intrin.h|void _disable(void)|
+|[_div64](../intrinsics/div64.md)||intrin.h|unsigned int \_div64(unsigned \__int64 dividend,unsigned int divisor,unsigned int* remainder)|
 |[__emul](../intrinsics/emul-emulu.md)||intrin.h|__int64 [pascal/cdecl] \__emul(int,int)|
 |[__emulu](../intrinsics/emul-emulu.md)||intrin.h|unsigned __int64 [pascal/cdecl]\__emulu(unsigned int,unsigned int)|
 |[_enable](../intrinsics/enable.md)||intrin.h|void _enable(void)|
@@ -1230,6 +1231,7 @@ The following table lists the intrinsics available on x86 processors. The Techno
 |[_tzcnt_u32](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_tzcnt_u32)|BMI|ammintrin.h, immintrin.h|unsigned int _tzcnt_u32(unsigned int)|
 |_tzmsk_u32|ABM [1]|ammintrin.h|unsigned int _tzmsk_u32(unsigned int)|
 |[__ud2](../intrinsics/ud2.md)||intrin.h|void __ud2(void)|
+|[_udiv64](../intrinsics/udiv64.md)||intrin.h|unsigned int \_udiv64(unsigned \__int64 dividend,unsigned int divisor,unsigned int* remainder)|
 |[__ull_rshift](../intrinsics/ull-rshift.md)||intrin.h|unsigned __int64 [pascal/cdecl] \__ull_rshift(unsigned \__int64,int)|
 |[__vmx_off](../intrinsics/vmx-off.md)||intrin.h|void __vmx_off(void)|
 |[__vmx_vmptrst](../intrinsics/vmx-vmptrst.md)||intrin.h|void __vmx_vmptrst(unsigned \__int64 \*)|


### PR DESCRIPTION
_udiv128, _div128, _udiv64, _div64 intrinsics were added in Visual Studio 2019.