### PR TITLE
fix the format in issue #1697

### DIFF
--- a/docs/get-started/tutorial-console-cpp.md
+++ b/docs/get-started/tutorial-console-cpp.md
@@ -98,7 +98,7 @@ Now let's turn the code in this template into a calculator app.
     int main()
     {
         cout << "Calculator Console Application" << endl << endl;
-        cout << "Please enter the operation to perform. Format: a+b | a-b | a*b | a/b"
+        cout << "Please enter the operation to perform. Format: a + b | a - b | a * b | a / b"
             << endl;
         return 0;
     }


### PR DESCRIPTION
as in the issue #1697, I did the following: 
in the edit code section, the format was "a+b | a-b | a*b | a/b" and I added spaces to become "a + b | a - b | a * b | a / b"