### PR TITLE
Conversions from floating point types vc2019

### DIFF
--- a/docs/c-language/assignment-conversions.md
+++ b/docs/c-language/assignment-conversions.md
@@ -1,25 +1,25 @@
 ---
-title: "Assignment Conversions"
+title: "Assignment conversions"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["conversions, assignment", "assignment conversions"]
 ms.assetid: 4ee01013-de32-4aae-b12e-0051d0cde927
 ---
-# Assignment Conversions
+# Assignment conversions
 
 In assignment operations, the type of the value being assigned is converted to the type of the variable that receives the assignment. C allows conversions by assignment between integral and floating types, even if information is lost in the conversion. The conversion method used depends on the types involved in the assignment, as described in [Usual Arithmetic Conversions](../c-language/usual-arithmetic-conversions.md) and in the following sections:
 
-- [Conversions from Signed Integral Types](../c-language/conversions-from-signed-integral-types.md)
+- [Conversions from signed integral types](../c-language/conversions-from-signed-integral-types.md)
 
-- [Conversions from Unsigned Integral Types](../c-language/conversions-from-unsigned-integral-types.md)
+- [Conversions from unsigned integral types](../c-language/conversions-from-unsigned-integral-types.md)
 
-- [Conversions from Floating-Point Types](../c-language/conversions-from-floating-point-types.md)
+- [Conversions from floating-point types](../c-language/conversions-from-floating-point-types.md)
 
-- [Conversions to and from Pointer Types](../c-language/conversions-to-and-from-pointer-types.md)
+- [Conversions to and from pointer types](../c-language/conversions-to-and-from-pointer-types.md)
 
-- [Conversions from Other Types](../c-language/conversions-from-other-types.md)
+- [Conversions from other types](../c-language/conversions-from-other-types.md)
 
 Type qualifiers do not affect the allowability of the conversion although a **const** l-value cannot be used on the left side of the assignment.
 
 ## See also
 
-[Type Conversions](../c-language/type-conversions-c.md)
+[Type conversions](../c-language/type-conversions-c.md)

--- a/docs/c-language/conversions-from-floating-point-types.md
+++ b/docs/c-language/conversions-from-floating-point-types.md
@@ -1,33 +1,36 @@
 ---
-title: "Conversions from Floating-Point Types"
+title: "Conversions from floating-point types"
 ms.date: "10/02/2019"
 helpviewer_keywords: ["converting floating point", "floating-point conversion"]
 ms.assetid: 96804c8e-fa3b-4742-9006-0082ed9e57f2
 ---
 # Conversions from floating-point types
 
