### PR TITLE
Corrected the func definition for vector emplace

### DIFF
--- a/docs/standard-library/vector-class.md
+++ b/docs/standard-library/vector-class.md
@@ -796,16 +796,16 @@ Inserts an element constructed in place into the vector at a specified position.
 ```cpp
 template <class... Types>
 iterator emplace(
-    const_iterator _Where,
-    Types&&... _Args);
+    const_iterator position,
+    Types&&... args);
 ```
 
 ### Parameters
 
-*_Where*\
+*position*\
 The position in the [vector](../standard-library/vector-class.md) where the first element is inserted.
 
-*_Args*\
+*args*\
 Constructor arguments. The function infers which constructor overload to invoke based on the arguments provided.
 
 ### Return Value
@@ -864,12 +864,12 @@ Adds an element constructed in place to the end of the vector.
 
 ```cpp
 template <class... Types>
-void emplace_back(Types&&... _Args);
+void emplace_back(Types&&... args);
 ```
 
 ### Parameters
 
-*_Args*\
+*args*\
 Constructor arguments. The function infers which constructor overload to invoke based on the arguments provided.
 
 ### Example

--- a/docs/standard-library/vector-class.md
+++ b/docs/standard-library/vector-class.md
@@ -794,9 +794,10 @@ The number '30' is in c1 collection 3 times.
 Inserts an element constructed in place into the vector at a specified position.
 
 ```cpp
+template <class... Types>
 iterator emplace(
     const_iterator _Where,
-    Type&& val);
+    Types&&... _Args);
 ```
 
 ### Parameters
@@ -804,8 +805,8 @@ iterator emplace(
 *_Where*\
 The position in the [vector](../standard-library/vector-class.md) where the first element is inserted.
 
-*val*\
-The value of the element being inserted into the `vector`.
+*_Args*\
+Constructor arguments. The function infers which constructor overload to invoke based on the arguments provided.
 
 ### Return Value
 


### PR DESCRIPTION
The emplace member function of std::vector should take const_iterator and variadic list of arguments as their input for perfect forwarding [link](https://en.cppreference.com/w/cpp/container/vector/emplace). This document had rvalue reference instead of variadic list of arguments. I also checked the std::vector implementation MSVC, it is now according to the changes proposed. 
Probably why it still had rvalue reference is explained in this link [link](https://stackoverflow.com/questions/4303513/push-back-vs-emplace-back).