### PR TITLE
Add F1 link from Command Line in C++ properties

### DIFF
--- a/docs/build/reference/compiler-command-line-syntax.md
+++ b/docs/build/reference/compiler-command-line-syntax.md
@@ -1,6 +1,7 @@
 ---
 title: "MSVC Compiler Command-Line Syntax"
 ms.date: "11/04/2016"
+f1_keywords: ["VC.Project.AdditionalOptionsPage"]
 helpviewer_keywords: ["syntax, CL compiler command line", "cl.exe compiler, command-line syntax"]
 ms.assetid: acba2c1c-0803-4a3a-af25-63e849b930a2
 ---


### PR DESCRIPTION
In a C++ project, go to project properties, and select Configuration Properties > C/C++ > Command Line. Press F1. You end up on the [Clang Linker properties (Android C++) page](https://docs.microsoft.com/en-us/visualstudio/cross-platform/clanglink-prop-page?f1url=https://msdn.microsoft.com/query/dev16.query?appId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk%28vc.project.AdditionalOptionsPage%29%26rd%3Dtrue&view=vs-2019), but this page seems like a much better fit.