### PR TITLE
Recommend Docs Authoring Pack extension and configure dev langs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"docsmsft.docs-authoring-pack"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,16 @@
     "files.associations": {
         "random": "cpp"
     },
-
-    "git.ignoreLimitWarning": true
+    "git.ignoreLimitWarning": true,
+    "markdown.docsetLanguages": [
+        "ARM assembler",
+        "C",
+        "C#",
+        "C++",
+        "HTML",
+        "JSON",
+        "Makefile",
+        "VB.NET",
+        "XML"
+    ]
 }


### PR DESCRIPTION
Recommend the [Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) extension for contributors using VS Code. VS Code users who don't already have the extension installed will be asked if they want to install it.

The other part of this PR configures the docs-markdown extension that is bundled with Docs Authoring Pack. Commonly used dev langs for code snippets in the docset are presented to the user when typing 3 backticks (```). I came up with this list based on search results. See https://github.com/aspnet/AspNetCore.Docs/pull/16986 for a preview of that functionality.