### PR TITLE
Remove what's new in 2019?

### DIFF
--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -13,7 +13,7 @@ CMake is a cross-platform, open-source tool for defining build processes that ru
 
 ::: moniker range="vs-2019"
 
-Visual Studio 2019 introduces the **CMake Settings editor** and other improvements over Visual Studio 2017. The **C++ CMake tools for Windows** component uses the **Open Folder** feature to enable the IDE to consume CMake project files (such as CMakeLists.txt) directly for the purposes of IntelliSense and browsing. Both Ninja and Visual Studio generators are supported. If you use a Visual Studio generator, a temporary project file is generated and passed to msbuild.exe, but is never loaded for IntelliSense or browsing purposes. You can also import an existing CMake cache. 
+The **C++ CMake tools for Windows** component uses the [Open Folder](https://docs.microsoft.com/en-us/cpp/build/open-folder-projects-cpp?view=vs-2019) feature to consume CMake project files (such as CMakeLists.txt) directly for the purposes of IntelliSense and browsing. Both Ninja and Visual Studio generators are supported. If you use a Visual Studio generator, a temporary project file is generated and passed to msbuild.exe, but is never loaded for IntelliSense or browsing purposes. You can also import an existing CMake cache.
 
 ## Installation
 


### PR DESCRIPTION
With Overview Pages landing in 16.4, this piece of documentation will be the first piece of external documentation that we link to to get started with CMake. I'm not sure it makes sense to start with a list of everything new in 2019 - many users are not familiar with our old support, and listing new features that they may not understand (e.g. CMake Settings Editor) could add complexity. 

(sorry for the dup PRs - I deleted too much the first time. I closed the other one, this is the open PR for consideration. Thanks!)