### PR TITLE
Add encoding of __debugbreak() for ARM64

### DIFF
--- a/docs/intrinsics/debugbreak.md
+++ b/docs/intrinsics/debugbreak.md
@@ -50,6 +50,8 @@ main() {
 
 on an x86 computer.
 
+On ARM64, `__debugbreak` intrinsic is compiled into instruction `brk #0xF000`.
+
 This routine is only available as an intrinsic.
 
 **END Microsoft Specific**

--- a/docs/intrinsics/debugbreak.md
+++ b/docs/intrinsics/debugbreak.md
@@ -50,7 +50,7 @@ main() {
 
 on an x86 computer.
 
-On ARM64, `__debugbreak` intrinsic is compiled into instruction `brk #0xF000`.
+On ARM64, the `__debugbreak` intrinsic is compiled into the instruction `brk #0xF000`.
 
 This routine is only available as an intrinsic.
 


### PR DESCRIPTION
ARM64 `__debubbreak()` has encoding as `brk #0xf0000`.