### PR TITLE
Final changes

### DIFF
--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -1,6 +1,6 @@
 ---
 title: "CMake projects in Visual Studio"
-ms.date: "06/12/2019"
+ms.date: "10/01/2019"
 helpviewer_keywords: ["CMake in Visual C++"]
 ms.assetid: 444d50df-215e-4d31-933a-b41841f186f8
 ---
@@ -25,7 +25,7 @@ For more information, see [Install the C++ Linux workload in Visual Studio](../l
 
 ## IDE Integration
 
-When you choose **File | Open | Folder** to open a folder containing a CMakeLists.txt file, the following things happen:
+When you choose **File > Open > Folder** to open a folder containing a CMakeLists.txt file, the following things happen:
 
 - Visual Studio adds **CMake** items to the **Project** menu, with commands for viewing and editing CMake scripts.
 
@@ -54,23 +54,23 @@ If you need to pass arguments to an executable at debug time, you can use anothe
 
 ## Import an existing cache
 
-When you import an existing CMakeCache.txt file, Visual Studio automatically extracts customized variables and creates a pre-populated **CMakeSettings.json** file based on them. The original cache is not modified in any way and can still be used from the command line or with whatever tool or IDE was used to generate it. The new  **CMakeSettings.json** file is placed alongside the project’s root CMakeLists.txt. Visual Studio generates a new cache based the settings file. You can override automatic cache generation in the **Tools | Options | CMake | General** dialog.
+When you import an existing CMakeCache.txt file, Visual Studio automatically extracts customized variables and creates a pre-populated **CMakeSettings.json** file based on them. The original cache is not modified in any way and can still be used from the command line or with whatever tool or IDE was used to generate it. The new  **CMakeSettings.json** file is placed alongside the project’s root CMakeLists.txt. Visual Studio generates a new cache based the settings file. You can override automatic cache generation in the **Tools > Options > CMake > General** dialog.
 
-Not everything in the cache is imported.  Properties such as the generator and the location of the compilers are replaced with defaults that are known to work well with the IDE.
+Not everything in the cache is imported. Properties such as the generator and the location of the compilers are replaced with defaults that are known to work well with the IDE.
 
-### To open an existing cache
+## Open an existing cache
 
-When you open an existing CMake cache, Visual Studio will not attempt to manage your cache and build tree for you. This gives your custom or preferred tools complete control over how CMake configures your project. You can open an existing cache in Visual Studio via **File > Open > CMake** and navigating to an existing CMakeCache.txt. Alternatively, if you have already opened the project in Visual Studio, you can add an existing cache to it the same way you would add a new configuration. See our blog post on [opening an existing cache in Visual Studio](https://devblogs.microsoft.com/cppblog/open-existing-cmake-caches-in-visual-studio/) for more information.
+When you open an existing CMake cache, Visual Studio will not attempt to manage your cache and build tree for you. This gives your custom or preferred tools complete control over how CMake configures your project. You can open an existing cache in Visual Studio via **File > Open > CMake** and navigating to an existing CMakeCache.txt. Alternatively, if you have already opened the project in Visual Studio, you can add an existing cache to it the same way you would add a new configuration. For more information, see our blog post on [opening an existing cache in Visual Studio](https://devblogs.microsoft.com/cppblog/open-existing-cmake-caches-in-visual-studio/).
 
 ## Building CMake projects
 
 To build a CMake project, you have these choices:
 
-1. In the General toolbar, find the **Configurations** dropdown; it is probably showing "x64-Debug" by default. Select the desired configuration and press **F5**, or click the **Run** (green triangle) button on the toolbar. The project automatically builds first, just like a Visual Studio solution.
+1. In the General toolbar, find the **Configurations** dropdown. It probably shows "x64-Debug" by default. Select the desired configuration and press **F5**, or click the **Run** (green triangle) button on the toolbar. The project automatically builds first, just like a Visual Studio solution.
 
 1. Right click on the CMakeLists.txt and select **Build** from the context menu. If you have multiple targets in your folder structure, you can choose to build all or only one specific target.
 
-1. From the main menu, select **Build | Build All** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
+1. From the main menu, select **Build > Build All** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
 
 ![CMake build menu command](media/cmake-build-menu.png "CMake build command menu")
 
@@ -133,7 +133,7 @@ If you need more information about the state of the CMake cache to diagnose a pr
 
 - **Generate Cache** forces the generate step to run even if Visual Studio considers the environment up-to-date.
 
-Automatic cache generation can be disabled in the **Tools | Options | CMake | General** dialog.
+Automatic cache generation can be disabled in the **Tools > Options > CMake > General** dialog.
 
 ## Run CMake from the command line
 
@@ -161,7 +161,7 @@ For more information, see [Install the C++ Linux workload in Visual Studio](../l
 
 ## IDE Integration
 
-When you choose **File | Open | Folder** to open a folder containing a CMakeLists.txt file, the following things happen:
+When you choose **File > Open > Folder** to open a folder containing a CMakeLists.txt file, the following things happen:
 
 - Visual Studio adds a **CMake** menu item to the main menu, with commands for viewing and editing CMake scripts.
 
@@ -190,13 +190,13 @@ If you need to pass arguments to an executable at debug time, you can use anothe
 
 ## Import an existing cache
 
-When you import an existing CMakeCache.txt file, Visual Studio automatically extracts customized variables and creates a pre-populated **CMakeSettings.json** file based on them. The original cache is not modified in any way and can still be used from the command line or with whatever tool or IDE was used to generate it. The new  **CMakeSettings.json** file is placed alongside the project’s root CMakeLists.txt. Visual Studio generates a new cache based the settings file. You can override automatic cache generation in the **Tools | Options | CMake | General** dialog.
+When you import an existing CMakeCache.txt file, Visual Studio automatically extracts customized variables and creates a pre-populated **CMakeSettings.json** file based on them. The original cache is not modified in any way and can still be used from the command line or with whatever tool or IDE was used to generate it. The new  **CMakeSettings.json** file is placed alongside the project’s root CMakeLists.txt. Visual Studio generates a new cache based the settings file. You can override automatic cache generation in the **Tools > Options > CMake > General** dialog.
 
 Not everything in the cache is imported.  Properties such as the generator and the location of the compilers are replaced with defaults that are known to work well with the IDE.
 
 ### To import an existing cache
 
-1. From the main menu, choose **File | Open | CMake**:
+1. From the main menu, choose **File > Open > CMake**:
 
    ![Open CMake](media/cmake-file-open.png "File, Open, CMake")
 
@@ -216,7 +216,7 @@ To build a CMake project, you have these choices:
 
 1. Right click on the CMakeLists.txt and select **Build** from the context menu. If you have multiple targets in your folder structure, you can choose to build all or only one specific target.
 
-1. From the main menu, select **Build | Build Solution** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
+1. From the main menu, select **Build > Build Solution** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
 
 ![CMake build menu command](media/cmake-build-menu.png "CMake build command menu")
 
@@ -272,7 +272,7 @@ If you need more information about the state of the CMake cache to diagnose a pr
 
 - **Generate Cache** forces the generate step to run even if Visual Studio considers the environment up-to-date.
 
-Automatic cache generation can be disabled in the **Tools | Options | CMake | General** dialog.
+Automatic cache generation can be disabled in the **Tools > Options > CMake > General** dialog.
 
 ## Single File Compilation
 

--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -58,29 +58,19 @@ When you import an existing CMakeCache.txt file, Visual Studio automatically ext
 
 Not everything in the cache is imported.  Properties such as the generator and the location of the compilers are replaced with defaults that are known to work well with the IDE.
 
-### To import an existing cache
+### To open an existing cache
 
-1. From the main menu, choose **File | Open | CMake**:
-
-   ![Open CMake](media/cmake-file-open.png "File, Open, CMake")
-
-   This brings up the **Import CMake from Cache** wizard.
-
-2. Navigate to the CMakeCache.txt file that you want to import, and then click **OK**. The **Import CMake Project from Cache** wizard appears:
-
-   ![Import a CMake cache](media/cmake-import-wizard.png "Open the CMake import cache wizard")
-
-   When the wizard completes, you can see the new CMakeCache.txt file in **Solution Explorer** next to the root CMakeLists.txt file in your project.
+When you open an existing CMake cache, Visual Studio will not attempt to manage your cache and build tree for you. This gives your custom or preferred tools complete control over how CMake configures your project. You can open an existing cache in Visual Studio via **File > Open > CMake** and navigating to an existing CMakeCache.txt. Alternatively, if you have already opened the project in Visual Studio, you can add an existing cache to it the same way you would add a new configuration. See our blog post on [opening an existing cache in Visual Studio](https://devblogs.microsoft.com/cppblog/open-existing-cmake-caches-in-visual-studio/) for more information.
 
 ## Building CMake projects
 
 To build a CMake project, you have these choices:
 
-1. In the General toolbar, find the **Configurations** dropdown; it is probably showing "Linux-Debug" or "x64-Debug" by default. Select the desired configuration and press **F5**, or click the **Run** (green triangle) button on the toolbar. The project automatically builds first, just like a Visual Studio solution.
+1. In the General toolbar, find the **Configurations** dropdown; it is probably showing "x64-Debug" by default. Select the desired configuration and press **F5**, or click the **Run** (green triangle) button on the toolbar. The project automatically builds first, just like a Visual Studio solution.
 
 1. Right click on the CMakeLists.txt and select **Build** from the context menu. If you have multiple targets in your folder structure, you can choose to build all or only one specific target.
 
-1. From the main menu, select **Build | Build Solution** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
+1. From the main menu, select **Build | Build All** (**F7** or **Ctrl+Shift+B**). Make sure that a CMake target is already selected in the **Startup Item** dropdown in the **General** toolbar.
 
 ![CMake build menu command](media/cmake-build-menu.png "CMake build command menu")
 
@@ -102,13 +92,13 @@ The **Run** or **F5** commands first build the project if changes have been made
 
 You can customize a CMake debugging session by setting properties in the **launch.vs.json** file. For more information, see [Configure CMake debugging sessions](configure-cmake-debugging-sessions.md).
 
-## Vcpkg Integration
-
-If you have installed [vcpkg](vcpkg.md), CMake projects opened in Visual Studio will automatically integrate the vcpkg toolchain file. This means no additional configuration is required to use vcpkg with your CMake projects. This support works for both local vcpkg installations and vcpkg installations on remote machines that you are targeting. This behavior is disabled automatically when you specify any other toolchain in your CMake Settings configuration.
-
 ## Just My Code for CMake projects
 
-When you build for Windows using the MSVC compiler, your CMake projects now support Just my Code debugging in the compiler and linker if the option is enabled in Visual Studio. To change the setting, go to **Tools** > **Options** > **Debugging** > **General**.
+When you build for Windows using the MSVC compiler, your CMake projects have support for Just my Code debugging in the compiler and linker if the option is enabled in Visual Studio. To change the setting, go to **Tools** > **Options** > **Debugging** > **General**.
+
+## Vcpkg Integration
+
+If you have installed [vcpkg](vcpkg.md), CMake projects opened in Visual Studio will automatically integrate the vcpkg toolchain file. This means no additional configuration is required to use vcpkg with your CMake projects. This support works for both local vcpkg installations and vcpkg installations on remote systems that you are targeting. This behavior is disabled automatically when you specify any other toolchain in your CMake Settings configuration.
 
 ## Customize configuration feedback
 
@@ -131,15 +121,9 @@ As soon as you save the file, the configuration step automatically runs again an
 
 When significant changes are made to the  **CMakeSettings.json** or to CMakeLists.txt files, Visual Studio automatically reruns the CMake configure step. If the configure step finishes without errors, the information that is collected is available in C++ IntelliSense and language services and also in build and debug operations.
 
-When multiple CMake projects use the same CMake configuration name (for example, x86-Debug), all of them are configured and built (in their own build root folder) when that configuration is selected. You can debug the targets from all of the CMake projects that participate in that CMake configuration.
-
-   ![CMake Build Only menu item](media/cmake-build-only.png "CMake Build Only menu item")
-
-To limit builds and debug sessions to a subset of the projects in the workspace, create a new configuration with a unique name in the  **CMakeSettings.json** file and apply it to those projects only. When that configuration is selected, the IntelliSense and build and debug commands are enabled only for those specified projects.
-
 ## Troubleshooting CMake cache errors
 
-If you need more information about the state of the CMake cache to diagnose a problem, open the **CMake** main menu or the **CMakeLists.txt** context menu in **Solution Explorer** to run one of these commands:
+If you need more information about the state of the CMake cache to diagnose a problem, open the **Project** main menu or the **CMakeLists.txt** context menu in **Solution Explorer** to run one of these commands:
 
 - **View Cache** opens the CMakeCache.txt file from the build root folder in the editor. (Any edits you make here to CMakeCache.txt are wiped out if you clean the cache. To make changes that persist after the cache is cleaned, see [Customize CMake settings](customize-cmake-settings.md).)
 
@@ -150,12 +134,6 @@ If you need more information about the state of the CMake cache to diagnose a pr
 - **Generate Cache** forces the generate step to run even if Visual Studio considers the environment up-to-date.
 
 Automatic cache generation can be disabled in the **Tools | Options | CMake | General** dialog.
-
-## Single File Compilation
-
-To build a single file in a CMake project, right-click on the file in **Solution Explorer** and choose **Compile**. You can also build the file that is currently open in the editor by using the main CMake menu:
-
-![CMake single file compilation](media/cmake-single-file-compile.png)
 
 ## Run CMake from the command line
 


### PR DESCRIPTION
[This PR includes my previous changes]
You can no longer have multiple configs with the same name, single file compilation references a menu that no longer exists, swapped the order of vcpkg integration and JMC debugging (so JMC follows the general debugging section), and small edits. Thanks!