### PR TITLE
Stringizing operator code example was misplaced

### DIFF
--- a/docs/preprocessor/stringizing-operator-hash.md
+++ b/docs/preprocessor/stringizing-operator-hash.md
@@ -22,16 +22,6 @@ The Visual C++ stringizing operator does not behave correctly when it is used wi
 
 The following example shows a macro definition that includes the stringizing operator and a main function that invokes the macro:
 
-Such invocations would be expanded during preprocessing, producing the following code:
-
-```cpp
-int main() {
-   printf_s( "In quotes in the printf function call\n" "\n" );
-   printf_s( "\"In quotes when printed to the screen\"\n" "\n" );
-   printf_s( "\"This: \\\" prints an escaped double quote\"" "\n" );
-}
-```
-
 ```cpp
 // stringizer.cpp
 #include <stdio.h>
@@ -40,6 +30,16 @@ int main() {
    stringer( In quotes in the printf function call );
    stringer( "In quotes when printed to the screen" );
    stringer( "This: \"  prints an escaped double quote" );
+}
+```
+
+Such invocations would be expanded during preprocessing, producing the following code:
+
+```cpp
+int main() {
+   printf_s( "In quotes in the printf function call\n" "\n" );
+   printf_s( "\"In quotes when printed to the screen\"\n" "\n" );
+   printf_s( "\"This: \\\" prints an escaped double quote\"" "\n" );
 }
 ```
 


### PR DESCRIPTION
Previously, the two descriptions were before both code blocks, but the second code block corresponds with the first description.