### PR TITLE
Add more prominent overview links to CX Vector & Map

### DIFF
--- a/docs/cppcx/platform-collections-map-class.md
+++ b/docs/cppcx/platform-collections-map-class.md
@@ -10,8 +10,6 @@ ms.assetid: 2b8cf968-1167-4898-a149-1195b32c1785
 
 Represents a *map*, which is a collection of key-value pairs. Implements [Windows::Foundation::Collections::IObservableMap](/uwp/api/windows.foundation.collections.iobservablemap_k_v_) to help with XAML [data binding](/windows/uwp/data-binding/data-binding-in-depth).
 
-See also [Collections (C++/CX)](/cpp/cppcx/collections-c-cx).
-
 ## Syntax
 
 ```cpp
@@ -282,5 +280,6 @@ The number of elements in the Map.
 
 ## See also
 
+[Collections (C++/CX)](/cpp/cppcx/collections-c-cx)<br/>
 [Platform Namespace](platform-namespace-c-cx.md)<br/>
 [Creating Windows Runtime Components in C++](/windows/uwp/winrt-components/creating-windows-runtime-components-in-cpp)

--- a/docs/cppcx/platform-collections-map-class.md
+++ b/docs/cppcx/platform-collections-map-class.md
@@ -1,6 +1,6 @@
 ---
 title: "Platform::Collections::Map Class"
-ms.date: "03/27/2019"
+ms.date: "10/01/2019"
 ms.topic: "reference"
 f1_keywords: ["COLLECTION/Platform::Collections::Map::Map", "COLLECTION/Platform::Collections::Map::Clear", "COLLECTION/Platform::Collections::Map::First", "COLLECTION/Platform::Collections::Map::GetView", "COLLECTION/Platform::Collections::Map::HasKey", "COLLECTION/Platform::Collections::Map::Insert", "COLLECTION/Platform::Collections::Map::Lookup", "COLLECTION/Platform::Collections::Map::Remove", "COLLECTION/Platform::Collections::Map::Size"]
 helpviewer_keywords: ["Map Class (C++/Cx)"]
@@ -280,6 +280,6 @@ The number of elements in the Map.
 
 ## See also
 
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx)<br/>
+[Collections (C++/CX)](collections-c-cx)<br/>
 [Platform Namespace](platform-namespace-c-cx.md)<br/>
 [Creating Windows Runtime Components in C++](/windows/uwp/winrt-components/creating-windows-runtime-components-in-cpp)

--- a/docs/cppcx/platform-collections-map-class.md
+++ b/docs/cppcx/platform-collections-map-class.md
@@ -8,7 +8,9 @@ ms.assetid: 2b8cf968-1167-4898-a149-1195b32c1785
 ---
 # Platform::Collections::Map Class
 
-Represents a *map*, which is a collection of key-value pairs.
+Represents a *map*, which is a collection of key-value pairs. Implements [Windows::Foundation::Collections::IObservableMap](/uwp/api/windows.foundation.collections.iobservablemap_k_v_) to help with XAML [data binding](/windows/uwp/data-binding/data-binding-in-depth).
+
+See also [Collections (C++/CX)](/cpp/cppcx/collections-c-cx).
 
 ## Syntax
 

--- a/docs/cppcx/platform-collections-vector-class.md
+++ b/docs/cppcx/platform-collections-vector-class.md
@@ -370,6 +370,6 @@ The last element in a sequence of objects that are used to initialize the curren
 
 ## See also
 
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx).<br/>
+[Collections (C++/CX)](/cpp/cppcx/collections-c-cx)<br/>
 [Platform Namespace](platform-namespace-c-cx.md)<br/>
 [Creating Windows Runtime Components in C++](/windows/uwp/winrt-components/creating-windows-runtime-components-in-cpp)

--- a/docs/cppcx/platform-collections-vector-class.md
+++ b/docs/cppcx/platform-collections-vector-class.md
@@ -1,6 +1,6 @@
 ---
 title: "Platform::Collections::Vector Class"
-ms.date: "12/30/2016"
+ms.date: "10/01/2019"
 ms.topic: "reference"
 f1_keywords: ["COLLECTION/Platform::Collections::Vector::Vector", "COLLECTION/Platform::Collections::Vector::Append", "COLLECTION/Platform::Collections::Vector::Clear", "COLLECTION/Platform::Collections::Vector::First", "COLLECTION/Platform::Collections::Vector::GetAt", "COLLECTION/Platform::Collections::Vector::GetMany", "COLLECTION/Platform::Collections::Vector::GetView", "COLLECTION/Platform::Collections::Vector::IndexOf", "COLLECTION/Platform::Collections::Vector::InsertAt", "COLLECTION/Platform::Collections::Vector::ReplaceAll", "COLLECTION/Platform::Collections::Vector::RemoveAt", "COLLECTION/Platform::Collections::Vector::RemoveAtEnd", "COLLECTION/Platform::Collections::Vector::SetAt", "COLLECTION/Platform::Collections::Vector::Size", "COLLECTION/Platform::Collections::Vector::VectorChanged"]
 helpviewer_keywords: ["Vector Class (C++/Cx)"]
@@ -370,6 +370,6 @@ The last element in a sequence of objects that are used to initialize the curren
 
 ## See also
 
-[Collections (C++/CX)](/cpp/cppcx/collections-c-cx)<br/>
+[Collections (C++/CX)](collections-c-cx)<br/>
 [Platform Namespace](platform-namespace-c-cx.md)<br/>
 [Creating Windows Runtime Components in C++](/windows/uwp/winrt-components/creating-windows-runtime-components-in-cpp)

--- a/docs/cppcx/platform-collections-vector-class.md
+++ b/docs/cppcx/platform-collections-vector-class.md
@@ -10,8 +10,6 @@ ms.assetid: aee8c076-9700-47c3-99b6-799fd3edb0ca
 
 Represents a sequential collection of objects that can be individually accessed by index. Implements [Windows::Foundation::Collections::IObservableVector](/uwp/api/Windows.Foundation.Collections.IObservableVector_T_) to help with XAML [data binding](/windows/uwp/data-binding/data-binding-in-depth).
 
-See also [Collections (C++/CX)](/cpp/cppcx/collections-c-cx).
-
 ## Syntax
 
 ```
