### PR TITLE
Improve example for signal function

### DIFF
--- a/docs/c-runtime-library/reference/signal.md
+++ b/docs/c-runtime-library/reference/signal.md
@@ -125,10 +125,12 @@ int main()
 }
 ```
 
+The output depends on the version of the runtime used, whether the app is a console or Windows app, and on Windows registry settings. For a console app, something like the following message may be sent to stderr:
+
 ```Output
 Debug Error!
 
-Program: c:\Projects\ConsoleApplication1\Debug\ConsoleApplication1.exe
+Program: c:\Projects\crt_signal\Debug\crt_signal.exe
 
 R6010
 

--- a/docs/c-runtime-library/reference/signal.md
+++ b/docs/c-runtime-library/reference/signal.md
@@ -104,7 +104,6 @@ The following example shows how to use **signal** to add some custom behavior to
 // Use signal to attach a signal handler to the abort routine
 #include <stdlib.h>
 #include <signal.h>
-#include <tchar.h>
 
 void SignalHandler(int signal)
 {
@@ -127,8 +126,13 @@ int main()
 ```
 
 ```Output
-This application has requested the Runtime to terminate it in an unusual way.
-Please contact the application's support team for more information.
+Debug Error!
+
+Program: c:\Projects\ConsoleApplication1\Debug\ConsoleApplication1.exe
+
+R6010
+
+- abort() has been called
 ```
 
 ## See also


### PR DESCRIPTION
- Remove tchar.h include. There's nothing used from this header file.
- Update output to reflect the actual message displayed in modern Visual C++ versions (default abort message was changed around VC++ version 6.0)