### PR TITLE
Use <iostream> instead of <iostream.h> in Example Code for PCH

### DIFF
--- a/docs/build/creating-precompiled-header-files.md
+++ b/docs/build/creating-precompiled-header-files.md
@@ -247,7 +247,7 @@ void savetime( void );
 //
 #ifndef __UNSTABLE_H
 #define __UNSTABLE_H
-#include<iostream.h>
+#include<iostream>
 void notstable( void );
 #endif // __UNSTABLE_H
 ```

--- a/docs/build/creating-precompiled-header-files.md
+++ b/docs/build/creating-precompiled-header-files.md
@@ -169,9 +169,9 @@ UNSTABLEHDRS = unstable.h
 CLFLAGS = /c /W3
 # List all linker options common to both debug and final
 # versions of your code here:
-LINKFLAGS = /NOD /ONERROR:NOEXE
+LINKFLAGS = /nologo
 !IF "$(DEBUG)" == "1"
-CLFLAGS   = /D_DEBUG $(CLFLAGS) /Od /Zi /f
+CLFLAGS   = /D_DEBUG $(CLFLAGS) /Od /Zi
 LINKFLAGS = $(LINKFLAGS) /COD
 LIBS      = slibce
 !ELSE
@@ -260,6 +260,7 @@ void notstable( void );
 #include"another.h"
 #include"stable.h"
 #include"unstable.h"
+using namespace std;
 // The following code represents code that is deemed stable and
 // not likely to change. The associated interface code is
 // precompiled. In this example, the header files STABLE.H and

--- a/docs/build/creating-precompiled-header-files.md
+++ b/docs/build/creating-precompiled-header-files.md
@@ -1,6 +1,6 @@
 ---
 title: "Precompiled Header Files"
-ms.date: "08/19/2019"
+ms.date: "10/24/2019"
 helpviewer_keywords: ["precompiled header files, creating", "PCH files, creating", "cl.exe compiler, precompiling code", ".pch files, creating"]
 ms.assetid: e2cdb404-a517-4189-9771-c869c660cb1b
 ---


### PR DESCRIPTION
This old header seems to have been forgotten in one of the example files (UNSTABLE.H).