### PR TITLE
Disable failing rules for CI enablement

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,7 +3,9 @@
     "DOCSMD006": false,
     "MD001": false,
     "MD013": false,
-    "MD024": false,
+    "MD024": {
+        "siblings_only": true
+    },
     "MD025": {
         "front_matter_title": ""
     },

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,12 +1,30 @@
 {
     "default": true,
-    "MD002": false,
     "DOCSMD006": false,
+    "MD001": false,
     "MD013": false,
-    "MD024": { "siblings_only": true },
-    "MD025": { "front_matter_title": "" },
+    "MD024": false,
+    "MD025": {
+        "front_matter_title": ""
+    },
     "MD026": false,
     "MD028": false,
-    "MD038": false,
-    "MD033": { "allowed_elements": ["a", "br", "em", "strong", "sub", "sup"] }
+    "MD033": {
+        "allowed_elements": [
+            "a",
+            "br",
+            "em",
+            "iframe",
+            "strong",
+            "sub",
+            "sup"
+        ]
+    },
+    "MD036": false,
+    "MD037": false,
+    "MD040": false,
+    "MD041": false,
+    "MD046": {
+        "style": "fenced"
+    }
 }


### PR DESCRIPTION
This turns off all rules that don' currently pass running `markdownlint "**/*.md" -i "**/TOC.md"`.
Most rules will be re-enabled, but disabling them and then enforcing the current set through GitHub Actions prevents new issues being introduced.
Some of the rules now are autofixable, so separate PRs are being submitted by removing the rule from the file and running markdownlint-cli using the `--fix` parameter.