### PR TITLE
fix: MD022/blanks-around-headings/blanks-around-headers

### DIFF
--- a/docs/atl/reference/security-global-functions.md
+++ b/docs/atl/reference/security-global-functions.md
@@ -97,6 +97,7 @@ Returns true on success, false on failure.
 ### Remarks
 
 In debug builds, an assertion error will occur if *hObject* is invalid, or if *dwInheritanceFlowControl* is not one of the three permitted values.
+
 ### Requirements
 
 **Header:** atlsecurity.h

--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -688,6 +688,7 @@ When you choose a configuration, it is added to the CMakeSettings.json file in t
 ```
 
 ::: moniker-end
+
 ## See also
 
 [CMake Projects in Visual Studio](cmake-projects-in-visual-studio.md)<br/>

--- a/docs/code-quality/c26432.md
+++ b/docs/code-quality/c26432.md
@@ -7,6 +7,7 @@ helpviewer_keywords: ["C26432"]
 ms.assetid: f587b05a-5c69-4176-baa6-fcb79d228b24
 ---
 # C26432 DEFINE_OR_DELETE_SPECIAL_OPS
+
 "If you define or delete any default operation in the type, define or delete them all."
 
 **C++ Core Guidelines**:
@@ -15,6 +16,7 @@ ms.assetid: f587b05a-5c69-4176-baa6-fcb79d228b24
 Special operations like constructors are assumed to alter behavior of types so that they rely more on language mechanisms to automatically enforce specific scenarios (the canonical example is resource management). If any of these operations is explicitly defined, defaulted or deleted (as an indication that user wants to avoid any special handling of a type) it would be inconsistent to leave the other operations from the same group unspecified (i.e. implicitly defined by compiler).
 
 ## Remarks
+
 - This check implements "the rule of five" which treats the following operations as special:
   - copy constructors;
   - move constructors;

--- a/docs/code-quality/c26436.md
+++ b/docs/code-quality/c26436.md
@@ -7,6 +7,7 @@ helpviewer_keywords: ["C26436"]
 ms.assetid: 82d14d5d-5c5d-4e27-bdc8-268f9973a312
 ---
 # C26436 NEED_VIRTUAL_DTOR
+
 "The type with a virtual function needs either public virtual or protected nonvirtual destructor."
 
 **C++ Core Guidelines**:
@@ -15,5 +16,6 @@ C.35: A base class destructor should be either public and virtual, or protected 
 If a class defines a virtual function it becomes polymorphic, which implies that derived classes can change its behavior including resource management and destruction logic. Because client code may call polymorphic types via pointers to base classes, there is no way a client can explicitly choose which behavior is appropriate without downcasting. To make sure that resources are managed consistently and destruction occurs according to the actual type’s rules it is recommended to define a public virtual destructor. If the type hierarchy is designed to disallow client code to destroy objects directly, destructors should be defined as protected non-virtual.
 
 ## Remarks
+
 - The warning shows up on the first virtual function definition of a type (it can be a virtual destructor if it is not public), once per type.
   - Since definition can be placed separately from declaration, it may not always have any of the virtual specifiers. But the warning is still valid – it checks the actual ‘virtuality’ of a function.

--- a/docs/code-quality/c26439.md
+++ b/docs/code-quality/c26439.md
@@ -7,6 +7,7 @@ helpviewer_keywords: ["C26439"]
 ms.assetid: 9df2a1b0-ea94-4884-9d28-c1522ec33a1b
 ---
 # C26439 SPECIAL_NOEXCEPT
+
 "This kind of function may not throw. Declare it 'noexcept'."
 
 **C++ Core Guidelines**:
@@ -15,6 +16,7 @@ F.6: If your function may not throw, declare it noexcept
 Some kinds of operations should never cause exceptions. Their implementations should be reliable and should handle possible errors conditions gracefully. They should never use exceptions to indicate failure. This rule flags cases where such operations are not explicitly marked as ‘noexcept’ which means that they may throw exceptions and cannot convey assumptions about their reliability.
 
 ## Remarks
+
 - Special kinds of operations are the following:
   - destructors;
   - default constructors;

--- a/docs/code-quality/c26440.md
+++ b/docs/code-quality/c26440.md
@@ -7,19 +7,21 @@ helpviewer_keywords: ["C26440"]
 ms.assetid: b6d2b188-35cc-4de2-878c-6f97d5a2444a
 ---
 # C26440 DECLARE_NOEXCEPT
+
 "Function can be declared 'noexcept'."
 
 **C++ Core Guidelines**:
 F.6: If your function may not throw, declare it noexcept
 
-If code is not supposed to cause any exceptions, it should be marked as such by using the ‘noexcept’ specifier. This would help to simplify error handling on the client code side, as well as enable compiler to do additional optimizations.
+If code is not supposed to cause any exceptions, it should be marked as such by using the 'noexcept' specifier. This would help to simplify error handling on the client code side, as well as enable compiler to do additional optimizations.
 
 ## Remarks
+
 - A function is considered non-throwing if:
   - it has no explicit throw statements;
   - function calls in its body, if any, invoke only functions that unlikely to throw: constexpr or functions marked with any exception specification which entails non-throwing behavior (this includes some non-standard specifications).
-  - Non-standard and outdated specifiers like throw() or declspec(nothrow) are not equivalent to ‘noexcept’.
+  - Non-standard and outdated specifiers like throw() or declspec(nothrow) are not equivalent to 'noexcept'.
   - Explicit specifiers noexcept(false) and noexcept(true) are respected appropriately.
   - Functions marked as constexpr are not supposed to cause exceptions and are not analyzed.
   - The rule also applies to lambda expressions.
-  - The logic doesn’t consider recursive calls as potentially non-throwing. This may change in the future.
+  - The logic doesn't consider recursive calls as potentially non-throwing. This may change in the future.

--- a/docs/cppcx/platform-string-class.md
+++ b/docs/cppcx/platform-string-class.md
@@ -456,6 +456,7 @@ A number that specifies the length of the string.
 ### Remarks
 
 If performance is critical and you control the lifetime of the source string, you can use [Platform::StringReference](../cppcx/platform-stringreference-class.md) in place of String.
+
 ### Example
 
 ```cpp