-A floating-point value converted to another floating-point type undergoes no change in value if the original value can be represented exactly in the result type. If the original value is numeric but cannot be represented exactly, the result will be either the next greater or next lower repersentable value. See [Limits on Floating-Point Constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
+A floating-point value that's converted to another floating-point type undergoes no change in value if the original value can be represented exactly in the result type. If the original value is numeric but can't be represented exactly, the result will be either the next greater or next lower representable value. See [Limits on floating-point constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
 
-A floating-point value that is converted to an integral type is first truncated by discarding any fractional value. If this truncated value is representable in the result type the result must be that value. If it cannot, the result value is undefined.
+A floating-point value that is converted to an integral type is first truncated by discarding any fractional value. If this truncated value is representable in the result type, the result must be that value. If it isn't representable, the result value is undefined.
 
 **Microsoft Specific**
 
-Microsoft VC++ compilers use IEEE-754 binary32 representation for **float** values and binary64 representation for **long double** and **double**. Note that **long double** and **double** use the same representation, and therefore have the same range and precision.
+Microsoft VC++ compilers use IEEE-754 binary32 representation for **float** values and binary64 representation for **long double** and **double**. Since **long double** and **double** use the same representation, they have the same range and precision.
 
-When converting a **double** or **long double** floating-point number to a **float**, the result is rounded according to the floating-point environment controls, which default to “round to nearest, ties to even”. If a numeric value is too high or too low to be represented as a numeric **float** value, the conversion result will be positive or negative infinity according to the sign of the original value, and an overflow exception will be raised if enabled.
+When converting a **double** or **long double** floating-point number to a **float**, the result is rounded according to the floating-point environment controls, which default to "round to nearest, ties to even". If a numeric value is too high or too low to be represented as a numeric **float** value, the conversion result will be positive or negative infinity according to the sign of the original value, and an overflow exception will be raised if enabled.
 
-When converting to integer types, the result of a conversion to a type smaller than **long** is the result of converting the value to **long** and then converting to the result type. 
+When converting to integer types, the result of a conversion to a type smaller than **long** is the result of converting the value to **long** and then converting to the result type.
 
-For conversion to integer types at least as large as **long**, a conversion of a value that is too high or too low to represent in the result type may return any the following values:
-- The result may be a sentinel value which is the representable value farthest from zero. For signed types this is the lowest representable value (0x800…0). For unsigned types this is the highest representable value (0xFF…F).
-- The result may be saturated so that too high values are converted to the highest representable value and too low values are converted to the lowest representable value. Note that one of these two values is also used as the sentinel value.
-- For conversion to **unsigned long** or **unsigned long long**, the result of converting an out of range value may be some value other than the highest or lowest representable value, depending on compiler options and target architecture. Future compiler releases may return a saturated or sentinel value instead.
+For conversion to integer types at least as large as **long**, a conversion of a value that is too high or too low to represent in the result type may return any of the following values:
+
+- The result may be a *sentinel value*. That's the representable value farthest from zero. For signed types, it's the lowest representable value (0x800...0). For unsigned types, it's the highest representable value (0xFF...F).
+
+- The result may be *saturated*, so that too high values are converted to the highest representable value, and too low values are converted to the lowest representable value. One of these two values is also used as the sentinel value.
+
+- For conversion to **unsigned long** or **unsigned long long**, the result of converting an out-of-range value may be some value other than the highest or lowest representable value. The result depends on the compiler options and target architecture. Future compiler releases may return a saturated or sentinel value instead.
 
 **END Microsoft Specific**
 
 The following table summarizes conversions from floating types.
 
-## Conversions from floating-point types
+## Table of conversions from floating-point types
 
 |From|To|Method|
 |----------|--------|------------|
@@ -52,7 +55,7 @@ The following table summarizes conversions from floating types.
 |**double**|**unsigned**|Truncate at decimal point. If result is too large to be represented as **unsigned**, result is undefined.|
 |**double**|**unsigned long**|Truncate at decimal point. If result is too large to be represented as **unsigned long**, result is undefined.|
 |**double**|**unsigned long long**|Truncate at decimal point. If result is too large to be represented as **unsigned long long**, result is undefined.|
-|**double**|**float**|Represent as a **float**. If **double** value cannot be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
+|**double**|**float**|Represent as a **float**. If **double** value can't be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
 |**double**|**long double**|The **long double** value is treated as **double**.|
 |**long double**|**char**|Convert to **float**; convert **float** to **char**|
 |**long double**|**short**|Convert to **float**; convert **float** to **short**|
@@ -63,7 +66,7 @@ The following table summarizes conversions from floating types.
 |**long double**|**unsigned**|Truncate at decimal point. If result is too large to be represented as **unsigned**, result is undefined.|
 |**long double**|**unsigned long**|Truncate at decimal point. If result is too large to be represented as **unsigned long**, result is undefined.|
 |**long double**|**unsigned long long**|Truncate at decimal point. If result is too large to be represented as **unsigned long long**, result is undefined.|
-|**long double**|**float**|Represent as a **float**. If **double** value cannot be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
+|**long double**|**float**|Represent as a **float**. If **double** value can't be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
 |**long double**|**double**|The **long double** value is treated as **double**.|
 
 ## See also

--- a/docs/c-language/conversions-from-floating-point-types.md
+++ b/docs/c-language/conversions-from-floating-point-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Conversions from Floating-Point Types"
-ms.date: "01/29/2018"
+ms.date: "10/02/2019"
 helpviewer_keywords: ["converting floating point", "floating-point conversion"]
 ms.assetid: 96804c8e-fa3b-4742-9006-0082ed9e57f2
 ---

--- a/docs/c-language/conversions-from-floating-point-types.md
+++ b/docs/c-language/conversions-from-floating-point-types.md
@@ -6,13 +6,22 @@ ms.assetid: 96804c8e-fa3b-4742-9006-0082ed9e57f2
 ---
 # Conversions from floating-point types
 
-A **float** value converted to a **double** or **long double**, or a **double** converted to a **long double**, undergoes no change in value. A **double** value converted to a **float** value is represented exactly, if possible. Precision may be lost if the value cannot be represented exactly. If the result is out of range, the behavior is undefined. See [Limits on Floating-Point Constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
+A **float** value converted to a **double** or **long double**, or a **double** converted to a **long double**, undergoes no change in value. The range of representable **double** or **long double** values is larger than for **float**, and when converting from the former to the latter if the value is beyond the representable range for **float**, the behavior is undefined. Otherwise if the result cannot be represented exactly, the value is rounded. See [Limits on Floating-Point Constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
 
-A floating value is converted to an integral value by first converting to a **long**, then from the **long** value to the specific integral value. The decimal portion of the floating value is discarded in the conversion to a **long**. If the result is still too large to fit into a **long**, the result of the conversion is undefined.
+A floating-point value that is converted to an integral type is first truncated by discarding any fractional value. If this truncated value is representable in the result type the result must be that value. If it cannot, the result value is undefined.
 
 **Microsoft Specific**
 
-When converting a **double** or **long double** floating-point number to a smaller floating-point number, the value of the floating-point variable is truncated toward zero when an underflow occurs. An overflow causes a run-time error. Note that the Microsoft C compiler maps **long double** to type **double**.
+Note that the Microsoft VC++ compilers map **long double** to type **double** and **int** to **long**.
+
+When converting a **double** or **long double** floating-point number to a **float**, the result is rounded according to the floating-point environment controls, which default to “round to nearest, ties to even”. If a numeric value is too high or too low to be represented in the result type, the result will be positive or negative infinity according to the sign of the original value, and an overflow exception will be raised if enabled.
+
+When converting to integer types, the result of a conversion to a type smaller than **long** is the result of converting the value to **long** and then converting to the result type. 
+
+For integer types at least as large as **long**, a conversion of a value that is too high or too low to represent in the result type may return any the following values:
+- The result may be a sentinel value which is the representable value farthest from zero. For signed types this is the lowest representable value (0x800…0). For unsigned types this is the highest representable value (0xFF…F).
+- The result may be saturated so that too high values are converted to the highest representable value and too low values are converted to the lowest representable value. Note that one of these two values is also used as the sentinel value.
+- For conversion to **unsigned long** or **unsigned long long**, the result of converting an out of range value may be some value other than the highest or lowest representable value, depending on compiler options and target architecture. Future compiler releases may return a saturated or sentinel value instead.
 
 **END Microsoft Specific**
 
@@ -24,26 +33,38 @@ The following table summarizes conversions from floating types.
 |----------|--------|------------|
 |**float**|**char**|Convert to **long**; convert **long** to **char**|
 |**float**|**short**|Convert to **long**; convert **long** to **short**|
+|**float**|**int**|Truncate at decimal point. If result is too large to be represented as **int**, result is undefined.|
 |**float**|**long**|Truncate at decimal point. If result is too large to be represented as **long**, result is undefined.|
+|**float**|**long long**|Truncate at decimal point. If result is too large to be represented as **long long**, result is undefined.|
+|**float**|**unsigned char**|Convert to **long**; convert **long** to **unsigned char**|
 |**float**|**unsigned short**|Convert to **long**; convert **long** to **unsigned short**|
-|**float**|**unsigned long**|Convert to **long**; convert **long** to **unsigned long**|
-|**float**|**double**|Change internal representation|
-|**float**|**long double**|Change internal representation|
+|**float**|**unsigned**|Truncate at decimal point. If result is too large to be represented as **unsigned**, result is undefined.|
+|**float**|**unsigned long**|Truncate at decimal point. If result is too large to be represented as **unsigned long**, result is undefined.|
+|**float**|**unsigned long long**|Truncate at decimal point. If result is too large to be represented as **unsigned long long**, result is undefined.|
+|**float**|**double**|Represent as a **double**.|
+|**float**|**long double**|Represent as a **long double**.|
 |**double**|**char**|Convert to **float**; convert **float** to **char**|
 |**double**|**short**|Convert to **float**; convert **float** to **short**|
+|**double**|**int**|Truncate at decimal point. If result is too large to be represented as **int**, result is undefined.|
 |**double**|**long**|Truncate at decimal point. If result is too large to be represented as **long**, result is undefined.|
+|**double**|**unsigned char**|Convert to **long**; convert **long** to **unsigned char**|
 |**double**|**unsigned short**|Convert to **long**; convert **long** to **unsigned short**|
-|**double**|**unsigned long**|Convert to **long**; convert **long** to **unsigned long**|
+|**double**|**unsigned**|Truncate at decimal point. If result is too large to be represented as **unsigned**, result is undefined.|
+|**double**|**unsigned long**|Truncate at decimal point. If result is too large to be represented as **unsigned long**, result is undefined.|
+|**double**|**unsigned long long**|Truncate at decimal point. If result is too large to be represented as **unsigned long long**, result is undefined.|
 |**double**|**float**|Represent as a **float**. If **double** value cannot be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
+|**double**|**long double**|The **long double** value is treated as **double**.|
 |**long double**|**char**|Convert to **float**; convert **float** to **char**|
 |**long double**|**short**|Convert to **float**; convert **float** to **short**|
+|**long double**|**int**|Truncate at decimal point. If result is too large to be represented as **int**, result is undefined.|
 |**long double**|**long**|Truncate at decimal point. If result is too large to be represented as **long**, result is undefined.|
+|**long double**|**unsigned char**|Convert to **long**; convert **long** to **unsigned char**|
 |**long double**|**unsigned short**|Convert to **long**; convert **long** to **unsigned short**|
-|**long double**|**unsigned long**|Convert to **long**; convert **long** to **unsigned long**|
+|**long double**|**unsigned**|Truncate at decimal point. If result is too large to be represented as **unsigned**, result is undefined.|
+|**long double**|**unsigned long**|Truncate at decimal point. If result is too large to be represented as **unsigned long**, result is undefined.|
+|**long double**|**unsigned long long**|Truncate at decimal point. If result is too large to be represented as **unsigned long long**, result is undefined.|
 |**long double**|**float**|Represent as a **float**. If **double** value cannot be represented exactly as **float**, loss of precision occurs. If value is too large to be represented as **float**, the result is undefined.|
 |**long double**|**double**|The **long double** value is treated as **double**.|
-
-Conversions from **float**, **double**, or **long double** values to **unsigned long** are not accurate if the value being converted is larger than the maximum positive **long** value.
 
 ## See also
 

--- a/docs/c-language/conversions-from-floating-point-types.md
+++ b/docs/c-language/conversions-from-floating-point-types.md
@@ -6,19 +6,19 @@ ms.assetid: 96804c8e-fa3b-4742-9006-0082ed9e57f2
 ---
 # Conversions from floating-point types
 
-A **float** value converted to a **double** or **long double**, or a **double** converted to a **long double**, undergoes no change in value. The range of representable **double** or **long double** values is larger than for **float**, and when converting from the former to the latter if the value is beyond the representable range for **float**, the behavior is undefined. Otherwise if the result cannot be represented exactly, the value is rounded. See [Limits on Floating-Point Constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
+A floating-point value converted to another floating-point type undergoes no change in value if the original value can be represented exactly in the result type. If the original value is numeric but cannot be represented exactly, the result will be either the next greater or next lower repersentable value. See [Limits on Floating-Point Constants](../c-language/limits-on-floating-point-constants.md) for the range of floating-point types.
 
 A floating-point value that is converted to an integral type is first truncated by discarding any fractional value. If this truncated value is representable in the result type the result must be that value. If it cannot, the result value is undefined.
 
 **Microsoft Specific**
 
-Note that the Microsoft VC++ compilers map **long double** to type **double** and **int** to **long**.
+Microsoft VC++ compilers use IEEE-754 binary32 representation for **float** values and binary64 representation for **long double** and **double**. Note that **long double** and **double** use the same representation, and therefore have the same range and precision.
 
-When converting a **double** or **long double** floating-point number to a **float**, the result is rounded according to the floating-point environment controls, which default to “round to nearest, ties to even”. If a numeric value is too high or too low to be represented in the result type, the result will be positive or negative infinity according to the sign of the original value, and an overflow exception will be raised if enabled.
+When converting a **double** or **long double** floating-point number to a **float**, the result is rounded according to the floating-point environment controls, which default to “round to nearest, ties to even”. If a numeric value is too high or too low to be represented as a numeric **float** value, the conversion result will be positive or negative infinity according to the sign of the original value, and an overflow exception will be raised if enabled.
 
 When converting to integer types, the result of a conversion to a type smaller than **long** is the result of converting the value to **long** and then converting to the result type. 
 
-For integer types at least as large as **long**, a conversion of a value that is too high or too low to represent in the result type may return any the following values:
+For conversion to integer types at least as large as **long**, a conversion of a value that is too high or too low to represent in the result type may return any the following values:
 - The result may be a sentinel value which is the representable value farthest from zero. For signed types this is the lowest representable value (0x800…0). For unsigned types this is the highest representable value (0xFF…F).
 - The result may be saturated so that too high values are converted to the highest representable value and too low values are converted to the lowest representable value. Note that one of these two values is also used as the sentinel value.
 - For conversion to **unsigned long** or **unsigned long long**, the result of converting an out of range value may be some value other than the highest or lowest representable value, depending on compiler options and target architecture. Future compiler releases may return a saturated or sentinel value instead.

--- a/docs/c-language/conversions-from-signed-integral-types.md
+++ b/docs/c-language/conversions-from-signed-integral-types.md
@@ -6,7 +6,9 @@ ms.assetid: 5eea32f8-8b14-413d-acac-c063b3d118d7
 ---
 # Conversions from Signed Integral Types
 
-When a signed integer is converted to an unsigned integer with equal or greater size and the value of the signed integer is not negative, the value is unchanged. The conversion is made by sign-extending the signed integer. A signed integer is converted to a shorter signed integer by truncating the high-order bits. The result is interpreted as an unsigned value, as shown in this example.
+When a signed integer is converted to an integer or floating-point type, if the original value is representable in the result type the value is unchanged.
+
+When converting a signed integer to an integer of greater size, the value is sign-extended. When converting to an integer of smaller size the high-order bits are truncated. The result is interpreted using the result type, as shown in this example.
 
 ```C
 int i = -3;
@@ -16,9 +18,11 @@ u = i;
 printf_s( "%hu\n", u );  // Prints 65533
 ```
 
-No information is lost when a signed integer is converted to a floating value, except that some precision may be lost when a **long int** or **unsigned long int** value is converted to a **float** value.
+When a signed integer is converted to a floating-point type that is the same size or smaller than the original type, if the value is not representable in the result type, the result will be either the next higher or next lower representable value.
 
-The following table summarizes conversions from signed integral types. This table assumes that the **char** type is signed by default. If you use a compile-time option to change the default for the **char** type to unsigned, the conversions given in the [Conversions from Unsigned Integral Types](../c-language/conversions-from-unsigned-integral-types.md) table for the **unsigned char** type apply instead of the conversions in the following table, Conversions from Signed Integral Types.
+See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
+
+The following table summarizes conversions from signed integral types. This table assumes that the **char** type is signed by default. If you use a compile-time option to change the default for the **char** type to unsigned, the conversions given in the [Conversions from Unsigned Integral Types](../c-language/conversions-from-unsigned-integral-types.md) table for the **unsigned char** type apply instead of the conversions in the following table.
 
 ### Conversions from Signed Integral Types
 
@@ -26,34 +30,50 @@ The following table summarizes conversions from signed integral types. This tabl
 |----------|--------|------------|
 |**char**1|**short**|Sign-extend|
 |**char**|**long**|Sign-extend|
+|**char**|**long long**|Sign-extend|
 |**char**|**unsigned char**|Preserve pattern; high-order bit loses function as sign bit|
 |**char**|**unsigned short**|Sign-extend to **short**; convert **short** to **unsigned short**|
 |**char**|**unsigned long**|Sign-extend to **long**; convert **long** to **unsigned long**|
+|**char**|**unsigned long long**|Sign-extend to **long long**; convert **long long** to **unsigned long long**|
 |**char**|**float**|Sign-extend to **long**; convert **long** to **float**|
 |**char**|**double**|Sign-extend to **long**; convert **long** to **double**|
 |**char**|**long double**|Sign-extend to **long**; convert **long** to **double**|
 |**short**|**char**|Preserve low-order byte|
 |**short**|**long**|Sign-extend|
+|**short**|**long long**|Sign-extend|
 |**short**|**unsigned char**|Preserve low-order byte|
 |**short**|**unsigned short**|Preserve bit pattern; high-order bit loses function as sign bit|
 |**short**|**unsigned long**|Sign-extend to **long**; convert **long** to **unsigned long**|
+|**short**|**unsigned long long**|Sign-extend to **long long**; convert **long long** to **unsigned long long**|
 |**short**|**float**|Sign-extend to **long**; convert **long** to **float**|
 |**short**|**double**|Sign-extend to **long**; convert **long** to **double**|
 |**short**|**long double**|Sign-extend to **long**; convert **long** to **double**|
 |**long**|**char**|Preserve low-order byte|
 |**long**|**short**|Preserve low-order word|
+|**long**|**long long**|Sign-extend|
 |**long**|**unsigned char**|Preserve low-order byte|
 |**long**|**unsigned short**|Preserve low-order word|
 |**long**|**unsigned long**|Preserve bit pattern; high-order bit loses function as sign bit|
+|**long**|**unsigned long long**|Sign-extend to **long long**; convert **long long** to **unsigned long long**|
 |**long**|**float**|Represent as **float**. If **long** cannot be represented exactly, some precision is lost.|
 |**long**|**double**|Represent as **double**. If **long** cannot be represented exactly as a **double**, some precision is lost.|
 |**long**|**long double**|Represent as **double**. If **long** cannot be represented exactly as a **double**, some precision is lost.|
+|**long long**|**char**|Preserve low-order byte|
+|**long long**|**short**|Preserve low-order word|
+|**long long**|**long**|Preserve low-order dword|
+|**long long**|**unsigned char**|Preserve low-order byte|
+|**long long**|**unsigned short**|Preserve low-order word|
+|**long long**|**unsigned long**|Preserve low-order dword|
+|**long long**|**unsigned long long**|Preserve bit pattern; high-order bit loses function as sign bit|
+|**long long**|**float**|Represent as **float**. If **long long** cannot be represented exactly, some precision is lost.|
+|**long long**|**double**|Represent as **double**. If **long long** cannot be represented exactly as a **double**, some precision is lost.|
+|**long long**|**long double**|Represent as **double**. If **long long** cannot be represented exactly as a **double**, some precision is lost.|
 
 1. All **char** entries assume that the **char** type is signed by default.
 
 **Microsoft Specific**
 
-For the Microsoft 32-bit C compiler, an integer is equivalent to a **long**. Conversion of an **int** value proceeds the same as for a **long**.
+For the Microsoft 32-bit C compiler, an **int** is equivalent to a **long**. Conversion of an **int** value proceeds the same as for a **long**. Similarly, **unsigned** or **unsigned int** is equivalent to **unsigned long**.
 
 **END Microsoft Specific**
 

--- a/docs/c-language/conversions-from-signed-integral-types.md
+++ b/docs/c-language/conversions-from-signed-integral-types.md
@@ -18,7 +18,7 @@ u = i;
 printf_s( "%hu\n", u );  // Prints 65533
 ```
 
-When a signed integer is converted to a floating-point type that is the same size or smaller than the original type, if the value is not representable in the result type, the result will be either the next higher or next lower representable value.
+When converting a signed integer to a floating-point type, if the original value cannot be represented exactly in the result type, the result will be the next higher or lower representable value.
 
 See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
 
@@ -73,7 +73,7 @@ The following table summarizes conversions from signed integral types. This tabl
 
 **Microsoft Specific**
 
-For the Microsoft 32-bit C compiler, an **int** is equivalent to a **long**. Conversion of an **int** value proceeds the same as for a **long**. Similarly, **unsigned** or **unsigned int** is equivalent to **unsigned long**.
+For the Microsoft 32-bit C compiler, an **int** is equivalent to a **long**; conversion of an **int** value proceeds the same as for a **long**.
 
 **END Microsoft Specific**
 

--- a/docs/c-language/conversions-from-signed-integral-types.md
+++ b/docs/c-language/conversions-from-signed-integral-types.md
@@ -1,14 +1,14 @@
 ---
-title: "Conversions from Signed Integral Types"
+title: "Conversions from signed integral types"
 ms.date: "10/02/2019"
 helpviewer_keywords: ["integral conversions, from signed", "integers, converting", "conversions [C++], integral", "data type conversion [C++], signed and unsigned integers", "type conversion [C++], signed and unsigned integers"]
 ms.assetid: 5eea32f8-8b14-413d-acac-c063b3d118d7
 ---
-# Conversions from Signed Integral Types
+# Conversions from signed integral types
 
-When a signed integer is converted to an integer or floating-point type, if the original value is representable in the result type the value is unchanged.
+When a signed integer is converted to an integer or a floating-point type, if the original value is representable in the result type, the value is unchanged.
 
-When converting a signed integer to an integer of greater size, the value is sign-extended. When converting to an integer of smaller size the high-order bits are truncated. The result is interpreted using the result type, as shown in this example.
+When a signed integer is converted to an integer of greater size, the value is sign-extended. When converted to an integer of smaller size, the high-order bits are truncated. The result is interpreted using the result type, as shown in this example:
 
 ```C
 int i = -3;
@@ -18,13 +18,13 @@ u = i;
 printf_s( "%hu\n", u );  // Prints 65533
 ```
 
-When converting a signed integer to a floating-point type, if the original value cannot be represented exactly in the result type, the result will be the next higher or lower representable value.
+When converting a signed integer to a floating-point type, if the original value can't be represented exactly in the result type, the result will be the next higher or lower representable value.
 
-See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
+See [Storage of basic types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
 
-The following table summarizes conversions from signed integral types. This table assumes that the **char** type is signed by default. If you use a compile-time option to change the default for the **char** type to unsigned, the conversions given in the [Conversions from Unsigned Integral Types](../c-language/conversions-from-unsigned-integral-types.md) table for the **unsigned char** type apply instead of the conversions in the following table.
+The following table summarizes conversions from signed integral types. This table assumes that the **char** type is signed by default. If you use a compile-time option to change the default for the **char** type to unsigned, the conversions given in the [Conversions from unsigned integral types](../c-language/conversions-from-unsigned-integral-types.md) table for the **unsigned char** type apply, instead of the conversions in the following table.
 
-### Conversions from Signed Integral Types
+## Table of conversions from signed integral types
 
 |From|To|Method|
 |----------|--------|------------|
@@ -55,9 +55,9 @@ The following table summarizes conversions from signed integral types. This tabl
 |**long**|**unsigned short**|Preserve low-order word|
 |**long**|**unsigned long**|Preserve bit pattern; high-order bit loses function as sign bit|
 |**long**|**unsigned long long**|Sign-extend to **long long**; convert **long long** to **unsigned long long**|
-|**long**|**float**|Represent as **float**. If **long** cannot be represented exactly, some precision is lost.|
-|**long**|**double**|Represent as **double**. If **long** cannot be represented exactly as a **double**, some precision is lost.|
-|**long**|**long double**|Represent as **double**. If **long** cannot be represented exactly as a **double**, some precision is lost.|
+|**long**|**float**|Represent as **float**. If **long** can't be represented exactly, some precision is lost.|
+|**long**|**double**|Represent as **double**. If **long** can't be represented exactly as a **double**, some precision is lost.|
+|**long**|**long double**|Represent as **double**. If **long** can't be represented exactly as a **double**, some precision is lost.|
 |**long long**|**char**|Preserve low-order byte|
 |**long long**|**short**|Preserve low-order word|
 |**long long**|**long**|Preserve low-order dword|
@@ -65,18 +65,18 @@ The following table summarizes conversions from signed integral types. This tabl
 |**long long**|**unsigned short**|Preserve low-order word|
 |**long long**|**unsigned long**|Preserve low-order dword|
 |**long long**|**unsigned long long**|Preserve bit pattern; high-order bit loses function as sign bit|
-|**long long**|**float**|Represent as **float**. If **long long** cannot be represented exactly, some precision is lost.|
-|**long long**|**double**|Represent as **double**. If **long long** cannot be represented exactly as a **double**, some precision is lost.|
-|**long long**|**long double**|Represent as **double**. If **long long** cannot be represented exactly as a **double**, some precision is lost.|
+|**long long**|**float**|Represent as **float**. If **long long** can't be represented exactly, some precision is lost.|
+|**long long**|**double**|Represent as **double**. If **long long** can't be represented exactly as a **double**, some precision is lost.|
+|**long long**|**long double**|Represent as **double**. If **long long** can't be represented exactly as a **double**, some precision is lost.|
 
 1. All **char** entries assume that the **char** type is signed by default.
 
 **Microsoft Specific**
 
-For the Microsoft 32-bit C compiler, an **int** is equivalent to a **long**; conversion of an **int** value proceeds the same as for a **long**.
+For the Microsoft compiler, an **int** is equivalent to a **long**; conversion of an **int** value proceeds the same as for a **long**.
 
 **END Microsoft Specific**
 
 ## See also
 
-[Assignment Conversions](../c-language/assignment-conversions.md)
+[Assignment conversions](../c-language/assignment-conversions.md)

--- a/docs/c-language/conversions-from-signed-integral-types.md
+++ b/docs/c-language/conversions-from-signed-integral-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Conversions from Signed Integral Types"
-ms.date: "11/04/2016"
+ms.date: "10/02/2019"
 helpviewer_keywords: ["integral conversions, from signed", "integers, converting", "conversions [C++], integral", "data type conversion [C++], signed and unsigned integers", "type conversion [C++], signed and unsigned integers"]
 ms.assetid: 5eea32f8-8b14-413d-acac-c063b3d118d7
 ---

--- a/docs/c-language/conversions-from-unsigned-integral-types.md
+++ b/docs/c-language/conversions-from-unsigned-integral-types.md
@@ -1,14 +1,14 @@
 ---
-title: "Conversions from Unsigned Integral Types"
+title: "Conversions from unsigned integral types"
 ms.date: "10/02/2019"
 helpviewer_keywords: ["integers, converting", "type casts, involving integers", "data type conversion [C++], signed and unsigned integers", "type conversion [C++], signed and unsigned integers", "integral conversions, from unsigned"]
 ms.assetid: 60fb7e10-bff9-4a13-8a48-e19f25a36a02
 ---
-# Conversions from Unsigned Integral Types
+# Conversions from unsigned integral types
 
 When an unsigned integer is converted to an integer or floating-point type, if the original value is representable in the result type the value is unchanged.
 
-When converting an unsigned integer to an integer of greater size, the value is zero-extended. When converting to an integer of smaller size the high-order bits are truncated. The result is interpreted using the result type, as shown in this example.
+When converting an unsigned integer to an integer of greater size, the value is zero-extended. When converting to an integer of smaller size, the high-order bits are truncated. The result is interpreted using the result type, as shown in this example.
 
 ```C
 unsigned k = 65533;
@@ -18,13 +18,13 @@ j = k;
 printf_s( "%hd\n", j );   // Prints -3
 ```
 
-When converting an unsigned integer to a floating-point type, if the original value cannot be represented exactly in the result type, the result will be the next higher or lower representable value.
+When converting an unsigned integer to a floating-point type, if the original value can't be represented exactly in the result type, the result will be the next higher or lower representable value.
 
-See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
+See [Storage of basic types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
 
 The following table summarizes conversions from unsigned integral types.
 
-## Conversions from unsigned integral types table
+## Table of conversions from unsigned integral types
 
 |From|To|Method|
 |----------|--------|------------|
@@ -71,10 +71,10 @@ The following table summarizes conversions from unsigned integral types.
 
 **Microsoft Specific**
 
-For the Microsoft C compiler, the **unsigned** or **unsigned int** type is equivalent to the **unsigned long** type; conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**.
+For the Microsoft compiler, the **unsigned** or **unsigned int** type is equivalent to the **unsigned long** type. Conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**.
 
 **END Microsoft Specific**
 
 ## See also
 
-[Assignment Conversions](../c-language/assignment-conversions.md)
+[Assignment conversions](../c-language/assignment-conversions.md)

--- a/docs/c-language/conversions-from-unsigned-integral-types.md
+++ b/docs/c-language/conversions-from-unsigned-integral-types.md
@@ -18,7 +18,7 @@ j = k;
 printf_s( "%hd\n", j );   // Prints -3
 ```
 
-When an unsigned integer is converted to a floating-point type that is the same size or smaller than the original type, if the value is not representable in the result type, the result will be either the next higher or next lower representable value.
+When converting an unsigned integer to a floating-point type, if the original value cannot be represented exactly in the result type, the result will be the next higher or lower representable value.
 
 See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
 
@@ -71,7 +71,7 @@ The following table summarizes conversions from unsigned integral types.
 
 **Microsoft Specific**
 
-For the Microsoft C compiler, the **unsigned** or **unsigned int** type is equivalent to the **unsigned long** type. Conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**.
+For the Microsoft C compiler, the **unsigned** or **unsigned int** type is equivalent to the **unsigned long** type; conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**.
 
 **END Microsoft Specific**
 

--- a/docs/c-language/conversions-from-unsigned-integral-types.md
+++ b/docs/c-language/conversions-from-unsigned-integral-types.md
@@ -6,21 +6,21 @@ ms.assetid: 60fb7e10-bff9-4a13-8a48-e19f25a36a02
 ---
 # Conversions from Unsigned Integral Types
 
-An unsigned integer is converted to a shorter unsigned or signed integer by truncating the high-order bits, or to a longer unsigned or signed integer by zero-extending. For more information, see the [Conversions from unsigned integral types table](#conversions-from-unsigned-integral-types-table).
+When an unsigned integer is converted to an integer or floating-point type, if the original value is representable in the result type the value is unchanged.
 
-When the value with integral type is demoted to a signed integer with smaller size, or an unsigned integer is converted to its corresponding signed integer, the value is unchanged if it can be represented in the new type. However, the value it represents changes if the sign bit is set, as in the following example.
+When converting an unsigned integer to an integer of greater size, the value is zero-extended. When converting to an integer of smaller size the high-order bits are truncated. The result is interpreted using the result type, as shown in this example.
 
 ```C
-int j;
-unsigned short k = 65533;
+unsigned k = 65533;
+short j;
 
 j = k;
 printf_s( "%hd\n", j );   // Prints -3
 ```
 
-If it cannot be represented, the result is implementation-defined. See [Type-Cast Conversions](../c-language/type-cast-conversions.md) for information on the Microsoft C compiler's handling of demotion of integers. The same behavior results from integer conversion or from type casting the integer.
+When an unsigned integer is converted to a floating-point type that is the same size or smaller than the original type, if the value is not representable in the result type, the result will be either the next higher or next lower representable value.
 
-Unsigned values are converted in a way that preserves their value and is not representable directly in C. The only exception is a conversion from **unsigned long** to **float**, which loses at most the low-order bits. Otherwise, value is preserved, signed or unsigned. When a value of integral type is converted to floating, and the value is outside the range representable, the result is undefined. (See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the range for integral and floating-point types.)
+See [Storage of Basic Types](../c-language/storage-of-basic-types.md) for information about the sizes of integral and floating-point types.
 
 The following table summarizes conversions from unsigned integral types.
 
@@ -31,31 +31,47 @@ The following table summarizes conversions from unsigned integral types.
 |**unsigned char**|**char**|Preserve bit pattern; high-order bit becomes sign bit|
 |**unsigned char**|**short**|Zero-extend|
 |**unsigned char**|**long**|Zero-extend|
+|**unsigned char**|**long long**|Zero-extend|
 |**unsigned char**|**unsigned short**|Zero-extend|
 |**unsigned char**|**unsigned long**|Zero-extend|
+|**unsigned char**|**unsigned long long**|Zero-extend|
 |**unsigned char**|**float**|Convert to **long**; convert **long** to **float**|
 |**unsigned char**|**double**|Convert to **long**; convert **long** to **double**|
 |**unsigned char**|**long double**|Convert to **long**; convert **long** to **double**|
 |**unsigned short**|**char**|Preserve low-order byte|
 |**unsigned short**|**short**|Preserve bit pattern; high-order bit becomes sign bit|
 |**unsigned short**|**long**|Zero-extend|
+|**unsigned short**|**long long**|Zero-extend|
 |**unsigned short**|**unsigned char**|Preserve low-order byte|
 |**unsigned short**|**unsigned long**|Zero-extend|
+|**unsigned short**|**unsigned long long**|Zero-extend|
 |**unsigned short**|**float**|Convert to **long**; convert **long** to **float**|
 |**unsigned short**|**double**|Convert to **long**; convert **long** to **double**|
 |**unsigned short**|**long double**|Convert to **long**; convert **long** to **double**|
 |**unsigned long**|**char**|Preserve low-order byte|
 |**unsigned long**|**short**|Preserve low-order word|
 |**unsigned long**|**long**|Preserve bit pattern; high-order bit becomes sign bit|
+|**unsigned long**|**long long**|Zero-extend|
 |**unsigned long**|**unsigned char**|Preserve low-order byte|
 |**unsigned long**|**unsigned short**|Preserve low-order word|
+|**unsigned long**|**unsigned long long**|Zero-extend|
 |**unsigned long**|**float**|Convert to **long**; convert **long** to **float**|
 |**unsigned long**|**double**|Convert directly to **double**|
 |**unsigned long**|**long double**|Convert to **long**; convert **long** to **double**|
+|**unsigned long long**|**char**|Preserve low-order byte|
+|**unsigned long long**|**short**|Preserve low-order word|
+|**unsigned long long**|**long**|Preserve low-order dword|
+|**unsigned long long**|**long long**|Preserve bit pattern; high-order bit becomes sign bit|
+|**unsigned long long**|**unsigned char**|Preserve low-order byte|
+|**unsigned long long**|**unsigned short**|Preserve low-order word|
+|**unsigned long long**|**unsigned long**|Preserve low-order dword|
+|**unsigned long long**|**float**|Convert to **long**; convert **long** to **float**|
+|**unsigned long long**|**double**|Convert directly to **double**|
+|**unsigned long long**|**long double**|Convert to **long**; convert **long** to **double**|
 
 **Microsoft Specific**
 
-For the Microsoft C compiler, the **unsigned int** type is equivalent to the **unsigned long** type. Conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**. Conversions from **unsigned long** values to **float** are not accurate if the value being converted is larger than the maximum positive signed **long** value.
+For the Microsoft C compiler, the **unsigned** or **unsigned int** type is equivalent to the **unsigned long** type. Conversion of an **unsigned int** value proceeds in the same way as conversion of an **unsigned long**.
 
 **END Microsoft Specific**
 

--- a/docs/c-language/conversions-from-unsigned-integral-types.md
+++ b/docs/c-language/conversions-from-unsigned-integral-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Conversions from Unsigned Integral Types"
-ms.date: "03/27/2019"
+ms.date: "10/02/2019"
 helpviewer_keywords: ["integers, converting", "type casts, involving integers", "data type conversion [C++], signed and unsigned integers", "type conversion [C++], signed and unsigned integers", "integral conversions, from unsigned"]
 ms.assetid: 60fb7e10-bff9-4a13-8a48-e19f25a36a02
 ---

--- a/docs/c-language/storage-of-basic-types.md
+++ b/docs/c-language/storage-of-basic-types.md
@@ -1,14 +1,14 @@
 ---
-title: "Storage of Basic Types"
+title: "Storage of basic types"
 ms.date: "10/02/2019"
 helpviewer_keywords: ["specifiers [C++], type", "integral types, storage", "storage [C++], types", "floating-point numbers, storage", "type specifiers [C++], sizes", "arithmetic operations [C++], types", "int data type", "short data type", "signed types [C++], storage", "long double keyword [C], storage", "long keyword [C]", "double data type, storage", "types [C], arithmetic", "integral types", "data types [C], specifiers", "storing types [C++]", "unsigned types [C++], storage", "data types [C], storage"]
 ms.assetid: bd1f33c1-c6b9-4558-8a72-afb21aef3318
 ---
-# Storage of Basic Types
+# Storage of basic types
 
 The following table summarizes the storage associated with each basic type.
 
-### Sizes of Fundamental Types
+## Sizes of fundamental types
 
 |Type|Storage|
 |----------|-------------|
@@ -25,4 +25,4 @@ The C data types fall into general categories. The "integral types" include **ch
 
 ## See also
 
-[Declarations and Types](../c-language/declarations-and-types.md)
+[Declarations and types](../c-language/declarations-and-types.md)

--- a/docs/c-language/storage-of-basic-types.md
+++ b/docs/c-language/storage-of-basic-types.md
@@ -12,15 +12,16 @@ The following table summarizes the storage associated with each basic type.
 
 |Type|Storage|
 |----------|-------------|
-|`char`, `unsigned char`, **signed char**|1 byte|
+|**char**, **unsigned char**, **signed char**|1 byte|
 |**short**, **unsigned short**|2 bytes|
-|`int`, `unsigned int`|4 bytes|
-|**long**, `unsigned long`|4 bytes|
+|**int**, **unsigned int**|4 bytes|
+|**long**, **unsigned long**|4 bytes|
+|**long long**, **unsigned long long**|8 bytes|
 |**float**|4 bytes|
 |**double**|8 bytes|
-|`long double`|8 bytes|
+|**long double**|8 bytes|
 
-The C data types fall into general categories. The "integral types" include `char`, `int`, **short**, **long**, **signed**, `unsigned`, and `enum`. The "floating types" include **float**, **double**, and `long double`. The "arithmetic types" include all floating and integral types.
+The C data types fall into general categories. The "integral types" include **char**, **int**, **short**, **long**, **signed**, **unsigned**, and **enum**. The "floating types" include **float**, **double**, and **long double**. The "arithmetic types" include all floating and integral types.
 
 ## See also
 

--- a/docs/c-language/storage-of-basic-types.md
+++ b/docs/c-language/storage-of-basic-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Storage of Basic Types"
-ms.date: "11/04/2016"
+ms.date: "10/02/2019"
 helpviewer_keywords: ["specifiers [C++], type", "integral types, storage", "storage [C++], types", "floating-point numbers, storage", "type specifiers [C++], sizes", "arithmetic operations [C++], types", "int data type", "short data type", "signed types [C++], storage", "long double keyword [C], storage", "long keyword [C]", "double data type, storage", "types [C], arithmetic", "integral types", "data types [C], specifiers", "storing types [C++]", "unsigned types [C++], storage", "data types [C], storage"]
 ms.assetid: bd1f33c1-c6b9-4558-8a72-afb21aef3318
 ---

--- a/docs/cpp/standard-conversions.md
+++ b/docs/cpp/standard-conversions.md
@@ -130,7 +130,7 @@ The maximum value representable by type **float** is 3.402823466E38 — a much s
 
 Certain expressions can cause objects of floating type to be converted to integral types, or vice versa. When an object of integral type is converted to a floating type and the original value cannot be represented exactly, the result is either the next higher or the next lower representable value.
 
-When an object of floating type is converted to an integral type, the fractional part is truncated. No rounding takes place in the conversion process. Truncation means that a number like 1.3 is converted to 1, and -1.3 is converted to -1. If the truncated value is higher than the highest representable value or lower than the lowest representable value, the result is undefined.
+When an object of floating type is converted to an integral type, the fractional part is truncated (round toward zero). Truncation means that a number like 1.3 is converted to 1, and -1.3 is converted to -1. If the truncated value is higher than the highest representable value or lower than the lowest representable value, the result is undefined.
 
 ## Arithmetic conversions
 

--- a/docs/cpp/standard-conversions.md
+++ b/docs/cpp/standard-conversions.md
@@ -1,10 +1,10 @@
 ---
-title: "Standard Conversions"
+title: "Standard conversions"
 ms.date: "10/02/2019"
 helpviewer_keywords: ["standard conversions, categories of", "L-values [C++]", "conversions, standard"]
 ms.assetid: ce7ac8d3-5c99-4674-8229-0672de05528d
 ---
-# Standard Conversions
+# Standard conversions
 
 The C++ language defines conversions between its fundamental types. It also defines conversions for pointer, reference, and pointer-to-member derived types. These conversions are called *standard conversions*.
 
@@ -26,8 +26,8 @@ This section discusses the following standard conversions:
 
 - Pointer-to-member conversions
 
-    > [!NOTE]
-    >  User-defined types can specify their own conversions. Conversion of user-defined types is covered in [Constructors](../cpp/constructors-cpp.md) and [Conversions](../cpp/user-defined-type-conversions-cpp.md).
+  > [!NOTE]
+  > User-defined types can specify their own conversions. Conversion of user-defined types is covered in [Constructors](../cpp/constructors-cpp.md) and [Conversions](../cpp/user-defined-type-conversions-cpp.md).
 
 The following code causes conversions (in this example, integral promotions):
 
@@ -42,11 +42,11 @@ long_num1 = int_num;
 long_num2 = int_num * long_num2;
 ```
 
-The result of a conversion is an l-value only if it produces a reference type. For example, a user-defined conversion declared as `operator int&()` returns a reference and is an l-value. However, a conversion declared as `operator int()`returns an object and is not an l-value.
+The result of a conversion is an l-value only if it produces a reference type. For example, a user-defined conversion declared as `operator int&()` returns a reference and is an l-value. However, a conversion declared as `operator int()` returns an object and isn't an l-value.
 
 ## Integral promotions
 
-Objects of an integral type can be converted to another wider integral type (that is, a type that can represent a larger set of values). This widening type of conversion is called "integral promotion." With integral promotion, you can use the following in an expression wherever another integral type can be used:
+Objects of an integral type can be converted to another wider integral type, that is, a type that can represent a larger set of values. This widening type of conversion is called "integral promotion." With integral promotion, you can use the following types in an expression wherever another integral type can be used:
 
 - Objects, literals, and constants of type **char** and **short int**
 
@@ -56,9 +56,9 @@ Objects of an integral type can be converted to another wider integral type (tha
 
 - Enumerators
 
-C++ promotions are "value-preserving." That is, the value after the promotion is guaranteed to be the same as the value before the promotion. In value-preserving promotions, objects of shorter integral types (such as bit fields or objects of type **char**) are promoted to type **int** if **int** can represent the full range of the original type. If **int** cannot represent the full range of values, then the object is promoted to type **unsigned int**. Although this strategy is the same as that used by ANSI C, value-preserving conversions do not preserve the "signedness" of the object.
+C++ promotions are "value-preserving"; the value after the promotion is guaranteed to be the same as the value before the promotion. In value-preserving promotions, objects of shorter integral types (such as bit fields or objects of type **char**) are promoted to type **int** if **int** can represent the full range of the original type. If **int** can't represent the full range of values, then the object is promoted to type **unsigned int**. Although this strategy is the same as the one used by the C standard, value-preserving conversions don't preserve the "signedness" of the object.
 
-Value-preserving promotions and promotions that preserve signedness normally produce the same results. However, they can produce different results if the promoted object is one of the following:
+Value-preserving promotions and promotions that preserve signedness normally produce the same results. However, they can produce different results if the promoted object is one of the following operands:
 
 - An operand of **/**, `%`, `/=`, `%=`, **<**, **\<=**, **>**, or **>=**
 
@@ -74,9 +74,9 @@ Value-preserving promotions and promotions that preserve signedness normally pro
 
 Integral conversions are performed between integral types. The integral types are **char**, **int**, and **long** (and the **short**, **signed**, and **unsigned** versions of these types).
 
-**Signed to unsigned**
+### Signed to unsigned
 
-Objects of signed integral types can be converted to corresponding unsigned types. When these conversions occur, the actual bit pattern does not change; however, the interpretation of the data changes. Consider this code:
+Objects of signed integral types can be converted to corresponding unsigned types. When these conversions occur, the actual bit pattern doesn't change; however, the interpretation of the data changes. Consider this code:
 
 ```cpp
 #include <iostream>
@@ -92,9 +92,9 @@ int main()
 // Output: 65533
 ```
 
-In the preceding example, a **signed short**, `i`, is defined and initialized to a negative number. The expression `(u = i)` causes `i` to be converted to an **unsigned short** prior to the assignment to `u`.
+In the preceding example, a **signed short**, `i`, is defined and initialized to a negative number. The expression `(u = i)` causes `i` to be converted to an **unsigned short** before the assignment to `u`.
 
-**Unsigned to signed**
+### Unsigned to signed
 
 Objects of unsigned integral types can be converted to corresponding signed types. However, such a conversion can cause misinterpretation of data if the value of the unsigned object is outside the range representable by the signed type, as demonstrated in the following example:
 
@@ -112,13 +112,13 @@ cout << (i = u) << "\n";
 //Output: -3
 ```
 
-In the preceding example, `u` is an **unsigned short** integral object that must be converted to a signed quantity to evaluate the expression `(i = u)`. Because its value cannot be properly represented in a **signed short**, the data is misinterpreted as shown.
+In the preceding example, `u` is an **unsigned short** integral object that must be converted to a signed quantity to evaluate the expression `(i = u)`. Because its value can't be properly represented in a **signed short**, the data is misinterpreted as shown.
 
 ## Floating point conversions
 
 An object of a floating type can be safely converted to a more precise floating type — that is, the conversion causes no loss of significance. For example, conversions from **float** to **double** or from **double** to **long double** are safe, and the value is unchanged.
 
-An object of a floating type can also be converted to a less precise type, if it is in a range representable by that type. (See [Floating Limits](../cpp/floating-limits.md) for the ranges of floating types.) If the original value cannot be represented precisely, it can be converted to either the next higher or the next lower representable value. If no such value exists, the result is undefined. Consider the following example:
+An object of a floating type can also be converted to a less precise type, if it is in a range representable by that type. (See [Floating Limits](../cpp/floating-limits.md) for the ranges of floating types.) If the original value can't be represented precisely, it can be converted to either the next higher or the next lower representable value. If no such value exists, the result is undefined. Consider the following example:
 
 ```cpp
 cout << (float)1E300 << endl;
@@ -128,7 +128,7 @@ The maximum value representable by type **float** is 3.402823466E38 — a much s
 
 ## Conversions between integral and floating point types
 
-Certain expressions can cause objects of floating type to be converted to integral types, or vice versa. When an object of integral type is converted to a floating type and the original value cannot be represented exactly, the result is either the next higher or the next lower representable value.
+Certain expressions can cause objects of floating type to be converted to integral types, or vice versa. When an object of integral type is converted to a floating type and the original value can't be represented exactly, the result is either the next higher or the next lower representable value.
 
 When an object of floating type is converted to an integral type, the fractional part is truncated (round toward zero). Truncation means that a number like 1.3 is converted to 1, and -1.3 is converted to -1. If the truncated value is higher than the highest representable value or lower than the lowest representable value, the result is undefined.
 
@@ -136,7 +136,7 @@ When an object of floating type is converted to an integral type, the fractional
 
 Many binary operators (discussed in [Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)) cause conversions of operands and yield results the same way. The way these operators cause conversions is called "usual arithmetic conversions." Arithmetic conversions of operands of different native types are performed as shown in the following table. Typedef types behave according to their underlying native types.
 
-### Conditions for Type Conversion
+### Conditions for type conversion
 
 |Conditions Met|Conversion|
 |--------------------|----------------|
@@ -185,7 +185,7 @@ Inheritance Graph for Illustration of Base-Class Accessibility
 
 The following table shows the base-class accessibility for the situation illustrated in the figure.
 
-### Base-Class Accessibility
+### Base-class accessibility
 
 |Type of Function|Derivation|Conversion from<br /><br /> B* to A\* Legal?|
 |----------------------|----------------|-------------------------------------------|
@@ -249,7 +249,7 @@ A pointer to any object that is not **const** or **volatile** can be implicitly 
 C++ does not supply a standard conversion from a **const** or **volatile** type to a type that is not **const** or **volatile**. However, any sort of conversion can be specified using explicit type casts (including conversions that are unsafe).
 
 > [!NOTE]
->  C++ pointers to members, except pointers to static members, are different from normal pointers and do not have the same standard conversions. Pointers to static members are normal pointers and have the same conversions as normal pointers.
+>  C++ pointers to members, except pointers to static members, are different from normal pointers and don't have the same standard conversions. Pointers to static members are normal pointers and have the same conversions as normal pointers.
 
 ### null pointer conversions
 
@@ -322,4 +322,4 @@ int main()
 
 ## See also
 
-[C++ Language Reference](../cpp/cpp-language-reference.md)
+[C++ language reference](../cpp/cpp-language-reference.md)

--- a/docs/cpp/standard-conversions.md
+++ b/docs/cpp/standard-conversions.md
@@ -130,7 +130,7 @@ The maximum value representable by type **float** is 3.402823466E38 — a much s
 
 Certain expressions can cause objects of floating type to be converted to integral types, or vice versa. When an object of integral type is converted to a floating type and the original value cannot be represented exactly, the result is either the next higher or the next lower representable value.
 
-When an object of floating type is converted to an integral type, the fractional part is truncated. No rounding takes place in the conversion process. Truncation means that a number like 1.3 is converted to 1, and -1.3 is converted to -1.
+When an object of floating type is converted to an integral type, the fractional part is truncated. No rounding takes place in the conversion process. Truncation means that a number like 1.3 is converted to 1, and -1.3 is converted to -1. If the truncated value is higher than the highest representable value or lower than the lowest representable value, the result is undefined.
 
 ## Arithmetic conversions
 

--- a/docs/cpp/standard-conversions.md
+++ b/docs/cpp/standard-conversions.md
@@ -1,6 +1,6 @@
 ---
 title: "Standard Conversions"
-ms.date: "11/19/2018"
+ms.date: "10/02/2019"
 helpviewer_keywords: ["standard conversions, categories of", "L-values [C++]", "conversions, standard"]
 ms.assetid: ce7ac8d3-5c99-4674-8229-0672de05528d
 ---


### PR DESCRIPTION
Correct numerous obsolete or inaccurate statements about numeric conversions, add **long long** types, and add explanation for the results of converting FP values to integer type.

The principal changes are for "Conversions from floating-point types". In particular, conversions to **unsigned long**, **long long**, or **unsigned long long** have worked correctly for many releases of Visual Studio. Because AVX-512 introduced conversion instructions for unsigned integers, VS2019 revised the behavior of conversion to **unsigned long** and **unsigned long long** on x86 to match. The Intel Architecture (IA) floating-point to integer conversion instructions return sentinel values as indicated. (ARM floating-point to integer conversion instructions return saturated values.)

"Conversions from Signed Integral Types" was clarified to indicate that when converting to a signed or unsigned integer type, the source value is sign-extended or truncated to the size of the result, and the resulting bits are interpreted using the destination type. For conversion to floating-point I replaced the ambiguous (and somewhat incorrect) statement that some precision may be lost when converting to **float**, with the more specific statement that if the result cannot be represented exactly the result will be the next higher or lower representable value. I also added a reference to Storage of Basic Types for size information. I removed a redundant reference to the name of the table as it should not be ambiguous.

"Conversions from Unsigned Integral Types" was similarly clarified and reconciled with the signed integer conversion page. The example code as shown is incorrect; I provided a correction. I am not certain that this is the best illustration of the point, but at least the revised version should work correctly. I removed the inaccurate statement that conversions to **float** are not accurate if the value being converted is larger than the maximum positive signed value. Conversions to floating-point have been accurate with any unsigned value for quite a while.

"Storage of Basic Types" was reconciled so that the names of all types are in bold, rather than some being in bold and others in monospaced typeface.

"Standard Conversions" was changed to say that truncation means rounding toward zero, rather than saying no rounding takes place. A statement about out-of-range values was added to make the description more complete.