@@ -372,5 +370,6 @@ The last element in a sequence of objects that are used to initialize the curren
 
 ## See also
 
+[Collections (C++/CX)](/cpp/cppcx/collections-c-cx).<br/>
 [Platform Namespace](platform-namespace-c-cx.md)<br/>
 [Creating Windows Runtime Components in C++](/windows/uwp/winrt-components/creating-windows-runtime-components-in-cpp)

--- a/docs/cppcx/platform-collections-vector-class.md
+++ b/docs/cppcx/platform-collections-vector-class.md
@@ -8,7 +8,9 @@ ms.assetid: aee8c076-9700-47c3-99b6-799fd3edb0ca
 ---
 # Platform::Collections::Vector Class
 
-Represents a sequential collection of objects that can be individually accessed by index.
+Represents a sequential collection of objects that can be individually accessed by index. Implements [Windows::Foundation::Collections::IObservableVector](/uwp/api/Windows.Foundation.Collections.IObservableVector_T_) to help with XAML [data binding](/windows/uwp/data-binding/data-binding-in-depth).
+
+See also [Collections (C++/CX)](/cpp/cppcx/collections-c-cx).
 
 ## Syntax
 


### PR DESCRIPTION
This PR:

* Adds links back to the main Collections (C++/CX) page on `Platform::Collections::Vector` and `Platform::Collections::Map`.
* Adds a note to both classes that they are observable and can be easily bound to XAML properties.