### PR TITLE
buil: Add MarkdownLint GitHub Action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,27 @@
+name: Markdownlint
+
+on:
+  push:
+    paths:
+      - "**/*.md"
+      - ".github/workflows/markdownlint.yml"
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".github/workflows/markdownlint.yml"
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Run Markdownlint
+      run: |
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md" -i "**/TOC.md"

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@ _themes.MSDN.Modern/
 _themes.VS.Modern/
 
 # Ignore local configuration changes
-.github/
+.github/workflows/*
+!.github/workflows/markdownlint.yml
 .openpublishing.buildcore.ps1
 .vscode/
 
 # Documentation build
 /docs/vcppdocs
+


### PR DESCRIPTION
This is the same setup from the dotnet/docs repo, which a slight change to ignore the TOC.md files.