--- a/docs/cppcx/platform-type-class.md
+++ b/docs/cppcx/platform-type-class.md
@@ -65,6 +65,7 @@ String^ FullName();
 ### Return Value
 
 The name of the type.
+
 ### Example
 
 ```

--- a/docs/dotnet/utility-stl-clr.md
+++ b/docs/dotnet/utility-stl-clr.md
@@ -44,6 +44,7 @@ Include the STL/CLR header `<cliext/utility>` to define the template class `pair
 ## Members
 
 ## <a name="pair"></a> pair (STL/CLR)
+
 The template class describes an object that wraps a pair of values.
 
 ### Syntax

--- a/docs/dotnet/vector-stl-clr.md
+++ b/docs/dotnet/vector-stl-clr.md
@@ -939,6 +939,7 @@ x b c
 ```
 
 ## <a name="front_item"></a> vector::front_item (STL/CLR)
+
 Accesses the first element.
 
 ### Syntax
@@ -989,6 +990,7 @@ x b c
 ```
 
 ## <a name="generic_container"></a> vector::generic_container (STL/CLR)
+
 The type of the generic interface for the container.
 
 ### Syntax
@@ -1112,6 +1114,7 @@ a a c
 ```
 
 ## <a name="generic_reverse_iterator"></a> vector::generic_reverse_iterator (STL/CLR)
+
 The type of a reverse iterator for use with the generic interface for the container.
 
 ### Syntax

--- a/docs/mfc/reference/cmfcdesktopalertwnd-class.md
+++ b/docs/mfc/reference/cmfcdesktopalertwnd-class.md
@@ -10,6 +10,7 @@ ms.assetid: 73a2dd7b-ea84-4ae2-9830-7cf6e8dd2425
 The `CMFCDesktopAlertWnd` class implements the functionality of a modeless dialog box which appears on the screen to inform the user about an event.
 
 For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cmfcdropdowntoolbar-class.md
+++ b/docs/mfc/reference/cmfcdropdowntoolbar-class.md
@@ -10,6 +10,7 @@ ms.assetid: 78818ec5-83ce-42fa-a0d4-2d9d5ecc8770
 A toolbar that appears when the user presses and holds a top-level toolbar button.
 
    For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cmfcoutlookbartabctrl-class.md
+++ b/docs/mfc/reference/cmfcoutlookbartabctrl-class.md
@@ -9,6 +9,7 @@ ms.assetid: b1f2b3f7-cc59-49a3-99d8-7ff9b37c044b
 
 A tab control that has the visual appearance of the **Navigation Pane** in Microsoft Outlook.
 For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cmfcrebar-class.md
+++ b/docs/mfc/reference/cmfcrebar-class.md
@@ -9,6 +9,7 @@ ms.assetid: 02a60e29-6224-49c1-9e74-e0a7d9f8d023
 
 A `CMFCReBar` object is a control bar that provides layout, persistence, and state information for rebar controls.
    For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cmfcshelltreectrl-class.md
+++ b/docs/mfc/reference/cmfcshelltreectrl-class.md
@@ -10,6 +10,7 @@ ms.assetid: 3d1da715-9554-4ed7-968c-055c48146267
 The `CMFCShellTreeCtrl` class extends [CTreeCtrl Class](../../mfc/reference/ctreectrl-class.md) functionality by displaying a hierarchy of Shell items.
 
 For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cmfctoolbarimages-class.md
+++ b/docs/mfc/reference/cmfctoolbarimages-class.md
@@ -9,6 +9,7 @@ ms.assetid: d4e50518-9ffc-406f-9996-f79e5cd38155
 
 The images on a toolbar. The `CMFCToolBarImages` class manages toolbar images loaded from application resources or from files.
    For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/cwinappex-class.md
+++ b/docs/mfc/reference/cwinappex-class.md
@@ -10,6 +10,7 @@ ms.assetid: a3d3e053-3e22-463f-9444-c73abb1bb9d7
 `CWinAppEx` handles the application state, saves the state to the registry, loads the state from the registry, initializes application managers, and provides links to those same application managers.
 
    For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
+
 ## Syntax
 
 ```

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -294,6 +294,7 @@ The macro ENSURE_ARG acts like the ENSURE macro.
 ENSURE_VALID calls the ASSERT_VALID macro (which has an effect only in Debug builds). In addition, ENSURE_VALID throws an exception if the pointer is NULL. The NULL test is performed in both Debug and Release configurations.
 
 If any of these tests fails, an alert message is displayed in the same manner as ASSERT. The macro throws an invalid argument exception if needed.
