### PR TITLE
Typo "<strong>CATCH_ALL88 or **AND_CATCH_ALL</strong>"→"**CATCH_ALL88…

### DIFF
--- a/docs/mfc/reference/exception-processing.md
+++ b/docs/mfc/reference/exception-processing.md
@@ -233,7 +233,7 @@ For more information on the END_CATCH macro, see the article [Exceptions](../../
 
 ##  <a name="end_catch_all"></a>  END_CATCH_ALL
 
-Marks the end of the last <strong>CATCH_ALL88 or **AND_CATCH_ALL</strong> block.
+Marks the end of the last **CATCH_ALL88** or **AND_CATCH_ALL** block.
 
 ```
 END_CATCH_ALL


### PR DESCRIPTION
…** or **AND_CATCH_ALL**"

https://docs.microsoft.com/en-us/cpp/mfc/reference/exception-processing?view=vs-2019#catch