### PR TITLE
Add ARM64 as supported platform

### DIFF
--- a/docs/intrinsics/debugbreak.md
+++ b/docs/intrinsics/debugbreak.md
@@ -21,7 +21,7 @@ void __debugbreak();
 
 |Intrinsic|Architecture|Header|
 |---------------|------------------|------------|
-|`__debugbreak`|x86, ARM, x64|\<intrin.h>|
+|`__debugbreak`|x86, x64, ARM, ARM64|\<intrin.h>|
 
 ## Remarks
 


### PR DESCRIPTION
`__debugbreak()` is supported on Windows ARM64.