### PR TITLE
Add dependency on ninja-build

### DIFF
--- a/docs/linux/cmake-linux-project.md
+++ b/docs/linux/cmake-linux-project.md
@@ -40,6 +40,7 @@ On the Linux system, make sure that the following are installed:
 - gdb
 - rsync
 - zip
+- ninja-build
 
 ::: moniker range="vs-2019"
 


### PR DESCRIPTION
In VS 2019 16.6 and later Ninja will be the default generator for new Linux/WSL configurations.