### PR TITLE
fix: MD031/blanks-around-fences

### DIFF
--- a/docs/atl/changing-the-drawing-code-atl-tutorial-part-4.md
+++ b/docs/atl/changing-the-drawing-code-atl-tutorial-part-4.md
@@ -104,12 +104,15 @@ Rebuild the control. Make sure the PolyCtl.htm file is closed if it is still ope
     > [!NOTE]
     > For errors involving `ATL::CW2AEX`, in Script.Cpp, replace line `TRACE( "XActiveScriptSite::GetItemInfo( %s )\n", pszNameT );` with `TRACE( "XActiveScriptSite::GetItemInfo( %s )\n", pszNameT.m_psz );`, and line `TRACE( "Source Text: %s\n", COLE2CT( bstrSourceLineText ) );` with `TRACE( "Source Text: %s\n", bstrSourceLineText );`.<br/>
     > For errors involving `HMONITOR`, open StdAfx.h in the `TCProps` project and replace:
+    >
     > ```
     > #ifndef WINVER
     > #define WINVER 0x0400
     > #endif
     > ```
+    >
     > with
+    >
     > ```
     > #ifndef WINVER
     > #define WINVER 0x0500

--- a/docs/atl/creating-the-project-atl-tutorial-part-1.md
+++ b/docs/atl/creating-the-project-atl-tutorial-part-1.md
@@ -11,18 +11,22 @@ This tutorial walks you step-by-step through a non-attributed ATL project that c
 > [!NOTE]
 > This tutorial creates the same source code as the Polygon sample. If you want to avoid entering the source code manually, you can download it from the [Polygon sample abstract](https://github.com/Microsoft/VCSamples/tree/master/VC2008Samples/ATL/Controls/Polygon). You can then refer to the Polygon source code as you work through the tutorial, or use it to check for errors in your own project.
 > To compile, open *pch.h* (*stdafx.h* in Visual Studio 2017 and earlier) and replace:
+>
 > ```
 > #ifndef WINVER
 > #define WINVER 0x0400
 > #endif
 > ```
+>
 > with
+>
 > ```
 > #ifndef WINVER
 > #define WINVER 0x0500
 > #define _WIN32_WINNT 0x0500
 > #endif
 > ```
+>
 > The compiler will still complain about `regsvr32` not exiting correctly, but you should still have the control's DLL built and available for use.
 
 ### To create the initial ATL project using the ATL Project Wizard

--- a/docs/atl/reference/worker-archetype.md
+++ b/docs/atl/reference/worker-archetype.md
@@ -72,6 +72,7 @@ A pointer to the [OVERLAPPED](/windows/win32/api/minwinbase/ns-minwinbase-overla
 ## <a name="initialize"></a> WorkerArchetype::Initialize
 
 Called to initialize the worker object before any requests are passed to `WorkerArchetype::Execute`.
+
 ```
 BOOL Initialize(void* pvParam) throw();
 ```

--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -345,6 +345,7 @@ These options allow you to run commands on the remote system before and after bu
   ]
 }
 ```
+
 ::: moniker-end
 
 ::: moniker range="vs-2019"

--- a/docs/build/projects-and-build-systems-cpp.md
+++ b/docs/build/projects-and-build-systems-cpp.md
@@ -29,6 +29,7 @@ You can build simple programs by invoking the MSVC compiler (cl.exe) directly fr
 ```cmd
 cl /EHsc hello.cpp
 ```
+
 Note that here the compiler (cl.exe) automatically invokes the C++ preprocessor and the linker to produce the final output file.  For more information, see [Building on the command line](building-on-the-command-line.md).
 
 ## Build systems and projects

--- a/docs/cpp/exception-specifications-throw-cpp.md
+++ b/docs/cpp/exception-specifications-throw-cpp.md
@@ -13,11 +13,13 @@ Prior to C++17 there were two kinds of exception specification. The *noexcept sp
 ```cpp
 void MyFunction(int i) throw();
 ```
+
 tells the compiler that the function does not throw any exceptions. However, in **/std:c++14** mode this could lead to undefined behavior if the function does throw an exception. Therefore we recommend using the [noexcept](../cpp/noexcept-cpp.md) operator instead of the one above:
 
 ```cpp
 void MyFunction(int i) noexcept;
 ```
+
 The following table summarizes the Microsoft C++ implementation of exception specifications:
 
 |Exception specification|Meaning|

--- a/docs/cppcx/wrl/hstring-class.md
+++ b/docs/cppcx/wrl/hstring-class.md
@@ -152,6 +152,7 @@ Retrieves a pointer to the underlying string data.
 ```cpp
 const wchar_t* GetRawBuffer(unsigned int* length) const;
 ```
