### PR TITLE
fix: MD023/heading-start-left/header-start-left

### DIFF
--- a/docs/ide/navigate-code-cpp.md
+++ b/docs/ide/navigate-code-cpp.md
@@ -51,7 +51,7 @@ You can open **Go To** with **Ctrl+,**. This action creates a search box over th
 
 When you first invoke **Go To** with **Ctrl +**, **Go To All** is activated (no filters on search results). You then can select the filter you want by using the buttons near the search box. You can invoke a specific filter using its corresponding keyboard shortcut. Doing so opens the **Go To** search box with that filter preselected. All keyboard shortcuts are configurable.
 
-To apply a text filter, start your search query with the filter’s corresponding character followed by a space. (**Go To Line** can optionally omit the space.) These text filters are available:
+To apply a text filter, start your search query with the filter's corresponding character followed by a space. (**Go To Line** can optionally omit the space.) These text filters are available:
 
 - Go To All: (no text filter)
 - Go To Line Number: :
@@ -100,7 +100,7 @@ You group results by the following categories:
 - Definition then Path
 - Definition, Project then Path
 
- #### Filter results
+#### Filter results
 
 To filter results, hover over a column and select the filtering icon that pops up. You can filter results from the first column to hide things like string and comment references that you might not want to see.
 
@@ -112,7 +112,7 @@ To filter results, hover over a column and select the filtering icon that pops u
 
 - **Unprocessed results**: **Find All References** operations can take time to complete on larger codebases, so the Results list shows "unprocessed" results here. Unprocessed results match the name of the symbol being searched for but haven't yet been confirmed as actual code references. You can turn on this filter to get faster results. Just be aware that some results might not be actual references.
 
- #### Sort results
+#### Sort results
 
 You can sort results by any column by selecting that column. You can swap between ascending or descending order by selecting the column again.
 

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -614,7 +614,8 @@ To use this function successfully:
 - The file IMAGEHLP.DLL must be on your path. If you do not have this DLL, the function will display an error message. See [Image Help Library](/windows/win32/Debug/image-help-library) for information on the function set provided by IMAGEHLP.
 
 - The modules that have frames on the stack must include debugging information. If they do not contain debugging information, the function will still generate a stack trace, but the trace will be less detailed.
-  ### Requirements
+
+### Requirements
 
 **Header:** afx.h
 

--- a/docs/mfc/reference/dialog-data-exchange-functions-for-crecordview-and-cdaorecordview.md
+++ b/docs/mfc/reference/dialog-data-exchange-functions-for-crecordview-and-cdaorecordview.md
@@ -454,7 +454,8 @@ See [DDX_FieldText](#ddx_fieldtext) for a general DDX_Field example. Calls to `D
 
   **Header** afxdao.h
 
-  ## <a name="ddx_fieldslider"></a>  DDX_FieldSlider
+## <a name="ddx_fieldslider"></a>  DDX_FieldSlider
+
 The `DDX_FieldSlider` function synchronizes the thumb position of a slider control in a record view and an **int** field data member of a recordset associated with the record view (or with whatever integer variable you choose to map it to).
 
 ### Syntax


### PR DESCRIPTION

Headings must start at the beginning of the line