### PR TITLE
Clarify removal of vcpkg directory uninstalls all libraries

### DIFF
--- a/docs/build/vcpkg.md
+++ b/docs/build/vcpkg.md
@@ -176,7 +176,7 @@ You can modify your clone of vcpkg in any way you like. You can create multiple 
 
 ## Uninstall vcpkg
 
-Just delete the directory.
+Just delete the vcpkg directory. This will uninstall the whole vcpkg distribution including all libraries the vcpkg installed.
 
 ## Send feedback about vcpkg
 

--- a/docs/build/vcpkg.md
+++ b/docs/build/vcpkg.md
@@ -176,7 +176,7 @@ You can modify your clone of vcpkg in any way you like. You can create multiple 
 
 ## Uninstall vcpkg
 
-Just delete the vcpkg directory. This will uninstall the whole vcpkg distribution including all libraries the vcpkg installed.
+Just delete the vcpkg directory. Deleting this directory uninstalls the vcpkg distribution, and all the libraries that vcpkg has installed.
 
 ## Send feedback about vcpkg
 


### PR DESCRIPTION
For (new) users of vcpkg, it may be helpful to clarify that removal of the directory actually means deinstallation of all ports and libraries installed by the `vcpkg`.

## References

- [How to remove vcpkg and all libraries installed with vcpkg](https://stackoverflow.com/a/59396543/151641)