+
 ### Parameters
 
 *length*

--- a/docs/cppcx/wrl/hstringreference-class.md
+++ b/docs/cppcx/wrl/hstringreference-class.md
@@ -93,6 +93,7 @@ Retrieves a pointer to the underlying string data.
 ```cpp
 const wchar_t* GetRawBuffer(unsigned int* length) const;
 ```
+
 ### Parameters
 
 *length*

--- a/docs/data/oledb/simplifying-data-access-with-database-attributes.md
+++ b/docs/data/oledb/simplifying-data-access-with-database-attributes.md
@@ -35,6 +35,7 @@ For information about the attributes discussed in this topic, see [OLE DB Consum
 
 > [!NOTE]
 > The following `include` statements are required to compile the examples below:
+
 > ```cpp
 > #include <atlbase.h>
 > #include <atlplus.h>

--- a/docs/linux/cmake-linux-project.md
+++ b/docs/linux/cmake-linux-project.md
@@ -197,6 +197,7 @@ The default Linux-Debug configuration in Visual Studio 2019 version 16.1 and lat
   ]
 }
 ```
+
 ::: moniker-end
 
 For more information about these settings, see [CMakeSettings.json reference](../build/cmakesettings-reference.md).

--- a/docs/linux/deploy-run-and-debug-your-linux-project.md
+++ b/docs/linux/deploy-run-and-debug-your-linux-project.md
@@ -185,6 +185,7 @@ If you want complete control over your deployment, you can append the following 
 ]
 
 ```
+
 ::: moniker-end
 
 ## Next steps

--- a/docs/mfc/reference/afx-global-data-structure.md
+++ b/docs/mfc/reference/afx-global-data-structure.md
@@ -478,6 +478,7 @@ TRUE if [Desktop Window Manager](/windows/win32/dwm/dwm-overview) (DWM) composit
 ## <a name="ishighcontrastmode"></a> AFX_GLOBAL_DATA::IsHighContrastMode
 
 Indicates whether images are currently displayed in high contrast.
+
 ```
 BOOL IsHighContrastMode() const;
 ```

--- a/docs/mfc/reference/clistctrl-class.md
+++ b/docs/mfc/reference/clistctrl-class.md
@@ -1115,6 +1115,7 @@ public:
 ### Example
 
 The following code example demonstrates the `GetGroupInfoByIndex` method. In an earlier section of this code example, we created a list-view control that displays two columns titled "ClientID" and "Grade" in a report view. The following code example retrieves information about the group whose index is 0, if such a group exists.
+
 ```cpp
     // GetGroupInfoByIndex
     const int GROUP_HEADER_BUFFER_SIZE = 40;
