### PR TITLE
Short description is wrong/misleading

### DIFF
--- a/docs/standard-library/is-move-constructible-class.md
+++ b/docs/standard-library/is-move-constructible-class.md
@@ -1,11 +1,11 @@
 ---
-title: "is_move_constructible Class"
-ms.date: "11/04/2016"
+title: "is_move_constructible class"
+ms.date: "10/24/2019"
 f1_keywords: ["type_traits/std::is_move_constructible"]
 helpviewer_keywords: ["is_move_constructible"]
 ms.assetid: becdf076-7419-488d-a335-78adf2478b9b
 ---
-# is_move_constructible Class
+# is_move_constructible class
 
 Tests whether the type can be constructed by using a move operation.
 
@@ -19,12 +19,11 @@ struct is_move_constructible;
 ### Parameters
 
 *T*\
-The type to be evaluated
+The type to be evaluated.
 
 ## Remarks
 
-A type predicate that evaluates to true if the type *T* can be constructed by using a move operation. This predicate is equivalent to `is_constructible<T, T&&>`.\
-Note: A type *T* without a move constructor, but with a copy constructor that accepts a `const T&` argument, satisfies `std::is_move_constructible`.
+A type predicate that evaluates to **true** if the type *T* can be constructed by using a move operation. This predicate is equivalent to `is_constructible<T, T&&>`. A type *T* that doesn't have a move constructor, but does have a copy constructor that accepts a `const T&` argument, satisfies `std::is_move_constructible`.
 
 ## Requirements
 

--- a/docs/standard-library/is-move-constructible-class.md
+++ b/docs/standard-library/is-move-constructible-class.md
@@ -7,7 +7,7 @@ ms.assetid: becdf076-7419-488d-a335-78adf2478b9b
 ---
 # is_move_constructible Class
 
-Tests whether the type has a move constructor.
+Tests whether the type can be constructed by using a move operation.
 
 ## Syntax
 
@@ -23,7 +23,8 @@ The type to be evaluated
 
 ## Remarks
 
-A type predicate that evaluates to true if the type *T* can be constructed by using a move operation. This predicate is equivalent to `is_constructible<T, T&&>`.
+A type predicate that evaluates to true if the type *T* can be constructed by using a move operation. This predicate is equivalent to `is_constructible<T, T&&>`.\
+Note: A type *T* without a move constructor, but with a copy constructor that accepts a `const T&` argument, satisfies `std::is_move_constructible`.
 
 ## Requirements
 


### PR DESCRIPTION
As discussed in https://github.com/MicrosoftDocs/cpp-docs/issues/1650
"Tests whether the type has a move constructor."
That is not true.
As stated on https://en.cppreference.com/w/cpp/types/is_move_constructible:
Types without a move constructor, but with a copy constructor that accepts const T& arguments, satisfy std::is_move_constructible.