+
 ### Requirements
 
 **Header:** afx.h

--- a/docs/mfc/reference/exception-processing.md
+++ b/docs/mfc/reference/exception-processing.md
@@ -189,6 +189,7 @@ See the example for [CATCH](#catch).
 ### Requirements
 
   **Header** afx.h
+
 ##  <a name="and_catch_all"></a>  AND_CATCH_ALL
 
 Defines a block of code for catching additional exception types thrown in a preceding **TRY** block.

--- a/docs/mfc/reference/icommandsource-interface.md
+++ b/docs/mfc/reference/icommandsource-interface.md
@@ -85,6 +85,7 @@ The beginning index of the command ID range.
 The ending index of the command ID range.
 *cmdHandler*<br/>
 A handle to the message handler method to which the commands are mapped.
+
 ### Remarks
 
 This method maps a contiguous range of command IDs to a single message handler and adds it to the command source object. This is used for handling a group of related buttons with one method.
@@ -146,6 +147,7 @@ void PostCommand(unsigned int command);
 
 *command*<br/>
 The command ID of the message to be posted.
+
 ### Remarks
 
 This method asynchronously posts the message mapped to the ID specified by command. It calls CWnd::PostMessage to place the message in the window's message queue and then returns without waiting for the corresponding window to process the message.
@@ -162,6 +164,7 @@ void RemoveCommandHandler(unsigned int cmdID);
 
 *cmdID*<br/>
 The command ID.
+
 ### Remarks
 
 This method removes the command handler mapped to cmdID from the command source object.
@@ -182,6 +185,7 @@ void RemoveCommandRangeUIHandler(
 The beginning index of the command ID range.
 *cmdIDMax*<br/>
 The ending index of the command ID range.
+
 ### Remarks
 
 This method removes a group of message handlers, mapped to the command IDs specified by cmdIDMin and cmdIDMax, from the command source object.
@@ -202,6 +206,7 @@ void RemoveCommandRangeUIHandler(
 The beginning index of the command ID range.
 *cmdIDMax*<br/>
 The ending index of the command ID range.
+
 ### Remarks
 
 This method removes a group of user interface command message handlers, mapped to the command IDs specified by cmdIDMin and cmdIDMax, from the command source object.
@@ -218,6 +223,7 @@ void RemoveCommandUIHandler(unsigned int cmdID);
 
 *cmdID*<br/>
 The command ID.
+
 ### Remarks
 
 This method removes the user interface command message handler mapped to cmdID from the command source object.
@@ -234,9 +240,11 @@ void SendCommand(unsigned int command);
 
 *command*<br/>
 The command ID of the message to be sent.
+
 ### Remarks
 
 This method synchronously sends the message mapped to the ID specified by command. It calls CWnd::SendMessage to place the message in the window's message queue and waits until that window procedure has processed the message before returning.
+
 ## See also
 
 [How to: Add Command Routing to the Windows Forms Control](../../dotnet/how-to-add-command-routing-to-the-windows-forms-control.md)<br/>

--- a/docs/parallel/amp/reference/out-of-memory-class.md
+++ b/docs/parallel/amp/reference/out-of-memory-class.md
@@ -36,6 +36,7 @@ class out_of_memory : public runtime_exception;
 **Header:** amprt.h
 
 **Namespace:** Concurrency
+
 ## <a name="ctor"></a> out_of_memory
 
 Initializes a new instance of the class.

--- a/docs/parallel/amp/reference/runtime-exception-class.md
+++ b/docs/parallel/amp/reference/runtime-exception-class.md
@@ -106,6 +106,7 @@ HRESULT get_error_code() const throw();
 The HRESULT of error that caused the exception.
 
 ## <a name="operator_eq"></a>  operator=
+
   Copies the contents of the specified `runtime_exception` object into this one.
 
 ### Syntax

--- a/docs/parallel/amp/reference/tiled-extent-class.md
+++ b/docs/parallel/amp/reference/tiled-extent-class.md
@@ -137,6 +137,7 @@ tiled_extent pad() const;
 ### Return Value
 
 The new `tiled_extent` object, by value.
+
 ## <a name="truncate"> </a>  truncate
 
 Returns a new `tiled_extent` object with extents adjusted down to be evenly divisible by the tile dimensions.
@@ -202,6 +203,7 @@ static const int tile_dim2 = _Dim2;
 ```
 
 ## <a name="tile_extent"> </a>  tile_extent
+
   Gets an `extent` object that captures the values of the `tiled_extent` template arguments `_Dim0`, `_Dim1`, and `_Dim2`.
 
 ### Syntax

--- a/docs/porting/porting-guide-com-spy.md
+++ b/docs/porting/porting-guide-com-spy.md
@@ -12,6 +12,7 @@ This topic is the second in a series of articles that demonstrates the process o
 COMSpy is a program that monitors and logs the activity of serviced components on a machine. Serviced components are COM+ components that run on a system and can be used by computers on the same network. They're managed by the Component Services functionality in the Windows Control Panel.
 
 ### Step 1. Converting the project file.
+
 The project file converts easily and produces a migration report. There are a few entries in the report that let us know about issues we might need to deal with. Here's one issue that is reported (note that throughout this topic, error messages are sometimes shortened for readability, for example to remove the full paths):
 
 ```Output
@@ -21,6 +22,7 @@ ComSpyAudit\ComSpyAudit.vcproj: MSB8012: $(TargetPath) ('C:\Users\UserName\Deskt
 One of the frequent problems in upgrading projects is that the **Linker OutputFile** setting in the project properties dialog box might need to be reviewed. For projects prior to Visual Studio 2010, the OutputFile is one setting that the automatic conversion wizard has trouble with, if it's set to a non-standard value. In this case, the paths for the output files were set to a non-standard folder, XP32_DEBUG. To find out more about this error, we consulted a [blog post](https://devblogs.microsoft.com/cppblog/visual-studio-2010-c-project-upgrade-guide/) related to the Visual Studio 2010 project upgrade, which was the upgrade that involved the change from vcbuild to msbuild, a significant change. According to this information, the default value for the **Output File** setting when you create a new project is `$(OutDir)$(TargetName)$(TargetExt)`, but this isn't set during conversion since it's not possible for converted projects to verify that everything is correct. However, let's try putting that in for OutputFile and see if it works.  It does, so we can move on. If there is no particular reason for using a nonstandard output folder, we recommend using the standard location. In this case, we chose to leave the output location as the non-standard during the porting and upgrading process; `$(OutDir)` resolves to the XP32_DEBUG folder in the **Debug** configuration and the ReleaseU folder for the **Release** configuration.
 
 ### Step 2. Getting it to build
+
 Building the ported project, a number of errors and warnings occur.
 
 `ComSpyCtl` doesn't compile though due to this compiler error:
@@ -61,6 +63,7 @@ error MSB3073: The command "regsvr32 /s /c "C:\Users\username\Desktop\spy\spy\Co
 We don't need this post-build registration command anymore. Instead, we simply remove the custom build command, and specify in the **Linker** settings to register the output.
 
 ### Dealing with warnings
+
 The project produces the following linker warning.
 
 ```Output
@@ -116,6 +119,7 @@ for (i=0;i<static_cast<UINT>(lCount);i++)
 Those warnings are cases where a variable was declared in a function that has a parameter with the same name, leading to potentially confusing code. We fixed that by changing the names of the local variables.
 
 ### Step 3. Testing and debugging
+
 We tested the app first by running through the various menus and commands, and then closing the application. The only issue noted was a debug assertion upon closing down the app. The problem appeared in the destructor for `CWindowImpl`, a base class of the `CSpyCon` object, the application's main COM component. The assertion failure occurred in the following code in atlwin.h.
 
 ```cpp

--- a/docs/standard-library/basic-string-view-class.md
+++ b/docs/standard-library/basic-string-view-class.md
@@ -255,6 +255,7 @@ constexpr const_iterator begin() const noexcept;
 ```
 
 ### Return Value
+
 Returns a const_iterator addressing the first element.
 
 ## <a name="cbegin"></a>  basic_string_view::cbegin

--- a/docs/windows/attributes/attributes-by-usage.md
+++ b/docs/windows/attributes/attributes-by-usage.md
@@ -26,6 +26,7 @@ If an attribute precedes an element that is not in the attribute's scope, the at
 |[Custom Attributes](custom-attributes-cpp.md)|Allows the user to extend metadata.|
 
 ## Module Attributes
+
 The following attribute can only be applied to the [module](module-cpp.md) attribute.
 
 |Attribute|Description|

--- a/docs/windows/attributes/module-attributes.md
+++ b/docs/windows/attributes/module-attributes.md
@@ -5,6 +5,7 @@ helpviewer_keywords: ["module attributes", "attributes [C++/CLI], reference topi
 ms.assetid: 46d135dc-613f-4810-90a4-e155ab8ed91a
 ---
 # Module Attributes
+
 The following attribute can only be applied to the [module](module-cpp.md) attribute.
 
 |Attribute|Description|

--- a/docs/windows/attributes/ole-db-consumer-attributes.md
+++ b/docs/windows/attributes/ole-db-consumer-attributes.md
@@ -5,6 +5,7 @@ helpviewer_keywords: ["attributes [C++/CLI], database", "attributes [C++/CLI], d
 ms.assetid: 017b591f-8f9a-42b4-84d5-cc42a21ab0cc
 ---
 # OLE DB Consumer Attributes
+
 The OLE DB consumer attributes inject code, based on the [OLE DB Consumer Templates](../../data/oledb/ole-db-consumer-templates-reference.md), to create a working OLE DB consumer that performs tasks such as opening tables, executing commands, and accessing data.
 
 |Attribute|Description|

--- a/docs/windows/overview-of-windows-programming-in-cpp.md
+++ b/docs/windows/overview-of-windows-programming-in-cpp.md
@@ -90,6 +90,7 @@ Other platforms such as Xbox and Azure have their own SDKs that you may have to 
 Visual Studio includes a powerful debugger for native code, static analysis tools, graphics debugging tools, a full-featured code editor, support for unit tests, and many other tools and utilities. For more information, see [Get started developing with Visual Studio](/visualstudio/ide/get-started-developing-with-visual-studio), and [Overview of C++ development in Visual Studio](../overview/overview-of-cpp-development.md).
 
 ## In this section
+
 |Title|Description|
 |-----------|-----------------|
 |[Walkthrough: Creating a Standard C++ Program](walkthrough-creating-a-standard-cpp-program-cpp.md)| Create a Windows console application.|


### PR DESCRIPTION

Headings should be surrounded by blank lines