### PR TITLE
Update bitscanforward-bitscanforward64.md

### DIFF
--- a/docs/intrinsics/bitscanforward-bitscanforward64.md
+++ b/docs/intrinsics/bitscanforward-bitscanforward64.md
@@ -45,7 +45,7 @@ If a set bit is found, the bit position of the first set bit found is returned i
 |Intrinsic|Architecture|
 |---------------|------------------|
 |`_BitScanForward`|x86, ARM, x64|
-|`_BitScanForward64`|ARM, x64|
+|`_BitScanForward64`|ARM64, x64|
 
 **Header file** \<intrin.h>
 


### PR DESCRIPTION
_BitScanForward64 was incorrectly marked as available on ARM, but it's only defined in `intrin0.h` for X64 and ARM64.

Fixes #1538.