@@ -1191,6 +1192,7 @@ This method sends the [LVM_GETGROUPRECT](/windows/win32/Controls/lvm-getgrouprec
 ### Example
 
 The following code example defines a variable, `m_listCtrl`, that is used to access the current list-view control. This variable is used in the next example.
+
 ```cpp
 public:
     // Variable used to access the list control.
@@ -3974,6 +3976,7 @@ int CALLBACK CompareFunc(LPARAM lParam1,
     LPARAM lParam2,
     LPARAM lParamSort);
 ```
+
 The comparison function must return a negative value if the first item should precede the second, a positive value if the first item should follow the second, or zero if the two items are equal.
 
 The *lParam1* parameter is the 32-bit value associated with the first item that is compared, and the *lParam2* parameter is the value associated with the second item. These are the values that were specified in the *lParam* member of the items' [LVITEM](/windows/win32/api/commctrl/ns-commctrl-lvitemw) structure when they were inserted into the list. The *lParamSort* parameter is the same as the *dwData* value.
@@ -4034,6 +4037,7 @@ int CALLBACK CompareFunc(LPARAM lParam1,
     LPARAM lParam2,
     LPARAM lParamSort);
 ```
+
 This message is like [LVM_SORTITEMS](/windows/win32/Controls/lvm-sortitems), except for the type of information passed to the comparison function. In [LVM_SORTITEMS](/windows/win32/Controls/lvm-sortitems), *lParam1* and *lParam2* are the values of the items to compare. In [LVM_SORTITEMSEX](/windows/win32/Controls/lvm-sortitemsex), *lParam1* is the current index of the first item to compare and *lParam2* is the current index of the second item. You can send an [LVM_GETITEMTEXT](/windows/win32/Controls/lvm-getitemtext) message to retrieve more information about an item.
 
 The comparison function must return a negative value if the first item should precede the second, a positive value if the first item should follow the second, or zero if the two items are equal.

--- a/docs/mfc/reference/cmfcribboncheckbox-class.md
+++ b/docs/mfc/reference/cmfcribboncheckbox-class.md
@@ -43,6 +43,7 @@ To use a `CMFCRibbonCheckBox` in your application, add the following constructor
 ```
 CMFCRibbonCheckBox (UINT nID, LPCTSTR lpszText)
 ```
+
 where *nID* is the check box command ID and *lpszText* is the text label of the check box.
 
 You can add a check box to a ribbon panel by using [CMFCRibbonPanel::Add](../../mfc/reference/cmfcribbonpanel-class.md#add).

--- a/docs/mfc/reference/cmfcribbonseparator-class.md
+++ b/docs/mfc/reference/cmfcribbonseparator-class.md
@@ -59,6 +59,7 @@ CMFCRibbonMainPanel* pMainPanel = m_wndRibbonBar.AddMainCategory(_T("Main Menu")
 ...
 pMainPanel->Add(new CMFCRibbonSeparator(TRUE));
 ```
+
 Call [CMFCRibbonPanel::AddSeparator](../../mfc/reference/cmfcribbonpanel-class.md#addseparator) to add separators to ribbon panels. The separators are allocated and added internally by the `AddSeparator` method.
 
 ## Inheritance Hierarchy

--- a/docs/mfc/reference/cmfctooltipctrl-class.md
+++ b/docs/mfc/reference/cmfctooltipctrl-class.md
@@ -69,18 +69,21 @@ if (m_bCustomColors)
 
 }
 ```
+
 3. Use the [CTooltipManager::SetTooltipParams](../../mfc/reference/ctooltipmanager-class.md#settooltipparams) method to set the visual style for all tooltips in the application by using the styles defined in the `CMFCToolTipInfo` object:
 
 ```
 theApp.GetTooltipManager ()->SetTooltipParams (AFX_TOOLTIP_TYPE_ALL,
     RUNTIME_CLASS (CMFCToolTipCtrl), &params);
 ```
+
 You can also derive a new class from `CMFCToolTipCtrl` to control tooltip behavior and rendering. To specify a new tooltip control class, use the `CTooltipManager::SetTooltipParams` method:
 
 ```
 myApp.GetTooltipManager ()->SetTooltipParams (AFX_TOOLTIP_TYPE_ALL,
     RUNTIME_CLASS (CMyToolTipCtrl))
 ```
+
 To restore the default tooltip control class and reset the tooltip appearance to its default state, specify NULL in the runtime class and tooltip info parameters of `SetTooltipParams`:
 
 ```

--- a/docs/mfc/reference/cstatic-class.md
+++ b/docs/mfc/reference/cstatic-class.md
@@ -253,6 +253,7 @@ You can use various window and static control styles, including these:
 ```
 MyStaticControl.SetBitmap(HBITMAP(MyBitmap));
 ```
+
 The following example creates two `CStatic` objects on the heap. It then loads one with a system bitmap using `CBitmap::LoadOEMBitmap` and the other from a file using `CImage::Load`.
 
 ### Example

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -88,6 +88,7 @@ This code sample would cause a compiler warning if _AFX_SECURE_NO_WARNINGS were 
 // define this before including any afx files in *pch.h* (*stdafx.h* in Visual Studio 2017 and earlier)
 #define _AFX_SECURE_NO_WARNINGS
 ```
+
 ```cpp
 CRichEditCtrl* pRichEdit = new CRichEditCtrl;
 pRichEdit->Create(WS_CHILD|WS_VISIBLE|WS_BORDER|ES_MULTILINE,

--- a/docs/mfc/reference/icommandsource-interface.md
+++ b/docs/mfc/reference/icommandsource-interface.md
@@ -47,6 +47,7 @@ For more information on using Windows Forms, see [Using a Windows Form User Cont
 ## <a name="addcommandhandler"></a>  ICommandSource::AddCommandHandler
 
 Adds a command handler to a command source object.
+
 ```
 void AddCommandHandler(
     unsigned int cmdID,
@@ -68,6 +69,7 @@ See [How to: Add Command Routing to the Windows Forms Control](../../dotnet/how-
 ## <a name="addcommandrangehandler"></a> ICommandSource::AddCommandRangeHandler
 
 Adds a group of command handlers to a command source object.
+
 ```
 void AddCommandRangeHandler(
     unsigned int cmdIDMin,
@@ -90,6 +92,7 @@ This method maps a contiguous range of command IDs to a single message handler a
 ## <a name="addcommandrangeuihandler"></a> ICommandSource::AddCommandRangeUIHandler
 
 Adds a group of user interface command message handlers to a command source object.
+
 ```
 void AddCommandRangeUIHandler(
     unsigned int cmdIDMin,
@@ -113,6 +116,7 @@ This method maps a contiguous range of command IDs to a single user interface co
 ## <a name="addcommanduihandler"></a> ICommandSource::AddCommandUIHandler
 
 Adds a user interface command message handler to a command source object.
+
 ```
 void AddCommandUIHandler(
     unsigned int cmdID,
@@ -133,6 +137,7 @@ This method adds the user interface command message handler cmdHandler to the co
 ## <a name="postcommand"></a> ICommandSource::PostCommand
 
 Posts a message without waiting for it to be processed.
+
 ```
 void PostCommand(unsigned int command);
 ```
@@ -148,6 +153,7 @@ This method asynchronously posts the message mapped to the ID specified by comma
 ## <a name="removecommandhandler"></a> ICommandSource::RemoveCommandHandler
 
 Removes a command handler from a command source object.
+
 ```
 void RemoveCommandHandler(unsigned int cmdID);
 ```
@@ -163,6 +169,7 @@ This method removes the command handler mapped to cmdID from the command source 
 ## <a name="removecommandrangehandler"></a> ICommandSource::RemoveCommandRangeHandler
 
 Removes a group of command handlers from a command source object.
+
 ```
 void RemoveCommandRangeUIHandler(
     unsigned int cmdIDMin,
@@ -182,6 +189,7 @@ This method removes a group of message handlers, mapped to the command IDs speci
 ## <a name="removecommandrangeuihandler"></a> ICommandSource::RemoveCommandRangeUIHandler
 
 Removes a group of user interface command message handlers from a command source object.
+
 ```
 void RemoveCommandRangeUIHandler(
     unsigned int cmdIDMin,
@@ -201,6 +209,7 @@ This method removes a group of user interface command message handlers, mapped t
 ## <a name="removecommanduihandler"></a> ICommandSource::RemoveCommandUIHandler
 
 Removes a user interface command message handler from a command source object.
+
 ```
 void RemoveCommandUIHandler(unsigned int cmdID);
 ```
@@ -216,6 +225,7 @@ This method removes the user interface command message handler mapped to cmdID f
 ## <a name="sendcommand"></a> ICommandSource::SendCommand
 
 Sends a message and waits for it to be processed before returning.
+
 ```
 void SendCommand(unsigned int command);
 ```

--- a/docs/mfc/reference/icommandui-interface.md
+++ b/docs/mfc/reference/icommandui-interface.md
@@ -44,6 +44,7 @@ For more information on how user interface commands are managed in MFC, see [CCm
 ## <a name="check"></a> ICommandUI::Check
 
 Sets the user interface item for this command to the appropriate check state.
+
 ```
 property UICheckState Check;
 ```
@@ -58,6 +59,7 @@ This property sets the user interface item for this command to the appropriate c
 ## <a name="continuerouting"></a> ICommandUI::ContinueRouting
 
 Tells the command routing mechanism to continue routing the current message down the chain of handlers.
+
 ```
 void ContinueRouting();
 ```
@@ -69,6 +71,7 @@ This is an advanced member function that should be used in conjunction with an O
 ## <a name="enabled"></a> ICommandUI::Enabled
 
 Enables or disables the user interface item for this command.
+
 ```
 property bool Enabled;
 ```
@@ -80,6 +83,7 @@ This property enables or disables the user interface item for this command. Set 
 ## <a name="id"></a> ICommandUI::ID
 
 Gets the ID of the user interface object represented by the ICommandUI object.
+
 ```
 property unsigned int ID;
 ```
@@ -91,6 +95,7 @@ This property gets the ID (a handle) of the menu item, toolbar button, or other 
 ## <a name="index"></a> ICommandUI::Index
 
 Gets the index of the user interface object represented by the ICommandUI object.
+
 ```
 property unsigned int Index;
 ```
@@ -102,6 +107,7 @@ This property gets the index (a handle) of the menu item, toolbar button, or oth
 ## <a name="radio"></a> ICommandUI::Radio
 
 Sets the user interface item for this command to the appropriate check state.
+
 ```
 property bool Radio;
 ```
@@ -113,6 +119,7 @@ This property sets the user interface item for this command to the appropriate c
 ## <a name="text"></a> ICommandUI::Text
 
 Sets the text of the user interface item for this command.
+
 ```
 property String^ Text;
 ```

--- a/docs/mfc/reference/iview-interface.md
+++ b/docs/mfc/reference/iview-interface.md
@@ -40,6 +40,7 @@ Header: afxwinforms.h (defined in assembly atlmfc\lib\mfcmifc80.dll)
 ## <a name="onactivateview"></a> IView::OnActivateView
 
 Called by MFC when a view is activated or deactivated.
+
 ```
 void OnActivateView(bool activate);
 ```
@@ -52,6 +53,7 @@ Indicates whether the view is being activated or deactivated.
 ## <a name="oninitialupdate"></a> IView::OnInitialUpdate
 
 Called by the framework after the view is first attached to the document, but before the view is initially displayed.
+
 ```
 void OnInitialUpdate();
 ```
@@ -59,6 +61,7 @@ void OnInitialUpdate();
 ## <a name="onupdate"></a> IView::OnUpdate
 
 Called by MFC after the view's document has been modified.
+
 ```
 void OnUpdate();
 ```

--- a/docs/standard-library/basic-string-view-class.md
+++ b/docs/standard-library/basic-string-view-class.md
@@ -782,12 +782,14 @@ Assigns a string_view or convertible string object to another string_view.
 ```cpp
 constexpr basic_string_view& operator=(const basic_string_view&) noexcept = default;
 ```
+
 ### Example
 
 ```cpp
    string_view s = "Hello";
    string_view s2 = s;
 ```
+
 ## <a name="op_at"></a>  basic_string_view::operator[]
 
 Provides a const_reference to the character with a specified index.

--- a/docs/standard-library/execution.md
+++ b/docs/standard-library/execution.md
@@ -20,6 +20,7 @@ namespace std::execution {
     inline constexpr parallel_unsequenced_policy par_unseq { unspecified };
 }
 ```
+
 ### Classes and Structs
 
 |||

--- a/docs/standard-library/piecewise-constant-distribution-class.md
+++ b/docs/standard-library/piecewise-constant-distribution-class.md
@@ -252,6 +252,7 @@ The parameter structure used to construct the distribution.
 The default constructor sets the stored parameters such that there is one interval, 0 to 1, with a probability density of 1.
 
 The iterator range constructor
+
 ```cpp
 template <class InputIteratorI, class InputIteratorW>
 piecewise_constant_distribution(InputIteratorI firstI, InputIteratorI lastI,
@@ -261,6 +262,7 @@ piecewise_constant_distribution(InputIteratorI firstI, InputIteratorI lastI,
 constructs a distribution object with itnervals from iterators over the sequence [ `firstI`, `lastI`) and a matching weight sequence starting at `firstW`.
 
 The initializer list constructor
+
 ```cpp
 template <class UnaryOperation>
 piecewise_constant_distribution(initializer_list<result_type>
@@ -271,6 +273,7 @@ intervals,
 constructs a distribution object with intervals from the initializer list *intervals* and weights generated from the function *weightfunc*.
 
 The constructor defined as
+
 ```cpp
 template <class UnaryOperation>
 piecewise_constant_distribution(size_t count, result_type xmin, result_type xmax,
@@ -280,6 +283,7 @@ piecewise_constant_distribution(size_t count, result_type xmin, result_type xmax
 constructs a distribution object with *count* intervals distributed uniformly over [ `xmin,xmax`], assigning each interval weights according to the function *weightfunc*, and *weightfunc* must accept one parameter and have a return value, both of which are convertible to `double`. **Precondition:** `xmin < xmax`
 
 The constructor defined as
+
 ```cpp
 explicit piecewise_constant_distribution(const param_type& parm);
 ```

--- a/docs/standard-library/string-view-hash.md
+++ b/docs/standard-library/string-view-hash.md
@@ -19,6 +19,7 @@ struct hash<basic_string_view<CharType, Traits>>
         noexcept;
 };
 ```
+
 ### Remarks
 
 The hash of a string_view equals the hash of the underlying string object.

--- a/docs/standard-library/string-view-operators.md
+++ b/docs/standard-library/string-view-operators.md
@@ -96,6 +96,7 @@ The comparison is based on a pairwise lexicographical comparison of the characte
 ## <a name="op_lt"></a> operator&lt;
 
 Tests if the object on the left side of the operator is less than the object on the right sidestring_view
+
 ```cpp
 template <class CharType, class Traits>
 bool operator<(


### PR DESCRIPTION

Fenced code blocks should be surrounded by blank lines