### PR TITLE
Remove mention of native WSL support + separation of build/deploy

### DIFF
--- a/docs/linux/download-install-and-setup-the-linux-development-workload.md
+++ b/docs/linux/download-install-and-setup-the-linux-development-workload.md
@@ -25,8 +25,6 @@ For any of these scenarios, the **Linux development with C++** workload is requi
 
 ::: moniker range="vs-2019"
 
-In Visual Studio 2019 you can specify separate targets for building and debugging. When targeting WSL, it is no longer necessary to add a remote connection or configure SSH.
-
 Support for [AddressSanitizer (ASan)](https://github.com/google/sanitizers/wiki/AddressSanitizer) is integrated into Visual Studio for Linux projects.
 
 ::: moniker-end


### PR DESCRIPTION
Remote mention of both native WSL support and separation of build/deploy from "Install the C++ Linux workload in Visual Studio." Neither are very relevant when the user is trying to modify their VS installation and add extra complexity (especially when both features are documented elsewhere)