### PR TITLE
Remove what's new in 2019?

### DIFF
--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -13,8 +13,6 @@ CMake is a cross-platform, open-source tool for defining build processes that ru
 
 ::: moniker range="vs-2019"
 
-Visual Studio 2019 introduces the **CMake Settings editor** and other improvements over Visual Studio 2017. The **C++ CMake tools for Windows** component uses the **Open Folder** feature to enable the IDE to consume CMake project files (such as CMakeLists.txt) directly for the purposes of IntelliSense and browsing. Both Ninja and Visual Studio generators are supported. If you use a Visual Studio generator, a temporary project file is generated and passed to msbuild.exe, but is never loaded for IntelliSense or browsing purposes. You can also import an existing CMake cache. 
-
 ## Installation
 
 **C++ CMake tools for Windows** is installed by default as part of the **Desktop development with C++** workload and as part of the **Linux Development with C++** workload. See [Cross-platform CMake projects](../linux/cmake-linux-project.md) for more information.


### PR DESCRIPTION
With Overview Pages landing in 16.4, this piece of documentation will be the first piece of external documentation that we link to to get started with CMake. I'm not sure it makes sense to start with a list of everything new in 2019 - many users are not familiar with our old support, and listing new features that they may not understand (e.g. open an existing cache, the relationship between msbuild.exe and CMakeLists.txt) could add complexity. I think it would be better to remove this section.
That said, you are the domain expert and if this is standard practice, then please let me know.