### PR TITLE
Remove mention of AddressSanitizer support under "Install the C++ Lin…

### DIFF
--- a/docs/linux/download-install-and-setup-the-linux-development-workload.md
+++ b/docs/linux/download-install-and-setup-the-linux-development-workload.md
@@ -27,8 +27,6 @@ For any of these scenarios, the **Linux development with C++** workload is requi
 
 In Visual Studio 2019 you can specify separate targets for building and debugging. When targeting WSL, it is no longer necessary to add a remote connection or configure SSH.
 
-Support for [AddressSanitizer (ASan)](https://github.com/google/sanitizers/wiki/AddressSanitizer) is integrated into Visual Studio for Linux projects.
-
 ::: moniker-end
 
 ::: moniker range=">=vs-2017"


### PR DESCRIPTION
…ux workload in Visual Studio"

ASan support isn't very relevant when a user is trying to modify their VS install - I think this detail makes the page more confusing than it needs to be.