### PR TITLE
small grammatical fix

### DIFF
--- a/docs/text/locales-and-code-pages.md
+++ b/docs/text/locales-and-code-pages.md
@@ -12,7 +12,7 @@ The language determines the text and data formatting conventions, while the coun
 
 Different languages might use different code pages. For example, the ANSI code page 1252 is used for English and most European languages, and the ANSI code page 932 is used for Japanese Kanji. Virtually all code pages share the ASCII character set for the lowest 128 characters (0x00 to 0x7F).
 
-Any single-byte code page can be represented in a table (with 256 entries) as a mapping of byte values to characters (including numbers and punctuation marks), or glyphs. Any multibyte code page can also be represented as a very large table (with 64K entries) of double-byte values to characters. In practice, however, it are usually represented as a table for the first 256 (single-byte) characters and as ranges for the double-byte values.
+Any single-byte code page can be represented in a table (with 256 entries) as a mapping of byte values to characters (including numbers and punctuation marks), or glyphs. Any multibyte code page can also be represented as a very large table (with 64K entries) of double-byte values to characters. In practice, however, it is usually represented as a table for the first 256 (single-byte) characters and as ranges for the double-byte values.
 
 For more information about code pages, see [Code Pages](../c-runtime-library/code-pages.md).
 


### PR DESCRIPTION
Changed a sentence from: In practice, however, it are usually represented as a table for the first 256 characters and as ranges for the double-byte values
To: In practice, however, it is usually represented as a table for the first 256 characters and as ranges for the double-byte values