### PR TITLE
ARM64 ABI - HFA and HVA return values

### DIFF
--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -197,9 +197,9 @@ Effectively, it's the same as following rules C.12–C.15 to allocate arguments 
 
 Integral values are returned in x0.
 
-Floating-point values are returned in s0/d0/v0 as appropriate.
+Floating-point values are returned in s0, d0, or v0, as appropriate.
 
-HFA and HVA values are returned in s0-s3/d0-d3/v0-v3 as appropriate.
+HFA and HVA values are returned in s0-s3, d0-d3, or v0-v3, as appropriate.
 
 Types returned by value are handled differently depending on whether they have certain properties. Types which have all of these properties,
 

--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -199,6 +199,8 @@ Integral values are returned in x0.
 
 Floating-point values are returned in s0/d0/v0 as appropriate.
 
+HFA and HVA values are returned in s0-s3/d0-d3/v0-v3 as appropriate.
+
 Types returned by value are handled differently depending on whether they have certain properties. Types which have all of these properties,
 
 - they're *aggregate* by the C++14 standard definition, that is, they have no user-provided constructors, no private or protected non-static data members, no base classes, and no virtual functions, and


### PR DESCRIPTION
HFA and HVA values are returned in s0-s3, d0-d3 or v0-v3 registers depending on the size of the individual members of the HFA/HVA. For example a 4 member double type HFA is returned in d0-d3 with the first member returned in d0 and the 4th member returned in d3.