### PR TITLE
Add link to DevCom ticket

### DIFF
--- a/docs/linux/connect-to-your-remote-linux-computer.md
+++ b/docs/linux/connect-to-your-remote-linux-computer.md
@@ -76,7 +76,7 @@ To set up this remote connection:
 
 ## TCP Port Forwarding
 
-Visual Studio's Linux support has a dependency on TCP port forwarding. **Rsync** and **gdbserver** will be affected if TCP port forwarding is disabled on your remote system. 
+Visual Studio's Linux support has a dependency on TCP port forwarding. **Rsync** and **gdbserver** will be affected if TCP port forwarding is disabled on your remote system. If you're impacted by this dependency, you can upvote this [suggestion ticket](https://developercommunity.visualstudio.com/idea/840265/dont-rely-on-ssh-tcp-port-forwarding-for-c-remote.html) on Developer Community.
 
 rsync is used by both MSBuild-based Linux projects and CMake projects to [copy headers from your remote system to Windows for use by IntelliSense](configure-a-linux-project.md#remote_intellisense). When you can't enable TCP port forwarding, disable the automatic download of remote headers. To disable it, use **Tools > Options > Cross Platform > Connection Manager > Remote Headers IntelliSense Manager**. If the remote system doesn't have TCP port forwarding enabled, you'll see this error when the download of remote headers for IntelliSense begins:
 


### PR DESCRIPTION
There is a lot of overlap between customers who have TCP port forwarding disabled, and customers who have a firewall up and don't show up in our telemetry. I've added a link to a DevCom suggestion ticket as a mechanism to determine how widespread and impactful the issue is,