### PR TITLE
Correct size based alignment for global data

### DIFF
--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -59,8 +59,8 @@ Default layout alignment for globals and statics:
 | Size in bytes | Alignment in bytes |
 | - | - |
 | 1 | 1 |
-| 2 - 4 | 4 |
-| 5 - 63 | 8 |
+| 2 - 7 | 4 |
+| 8 - 63 | 8 |
 | >= 64 | 16 |
 
 ## Integer registers


### PR DESCRIPTION
The ranges `2-4`, `5-63` for alignment are incorrect for global data.