### PR TITLE
Add dependency on ninja-build

### DIFF
--- a/docs/build/get-started-linux-cmake.md
+++ b/docs/build/get-started-linux-cmake.md
@@ -24,10 +24,10 @@ In this tutorial, you learn how to:
 
 * Set up a Linux machine for Cross Platform C++ Development
   * Visual Studio doesn't require any specific distribution of Linux. The OS can be running on a physical machine, in a VM, or in the cloud. You could also use the Windows Subsystem for Linux (WSL). However, for this tutorial a graphical environment is required. WSL isn't recommended here, because it's intended primarily for command-line operations.
-  * Visual Studio requires these tools on the Linux machine: C++ compilers, gdb, ssh, rsync, and zip. On Debian-based systems, you can use this command to install these dependencies:
+  * Visual Studio requires these tools on the Linux machine: C++ compilers, gdb, ssh, rsync, ninja, and zip. On Debian-based systems, you can use this command to install these dependencies:
 
     ```cmd
-    sudo apt install -y openssh-server build-essential gdb rsync zip
+    sudo apt install -y openssh-server build-essential gdb rsync ninja-build zip
     ```
 
   * Visual Studio requires a recent version of CMake on the Linux machine that has server mode enabled (at least 3.8). Microsoft produces a universal build of CMake that you can install on any Linux distro. We recommend you use this build to ensure that you have the latest features. You can get the CMake binaries from [the Microsoft fork of the CMake repo](https://github.com/Microsoft/CMake/releases) on GitHub. Go to that page and download the version that matches the system architecture on your Linux machine, then mark it as an executable:


### PR DESCRIPTION
In VS 2019 16.6 and later Ninja will be the default generator for new Linux/WSL configurations.