### PR TITLE
fix: MD040/fenced-code-language

### DIFF
--- a/docs/atl-mfc-shared/reference/cfiletime-class.md
+++ b/docs/atl-mfc-shared/reference/cfiletime-class.md
@@ -414,7 +414,7 @@ See the example for [CFileTime::Millisecond](#millisecond).
 
 Call this method to set the date and time stored by the `CFileTime` object.
 
-```
+```cpp
 void SetTime(ULONGLONG nTime) throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/cimage-class.md
+++ b/docs/atl-mfc-shared/reference/cimage-class.md
@@ -242,7 +242,7 @@ When *bBlendOp* is set to the default of AC_SRC_OVER, the source bitmap is place
 
 Attaches *hBitmap* to a `CImage` object.
 
-```
+```cpp
 void Attach(HBITMAP hBitmap, DIBOrientation eOrientation = DIBOR_DEFAULT) throw();
 ```
 
@@ -451,7 +451,7 @@ m_myImage.CreateEx(100, 100, 16, BI_BITFIELDS, adwBitmasks, 0);
 
 Detaches the bitmap from the `CImage` object and destroys the bitmap.
 
-```
+```cpp
 void Destroy() throw();
 ```
 
@@ -561,7 +561,7 @@ For versions of `Draw` that do not specify a source rectangle, the entire source
 
 Retrieves a pointer to the actual bit values of a given pixel in a bitmap.
 
-```
+```cpp
 void* GetBits() throw();
 ```
 
@@ -598,7 +598,7 @@ The bits per pixel is usually 1, 4, 8, 16, 24, or 32. See the `biBitCount` membe
 
 Retrieves red, green, blue (RGB) color values from a range of entries in the palette of the DIB section.
 
-```
+```cpp
 void GetColorTable(
     UINT iFirstColor,
     UINT nColors,
@@ -867,7 +867,7 @@ The red, green, blue (RGB) value of the pixel. If the pixel is outside of the cu
 
 Retrieves the exact address of a pixel.
 
-```
+```cpp
 void* GetPixelAddress(int x, int y) throw();
 ```
 
@@ -1020,7 +1020,7 @@ Valid image types are BMP, GIF, JPEG, PNG, and TIFF.
 
 Loads an image from a BITMAP resource.
 
-```
+```cpp
 void LoadFromResource(
     HINSTANCE hInstance,
     LPCTSTR pszResourceName) throw();
@@ -1222,7 +1222,7 @@ This method applies to Windows NT, versions 4.0 and later only. See [PlgBlt](/wi
 
 Releases the device context.
 
-```
+```cpp
 void ReleaseDC() const throw();
 ```
 
@@ -1234,7 +1234,7 @@ Because only one bitmap can be selected into a device context at a time, you mus
 
 Releases resources used by GDI+.
 
-```
+```cpp
 void ReleaseGDIPlus() throw();
 ```
 
@@ -1290,7 +1290,7 @@ Call this function to save the image using a specified name and type. If the *gu
 
 Sets the red, green, blue (RGB) color values for a range of entries in the palette of the DIB section.
 
-```
+```cpp
 void SetColorTable(
     UINT iFirstColor,
     UINT nColors,
@@ -1316,7 +1316,7 @@ This method supports only DIB section bitmaps.
 
 Sets the color of a pixel at a given location in the bitmap.
 
-```
+```cpp
 void SetPixel(int x, int y, COLORREF color) throw();
 ```
 
@@ -1339,7 +1339,7 @@ This method fails if the pixel coordinates lie outside of the selected clipping 
 
 Sets the pixel color to the color located at *iIndex* in the color palette.
 
-```
+```cpp
 void SetPixelIndexed(int x, int y, int iIndex) throw();
 ```
 
@@ -1358,7 +1358,7 @@ The index of a color in the color palette.
 
 Sets the pixel at the locations specified by *x* and *y* to the colors indicated by *r*, *g*, and *b*, in a red, green, blue (RGB) image.
 
-```
+```cpp
 void SetPixelRGB(
     int x,
     int y,

--- a/docs/atl-mfc-shared/reference/coledatetime-class.md
+++ b/docs/atl-mfc-shared/reference/coledatetime-class.md
@@ -1099,7 +1099,7 @@ See the example for [GetStatus](#getstatus).
 
 Sets the status of this `COleDateTime` object.
 
-```
+```cpp
 void SetStatus(DateTimeStatus status) throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/coledatetimespan-class.md
+++ b/docs/atl-mfc-shared/reference/coledatetimespan-class.md
@@ -650,7 +650,7 @@ This operator returns the value of this `COleDateTimeSpan` value as a floating-p
 
 Sets the value of this date/time-span value.
 
-```
+```cpp
 void SetDateTimeSpan(LONG lDays, int nHours, int nMins, int nSecs) throw();
 ```
 
@@ -687,7 +687,7 @@ For functions that query the value of a `COleDateTimeSpan` object, see the follo
 
 Sets the status (validity) of this `COleDateTimeSpan` object.
 
-```
+```cpp
 void SetStatus(DateTimeSpanStatus status) throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/cpoint-class.md
+++ b/docs/atl-mfc-shared/reference/cpoint-class.md
@@ -126,7 +126,7 @@ ASSERT(ptFromDouble == ptMFCHere);
 
 Adds values to the `x` and `y` members of the `CPoint`.
 
-```
+```cpp
 void Offset(int xOffset, int yOffset) throw();
 void Offset(POINT point) throw();
 void Offset(SIZE size) throw();
@@ -196,7 +196,7 @@ Nonzero if the points are not equal; otherwise 0.
 
 The first overload adds a size to the `CPoint`.
 
-```
+```cpp
 void operator+=(SIZE size) throw();
 void operator+=(POINT point) throw();
 ```
@@ -225,7 +225,7 @@ For example, adding `CPoint(5, -7)` to a variable which contains `CPoint(30, 40)
 
 The first overload subtracts a size from the `CPoint`.
 
-```
+```cpp
 void operator-=(SIZE size) throw();
 void operator-=(POINT point) throw();
 ```

--- a/docs/atl-mfc-shared/reference/crect-class.md
+++ b/docs/atl-mfc-shared/reference/crect-class.md
@@ -206,7 +206,7 @@ void CMyDlg::OnPaint()
 
 Copies the `lpSrcRect` rectangle into `CRect`.
 
-```
+```cpp
 void CopyRect(LPCRECT lpSrcRect) throw();
 ```
 
@@ -330,7 +330,7 @@ ASSERT(rect5 == rect4);
 
 `DeflateRect` deflates `CRect` by moving its sides toward its center.
 
-```
+```cpp
 void DeflateRect(int x, int y) throw();
 void DeflateRect(SIZE size) throw();
 void DeflateRect(LPCRECT lpRect) throw();
@@ -456,7 +456,7 @@ ASSERT(nHt == 40);
 
 `InflateRect` inflates `CRect` by moving its sides away from its center.
 
-```
+```cpp
 void InflateRect(int x, int y) throw();
 void InflateRect(SIZE size) throw();
 void InflateRect(LPCRECT lpRect) throw();
@@ -611,7 +611,7 @@ ASSERT(!rectNotNull.IsRectNull());
 
 Call this function to move the rectangle to the absolute x-coordinate specified by *x*.
 
-```
+```cpp
 void MoveToX(int x) throw();
 ```
 
@@ -634,7 +634,7 @@ ASSERT(rect == CRect(10, 0, 110, 100));
 
 Call this function to move the rectangle to the absolute x- and y-coordinates specified.
 
-```
+```cpp
 void MoveToXY(int x, int y) throw();
 void MoveToXY(POINT point) throw();
 ```
@@ -663,7 +663,7 @@ ASSERT(rect == CRect(10, 10, 110, 110));
 
 Call this function to move the rectangle to the absolute y-coordinate specified by *y*.
 
-```
+```cpp
 void MoveToY(int y) throw();
 ```
 
@@ -685,7 +685,7 @@ ASSERT(rect == CRect(0, 10, 100, 110));
 
 Normalizes `CRect` so that both the height and width are positive.
 
-```
+```cpp
 void NormalizeRect() throw();
 ```
 
@@ -710,7 +710,7 @@ ASSERT(rect1 == rect2);
 
 Moves `CRect` by the specified offsets.
 
-```
+```cpp
 void OffsetRect(int x, int y) throw();
 void OffsetRect(POINT point) throw();
 void OffsetRect(SIZE size) throw();
@@ -774,7 +774,7 @@ See the example for [CRect::operator LPCRECT](#operator_lpcrect).
 
 Assigns *srcRect* to `CRect`.
 
-```
+```cpp
 void operator=(const RECT& srcRect) throw();
 ```
 
@@ -877,7 +877,7 @@ ASSERT(rect3 != test);
 
 The first two overloads move `CRect` by the specified offsets.
 
-```
+```cpp
 void operator+=(POINT point) throw();
 void operator+=(SIZE size) throw();
 void operator+=(LPCRECT lpRect) throw();
@@ -915,7 +915,7 @@ ASSERT(rect1 == rect2);
 
 The first two overloads move `CRect` by the specified offsets.
 
-```
+```cpp
 void operator-=(POINT point) throw();
 void operator-=(SIZE size) throw();
 void operator-=(LPCRECT lpRect) throw();
@@ -953,7 +953,7 @@ ASSERT(rect1 == rectResult);
 
 Sets `CRect` equal to the intersection of `CRect` and `rect`.
 
-```
+```cpp
 void operator&=(const RECT& rect) throw();
 ```
 
@@ -977,7 +977,7 @@ See the example for [CRect::IntersectRect](#intersectrect).
 
 Sets `CRect` equal to the union of `CRect` and `rect`.
 
-```
+```cpp
 void operator|=(const RECT& rect) throw();
 ```
 
@@ -1219,7 +1219,7 @@ ASSERT(rect.PtInRect(pt));
 
 Sets the dimensions of `CRect` to the specified coordinates.
 
-```
+```cpp
 void SetRect(int x1, int y1, int x2, int y2) throw();
 ```
 
@@ -1249,7 +1249,7 @@ ASSERT(rect == CRect(256, 256, 512, 512));
 
 Makes `CRect` a null rectangle by setting all coordinates to zero.
 
-```
+```cpp
 void SetRectEmpty() throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/csimplestringt-class.md
+++ b/docs/atl-mfc-shared/reference/csimplestringt-class.md
@@ -95,7 +95,7 @@ Appends a `CSimpleStringT` object to an existing `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void Append(const CSimpleStringT& strSrc);
 void Append(PCXSTR pszSrc, int nLength);
 void Append(PCXSTR pszSrc);
@@ -134,7 +134,7 @@ Appends a character to an existing `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void AppendChar(XCHAR ch);
 ```
 
@@ -278,7 +278,7 @@ Makes this `CSimpleStringT` object an empty string and frees memory as appropria
 
 ### Syntax
 
-```
+```cpp
 void Empty() throw();
 ```
 
@@ -301,7 +301,7 @@ Frees any extra memory previously allocated by the string but no longer needed.
 
 ### Syntax
 
-```
+```cpp
 void FreeExtra();
 ```
 
@@ -857,7 +857,7 @@ Allocates a specific amount of bytes for the `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void Preallocate( int nLength);
 ```
 
@@ -899,7 +899,7 @@ Releases control of the buffer allocated by [GetBuffer](#getbuffer).
 
 ### Syntax
 
-```
+```cpp
 void ReleaseBuffer(int nNewLength = -1);
 ```
 
@@ -940,7 +940,7 @@ Releases control of the buffer allocated by [GetBuffer](#getbuffer).
 
 ### Syntax
 
-```
+```cpp
 void ReleaseBufferSetLength(int nNewLength);
 ```
 
@@ -959,7 +959,7 @@ Sets a single character from a `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void SetAt(int iChar, XCHAR ch);
 ```
 
@@ -991,7 +991,7 @@ Specifies the memory manager of the `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void SetManager(IAtlStringMgr* pStringMgr);
 ```
 
@@ -1019,7 +1019,7 @@ Sets the string of a `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void SetString(PCXSTR pszSrc, int nLength);
 void SetString(PCXSTR pszSrc);
 ```
@@ -1092,7 +1092,7 @@ Truncates the string to the new length.
 
 ### Syntax
 
-```
+```cpp
 void Truncate(int nNewLength);
 ```
 
@@ -1127,7 +1127,7 @@ Unlocks the buffer of the `CSimpleStringT` object.
 
 ### Syntax
 
-```
+```cpp
 void UnlockBuffer() throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/csize-class.md
+++ b/docs/atl-mfc-shared/reference/csize-class.md
@@ -126,7 +126,7 @@ Returns nonzero if the sizes are not equal, otherwise 0.
 
 Adds a size to this `CSize`.
 
-```
+```cpp
 void operator+=(SIZE size) throw();
 ```
 
@@ -138,7 +138,7 @@ void operator+=(SIZE size) throw();
 
 Subtracts a size from this `CSize`.
 
-```
+```cpp
 void operator-=(SIZE size) throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/cstrbuft-class.md
+++ b/docs/atl-mfc-shared/reference/cstrbuft-class.md
@@ -181,7 +181,7 @@ Determines if [CSimpleStringT::GetBuffer](../../atl-mfc-shared/reference/csimple
 
 Sets the length of the character buffer.
 
-```
+```cpp
 void SetLength(int nLength);
 ```
 

--- a/docs/atl-mfc-shared/reference/cstringdata-class.md
+++ b/docs/atl-mfc-shared/reference/cstringdata-class.md
@@ -70,7 +70,7 @@ This data is composed of:
 
 Increments the reference count of the string object.
 
-```
+```cpp
 void AddRef() throw();
 ```
 
@@ -85,7 +85,7 @@ Increments the reference count of the string object.
 
 Returns a pointer to the character buffer of a string object.
 
-```
+```cpp
 void* data() throw();
 ```
 
@@ -136,7 +136,7 @@ Call this function to determine if the character buffer of a string data object 
 
 Locks the character buffer of the associated string object.
 
-```
+```cpp
 void Lock() throw();
 ```
 
@@ -199,7 +199,7 @@ Stores the memory manager for the associated string object. For more information
 
 Decrements the reference count of the string data object.
 
-```
+```cpp
 void Release() throw();
 ```
 
@@ -215,7 +215,7 @@ For example, the following code would call `CStringData::Release` for the string
 
 Unlocks the character buffer of the associated string object.
 
-```
+```cpp
 void Unlock() throw();
 ```
 

--- a/docs/atl-mfc-shared/reference/cstringt-class.md
+++ b/docs/atl-mfc-shared/reference/cstringt-class.md
@@ -224,7 +224,7 @@ The following example demonstrates the use of `CStringT::AllocSysString`.
 
 Converts all the characters in this `CStringT` object from the ANSI character set to the OEM character set.
 
-```
+```cpp
 void AnsiToOem();
 ```
 
@@ -240,7 +240,7 @@ The function is not available if _UNICODE is defined.
 
 Appends formatted data to an existing `CStringT` object.
 
-```
+```cpp
 void __cdecl AppendFormat(PCXSTR pszFormat, [, argument] ...);
 void __cdecl AppendFormat(UINT nFormatID, [, argument] ...);
 ```
@@ -614,7 +614,7 @@ Finds the first occurrence of any of the characters in *pszCharSet*.
 
 Writes formatted data to a `CStringT` in the same way that [sprintf_s](../../c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l.md) formats data into a C-style character array.
 
-```
+```cpp
 void __cdecl Format(UINT nFormatID, [, argument]...);
 void __cdecl Format(PCXSTR pszFormat,  [, argument] ...);
 ```
@@ -648,7 +648,7 @@ For more information, see [Format Specification Syntax: printf and wprintf Funct
 
 Formats a message string.
 
-```
+```cpp
 void __cdecl FormatMessage(UINT nFormatID, [, argument]...);
 void __cdecl FormatMessage(PCXSTR pszFormat, [, argument]...);
 ```
@@ -681,7 +681,7 @@ Each insert must have a corresponding parameter following the *pszFormat* or *nF
 
 Formats a message string using a variable argument list.
 
-```
+```cpp
 void FormatMessageV(PCXSTR pszFormat, va_list* pArgList);
 ```
 
@@ -706,7 +706,7 @@ For more information, see the Windows [FormatMessage](/windows/win32/api/winbase
 
 Formats a message string using a variable argument list.
 
-```
+```cpp
 void FormatV(PCXSTR pszFormat, va_list args);
 ```
 
@@ -930,7 +930,7 @@ For multibyte character sets (MBCS), *nCount* refers to each 8-bit character; th
 
 Converts all the characters in this `CStringT` object from the OEM character set to the ANSI character set.
 
-```
+```cpp
 void OemToAnsi();
 ```
 

--- a/docs/atl-mfc-shared/reference/iatlstringmgr-class.md
+++ b/docs/atl-mfc-shared/reference/iatlstringmgr-class.md
@@ -92,7 +92,7 @@ However, if the memory manager does not support being used by multiple instances
 
 Frees a string data structure.
 
-```
+```cpp
 void Free(CStringData* pData) throw();
 ```
 

--- a/docs/atl/reference/caccesstoken-class.md
+++ b/docs/atl/reference/caccesstoken-class.md
@@ -90,7 +90,7 @@ For an introduction to the access control model in Windows, see [Access Control]
 
 Call this method to take ownership of the given access token handle.
 
-```
+```cpp
 void Attach(HANDLE hToken) throw();
 ```
 

--- a/docs/atl/reference/cacl-class.md
+++ b/docs/atl/reference/cacl-class.md
@@ -162,7 +162,7 @@ Returns the number of ACE entries in the `CAcl` object.
 
 Retrieves the access-control list (ACL) entries from the `CAcl` object.
 
-```
+```cpp
 void GetAclEntries(
     CSid::CSidArray* pSids,
     CAccessMaskArray* pAccessMasks = NULL,
@@ -196,7 +196,7 @@ See [ACE_HEADER](/windows/win32/api/winnt/ns-winnt-ace_header) for more details 
 
 Retrieves all of the information about an entry in an access-control list (ACL).
 
-```
+```cpp
 void GetAclEntry(
     UINT nIndex,
     CSid* pSid,
@@ -317,7 +317,7 @@ Returns a reference to the updated `CAcl` object.
 
 Removes a specific ACE (access-control entry) from the `CAcl` object.
 
-```
+```cpp
 void RemoveAce(UINT nIndex) throw();
 ```
 
@@ -347,7 +347,7 @@ A reference to a `CSid` object.
 
 Marks the `CAcl` object as empty.
 
-```
+```cpp
 void SetEmpty() throw();
 ```
 
@@ -359,7 +359,7 @@ The `CAcl` can be set to empty or to NULL: the two states are distinct.
 
 Marks the `CAcl` object as NULL.
 
-```
+```cpp
 void SetNull() throw();
 ```
 

--- a/docs/atl/reference/catlarray-class.md
+++ b/docs/atl/reference/catlarray-class.md
@@ -135,7 +135,7 @@ In debug builds, an ATLASSERT will be raised if the `CAtlArray` argument is not 
 
 Call this method to confirm that the array object is valid.
 
-```
+```cpp
 void AssertValid() const;
 ```
 
@@ -179,7 +179,7 @@ Frees up any resources used by the array object.
 
 Call this method to copy the elements of one array to another.
 
-```
+```cpp
 void Copy(const CAtlArray<E, ETraits>& aSrc);
 ```
 
@@ -207,7 +207,7 @@ In debug builds, an ATLASSERT will be raised if the existing `CAtlArray` object 
 
 Call this method to remove any empty elements from the array.
 
-```
+```cpp
 void FreeExtra() throw();
 ```
 
@@ -292,7 +292,7 @@ typedef ETraits::INARGTYPE INARGTYPE;
 
 Call this method to insert one array into another.
 
-```
+```cpp
 void InsertArrayAt(size_t iStart, const CAtlArray<E, ETraits>* paNew);
 ```
 
@@ -321,7 +321,7 @@ In debug builds, an ATLASSERT will be raised if the `CAtlArray` object is not va
 
 Call this method to insert a new element (or multiple copies of an element) into the array object.
 
-```
+```cpp
 void InsertAt(size_t iElement, INARGTYPE element, size_t nCount = 1);
 ```
 
@@ -402,7 +402,7 @@ typedef ETraits::OUTARGTYPE OUTARGTYPE;
 
 Call this method to remove all elements from the array object.
 
-```
+```cpp
 void RemoveAll() throw();
 ```
 
@@ -420,7 +420,7 @@ See the example for [CAtlArray::IsEmpty](#isempty).
 
 Call this method to remove one or more elements from the array.
 
-```
+```cpp
 void RemoveAt(size_t iElement, size_t nCount = 1);
 ```
 
@@ -446,7 +446,7 @@ In debug builds, an ATLASSERT will be raised if the `CAtlArray` object is not va
 
 Call this method to set the value of an element in the array object.
 
-```
+```cpp
 void SetAt(size_t iElement, INARGTYPE element);
 ```
 
@@ -500,7 +500,7 @@ See the example for [CAtlArray::GetData](#getdata).
 
 Call this method to set the value of an element in the array object, expanding the array as required.
 
-```
+```cpp
 void SetAtGrow(size_t iElement, INARGTYPE element);
 ```
 

--- a/docs/atl/reference/catlexemodulet-class.md
+++ b/docs/atl/reference/catlexemodulet-class.md
@@ -274,7 +274,7 @@ This method can be overridden. However, in practice is it better to override [CA
 
 This method executes the message loop.
 
-```
+```cpp
 void RunMessageLoop() throw();
 ```
 

--- a/docs/atl/reference/catlfilemappingbase-class.md
+++ b/docs/atl/reference/catlfilemappingbase-class.md
@@ -111,7 +111,7 @@ Returns S_OK on success, or an error HRESULT on failure.
 
 Call this method to get the data from a file-mapping object.
 
-```
+```cpp
 void* GetData() const throw();
 ```
 

--- a/docs/atl/reference/catllist-class.md
+++ b/docs/atl/reference/catllist-class.md
@@ -114,7 +114,7 @@ If the first version is used, an empty element is created using its default cons
 
 Call this method to add an existing list to the head of the list.
 
-```
+```cpp
 void AddHeadList(const CAtlList<E, ETraits>* plNew);
 ```
 
@@ -161,7 +161,7 @@ If the first version is used, an empty element is created using its default cons
 
 Call this method to add an existing list to the tail of this list.
 
-```
+```cpp
 void AddTailList(const CAtlList<E, ETraits>* plNew);
 ```
 
@@ -182,7 +182,7 @@ The list pointed to by *plNew* is inserted after the last element (if any) in th
 
 Call this method to confirm the list is valid.
 
-```
+```cpp
 void AssertValid() const;
 ```
 
@@ -560,7 +560,7 @@ Returns true if the list contains no objects, otherwise false.
 
 Call this method to move the specified element to the head of the list.
 
-```
+```cpp
 void MoveToHead(POSITION pos) throw();
 ```
 
@@ -581,7 +581,7 @@ The specified element is moved from its current position to the head of the list
 
 Call this method to move the specified element to the tail of the list.
 
-```
+```cpp
 void MoveToTail(POSITION pos) throw();
 ```
 
@@ -602,7 +602,7 @@ See the example for [CAtlList::MoveToHead](#movetohead).
 
 Call this method to remove all of the elements from the list.
 
-```
+```cpp
 void RemoveAll() throw();
 ```
 
@@ -618,7 +618,7 @@ See the example for [CAtlList::IsEmpty](#isempty).
 
 Call this method to remove a single element from the list.
 
-```
+```cpp
 void RemoveAt(POSITION pos) throw();
 ```
 
@@ -661,7 +661,7 @@ The head element is deleted from the list, and memory is freed. A copy of the el
 
 Call this method to remove the element at the head of the list without returning a value.
 
-```
+```cpp
 void RemoveHeadNoReturn() throw();
 ```
 
@@ -697,7 +697,7 @@ The tail element is deleted from the list, and memory is freed. A copy of the el
 
 Call this method to remove the element at the tail of the list without returning a value.
 
-```
+```cpp
 void RemoveTailNoReturn() throw();
 ```
 
@@ -713,7 +713,7 @@ See the example for [CAtlList::IsEmpty](#isempty).
 
 Call this method to set the value of the element at a given position in the list.
 
-```
+```cpp
 void SetAt(POSITION pos, INARGTYPE element);
 ```
 
@@ -737,7 +737,7 @@ Replaces the existing value with *element*. In debug builds, an assertion failur
 
 Call this method to swap elements in the list.
 
-```
+```cpp
 void SwapElements(POSITION pos1, POSITION pos2) throw();
 ```
 

--- a/docs/atl/reference/catlmap-class.md
+++ b/docs/atl/reference/catlmap-class.md
@@ -120,7 +120,7 @@ For more information, see [ATL Collection Classes](../../atl/atl-collection-clas
 
 Call this method to cause an ASSERT if the `CAtlMap` object is not valid.
 
-```
+```cpp
 void AssertValid() const;
 ```
 
@@ -210,7 +210,7 @@ This class is used by the methods [CAtlMap::GetNext](#getnext) and [CAtlMap::Loo
 
 Call this method to disable automatic rehashing of the `CAtlMap` object.
 
-```
+```cpp
 void DisableAutoRehash() throw();
 ```
 
@@ -224,7 +224,7 @@ When automatic rehashing is enabled (which it is by default), the number of bins
 
 Call this method to enable automatic rehashing of the `CAtlMap` object.
 
-```
+```cpp
 void EnableAutoRehash() throw();
 ```
 
@@ -238,7 +238,7 @@ When automatic rehashing is enabled (which it is by default), the number of bins
 
 Call this method to return the element at a specified position in the map.
 
-```
+```cpp
 void GetAt(
     POSITION pos,
     KOUTARGTYPE key,
@@ -337,7 +337,7 @@ Returns a pointer to the next pair of key/value elements stored in the map. The 
 
 Gets the next element for iterating.
 
-```
+```cpp
 void GetNextAssoc(
     POSITION& pos,
     KOUTARGTYPE key,
@@ -558,7 +558,7 @@ If the key already exists, the element is replaced. If the key does not exist, a
 
 Call this method to rehash the `CAtlMap` object.
 
-```
+```cpp
 void Rehash(UINT nBins = 0);
 ```
 
@@ -575,7 +575,7 @@ If *nBins* is 0, `CAtlMap` calculates a reasonable number based on the number of
 
 Call this method to remove all elements from the `CAtlMap` object.
 
-```
+```cpp
 void RemoveAll() throw();
 ```
 
@@ -587,7 +587,7 @@ Clears out the `CAtlMap` object, freeing the memory used to store the elements.
 
 Call this method to remove the element at the given position in the `CAtlMap` object.
 
-```
+```cpp
 void RemoveAtPos(POSITION pos) throw();
 ```
 
@@ -651,7 +651,7 @@ Returns the position of the key/value element pair in the `CAtlMap` object.
 
 Call this method to set the optimal load of the `CAtlMap` object.
 
-```
+```cpp
 void SetOptimalLoad(
     float fOptimalLoad,
     float fLoThreshold,
@@ -681,7 +681,7 @@ This method redefines the optimal load value for the `CAtlMap` object. See [CAtl
 
 Call this method to change the value stored at a given position in the `CAtlMap` object.
 
-```
+```cpp
 void SetValueAt(
     POSITION pos,
     VINARGTYPE value);

--- a/docs/atl/reference/catlmodule-class.md
+++ b/docs/atl/reference/catlmodule-class.md
@@ -200,7 +200,7 @@ IGlobalInterfaceTable* m_pGIT;
 
 Releases all data members.
 
-```
+```cpp
 void Term() throw();
 ```
 

--- a/docs/atl/reference/catlservicemodulet-class.md
+++ b/docs/atl/reference/catlservicemodulet-class.md
@@ -110,7 +110,7 @@ Initializes the data members and sets the initial service status.
 
 The handler routine for the service.
 
-```
+```cpp
 void Handler(DWORD dwOpcode) throw();
 ```
 
@@ -193,7 +193,7 @@ Returns TRUE if the service is installed, FALSE otherwise.
 
 Writes to the event log.
 
-```
+```cpp
 void __cdecl LogEvent(LPCTSTR pszFormat, ...) throw();
 ```
 
@@ -273,7 +273,7 @@ A null-terminated string which stores the name of the service.
 
 Override this method to continue the service.
 
-```
+```cpp
 void OnContinue() throw();
 ```
 
@@ -281,7 +281,7 @@ void OnContinue() throw();
 
 Override this method to interrogate the service.
 
-```
+```cpp
 void OnInterrogate() throw();
 ```
 
@@ -289,7 +289,7 @@ void OnInterrogate() throw();
 
 Override this method to pause the service.
 
-```
+```cpp
 void OnPause() throw();
 ```
 
@@ -297,7 +297,7 @@ void OnPause() throw();
 
 Override this method to shut down the service.
 
-```
+```cpp
 void OnShutdown() throw();
 ```
 
@@ -305,7 +305,7 @@ void OnShutdown() throw();
 
 Override this method to stop the service.
 
-```
+```cpp
 void OnStop() throw();
 ```
 
@@ -313,7 +313,7 @@ void OnStop() throw();
 
 Override this method to handle unknown requests to the service.
 
-```
+```cpp
 void OnUnknownRequest(DWORD /* dwOpcode*/) throw();
 ```
 
@@ -409,7 +409,7 @@ After being called, `Run` calls [CAtlServiceModuleT::PreMessageLoop](#premessage
 
 This method is called by the Service Control Manager.
 
-```
+```cpp
 void ServiceMain(DWORD dwArgc, LPTSTR* lpszArgv) throw();
 ```
 
@@ -431,7 +431,7 @@ After the SCM calls `ServiceMain`, a service must give the SCM a handler functio
 
 This method updates the service status.
 
-```
+```cpp
 void SetServiceStatus(DWORD dwState) throw();
 ```
 

--- a/docs/atl/reference/catlwinmodule-class.md
+++ b/docs/atl/reference/catlwinmodule-class.md
@@ -52,7 +52,7 @@ This class provides support for all ATL classes which require windowing features
 
 This method initializes and adds an `_AtlCreateWndData` structure.
 
-```
+```cpp
 void AddCreateWndData(_AtlCreateWndData* pData, void* pObject);
 ```
 
@@ -96,7 +96,7 @@ Frees all allocated resources.
 
 This method returns a pointer to an `_AtlCreateWndData` structure.
 
-```
+```cpp
 void* ExtractCreateWndData();
 ```
 

--- a/docs/atl/reference/cautoptr-class.md
+++ b/docs/atl/reference/cautoptr-class.md
@@ -79,7 +79,7 @@ See also [CAutoPtrArray](../../atl/reference/cautoptrarray-class.md) and [CAutoP
 
 Call this method to take ownership of an existing pointer.
 
-```
+```cpp
 void Attach(T* p) throw();
 ```
 
@@ -165,7 +165,7 @@ See the example in the [CAutoPtr Overview](../../atl/reference/cautoptr-class.md
 
 Call this method to delete an object pointed to by a `CAutoPtr`.
 
-```
+```cpp
 void Free() throw();
 ```
 

--- a/docs/atl/reference/cautorevertimpersonation-class.md
+++ b/docs/atl/reference/cautorevertimpersonation-class.md
@@ -48,7 +48,7 @@ For an introduction to the access control model in Windows, see [Access Control]
 
 Automates the impersonation reversion of an access token.
 
-```
+```cpp
 void Attach(const CAccessToken* pAT) throw();
 ```
 

--- a/docs/atl/reference/cautovectorptr-class.md
+++ b/docs/atl/reference/cautovectorptr-class.md
@@ -90,7 +90,7 @@ In debug builds, an assertion failure will occur if the [CAutoVectorPtr::m_p](#m
 
 Call this method to take ownership of an existing pointer.
 
-```
+```cpp
 void Attach(T* p) throw();
 ```
 
@@ -156,7 +156,7 @@ Releases ownership of a pointer, sets the [CAutoVectorPtr::m_p](#m_p) member var
 
 Call this method to delete an object pointed to by a `CAutoVectorPtr`.
 
-```
+```cpp
 void Free() throw();
 ```
 

--- a/docs/atl/reference/cbindstatuscallback-class.md
+++ b/docs/atl/reference/cbindstatuscallback-class.md
@@ -243,7 +243,7 @@ ATL_PDATAAVAILABLE m_pFunc;
 
 The function pointed to by `m_pFunc` is a member of your object's class and has the following syntax:
 
-```
+```cpp
 void Function_Name(
    CBindStatusCallback<T>* pbsc,
    BYTE* pBytes,
@@ -490,7 +490,7 @@ Every time data is available it is sent to the object through `OnDataAvailable`.
 
 The function pointed to by *pFunc* is a member of your object's class and has the following syntax:
 
-```
+```cpp
 void Function_Name(
     CBindStatusCallback<T>* pbsc,
     BYTE* pBytes,

--- a/docs/atl/reference/ccomaggobject-class.md
+++ b/docs/atl/reference/ccomaggobject-class.md
@@ -152,7 +152,7 @@ A standard HRESULT value.
 
 Called during object destruction, this method frees the [m_contained](#m_contained) member.
 
-```
+```cpp
 void FinalRelease();
 ```
 

--- a/docs/atl/reference/ccombstr-class.md
+++ b/docs/atl/reference/ccombstr-class.md
@@ -211,7 +211,7 @@ S_OK on success, or any standard HRESULT error value.
 
 Attaches a BSTR to the `CComBSTR` object by setting the [m_str](#m_str) member to *src*.
 
-```
+```cpp
 void Attach(BSTR src) throw();
 ```
 
@@ -393,7 +393,7 @@ The BSTR associated with the `CComBSTR` object.
 
 Frees the [m_str](#m_str) member.
 
-```
+```cpp
 void Empty() throw();
 ```
 

--- a/docs/atl/reference/ccomcachedtearoffobject-class.md
+++ b/docs/atl/reference/ccomcachedtearoffobject-class.md
@@ -129,7 +129,7 @@ A standard HRESULT value.
 
 Calls `m_contained::FinalRelease` to free `m_contained`, the `CComContainedObject`< `contained`> object.
 
-```
+```cpp
 void FinalRelease();
 ```
 

--- a/docs/atl/reference/ccomcontrolbase-class.md
+++ b/docs/atl/reference/ccomcontrolbase-class.md
@@ -712,7 +712,7 @@ This value is set using [CComControlBase::SetDirty](#setdirty).
 
 Retrieves the x and y values of the numerator and denominator of the zoom factor for a control activated for in-place editing.
 
-```
+```cpp
 void GetZoomInfo(ATL_DRAWINFO& di);
 ```
 
@@ -1471,7 +1471,7 @@ For a windowed control, the Windows API function [SetFocus](/windows/win32/api/w
 
 Sets the data member `m_bRequiresSave` to the value in *bDirty*.
 
-```
+```cpp
 void SetDirty(BOOL bDirty);
 ```
 

--- a/docs/atl/reference/ccomcritseclock-class.md
+++ b/docs/atl/reference/ccomcritseclock-class.md
@@ -96,7 +96,7 @@ If the object is already locked, an ASSERT error will occur in debug builds.
 
 Call this method to unlock the critical section object.
 
-```
+```cpp
 void Unlock() throw();
 ```
 

--- a/docs/atl/reference/ccomdynamicunkarray-class.md
+++ b/docs/atl/reference/ccomdynamicunkarray-class.md
@@ -93,7 +93,7 @@ Before using the `IUnknown` interface, you should check that it is not NULL.
 
 Empties the array.
 
-```
+```cpp
 void clear();
 ```
 

--- a/docs/atl/reference/ccommodule-class.md
+++ b/docs/atl/reference/ccommodule-class.md
@@ -432,7 +432,7 @@ Removes the class object. This method        is only available to EXEs.
 
 As of ATL 7.0, `CComModule` is obsolete: see [ATL Module Classes](../../atl/atl-module-classes.md) for more details.
 
-```
+```cpp
 void Term() throw();
 ```
 

--- a/docs/atl/reference/ccomobjectrootex-class.md
+++ b/docs/atl/reference/ccomobjectrootex-class.md
@@ -133,7 +133,7 @@ Here is a typical way to create an aggregate:
 
 You can override this method in your derived class to perform any cleanup required for your object.
 
-```
+```cpp
 void FinalRelease();
 ```
 
@@ -213,7 +213,7 @@ If the thread model is multithreaded, `InterlockedDecrement` is used to prevent 
 
 If the thread model is multithreaded, this method calls the Win32 API function [EnterCriticalSection](/windows/win32/api/synchapi/nf-synchapi-entercriticalsection), which waits until the thread can take ownership of the critical section object obtained through a private data member.
 
-```
+```cpp
 void Lock();
 ```
 
@@ -337,7 +337,7 @@ In non-debug builds, always returns 0. In debug builds, returns a value that may
 
 If the thread model is multithreaded, this method calls the Win32 API function [LeaveCriticalSection](/windows/win32/api/synchapi/nf-synchapi-leavecriticalsection), which releases ownership of the critical section object obtained through a private data member.
 
-```
+```cpp
 void Unlock();
 ```
 

--- a/docs/atl/reference/ccompolyobject-class.md
+++ b/docs/atl/reference/ccompolyobject-class.md
@@ -160,7 +160,7 @@ A standard HRESULT value.
 
 Called during object destruction, this method frees the [m_contained](#m_contained) data member.
 
-```
+```cpp
 void FinalRelease();
 ```
 

--- a/docs/atl/reference/ccomptrbase-class.md
+++ b/docs/atl/reference/ccomptrbase-class.md
@@ -103,7 +103,7 @@ See [AtlAdvise](connection-point-global-functions.md#atladvise) for more informa
 
 Call this method to take ownership of an existing pointer.
 
-```
+```cpp
 void Attach(T* p2) throw();
 ```
 
@@ -367,7 +367,7 @@ In debug builds, an assertion error will occur if *pp* is not equal to NULL.
 
 Call this method to release the interface.
 
-```
+```cpp
 void Release() throw();
 ```
 

--- a/docs/atl/reference/ccontainedwindowt-class.md
+++ b/docs/atl/reference/ccontainedwindowt-class.md
@@ -366,7 +366,7 @@ The subclassed window now uses [CContainedWindowT::WindowProc](#windowproc). The
 
 Changes which message map will be used to process the contained window's messages.
 
-```
+```cpp
 void SwitchMessageMap(DWORD dwMsgMapID);
 ```
 

--- a/docs/atl/reference/cdacl-class.md
+++ b/docs/atl/reference/cdacl-class.md
@@ -220,7 +220,7 @@ You should ensure that you only pass a DACL (discretionary access-control list) 
 
 Removes a specific ACE (access-control entry) from the `CDacl` object.
 
-```
+```cpp
 void RemoveAce(UINT nIndex) throw();
 ```
 
@@ -237,7 +237,7 @@ This method is derived from [CAtlArray::RemoveAt](../../atl/reference/catlarray-
 
 Removes all of the ACEs (access-control entries) contained in the `CDacl` object.
 
-```
+```cpp
 void RemoveAllAces() throw();
 ```
 

--- a/docs/atl/reference/cdebugreporthook-class.md
+++ b/docs/atl/reference/cdebugreporthook-class.md
@@ -112,7 +112,7 @@ The code in this function is executed in the underlying security context of the 
 
 Call this method to stop sending debug reports to the named pipe and restore the previous report hook.
 
-```
+```cpp
 void RemoveHook() throw();
 ```
 
@@ -124,7 +124,7 @@ Calls [_CrtSetReportHook2](../../c-runtime-library/reference/crtsetreporthook2-c
 
 Call this method to start sending debug reports to the named pipe.
 
-```
+```cpp
 void SetHook() throw();
 ```
 
@@ -158,7 +158,7 @@ Returns TRUE on success, FALSE on failure.
 
 Call this method to set the time in milliseconds that this class will wait for the named pipe to become available.
 
-```
+```cpp
 void SetTimeout(DWORD dwTimeout);
 ```
 

--- a/docs/atl/reference/chandle-class.md
+++ b/docs/atl/reference/chandle-class.md
@@ -60,7 +60,7 @@ A `CHandle` object can be used whenever a handle is required: the main differenc
 
 Call this method to attach the `CHandle` object to an existing handle.
 
-```
+```cpp
 void Attach(HANDLE h) throw();
 ```
 
@@ -108,7 +108,7 @@ Frees the `CHandle` object by calling [CHandle::Close](#close).
 
 Call this method to close a `CHandle` object.
 
-```
+```cpp
 void Close() throw();
 ```
 

--- a/docs/atl/reference/cheapptrbase-class.md
+++ b/docs/atl/reference/cheapptrbase-class.md
@@ -92,7 +92,7 @@ In debug builds, an assertion failure will occur if the [CHeapPtrBase::m_pData](
 
 Call this method to take ownership of an existing pointer.
 
-```
+```cpp
 void Attach(T* pData) throw();
 ```
 
@@ -139,7 +139,7 @@ Releases ownership of a pointer, sets the [CHeapPtrBase::m_pData](#m_pdata) memb
 
 Call this method to delete an object pointed to by a `CHeapPtrBase`.
 
-```
+```cpp
 void Free() throw();
 ```
 

--- a/docs/atl/reference/cnonstatelessworker-class.md
+++ b/docs/atl/reference/cnonstatelessworker-class.md
@@ -54,7 +54,7 @@ The benefit of this class is that it provides a convenient way to change the sta
 
 Implementation of [WorkerArchetype::Execute](worker-archetype.md#execute).
 
-```
+```cpp
 void Execute(
     Worker::RequestType request,
     void* pvWorkerParam,
@@ -97,7 +97,7 @@ This class handles the same type of work item as the class used for the *Worker*
 
 Implementation of [WorkerArchetype::Terminate](worker-archetype.md#terminate).
 
-```
+```cpp
 void Terminate(void* /* pvParam */) throw();
 ```
 

--- a/docs/atl/reference/cpatht-class.md
+++ b/docs/atl/reference/cpatht-class.md
@@ -115,7 +115,7 @@ The ATL/MFC string class to use for the path (see [CStringT](../../atl-mfc-share
 
 Call this method to add a backslash to the end of a string to create the correct syntax for a path. If the path already has a trailing backslash, no backslash will be added.
 
-```
+```cpp
 void AddBackslash();
 ```
 
@@ -169,7 +169,7 @@ For more information, see [PathAppend](/windows/win32/api/shlwapi/nf-shlwapi-pat
 
 Call this method to create a root path from a given drive number.
 
-```
+```cpp
 void BuildRoot(int iDrive);
 ```
 
@@ -186,7 +186,7 @@ For more information, see [PathBuildRoot](/windows/win32/api/shlwapi/nf-shlwapi-
 
 Call this method to convert the path to canonical form.
 
-```
+```cpp
 void Canonicalize();
 ```
 
@@ -198,7 +198,7 @@ For more information, see [PathCanonicalize](/windows/win32/api/shlwapi/nf-shlwa
 
 Call this method to concatenate a string representing a directory name and a string representing a file path name into one path.
 
-```
+```cpp
 void Combine(PCXSTR pszDir, PCXSTR  pszFile);
 ```
 
@@ -661,7 +661,7 @@ typedef StringType::PXSTR PXSTR;
 
 Call this method to enclose the path in quotation marks if it contains any spaces.
 
-```
+```cpp
 void QuoteSpaces();
 ```
 
@@ -707,7 +707,7 @@ For more information, see [PathRelativePathTo](/windows/win32/api/shlwapi/nf-shl
 
 Call this method to remove any command-line arguments from the path.
 
-```
+```cpp
 void RemoveArgs();
 ```
 
@@ -719,7 +719,7 @@ For more information, see [PathRemoveArgs](/windows/win32/api/shlwapi/nf-shlwapi
 
 Call this method to remove the trailing backslash from the path.
 
-```
+```cpp
 void RemoveBackslash();
 ```
 
@@ -731,7 +731,7 @@ For more information, see [PathRemoveBackslash](/windows/win32/api/shlwapi/nf-sh
 
 Call this method to remove all leading and trailing spaces from the path.
 
-```
+```cpp
 void RemoveBlanks();
 ```
 
@@ -743,7 +743,7 @@ For more information, see [PathRemoveBlanks](/windows/win32/api/shlwapi/nf-shlwa
 
 Call this method to remove the file extension from the path, if there is one.
 
-```
+```cpp
 void RemoveExtension();
 ```
 
@@ -808,7 +808,7 @@ For more information, see [PathSkipRoot](/windows/win32/api/shlwapi/nf-shlwapi-p
 
 Call this method to remove the path portion of a fully qualified path and file name.
 
-```
+```cpp
 void StripPath();
 ```
 
@@ -836,7 +836,7 @@ For more information, see [PathStripToRoot](/windows/win32/api/shlwapi/nf-shlwap
 
 Call this method to remove quotation marks from the beginning and end of a path.
 
-```
+```cpp
 void UnquoteSpaces();
 ```
 

--- a/docs/atl/reference/crbtree-class.md
+++ b/docs/atl/reference/crbtree-class.md
@@ -247,7 +247,7 @@ The *pos* position counter is updated after each call. If the retrieved element 
 
 Call this method to get the key and value of an element stored in the map and advance the position to the next element.
 
-```
+```cpp
 void GetNextAssoc(
     POSITION& pos,
     KOUTARGTYPE key,
@@ -400,7 +400,7 @@ typedef KTraits::OUTARGTYPE KOUTARGTYPE;
 
 Call this method to remove all elements from the `CRBTree` object.
 
-```
+```cpp
 void RemoveAll() throw();
 ```
 
@@ -412,7 +412,7 @@ Clears out the `CRBTree` object, freeing the memory used to store the elements.
 
 Call this method to remove the element at the given position in the `CRBTree` object.
 
-```
+```cpp
 void RemoveAt(POSITION pos) throw();
 ```
 
@@ -429,7 +429,7 @@ Removes the key/value pair stored at the specified position. The memory used to 
 
 Call this method to change the value stored at a given position in the `CRBTree` object.
 
-```
+```cpp
 void SetValueAt(POSITION pos, VINARGTYPE value);
 ```
 

--- a/docs/atl/reference/cregkey-class.md
+++ b/docs/atl/reference/cregkey-class.md
@@ -93,7 +93,7 @@ When you close a key, its registry data is written (flushed) to the hard disk. T
 
 Call this method to attach an HKEY to the `CRegKey` object by setting the [m_hKey](#m_hkey) member handle to *hKey*.
 
-```
+```cpp
 void Attach(HKEY hKey) throw();
 ```
 

--- a/docs/atl/reference/csacl-class.md
+++ b/docs/atl/reference/csacl-class.md
@@ -180,7 +180,7 @@ Returns a reference to the updated `CSacl` object. Ensure that the `ACL` paramet
 
 Removes a specific ACE (access-control entry) from the `CSacl` object.
 
-```
+```cpp
 void RemoveAce(UINT nIndex) throw();
 ```
 
@@ -197,7 +197,7 @@ This method is derived from [CAtlArray::RemoveAt](../../atl/reference/catlarray-
 
 Removes all of the access-control entries (ACEs) contained in the `CSacl` object.
 
-```
+```cpp
 void RemoveAllAces() throw();
 ```
 

--- a/docs/atl/reference/csecurityattributes-class.md
+++ b/docs/atl/reference/csecurityattributes-class.md
@@ -69,7 +69,7 @@ Specifies whether the returned handle is inherited when a new process is created
 
 Call this method to set the attributes of the `CSecurityAttributes` object.
 
-```
+```cpp
 void Set(const CSecurityDesc& rSecurityDescriptor, bool bInheritHandle = false) throw(...);
 ```
 

--- a/docs/atl/reference/csimplearray-class.md
+++ b/docs/atl/reference/csimplearray-class.md
@@ -238,7 +238,7 @@ When an element is removed, the remaining elements in the array are renumbered t
 
 Removes all elements from the array.
 
-```
+```cpp
 void RemoveAll();
 ```
 

--- a/docs/atl/reference/csimplemap-class.md
+++ b/docs/atl/reference/csimplemap-class.md
@@ -269,7 +269,7 @@ Returns TRUE if the key, and matching value, were successfully removed, FALSE ot
 
 Removes all keys and values.
 
-```
+```cpp
 void RemoveAll();
 ```
 

--- a/docs/atl/reference/csnapinitemimpl-class.md
+++ b/docs/atl/reference/csnapinitemimpl-class.md
@@ -353,7 +353,7 @@ QueryPagesFor(DATA_OBJECT_TYPES type);
 
 Call this function to modify the menu insertion flags, specified by *pInsertionAllowed*, for the snap-in object.
 
-```
+```cpp
 void SetMenuInsertionFlags(
     bool bBeforeInsertion,
     long* pInsertionAllowed);
@@ -385,7 +385,7 @@ You should not attempt to set bits in *pInsertionAllowed* that were originally c
 
 Call this function to modify any toolbar button styles, of the snap-in object, before the toolbar is created.
 
-```
+```cpp
 void SetToolbarButtonInfo(
     UINT id,
     BYTE* fsState,
@@ -429,7 +429,7 @@ void SetToolbarButtonInfo(
 
 Call this function to modify a menu item before it is inserted into the context menu of the snap-in object.
 
-```
+```cpp
 void UpdateMenuState(
     UINT id,
     LPTSTR pBuf,

--- a/docs/atl/reference/csnapinpropertypageimpl-class.md
+++ b/docs/atl/reference/csnapinpropertypageimpl-class.md
@@ -68,7 +68,7 @@ CSnapInPropertyPageImpl : public CDialogImplBase
 
 Call this function after an unrecoverable change has been made to the data in a page of a modal property sheet.
 
-```
+```cpp
 void CancelToClose();
 ```
 
@@ -149,7 +149,7 @@ The default implementation of `OnApply` returns TRUE.
 
 This member function is called when the user clicks the **Help** button for the property page.
 
-```
+```cpp
 void OnHelp();
 ```
 
@@ -195,7 +195,7 @@ The default implementation of `OnQueryCancel` returns TRUE.
 
 This member function is called when the user clicks the **Cancel** button.
 
-```
+```cpp
 void OnReset();
 ```
 
@@ -307,7 +307,7 @@ If a page returns a nonzero value, the property sheet does not send the message 
 
 Call this member function to enable or disable the **Apply Now** button, based on whether the settings in the property page should be applied to the appropriate external object.
 
-```
+```cpp
 void SetModified(BOOL bChanged = TRUE);
 ```
 

--- a/docs/atl/reference/cthreadpool-class.md
+++ b/docs/atl/reference/cthreadpool-class.md
@@ -311,7 +311,7 @@ Note that *dwMaxWait* is the time that the pool will wait for a single thread to
 
 Call this method to shut down the thread pool.
 
-```
+```cpp
 void Shutdown(DWORD dwMaxWait = 0) throw();
 ```
 

--- a/docs/atl/reference/ctokengroups-class.md
+++ b/docs/atl/reference/ctokengroups-class.md
@@ -63,7 +63,7 @@ For an introduction to the access control model in Windows, see [Access Control]
 
 Adds a `CSid` or existing `TOKEN_GROUPS` structure to the `CTokenGroups` object.
 
-```
+```cpp
 void Add(const CSid& rSid, DWORD dwAttributes) throw(... );
 void Add(const TOKEN_GROUPS& rTokenGroups) throw(...);
 ```
@@ -135,7 +135,7 @@ Returns true if the `CSid` is removed, false otherwise.
 
 Deletes all `CSid` objects and their associated attributes from the `CTokenGroups` object.
 
-```
+```cpp
 void DeleteAll() throw();
 ```
 
@@ -179,7 +179,7 @@ Retrieves a pointer to the [TOKEN_GROUPS](/windows/win32/api/winnt/ns-winnt-toke
 
 Retrieves the `CSid` objects and (optionally) the attributes belonging to the `CTokenGroups` object.
 
-```
+```cpp
 void GetSidsAndAttributes(
     CSid::CSidArray* pSids,
     CAtlArray<DWORD>* pAttributes = NULL) const throw(...);

--- a/docs/atl/reference/ctokenprivileges-class.md
+++ b/docs/atl/reference/ctokenprivileges-class.md
@@ -146,7 +146,7 @@ This method is useful as a tool for creating restricted tokens.
 
 Deletes all privileges from the `CTokenPrivileges` access token object.
 
-```
+```cpp
 void DeleteAll() throw();
 ```
 
@@ -158,7 +158,7 @@ Deletes all privileges contained in the `CTokenPrivileges` access token object.
 
 Retrieves display names for the privileges contained in the `CTokenPrivileges` access token object.
 
-```
+```cpp
 void GetDisplayNames(CNames* pDisplayNames) const throw(...);
 ```
 
@@ -201,7 +201,7 @@ Returns the number of bytes required to hold a `TOKEN_PRIVILEGES` structure repr
 
 Retrieves the locally unique identifiers (LUIDs) and attribute flags from the `CTokenPrivileges` object.
 
-```
+```cpp
 void GetLuidsAndAttributes(
     CLUIDArray* pPrivileges,
     CAttributes* pAttributes = NULL) const throw(...);
@@ -223,7 +223,7 @@ This method will enumerate all of the privileges contained in the `CTokenPrivile
 
 Retrieves the name and attribute flags from the `CTokenPrivileges` object.
 
-```
+```cpp
 void GetNamesAndAttributes(
     CNames* pNames,
     CAttributes* pAttributes = NULL) const throw(...);

--- a/docs/atl/reference/cwin32heap-class.md
+++ b/docs/atl/reference/cwin32heap-class.md
@@ -90,7 +90,7 @@ Implemented using [HeapAlloc](/windows/win32/api/heapapi/nf-heapapi-heapalloc).
 
 Attaches the heap object to an existing heap.
 
-```
+```cpp
 void Attach(HANDLE hHeap, bool bTakeOwnership) throw();
 ```
 

--- a/docs/atl/reference/cwindow-class.md
+++ b/docs/atl/reference/cwindow-class.md
@@ -239,7 +239,7 @@ See [ArrangeIconicWindows](/windows/win32/api/winuser/nf-winuser-arrangeiconicwi
 
 Attaches the window identified by *hWndNew* to the `CWindow` object.
 
-```
+```cpp
 void Attach(HWND hWndNew) throw();
 ```
 
@@ -616,7 +616,7 @@ See [DlgDirSelectComboBoxEx](/windows/win32/api/winuser/nf-winuser-dlgdirselectc
 
 Registers whether the window accepts dragged files.
 
-```
+```cpp
 void DragAcceptFiles(BOOL bAccept = TRUE);
 ```
 
@@ -668,7 +668,7 @@ See [EnableWindow](/windows/win32/api/winuser/nf-winuser-enablewindow) in the Wi
 
 Marks the end of painting.
 
-```
+```cpp
 void EndPaint(LPPAINTSTRUCT lpPaint) throw();
 ```
 
@@ -1349,7 +1349,7 @@ See [GetWindowLong](/windows/win32/api/winuser/nf-winuser-getwindowlongw) in the
 
 Sets the keyboard focus to a control in the dialog box.
 
-```
+```cpp
 void GotoDlgCtrl(HWND hWndCtrl) const throw();
 ```
 
@@ -1422,7 +1422,7 @@ See [InvalidateRect](/windows/win32/api/winuser/nf-winuser-invalidaterect) in th
 
 Invalidates the client area within the specified region.
 
-```
+```cpp
 void InvalidateRgn(HRGN hRgn, BOOL bErase = TRUE) throw();
 ```
 
@@ -1774,7 +1774,7 @@ The second version of this method uses a [RECT](/previous-versions/dd162897\(v=v
 
 Sets the keyboard focus to the next control in the dialog box.
 
-```
+```cpp
 void NextDlgCtrl() const throw();
 ```
 
@@ -1835,7 +1835,7 @@ Returns without waiting for the thread to process the message.
 
 Sets the keyboard focus to the previous control in the dialog box.
 
-```
+```cpp
 void PrevDlgCtrl() const throw();
 ```
 
@@ -1847,7 +1847,7 @@ See [WM_NEXTDLGCTL](/windows/win32/dlgbox/wm-nextdlgctl) in the Windows SDK.
 
 Sends a [WM_PRINT](/windows/win32/gdi/wm-print) message to the window to request that it draw itself in the specified device context.
 
-```
+```cpp
 void Print(HDC hDC, DWORD dwFlags) const throw();
 ```
 
@@ -1875,7 +1875,7 @@ void Print(HDC hDC, DWORD dwFlags) const throw();
 
 Sends a [WM_PRINTCLIENT](/windows/win32/gdi/wm-printclient) message to the window to request that it draw its client area in the specified device context.
 
-```
+```cpp
 void PrintClient(HDC hDC, DWORD dwFlags) const throw();
 ```
 
@@ -2061,7 +2061,7 @@ See [SendMessage](/windows/win32/api/winuser/nf-winuser-sendmessage) in the Wind
 
 Sends the specified message to all immediate children of the `CWindow` object.
 
-```
+```cpp
 void SendMessageToDescendants(
     UINT message,
     WPARAM wParam = 0,
@@ -2208,7 +2208,7 @@ See [SetFocus](/windows/win32/api/winuser/nf-winuser-setfocus) in the Windows SD
 
 Changes the window's current font by sending a [WM_SETFONT](/windows/win32/winmsg/wm-setfont) message to the window.
 
-```
+```cpp
 void SetFont(HFONT hFont, BOOL bRedraw = TRUE) throw();
 ```
 
@@ -2296,7 +2296,7 @@ See [SetParent](/windows/win32/api/winuser/nf-winuser-setparent) in the Windows 
 
 Sets or clears the redraw flag by sending a [WM_SETREDRAW](/windows/win32/gdi/wm-setredraw) message to the window.
 
-```
+```cpp
 void SetRedraw(BOOL bRedraw = TRUE) throw();
 ```
 

--- a/docs/atl/reference/iatlmemmgr-class.md
+++ b/docs/atl/reference/iatlmemmgr-class.md
@@ -45,7 +45,7 @@ This interface is implemented by [CComHeap](../../atl/reference/ccomheap-class.m
 
 Call this method to allocate a block of memory.
 
-```
+```cpp
 void* Allocate(size_t nBytes) throw();
 ```
 
@@ -70,7 +70,7 @@ For an example, see the [IAtlMemMgr Overview](../../atl/reference/iatlmemmgr-cla
 
 Call this method to free a block of memory.
 
-```
+```cpp
 void Free(void* p) throw();
 ```
 
@@ -112,7 +112,7 @@ For an example, see the [IAtlMemMgr Overview](../../atl/reference/iatlmemmgr-cla
 
 Call this method to reallocate memory allocated by this memory manager.
 
-```
+```cpp
 void* Reallocate(void* p, size_t nBytes) throw();
 ```
 

--- a/docs/atl/reference/ipropertypageimpl-class.md
+++ b/docs/atl/reference/ipropertypageimpl-class.md
@@ -262,7 +262,7 @@ See [IPropertyPage::Move](/windows/win32/api/ocidl/nf-ocidl-ipropertypage-move) 
 
 Flags the property page's state as changed or unchanged, depending on the value of *bDirty*.
 
-```
+```cpp
 void SetDirty(BOOL bDirty);
 ```
 

--- a/docs/atl/reference/worker-archetype.md
+++ b/docs/atl/reference/worker-archetype.md
@@ -51,7 +51,7 @@ These template parameters expect the class to conform to this archetype:
 
 Called to process a work item.
 
-```
+```cpp
 void Execute(
     RequestType request,
     void* pvWorkerParam,
@@ -102,7 +102,7 @@ This type must be used as the first parameter of `WorkerArchetype::Execute` and 
 
 Called to uninitialize the worker object after all requests have been passed to `WorkerArchetype::Execute`).
 
-```
+```cpp
 void Terminate(void* pvParam) throw();
 ```
 

--- a/docs/build/reference/gh-enable-penter-hook-function.md
+++ b/docs/build/reference/gh-enable-penter-hook-function.md
@@ -21,7 +21,7 @@ The `_penter` function is not part of any library and it is up to you to provide
 
 Unless you plan to explicitly call `_penter`, you do not need to provide a prototype. The function must appear as if it had the following prototype, and it must push the content of all registers on entry and pop the unchanged content on exit:
 
-```
+```cpp
 void __declspec(naked) __cdecl _penter( void );
 ```
 

--- a/docs/build/reference/gh-enable-pexit-hook-function.md
+++ b/docs/build/reference/gh-enable-pexit-hook-function.md
@@ -21,7 +21,7 @@ The `_pexit` function is not part of any library and it is up to you to provide 
 
 Unless you plan to explicitly call `_pexit`, you do not need to provide a prototype. The function must appear as if it had the following prototype, and it must push the content of all registers on entry and pop the unchanged content on exit:
 
-```
+```cpp
 void __declspec(naked) __cdecl _pexit( void );
 ```
 

--- a/docs/c-language/conditional-expression-operator.md
+++ b/docs/c-language/conditional-expression-operator.md
@@ -46,7 +46,7 @@ j = ( i < 0 ) ? ( -i ) : ( i );
 
 This example assigns the absolute value of `i` to `j`. If `i` is less than 0, `-i` is assigned to `j`. If `i` is greater than or equal to 0, `i` is assigned to `j`.
 
-```
+```cpp
 void f1( void );
 void f2( void );
 int x;

--- a/docs/c-language/obsolete-forms-of-function-declarations-and-definitions.md
+++ b/docs/c-language/obsolete-forms-of-function-declarations-and-definitions.md
@@ -23,7 +23,7 @@ Functions returning an integer or pointer with the same size as an `int` are not
 
 To comply with the ANSI C standard, old-style function declarations using an ellipsis now generate an error when compiling with the /Za option and a level 4 warning when compiling with /Ze. For example:
 
-```
+```cpp
 void funct1( a, ... )  /* Generates a warning under /Ze or */
 int a;                 /* an error when compiling with /Za */
 {
@@ -32,7 +32,7 @@ int a;                 /* an error when compiling with /Za */
 
 You should rewrite this declaration as a prototype:
 
-```
+```cpp
 void funct1( int a, ... )
 {
 }

--- a/docs/c-runtime-library/ciatan.md
+++ b/docs/c-runtime-library/ciatan.md
@@ -15,7 +15,7 @@ Calculates the arctangent of the top value on the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIatan();
 ```
 

--- a/docs/c-runtime-library/ciatan2.md
+++ b/docs/c-runtime-library/ciatan2.md
@@ -15,7 +15,7 @@ Calculates the arctangent of *x* / *y* where *x* and *y* are values on the top o
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIatan2();
 ```
 

--- a/docs/c-runtime-library/ciexp.md
+++ b/docs/c-runtime-library/ciexp.md
@@ -15,7 +15,7 @@ Calculates the exponential of the top value on the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIexp();
 ```
 

--- a/docs/c-runtime-library/cifmod.md
+++ b/docs/c-runtime-library/cifmod.md
@@ -15,7 +15,7 @@ Calculates the floating-point remainder of the top two values on the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIfmod();
 ```
 

--- a/docs/c-runtime-library/cilog.md
+++ b/docs/c-runtime-library/cilog.md
@@ -15,7 +15,7 @@ Calculates the natural logarithm of the top value in the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIlog();
 ```
 

--- a/docs/c-runtime-library/cilog10.md
+++ b/docs/c-runtime-library/cilog10.md
@@ -15,7 +15,7 @@ Performs a `log10` operation on the top value in the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIlog10();
 ```
 

--- a/docs/c-runtime-library/cipow.md
+++ b/docs/c-runtime-library/cipow.md
@@ -15,7 +15,7 @@ Calculates *x* raised to the *y* power based on the top values in the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIpow();
 ```
 

--- a/docs/c-runtime-library/cisqrt.md
+++ b/docs/c-runtime-library/cisqrt.md
@@ -15,7 +15,7 @@ Calculates the square root of the top value in the stack.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _CIsqrt();
 ```
 

--- a/docs/c-runtime-library/local-unwind2.md
+++ b/docs/c-runtime-library/local-unwind2.md
@@ -15,7 +15,7 @@ Internal CRT Function. Runs all termination handlers that are listed in the indi
 
 ## Syntax
 
-```
+```cpp
 void _local_unwind2(
    PEXCEPTION_REGISTRATION xr,
    int stop

--- a/docs/c-runtime-library/lock.md
+++ b/docs/c-runtime-library/lock.md
@@ -18,7 +18,7 @@ Acquires a multi-thread lock.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _lock
    int locknum
 );

--- a/docs/c-runtime-library/unlock.md
+++ b/docs/c-runtime-library/unlock.md
@@ -18,7 +18,7 @@ Releases a multi-thread lock.
 
 ## Syntax
 
-```
+```cpp
 void __cdecl _unlock(
    int locknum
 );

--- a/docs/cpp/bstr-t-assign.md
+++ b/docs/cpp/bstr-t-assign.md
@@ -13,7 +13,7 @@ Copies a `BSTR` into the `BSTR` wrapped by a **_**`bstr_t`.
 
 ## Syntax
 
-```
+```cpp
 void Assign(
    BSTR s
 );

--- a/docs/cpp/bstr-t-attach.md
+++ b/docs/cpp/bstr-t-attach.md
@@ -13,7 +13,7 @@ Links a `_bstr_t` wrapper to a `BSTR`.
 
 ## Syntax
 
-```
+```cpp
 void Attach(
    BSTR s
 );

--- a/docs/cpp/com-ptr-t-addref.md
+++ b/docs/cpp/com-ptr-t-addref.md
@@ -13,7 +13,7 @@ Calls the `AddRef` member function of `IUnknown` on the encapsulated interface p
 
 ## Syntax
 
-```
+```cpp
 void AddRef( );
 ```
 

--- a/docs/cpp/com-ptr-t-attach.md
+++ b/docs/cpp/com-ptr-t-attach.md
@@ -13,7 +13,7 @@ Encapsulates a raw interface pointer of this smart pointer's type.
 
 ## Syntax
 
-```
+```cpp
 void Attach( Interface* pInterface ) throw( );
 void Attach( Interface* pInterface, bool fAddRef ) throw( );
 ```

--- a/docs/cpp/com-ptr-t-release.md
+++ b/docs/cpp/com-ptr-t-release.md
@@ -13,7 +13,7 @@ Calls the **Release** member function of `IUnknown` on the encapsulated interfac
 
 ## Syntax
 
-```
+```cpp
 void Release( );
 ```
 

--- a/docs/cpp/com-raise-error.md
+++ b/docs/cpp/com-raise-error.md
@@ -13,7 +13,7 @@ Throws a [_com_error](../cpp/com-error-class.md) in response to a failure.
 
 ## Syntax
 
-```
+```cpp
 void __stdcall _com_raise_error(
    HRESULT hr,
    IErrorInfo* perrinfo = 0

--- a/docs/cpp/set-com-error-handler.md
+++ b/docs/cpp/set-com-error-handler.md
@@ -10,7 +10,7 @@ Replaces the default function that is used for COM error-handling. **_set_com_er
 
 ## Syntax
 
-```
+```cpp
 void __stdcall _set_com_error_handler(
    void (__stdcall *pHandler)(
       HRESULT hr,

--- a/docs/cpp/variant-t-attach.md
+++ b/docs/cpp/variant-t-attach.md
@@ -13,7 +13,7 @@ Attaches a `VARIANT` object into the **_variant_t** object.
 
 ## Syntax
 
-```
+```cpp
 void Attach(VARIANT& varSrc);
 ```
 

--- a/docs/cpp/variant-t-changetype.md
+++ b/docs/cpp/variant-t-changetype.md
@@ -13,7 +13,7 @@ Changes the type of the `_variant_t` object to the indicated `VARTYPE`.
 
 ## Syntax
 
-```
+```cpp
 void ChangeType(
    VARTYPE vartype,
    const _variant_t* pSrc = NULL

--- a/docs/cpp/variant-t-clear.md
+++ b/docs/cpp/variant-t-clear.md
@@ -13,7 +13,7 @@ Clears the encapsulated `VARIANT` object.
 
 ## Syntax
 
-```
+```cpp
 void Clear( );
 ```
 

--- a/docs/cpp/variant-t-setstring.md
+++ b/docs/cpp/variant-t-setstring.md
@@ -13,7 +13,7 @@ Assigns a string to this `_variant_t` object.
 
 ## Syntax
 
-```
+```cpp
 void SetString(const char* pSrc);
 ```
 

--- a/docs/cppcx/platform-collections-mapview-class.md
+++ b/docs/cppcx/platform-collections-mapview-class.md
@@ -184,7 +184,7 @@ Divides the current MapView object into two MapView objects. This method is non-
 
 ### Syntax
 
-```
+```cpp
 void Split(
    Windows::Foundation::Collections::IMapView<
                          K, V>^ * firstPartition,

--- a/docs/cppcx/strings-c-cx.md
+++ b/docs/cppcx/strings-c-cx.md
@@ -51,7 +51,7 @@ Note that `StringReference` is a standard C++ class type, not a ref class, you c
 
 The following example shows how to use StringReference:
 
-```
+```cpp
 void GetDecodedStrings(std::vector<std::wstring> strings)
 {
     using namespace Windows::Security::Cryptography;

--- a/docs/cppcx/value-classes-and-structs-c-cx.md
+++ b/docs/cppcx/value-classes-and-structs-c-cx.md
@@ -60,13 +60,13 @@ If you have a value type as a function or method parameter, it is normally passe
 
 To declare a parameter that passes a value type by value, use code like the following:
 
-```
+```cpp
 void Method1(MyValueType obj);
 ```
 
 To declare a parameter that passes a value type by reference, use the reference symbol (&), as in the following:
 
-```
+```cpp
 void Method2(MyValueType& obj);
 ```
 

--- a/docs/dotnet/how-to-do-ddx-ddv-data-binding-with-windows-forms.md
+++ b/docs/dotnet/how-to-do-ddx-ddv-data-binding-with-windows-forms.md
@@ -35,7 +35,7 @@ class CMFC01Dlg : public CDialog
 
 Put the following code in the implementation of CMFC01Dlg:
 
-```
+```cpp
 void CMFC01Dlg::DoDataExchange(CDataExchange* pDX)
 {
    CDialog::DoDataExchange(pDX);
@@ -56,7 +56,7 @@ Now we will add the handler method for a click on the OK button. Click the **Res
 
 Define the handler as follows.
 
-```
+```cpp
 void CMFC01Dlg::OnBnClickedOk()
 {
    AfxMessageBox(CString(m_MyControl.GetControl()->textBox1->Text));

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4291.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4291.md
@@ -68,7 +68,7 @@ int main(void)
 
 The above example generates warning C4291 because no placement form of operator **delete** has been defined that matches the placement form of operator **new**. To solve the problem, insert the following code above **main**. Notice that all of the overloaded operator **delete** function parameters match those of the overloaded operator **new**, except for the first parameter.
 
-```
+```cpp
 void operator delete(void* pMem, char* pszFilename, int nLine)
 {
    free(pMem);

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk1179.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk1179.md
@@ -17,7 +17,7 @@ This error can be caused by using [/H](../../build/reference/h-restrict-length-o
 
 In the following code, `function1` and `function2` are identical in the first eight characters. Compiling with **/Gy** and **/H8** produces a link error.
 
-```
+```cpp
 void function1(void);
 void function2(void);
 

--- a/docs/intrinsics/arm-intrinsics.md
+++ b/docs/intrinsics/arm-intrinsics.md
@@ -385,7 +385,7 @@ The values of the `coproc`, `opcode1`, `crn`, `crm`, and `opcode2` parameters of
 
 These intrinsic functions write data to ARM coprocessors by using the coprocessor data transfer instructions.
 
-```
+```cpp
 void _MoveFromCoprocessor64(
       unsigned __int64 value,
       unsigned int coproc,

--- a/docs/mfc/reference/afx-global-data-structure.md
+++ b/docs/mfc/reference/afx-global-data-structure.md
@@ -113,7 +113,7 @@ TRUE indicates alpha blending is supported; otherwise, FALSE.
 
 Releases resources that are allocated by the framework, such as brushes, fonts, and DLLs.
 
-```
+```cpp
 void CleanUp();
 ```
 
@@ -231,7 +231,7 @@ A theme defines the visual style of an application. A theme is not used to draw 
 
 Enables or disables Microsoft Active Accessibility support.
 
-```
+```cpp
 void EnableAccessibilitySupport(BOOL bEnable=TRUE);
 ```
 
@@ -619,7 +619,7 @@ The `AFX_GLOBAL_DATA::AFX_GLOBAL_DATA` constructor initializes this member to 4 
 
 Detects the current state of the desktop's menu animation and taskbar autohide features.
 
-```
+```cpp
 void OnSettingChange();
 ```
 
@@ -724,7 +724,7 @@ This method creates a horizontal regular font, an underlined font, and a bold fo
 
 Reintializes the logical fonts that are used by the framework.
 
-```
+```cpp
 void UpdateFonts();
 ```
 
@@ -736,7 +736,7 @@ For more information about logical fonts, see `CFont::CreateFontIndirect`.
 
 Initializes the colors, color depth, brushes, pens, and images that are used by the framework.
 
-```
+```cpp
 void UpdateSysColors();
 ```
 
@@ -804,7 +804,7 @@ An integer value with encoded flags that specify positions of auto hide bars. It
 
 Releases interfaces obtained through the `GetITaskbarList` and `GetITaskbarList3` methods.
 
-```
+```cpp
 void ReleaseTaskBarRefs();
 ```
 

--- a/docs/mfc/reference/application-control.md
+++ b/docs/mfc/reference/application-control.md
@@ -97,7 +97,7 @@ The user is in control of the application when the user has explicitly opened or
 
 Sets or clears the user-control flag, which is explained in the reference for `AfxOleGetUserCtrl`.
 
-```
+```cpp
 void AFXAPI AfxOleSetUserCtrl(BOOL bUserCtrl);
 ```
 
@@ -120,7 +120,7 @@ Call this function if other actions in your application should put the user in c
 
 Increments the framework's global count of the number of active objects in the application.
 
-```
+```cpp
 void AFXAPI AfxOleLockApp();
 ```
 
@@ -144,7 +144,7 @@ Call `AfxOleLockApp` from any object that exposes OLE interfaces, if it would be
 
 Decrements the framework's count of active objects in the application.
 
-```
+```cpp
 void AFXAPI AfxOleUnlockApp();
 ```
 
@@ -277,7 +277,7 @@ The symbols are filled in as follows:
 
 Implements the user interface for the *typename* Object command.
 
-```
+```cpp
 void AFXAPI AfxOleSetEditMenu(
     COleClientItem* pClient,
     CMenu* pMenu,

--- a/docs/mfc/reference/canimationbaseobject-class.md
+++ b/docs/mfc/reference/canimationbaseobject-class.md
@@ -194,7 +194,7 @@ Loops over list of animation variables encapsulated in a derived animation objec
 
 Detaches an animation object from parent animation controller.
 
-```
+```cpp
 void DetachFromController();
 ```
 
@@ -373,7 +373,7 @@ CAnimationController* m_pParentController;
 
 Sets a flag to automatically destroy transitions.
 
-```
+```cpp
 void SetAutodestroyTransitions(BOOL bValue);
 ```
 
@@ -390,7 +390,7 @@ Set this flag only if you allocated transition objects using operator new. If fo
 
 Sets new IDs.
 
-```
+```cpp
 void SetID(
     UINT32 nObjectID,
     UINT32 nGroupID = 0);
@@ -424,7 +424,7 @@ This helper can be used to establish a relationship between animation variables 
 
 Sets user-defined data.
 
-```
+```cpp
 void SetUserData (DWORD dwUserData);
 ```
 

--- a/docs/mfc/reference/canimationcolor-class.md
+++ b/docs/mfc/reference/canimationcolor-class.md
@@ -76,7 +76,7 @@ The CAnimationColor class encapsulates three CAnimationVariable objects and can 
 
 Adds transitions for Red, Green and Blue components.
 
-```
+```cpp
 void AddTransition(
     CBaseTransition* pRTransition,
     CBaseTransition* pGTransition,
@@ -264,7 +264,7 @@ operator COLORREF();
 
 Assigns color to CAnimationColor.
 
-```
+```cpp
 void operator=(COLORREF color);
 ```
 
@@ -281,7 +281,7 @@ It's recommended to do that before animation start, because this operator calls 
 
 Sets default value.
 
-```
+```cpp
 void SetDefaultValue(COLORREF color);
 ```
 

--- a/docs/mfc/reference/canimationcontroller-class.md
+++ b/docs/mfc/reference/canimationcontroller-class.md
@@ -194,7 +194,7 @@ CAnimationController(void);
 
 Called by the framework to clean up the group when animation has been scheduled.
 
-```
+```cpp
 void CleanUpGroup(UINT32 nGroupID);
 void CleanUpGroup(CAnimationGroup* pGroup);
 ```
@@ -905,7 +905,7 @@ This method is called if you enable storyboard events using CAnimationController
 
 Removes all animation groups from animation controller.
 
-```
+```cpp
 void RemoveAllAnimationGroups();
 ```
 
@@ -917,7 +917,7 @@ All groups will be deleted, their pointer, if stored at the application level, m
 
 Removes an animation group with specified ID from animation controller.
 
-```
+```cpp
 void RemoveAnimationGroup(UINT32 nGroupID);
 ```
 
@@ -934,7 +934,7 @@ This method removes an animation group from the internal list of groups and dele
 
 Remove an animation object from animation controller.
 
-```
+```cpp
 void RemoveAnimationObject(
     CAnimationBaseObject* pObject,
     BOOL bNoDelete = FALSE);
@@ -956,7 +956,7 @@ Removes an animation object from animation controller and animation group. Call 
 
 Removes transitions from animation objects that belong to the specified group.
 
-```
+```cpp
 void RemoveTransitions(UINT32 nGroupID);
 ```
 
@@ -999,7 +999,7 @@ You must call AnimateGroup with parameter bScheduleNow set to FALSE prior Schedu
 
 Establishes a relationship between animation controller and a window.
 
-```
+```cpp
 void SetRelatedWnd(CWnd* pWnd);
 ```
 

--- a/docs/mfc/reference/canimationgroup-class.md
+++ b/docs/mfc/reference/canimationgroup-class.md
@@ -87,7 +87,7 @@ The destructor. Called when an animation group is being destroyed.
 
 A helper that adds keyframes to a storyboard.
 
-```
+```cpp
 void AddKeyframes(IUIAnimationStoryboard* pStoryboard, BOOL bAddDeep);
 ```
 
@@ -103,7 +103,7 @@ Specifies whether this method should add to the storyboard keyframes that depend
 
 A helper that adds transitions to a storyboard.
 
-```
+```cpp
 void AddTransitions(
     IUIAnimationStoryboard* pStoryboard,
     BOOL bDependOnKeyframes);
@@ -145,7 +145,7 @@ This method creates an internal storyboard, creates and applies transitions and 
 
 Applies transitions to animation objects.
 
-```
+```cpp
 void ApplyTransitions();
 ```
 
@@ -278,7 +278,7 @@ ATL::CComPtr<IUIAnimationStoryboard> m_pStoryboard;
 
 Removes and optionally destroys all keyframes that belong to an animation group.
 
-```
+```cpp
 void RemoveKeyframes();
 ```
 
@@ -290,7 +290,7 @@ If m_bAutodestroyKeyframes member is TRUE then keyframes are removed and destroy
 
 Removes transitions from animation objects that belong to an animation group.
 
-```
+```cpp
 void RemoveTransitions();
 ```
 
@@ -326,7 +326,7 @@ Call this function to schedule an animation at the specified time. You must call
 
 Directs all animation objects that belong to group automatically destroy transitions.
 
-```
+```cpp
 void SetAutodestroyTransitions(BOOL bAutoDestroy = TRUE);
 ```
 

--- a/docs/mfc/reference/canimationmanagereventhandler-class.md
+++ b/docs/mfc/reference/canimationmanagereventhandler-class.md
@@ -111,7 +111,7 @@ Visual Studio 2010 SP1 is required.
 
 Stores a pointer to animation controller to route events.
 
-```
+```cpp
 void SetAnimationController(CAnimationController* pAnimationController);
 ```
 

--- a/docs/mfc/reference/canimationpoint-class.md
+++ b/docs/mfc/reference/canimationpoint-class.md
@@ -74,7 +74,7 @@ The CAnimationPoint class encapsulates two CAnimationVariable objects and can re
 
 Adds transitions for X and Y coordinates.
 
-```
+```cpp
 void AddTransition(
     CBaseTransition* pXTransition,
     CBaseTransition* pYTransition);
@@ -242,7 +242,7 @@ This function internally calls GetValue. If GetValue for some reason fails, the 
 
 Assigns ptSrc to CAnimationPoint.
 
-```
+```cpp
 void operator=(const CPoint& ptSrc);
 ```
 
@@ -259,7 +259,7 @@ Assigns ptSrc to CAnimationPoint. It's recommended to do that before animation s
 
 Sets default value.
 
-```
+```cpp
 void SetDefaultValue(const POINT& ptDefault);
 ```
 

--- a/docs/mfc/reference/canimationrect-class.md
+++ b/docs/mfc/reference/canimationrect-class.md
@@ -85,7 +85,7 @@ The CAnimationRect class encapsulates four CAnimationVariable objects and can re
 
 Adds transitions for left, top, right and bottom coordinates.
 
-```
+```cpp
 void AddTransition(
     CBaseTransition* pLeftTransition,
     CBaseTransition* pTopTransition,
@@ -365,7 +365,7 @@ This function internally calls GetValue. If GetValue for some reason fails, the 
 
 Assigns rect to CAnimationRect.
 
-```
+```cpp
 void operator=(const RECT& rect);
 ```
 
@@ -382,7 +382,7 @@ It's recommended to do that before animation start, because this operator calls 
 
 Sets default value.
 
-```
+```cpp
 void SetDefaultValue(const CRect& rect);
 ```
 

--- a/docs/mfc/reference/canimationsize-class.md
+++ b/docs/mfc/reference/canimationsize-class.md
@@ -74,7 +74,7 @@ The CAnimationSize class encapsulates two CAnimationVariable objects and can rep
 
 Adds transitions for Width and Height.
 
-```
+```cpp
 void AddTransition(
     CBaseTransition* pCXTransition,
     CBaseTransition* pCYTransition);
@@ -244,7 +244,7 @@ This function internally calls GetValue. If GetValue for some reason fails, the 
 
 Assigns szSrc to CAnimationSize.
 
-```
+```cpp
 void operator=(const CSize& szSrc);
 ```
 
@@ -261,7 +261,7 @@ Assigns szSrc to CAnimationSize. It's recommended to do that before animation st
 
 Sets default value.
 
-```
+```cpp
 void SetDefaultValue(const CSize& szDefault);
 ```
 

--- a/docs/mfc/reference/canimationstoryboardeventhandler-class.md
+++ b/docs/mfc/reference/canimationstoryboardeventhandler-class.md
@@ -124,7 +124,7 @@ S_OK if the method succeeds; otherwise E_FAIL.
 
 Stores a pointer to animation controller to route events.
 
-```
+```cpp
 void SetAnimationController(CAnimationController* pAnimationController);
 ```
 

--- a/docs/mfc/reference/canimationtimereventhandler-class.md
+++ b/docs/mfc/reference/canimationtimereventhandler-class.md
@@ -108,7 +108,7 @@ S_OK if the method succeeds; otherwise E_FAIL.
 
 Stores a pointer to animation controller to route events.
 
-```
+```cpp
 void SetAnimationController(CAnimationController* pAnimationController);
 ```
 

--- a/docs/mfc/reference/canimationvalue-class.md
+++ b/docs/mfc/reference/canimationvalue-class.md
@@ -72,7 +72,7 @@ The CAnimationValue class encapsulates a single CAnimationVariable object and ca
 
 Adds a transition to be applied to a value.
 
-```
+```cpp
 void AddTransition(CBaseTransition* pTransition);
 ```
 
@@ -217,7 +217,7 @@ Provides conversion between CAnimationValue and INT32. This method internally ca
 
 Assigns a DOUBLE value to CAnimationValue.
 
-```
+```cpp
 void operator=(DOUBLE dblVal);
 void operator=(INT32 nVal);
 ```
@@ -238,7 +238,7 @@ Assigns a DOUBLE value to CAnimationValue. This value is set as a default value 
 
 Sets default value.
 
-```
+```cpp
 void SetDefaultValue(DOUBLE dblDefaultValue);
 ```
 

--- a/docs/mfc/reference/canimationvariable-class.md
+++ b/docs/mfc/reference/canimationvariable-class.md
@@ -86,7 +86,7 @@ virtual ~CAnimationVariable();
 
 Adds a transition.
 
-```
+```cpp
 void AddTransition(CBaseTransition* pTransition);
 ```
 
@@ -103,7 +103,7 @@ This method is called to add a transition to the internal list of transitions to
 
 Adds transitions from the internal list to storyboard.
 
-```
+```cpp
 void ApplyTransitions(
     CAnimationController* pController,
     IUIAnimationStoryboard* pStoryboard,
@@ -146,7 +146,7 @@ Constructs an animation variable object and sets its default value. A default va
 
 Clears transitions.
 
-```
+```cpp
 void ClearTransitions(BOOL bAutodestroy);
 ```
 
@@ -207,7 +207,7 @@ This method is called by the framework when it needs to create transitions that 
 
 Enables or disables the IntegerValueChanged event.
 
-```
+```cpp
 void EnableIntegerValueChangedEvent (
     CAnimationController* pController,
     BOOL bEnable);
@@ -229,7 +229,7 @@ When ValueChanged event is enabled, the framework calls virtual method CAnimatio
 
 Enables or disables the ValueChanged event.
 
-```
+```cpp
 void EnableValueChangedEvent (
     CAnimationController* pController,
     BOOL bEnable);
@@ -368,7 +368,7 @@ ATL::CComPtr<IUIAnimationVariable> m_variable;
 
 Sets default value and releases IUIAnimationVariable COM object.
 
-```
+```cpp
 void SetDefaultValue(DOUBLE dblDefaultValue);
 ```
 
@@ -385,7 +385,7 @@ Use this method to reset the default value. This method releases the internal IU
 
 Sets the relationship between an animation variable and an animation object.
 
-```
+```cpp
 void SetParentAnimationObject(CAnimationBaseObject* pParentObject);
 ```
 

--- a/docs/mfc/reference/canimationvariablechangehandler-class.md
+++ b/docs/mfc/reference/canimationvariablechangehandler-class.md
@@ -81,7 +81,7 @@ If the method succeeds, it returns S_OK. Otherwise, it returns an HRESULT error 
 
 Stores a pointer to animation controller to route events.
 
-```
+```cpp
 void SetAnimationController(CAnimationController* pAnimationController);
 ```
 

--- a/docs/mfc/reference/canimationvariableintegerchangehandler-class.md
+++ b/docs/mfc/reference/canimationvariableintegerchangehandler-class.md
@@ -112,7 +112,7 @@ S_OK if the method succeeds; otherwise E_FAIL.
 
 Stores a pointer to animation controller to route events.
 
-```
+```cpp
 void SetAnimationController(CAnimationController* pAnimationController);
 ```
 

--- a/docs/mfc/reference/carchive-class.md
+++ b/docs/mfc/reference/carchive-class.md
@@ -92,7 +92,7 @@ For more information on `CArchive`, see the articles [Serialization](../../mfc/s
 
 Call this function to close the archive without throwing an exception.
 
-```
+```cpp
 void Abort ();
 ```
 
@@ -154,7 +154,7 @@ You may not use `CFile` operations to alter the state of the file until you have
 
 Flushes any data remaining in the buffer, closes the archive, and disconnects the archive from the file.
 
-```
+```cpp
 void Close();
 ```
 
@@ -172,7 +172,7 @@ The member function `Close` ensures that all data is transferred from the archiv
 
 Forces any data remaining in the archive buffer to be written to the file.
 
-```
+```cpp
 void Flush();
 ```
 
@@ -292,7 +292,7 @@ If the `IsStoring` status of an archive is nonzero, then its `IsLoading` status 
 
 Call this member function to place objects in the map that are not really serialized to the file, but that are available for subobjects to reference.
 
-```
+```cpp
 void MapObject(const CObject* pOb);
 ```
 
@@ -622,7 +622,7 @@ In the version of the member function with the *nMax* parameter, the buffer will
 
 Call this member function when you want to store and load the version information of a base class.
 
-```
+```cpp
 void SerializeClass(const CRuntimeClass* pClassRef);
 ```
 
@@ -649,7 +649,7 @@ Use the [RUNTIME_CLASS](../../mfc/reference/run-time-object-model-services.md#ru
 
 Call `SetLoadParams` when you are going to read a large number of `CObject`-derived objects from an archive.
 
-```
+```cpp
 void SetLoadParams(UINT nGrowBy = 1024);
 ```
 
@@ -672,7 +672,7 @@ You must not call `SetLoadParams` after any object is loaded, or after [MapObjec
 
 Call this member function to set the object schema stored in the archive object to *nSchema*.
 
-```
+```cpp
 void SetObjectSchema(UINT nSchema);
 ```
 
@@ -695,7 +695,7 @@ Use `SetObjectSchema` for advanced versioning; for example, when you want to for
 
 Use `SetStoreParams` when storing a large number of `CObject`-derived objects in an archive.
 
-```
+```cpp
 void SetStoreParams(UINT nHashSize = 2053, UINT nBlockSize = 128);
 ```
 
@@ -721,7 +721,7 @@ You must not call `SetStoreParams` after any objects are stored, or after [MapOb
 
 Writes a specified number of bytes to the archive.
 
-```
+```cpp
 void Write(const void* lpBuf, INT nMax);
 ```
 
@@ -747,7 +747,7 @@ You can use the `Write` member function within your `Serialize` function to writ
 
 Use `WriteClass` to store the version and class information of a base class during serialization of the derived class.
 
-```
+```cpp
 void WriteClass(const CRuntimeClass* pClassRef);
 ```
 
@@ -774,7 +774,7 @@ You can use [SerializeClass](#serializeclass) instead of `WriteClass`, which han
 
 Stores the specified `CObject` to the archive.
 
-```
+```cpp
 void WriteObject(const CObject* pOb);
 ```
 
@@ -804,7 +804,7 @@ For a definition of the class `CAge`, see the example for [CObList::CObList](../
 
 Use this member function to write data from a buffer to the file associated with the `CArchive` object.
 
-```
+```cpp
 void WriteString(LPCTSTR lpsz);
 ```
 

--- a/docs/mfc/reference/carray-class.md
+++ b/docs/mfc/reference/carray-class.md
@@ -165,7 +165,7 @@ The array grows one element at a time.
 
 Use this member function to copy the elements of one array to another.
 
-```
+```cpp
 void Copy(const CArray& src);
 ```
 
@@ -214,7 +214,7 @@ It is used to implement the left-side assignment operator for arrays.
 
 Frees any extra memory that was allocated while the array was grown.
 
-```
+```cpp
 void FreeExtra();
 ```
 
@@ -341,7 +341,7 @@ The condition `GetUpperBound( )` = -1 indicates that the array contains no eleme
 
 The first version of `InsertAt` inserts one element (or multiple copies of an element) at a specified index in an array.
 
-```
+```cpp
 void InsertAt(
     INT_PTR nIndex,
     ARG_TYPE newElement,
@@ -458,7 +458,7 @@ For arrays in which an element contains a pointer to one of its own members, or 
 
 Removes all the elements from this array.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -474,7 +474,7 @@ If the array is already empty, the function still works.
 
 Removes one or more elements starting at a specified index in an array.
 
-```
+```cpp
 void RemoveAt(
     INT_PTR nIndex,
     INT_PTR nCount = 1);
@@ -502,7 +502,7 @@ If you try to remove more elements than are contained in the array above the rem
 
 Sets the array element at the specified index.
 
-```
+```cpp
 void SetAt(INT_PTR nIndex, ARG_TYPE newElement);
 ```
 
@@ -531,7 +531,7 @@ You must ensure that your index value represents a valid position in the array. 
 
 Sets the array element at the specified index.
 
-```
+```cpp
 void SetAtGrow(INT_PTR nIndex, ARG_TYPE newElement);
 ```
 
@@ -558,7 +558,7 @@ The array grows automatically if necessary (that is, the upper bound is adjusted
 
 Establishes the size of an empty or existing array; allocates memory if necessary.
 
-```
+```cpp
 void SetSize(
     INT_PTR nNewSize,
     INT_PTR nGrowBy = -1);

--- a/docs/mfc/reference/casyncsocket-class.md
+++ b/docs/mfc/reference/casyncsocket-class.md
@@ -1036,7 +1036,7 @@ For more information, see [Windows Sockets: Socket Notifications](../../mfc/wind
 
 Assigns a new value to a `CAsyncSocket` object.
 
-```
+```cpp
 void operator=(const CAsyncSocket& rSrc);
 ```
 

--- a/docs/mfc/reference/cautohidedocksite-class.md
+++ b/docs/mfc/reference/cautohidedocksite-class.md
@@ -127,7 +127,7 @@ If *lpRect* is NULL, the framework puts the pane in the default location on the 
 
 Retrieves the size of the dock site in screen coordinates.
 
-```
+```cpp
 void GetAlignRect(CRect& rect) const;
 ```
 
@@ -158,7 +158,7 @@ When a `CMFCAutoHideBar` is docked at a `CAutoHideDockSite`, it should not occup
 
 Sets the margin on the left side of the docking bar.
 
-```
+```cpp
 void SetOffsetLeft(int nOffset);
 ```
 
@@ -175,7 +175,7 @@ void SetOffsetLeft(int nOffset);
 
 Sets the margin on the right side of the docking bar.
 
-```
+```cpp
 void SetOffsetRight(int nOffset);
 ```
 
@@ -211,7 +211,7 @@ The default implementation does not use *rectNewClientArea*. It redraws the pane
 
 Calls [CMFCAutoHideBar::UnSetAutoHideMode](../../mfc/reference/cmfcautohidebar-class.md#unsetautohidemode) for objects on the dock site.
 
-```
+```cpp
 void UnSetAutoHideMode(CMFCAutoHideBar* pAutoHideToolbar);
 ```
 

--- a/docs/mfc/reference/cbasepane-class.md
+++ b/docs/mfc/reference/cbasepane-class.md
@@ -209,7 +209,7 @@ virtual void AccNotifyObjectFocusEvent(int);
 
 Adds a pane to the docking manager.
 
-```
+```cpp
 void AddPane(CBasePane* pBar);
 ```
 
@@ -606,7 +606,7 @@ Call this function to dock a pane to another pane or a dock bar ( [CDockSite Cla
 
 Docks the pane by using run-time type information.
 
-```
+```cpp
 void DockPaneUsingRTTI(BOOL bUseDockSite);
 ```
 
@@ -1572,7 +1572,7 @@ virtual void RecalcLayout();
 
 Unregisters a pane and removes it from the list in the docking manager.
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pBar,
     BOOL bDestroy = TRUE,
@@ -1669,7 +1669,7 @@ virtual void SetControlBarStyle(DWORD dwNewStyle);
 
 Sets the docking mode for the pane.
 
-```
+```cpp
 void SetDockingMode(AFX_DOCK_TYPE dockModeNew);
 ```
 

--- a/docs/mfc/reference/cbasetabbedpane-class.md
+++ b/docs/mfc/reference/cbasetabbedpane-class.md
@@ -242,7 +242,7 @@ virtual void EnableSetCaptionTextToTabName(BOOL bEnable);
 
 Restores the internal tab order to a default state.
 
-```
+```cpp
 void FillDefaultTabsOrderArray();
 ```
 
@@ -537,7 +537,7 @@ Call this method to remove the pane specified by the *pBar* parameter from the t
 
 Determines whether the tabbed control bar will be destroyed automatically.
 
-```
+```cpp
 void SetAutoDestroy(BOOL bAutoDestroy = TRUE);
 ```
 

--- a/docs/mfc/reference/cbasetransition-class.md
+++ b/docs/mfc/reference/cbasetransition-class.md
@@ -134,7 +134,7 @@ CBaseTransition();
 
 Releases encapsulated IUIAnimationTransition COM object.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -328,7 +328,7 @@ TRANSITION_TYPE m_type;
 
 Sets keyframes for a transition.
 
-```
+```cpp
 void SetKeyframes(
     CBaseKeyFrame* pStart = NULL,
     CBaseKeyFrame* pEnd = NULL);
@@ -350,7 +350,7 @@ This method tells the transition to start after specified keyframe and, optional
 
 Establishes a relationship between animation variable and transition.
 
-```
+```cpp
 void SetRelatedVariable(CAnimationVariable* pVariable);
 ```
 

--- a/docs/mfc/reference/cbitmapbutton-class.md
+++ b/docs/mfc/reference/cbitmapbutton-class.md
@@ -198,7 +198,7 @@ Nonzero if successful; otherwise 0.
 
 Call this function to resize a bitmap button to the size of the bitmap.
 
-```
+```cpp
 void SizeToContent();
 ```
 

--- a/docs/mfc/reference/cbitmaprendertarget-class.md
+++ b/docs/mfc/reference/cbitmaprendertarget-class.md
@@ -60,7 +60,7 @@ class CBitmapRenderTarget : public CRenderTarget;
 
 Attaches existing render target interface to the object
 
-```
+```cpp
 void Attach(ID2D1BitmapRenderTarget* pTarget);
 ```
 

--- a/docs/mfc/reference/cbutton-class.md
+++ b/docs/mfc/reference/cbutton-class.md
@@ -588,7 +588,7 @@ You are responsible for releasing the bitmap when you are done with it.
 
 Changes the style of a button.
 
-```
+```cpp
 void SetButtonStyle(
     UINT nStyle,
     BOOL bRedraw = TRUE);
@@ -614,7 +614,7 @@ Use the `GetButtonStyle` member function to retrieve the button style. The low-o
 
 Sets or resets the check state of a radio button or check box.
 
-```
+```cpp
 void SetCheck(int nCheck);
 ```
 
@@ -998,7 +998,7 @@ The following code example sets the style of the split button drop-down arrow. T
 
 Sets whether a button control is highlighted or not.
 
-```
+```cpp
 void SetState(BOOL bHighlight);
 ```
 

--- a/docs/mfc/reference/cchecklistbox-class.md
+++ b/docs/mfc/reference/cchecklistbox-class.md
@@ -179,7 +179,7 @@ If checklist box items are not all the same height, the checklist box style (spe
 
 Call this function to enable or disable a checklist box item.
 
-```
+```cpp
 void Enable(
     int nIndex,
     BOOL bEnabled = TRUE);
@@ -296,7 +296,7 @@ The default implementation only returns the default position and size of the che
 
 Sets the state of the specified check box.
 
-```
+```cpp
 void SetCheck(
     int nIndex,
     int nCheck);
@@ -324,7 +324,7 @@ The following table lists possible values for the *nCheck* parameter.
 
 Call this function to set the style of check boxes in the checklist box.
 
-```
+```cpp
 void SetCheckStyle(UINT nStyle);
 ```
 

--- a/docs/mfc/reference/ccmdtarget-class.md
+++ b/docs/mfc/reference/ccmdtarget-class.md
@@ -73,7 +73,7 @@ Dispatch maps, similar to message maps, are used to expose OLE automation `IDisp
 
 Call this function to display the cursor as an hourglass when you expect a command to take a noticeable time interval to execute.
 
-```
+```cpp
 void BeginWaitCursor();
 ```
 
@@ -135,7 +135,7 @@ This member function is basically an implementation of [IOleObject::DoVerb](/win
 
 Call this function to enable OLE automation for an object.
 
-```
+```cpp
 void EnableAutomation();
 ```
 
@@ -147,7 +147,7 @@ This function is typically called from the constructor of your object and should
 
 Enables event firing over connection points.
 
-```
+```cpp
 void EnableConnections();
 ```
 
@@ -159,7 +159,7 @@ To enable connection points, call this member function in the constructor of you
 
 Enables an object's type library.
 
-```
+```cpp
 void EnableTypeLib();
 ```
 
@@ -171,7 +171,7 @@ Call this member function in the constructor of your `CCmdTarget`-derived object
 
 Call this function after you have called the `BeginWaitCursor` member function to return from the hourglass cursor to the previous cursor.
 
-```
+```cpp
 void EndWaitCursor();
 ```
 
@@ -466,7 +466,7 @@ Override this function to provide special handling for this situation. The defau
 
 Call this function to restore the appropriate hourglass cursor after the system cursor has changed (for example, after a message box has opened and then closed while in the middle of a lengthy operation).
 
-```
+```cpp
 void RestoreWaitCursor();
 ```
 

--- a/docs/mfc/reference/ccmdui-class.md
+++ b/docs/mfc/reference/ccmdui-class.md
@@ -71,7 +71,7 @@ For more on the use of this class, see [How to Update User-Interface Objects](..
 
 Call this member function to tell the command-routing mechanism to continue routing the current message down the chain of handlers.
 
-```
+```cpp
 void ContinueRouting();
 ```
 

--- a/docs/mfc/reference/ccolordialog-class.md
+++ b/docs/mfc/reference/ccolordialog-class.md
@@ -227,7 +227,7 @@ You can call [SetCurrentColor](#setcurrentcolor) from within `OnColorOK` to forc
 
 Call this function after calling `DoModal` to force the current color selection to the color value specified in *clr*.
 
-```
+```cpp
 void SetCurrentColor(COLORREF clr);
 ```
 

--- a/docs/mfc/reference/ccombobox-class.md
+++ b/docs/mfc/reference/ccombobox-class.md
@@ -198,7 +198,7 @@ CComboBox();
 
 Deletes (clears) the current selection, if any, in the edit control of the combo box.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -247,7 +247,7 @@ By default, this member function does nothing. If you create an owner-draw combo
 
 Copies the current selection, if any, in the edit control of the combo box onto the Clipboard in CF_TEXT format.
 
-```
+```cpp
 void Copy();
 ```
 
@@ -317,7 +317,7 @@ Apply the following [window styles](../../mfc/reference/styles-used-by-mfc.md#wi
 
 Deletes (cuts) the current selection, if any, in the combo-box edit control and copies the deleted text onto the Clipboard in CF_TEXT format.
 
-```
+```cpp
 void Cut();
 ```
 
@@ -598,7 +598,7 @@ The zero-based index of the currently selected item in the list box of a combo b
 
 Call the `GetDroppedControlRect` member function to retrieve the screen coordinates of the visible (dropped-down) list box of a drop-down combo box.
 
-```
+```cpp
 void GetDroppedControlRect(LPRECT lprect) const;
 ```
 
@@ -740,7 +740,7 @@ The 32-bit value can be set with the *dwItemData* parameter of a [SetItemData](#
 
 Retrieves the application-supplied 32-bit value associated with the specified combo-box item as a pointer (**void** <strong>\*</strong>).
 
-```
+```cpp
 void* GetItemDataPtr(int nIndex) const;
 ```
 
@@ -1015,7 +1015,7 @@ See [CWnd::OnMeasureItem](../../mfc/reference/cwnd-class.md#onmeasureitem) for a
 
 Inserts the data from the Clipboard into the edit control of the combo box at the current cursor position.
 
-```
+```cpp
 void Paste();
 ```
 
@@ -1031,7 +1031,7 @@ Data is inserted only if the Clipboard contains data in CF_TEXT format.
 
 Removes all items from the list box and edit control of a combo box.
 
-```
+```cpp
 void ResetContent();
 ```
 
@@ -1227,7 +1227,7 @@ Scrolling in the static control is disabled when the item list is not visible (t
 
 Sets the width, in pixels, by which the list-box portion of the combo box can be scrolled horizontally.
 
-```
+```cpp
 void SetHorizontalExtent(UINT nExtent);
 ```
 
@@ -1426,7 +1426,7 @@ The system scrolls the list box until either the item specified by *nIndex* appe
 
 Shows or hides the list box of a combo box that has the [CBS_DROPDOWN](../../mfc/reference/styles-used-by-mfc.md#combo-box-styles) or [CBS_DROPDOWNLIST](../../mfc/reference/styles-used-by-mfc.md#combo-box-styles) style.
 
-```
+```cpp
 void ShowDropDown(BOOL bShowIt = TRUE);
 ```
 

--- a/docs/mfc/reference/ccontextmenumanager-class.md
+++ b/docs/mfc/reference/ccontextmenumanager-class.md
@@ -157,7 +157,7 @@ If this method finds a menu that matches *lpszName*, `GetMenuByName` stores the 
 
 Returns the list of menu names added to the [CContextMenuManager](../../mfc/reference/ccontextmenumanager-class.md).
 
-```
+```cpp
 void GetMenuNames(CStringList& listOfNames) const;
 ```
 
@@ -232,7 +232,7 @@ Use the method [CContextMenuManager::LoadState](#loadstate) to load the shortcut
 
 Controls whether the [CContextMenuManager](../../mfc/reference/ccontextmenumanager-class.md) closes the active pop-up menu when it displays a new pop-up menu.
 
-```
+```cpp
 void SetDontCloseActiveMenu (BOOL bSet = TRUE);
 ```
 

--- a/docs/mfc/reference/ccontrolbar-class.md
+++ b/docs/mfc/reference/ccontrolbar-class.md
@@ -247,7 +247,7 @@ Override this function to customize the appearance of the control bar gripper.
 
 Call this function to enable a control bar to be docked.
 
-```
+```cpp
 void EnableDocking(DWORD dwDockStyle);
 ```
 
@@ -404,7 +404,7 @@ To update an individual button or pane, use the ON_UPDATE_COMMAND_UI macro in yo
 
 Call this function to set the desired **CBRS_** styles for the control bar.
 
-```
+```cpp
 void SetBarStyle(DWORD dwStyle);
 ```
 
@@ -447,7 +447,7 @@ Does not affect the **WS_** (window style) settings.
 
 Call this function to set the size of the control bar's borders.
 
-```
+```cpp
 void SetBorders(
     int cxLeft = 0,
     int cyTop = 0,
@@ -484,7 +484,7 @@ The following code example sets the top and bottom borders of the control bar to
 
 Changes the in-place owner of a control bar.
 
-```
+```cpp
 void SetInPlaceOwner(CWnd* pWnd);
 ```
 

--- a/docs/mfc/reference/ccustominterpolator-class.md
+++ b/docs/mfc/reference/ccustominterpolator-class.md
@@ -146,7 +146,7 @@ Basic implementation always returns TRUE. Return FALSE from overridden implement
 
 Initializes duration and final value.
 
-```
+```cpp
 void Init(
     UI_ANIMATION_SECONDS duration,
     DOUBLE finalValue);

--- a/docs/mfc/reference/ccustomtransition-class.md
+++ b/docs/mfc/reference/ccustomtransition-class.md
@@ -135,7 +135,7 @@ CCustomInterpolator* m_pInterpolator;
 
 Sets an initial value, which will be applied to an animation variable associated with this transition.
 
-```
+```cpp
 void SetInitialValue(DOUBLE initialValue);
 ```
 
@@ -147,7 +147,7 @@ void SetInitialValue(DOUBLE initialValue);
 
 Sets an initial velocity, which will be applied to an animation variable associated with this transition.
 
-```
+```cpp
 void SetInitialVelocity(DOUBLE initialVelocity);
 ```
 

--- a/docs/mfc/reference/cd2dbitmap-class.md
+++ b/docs/mfc/reference/cd2dbitmap-class.md
@@ -96,7 +96,7 @@ virtual ~CD2DBitmap();
 
 Attaches existing resource interface to the object.
 
-```
+```cpp
 void Attach(ID2D1Bitmap* pResource);
 ```
 
@@ -161,7 +161,7 @@ Handle to the bitmap.
 
 Initializes the object.
 
-```
+```cpp
 void CommonInit();
 ```
 

--- a/docs/mfc/reference/cd2dbitmapbrush-class.md
+++ b/docs/mfc/reference/cd2dbitmapbrush-class.md
@@ -88,7 +88,7 @@ virtual ~CD2DBitmapBrush();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1BitmapBrush* pResource);
 ```
 
@@ -156,7 +156,7 @@ Pointer to a null-terminated string that contains the name of file.
 
 Initializes the object
 
-```
+```cpp
 void CommonInit(D2D1_BITMAP_BRUSH_PROPERTIES* pBitmapBrushProperties);
 ```
 
@@ -302,7 +302,7 @@ Pointer to an ID2D1BitmapBrush interface or NULL if object is not initialized ye
 
 Specifies the bitmap source that this brush uses to paint
 
-```
+```cpp
 void SetBitmap(CD2DBitmap* pBitmap);
 ```
 
@@ -315,7 +315,7 @@ The bitmap source used by the brush
 
 Specifies how the brush horizontally tiles those areas that extend past its bitmap
 
-```
+```cpp
 void SetExtendModeX(D2D1_EXTEND_MODE extendModeX);
 ```
 
@@ -328,7 +328,7 @@ A value that specifies how the brush horizontally tiles those areas that extend 
 
 Specifies how the brush vertically tiles those areas that extend past its bitmap
 
-```
+```cpp
 void SetExtendModeY(D2D1_EXTEND_MODE extendModeY);
 ```
 
@@ -341,7 +341,7 @@ A value that specifies how the brush vertically tiles those areas that extend pa
 
 Specifies the interpolation mode used when the brush bitmap is scaled or rotated
 
-```
+```cpp
 void SetInterpolationMode(D2D1_BITMAP_INTERPOLATION_MODE interpolationMode);
 ```
 

--- a/docs/mfc/reference/cd2dbrush-class.md
+++ b/docs/mfc/reference/cd2dbrush-class.md
@@ -75,7 +75,7 @@ virtual ~CD2DBrush();
 
 Attaches existing resource interface to the object.
 
-```
+```cpp
 void Attach(ID2D1Brush* pResource);
 ```
 
@@ -154,7 +154,7 @@ A value between zero and 1 that indicates the opacity of the brush. This value i
 
 Gets the current transform of the render target
 
-```
+```cpp
 void GetTransform(D2D1_MATRIX_3X2_F* transform) const;
 ```
 
@@ -207,7 +207,7 @@ Pointer to an ID2D1Brush interface or NULL if object is not initialized yet.
 
 Sets the degree of opacity of this brush
 
-```
+```cpp
 void SetOpacity(FLOAT opacity);
 ```
 
@@ -220,7 +220,7 @@ A value between zero and 1 that indicates the opacity of the brush. This value i
 
 Applies the specified transform to the render target, replacing the existing transformation. All subsequent drawing operations occur in the transformed space.
 
-```
+```cpp
 void SetTransform(const D2D1_MATRIX_3X2_F* transform);
 ```
 

--- a/docs/mfc/reference/cd2dbrushproperties-class.md
+++ b/docs/mfc/reference/cd2dbrushproperties-class.md
@@ -64,7 +64,7 @@ The transformation to apply to the brush
 
 Initializes the object
 
-```
+```cpp
 void CommonInit();
 ```
 

--- a/docs/mfc/reference/cd2dgeometry-class.md
+++ b/docs/mfc/reference/cd2dgeometry-class.md
@@ -83,7 +83,7 @@ virtual ~CD2DGeometry();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1Geometry* pResource);
 ```
 

--- a/docs/mfc/reference/cd2dgeometrysink-class.md
+++ b/docs/mfc/reference/cd2dgeometrysink-class.md
@@ -75,7 +75,7 @@ virtual ~CD2DGeometrySink();
 
 Adds a single arc to the path geometry
 
-```
+```cpp
 void AddArc(const D2D1_ARC_SEGMENT& arc);
 ```
 
@@ -88,7 +88,7 @@ The arc segment to add to the figure
 
 Creates a cubic Bezier curve between the current point and the specified end point.
 
-```
+```cpp
 void AddBezier(const D2D1_BEZIER_SEGMENT& bezier);
 ```
 
@@ -101,7 +101,7 @@ A structure that describes the control points and end point of the Bezier curve 
 
 Creates a sequence of cubic Bezier curves and adds them to the geometry sink.
 
-```
+```cpp
 void AddBeziers(
     const CArray<D2D1_BEZIER_SEGMENT,
     D2D1_BEZIER_SEGMENT>& beziers);
@@ -116,7 +116,7 @@ An array of Bezier segments that describes the Bezier curves to create. A curve 
 
 Creates a line segment between the current point and the specified end point and adds it to the geometry sink.
 
-```
+```cpp
 void AddLine(CD2DPointF point);
 ```
 
@@ -129,7 +129,7 @@ The end point of the line to draw.
 
 Creates a sequence of lines using the specified points and adds them to the geometry sink.
 
-```
+```cpp
 void AddLines(
     const CArray<CD2DPointF,
     CD2DPointF>& points);
@@ -144,7 +144,7 @@ An array of one or more points that describe the lines to draw. A line is drawn 
 
 Creates a quadratic Bezier curve between the current point and the specified end point.
 
-```
+```cpp
 void AddQuadraticBezier(const D2D1_QUADRATIC_BEZIER_SEGMENT& bezier);
 ```
 
@@ -157,7 +157,7 @@ A structure that describes the control point and the end point of the quadratic 
 
 Adds a sequence of quadratic Bezier segments as an array in a single call.
 
-```
+```cpp
 void AddQuadraticBeziers(
     const CArray<D2D1_QUADRATIC_BEZIER_SEGMENT,
     D2D1_QUADRATIC_BEZIER_SEGMENT>& beziers);
@@ -172,7 +172,7 @@ An array of a sequence of quadratic Bezier segments.
 
 Starts a new figure at the specified point.
 
-```
+```cpp
 void BeginFigure(
     CD2DPointF startPoint,
     D2D1_FIGURE_BEGIN figureBegin);
@@ -215,7 +215,7 @@ Nonzero if successful; otherwise FALSE.
 
 Ends the current figure; optionally, closes it.
 
-```
+```cpp
 void EndFigure(D2D1_FIGURE_END figureEnd);
 ```
 
@@ -272,7 +272,7 @@ Pointer to an ID2D1GeometrySink interface or NULL if object is not initialized y
 
 Specifies the method used to determine which points are inside the geometry described by this geometry sink and which points are outside.
 
-```
+```cpp
 void SetFillMode(D2D1_FILL_MODE fillMode);
 ```
 
@@ -285,7 +285,7 @@ The method used to determine whether a given point is part of the geometry.
 
 Specifies stroke and join options to be applied to new segments added to the geometry sink.
 
-```
+```cpp
 void SetSegmentFlags(D2D1_PATH_SEGMENT vertexFlags);
 ```
 

--- a/docs/mfc/reference/cd2dlayer-class.md
+++ b/docs/mfc/reference/cd2dlayer-class.md
@@ -72,7 +72,7 @@ virtual ~CD2DLayer();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1Layer* pResource);
 ```
 

--- a/docs/mfc/reference/cd2dlineargradientbrush-class.md
+++ b/docs/mfc/reference/cd2dlineargradientbrush-class.md
@@ -79,7 +79,7 @@ virtual ~CD2DLinearGradientBrush();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1LinearGradientBrush* pResource);
 ```
 
@@ -235,7 +235,7 @@ Pointer to an ID2D1LinearGradientBrush interface or NULL if object is not initia
 
 Sets the ending coordinates of the linear gradient in the brush's coordinate space
 
-```
+```cpp
 void SetEndPoint(CD2DPointF point);
 ```
 
@@ -248,7 +248,7 @@ The ending two-dimensional coordinates of the linear gradient, in the brush's co
 
 Sets the starting coordinates of the linear gradient in the brush's coordinate space
 
-```
+```cpp
 void SetStartPoint(CD2DPointF point);
 ```
 

--- a/docs/mfc/reference/cd2dmesh-class.md
+++ b/docs/mfc/reference/cd2dmesh-class.md
@@ -72,7 +72,7 @@ virtual ~CD2DMesh();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1Mesh* pResource);
 ```
 

--- a/docs/mfc/reference/cd2dpathgeometry-class.md
+++ b/docs/mfc/reference/cd2dpathgeometry-class.md
@@ -60,7 +60,7 @@ class CD2DPathGeometry : public CD2DGeometry;
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1PathGeometry* pResource);
 ```
 

--- a/docs/mfc/reference/cd2dradialgradientbrush-class.md
+++ b/docs/mfc/reference/cd2dradialgradientbrush-class.md
@@ -83,7 +83,7 @@ virtual ~CD2DRadialGradientBrush();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1RadialGradientBrush* pResource);
 ```
 
@@ -263,7 +263,7 @@ Pointer to an ID2D1RadialGradientBrush interface or NULL if object is not initia
 
 Specifies the center of the gradient ellipse in the brush's coordinate space
 
-```
+```cpp
 void SetCenter(CD2DPointF point);
 ```
 
@@ -276,7 +276,7 @@ The center of the gradient ellipse, in the brush's coordinate space
 
 Specifies the offset of the gradient origin relative to the gradient ellipse's center
 
-```
+```cpp
 void SetGradientOriginOffset(CD2DPointF gradientOriginOffset);
 ```
 
@@ -289,7 +289,7 @@ The offset of the gradient origin from the center of the gradient ellipse
 
 Specifies the x-radius of the gradient ellipse, in the brush's coordinate space
 
-```
+```cpp
 void SetRadiusX(FLOAT radiusX);
 ```
 
@@ -302,7 +302,7 @@ The x-radius of the gradient ellipse. This value is in the brush's coordinate sp
 
 Specifies the y-radius of the gradient ellipse, in the brush's coordinate space
 
-```
+```cpp
 void SetRadiusY(FLOAT radiusY);
 ```
 

--- a/docs/mfc/reference/cd2dsolidcolorbrush-class.md
+++ b/docs/mfc/reference/cd2dsolidcolorbrush-class.md
@@ -75,7 +75,7 @@ virtual ~CD2DSolidColorBrush();
 
 Attaches existing resource interface to the object
 
-```
+```cpp
 void Attach(ID2D1SolidColorBrush* pResource);
 ```
 
@@ -213,7 +213,7 @@ Pointer to an ID2D1SolidColorBrush interface or NULL if object is not initialize
 
 Specifies the color of this solid color brush
 
-```
+```cpp
 void SetColor(D2D1_COLOR_F color);
 ```
 

--- a/docs/mfc/reference/cdaodatabase-class.md
+++ b/docs/mfc/reference/cdaodatabase-class.md
@@ -255,7 +255,7 @@ If you omit the encryption constant, an unencrypted database is created. You can
 
 Call this member function to establish a relation between one or more fields in a primary table in the database and one or more fields in a foreign table (another table in the database).
 
-```
+```cpp
 void CreateRelation(
     LPCTSTR lpszName,
     LPCTSTR lpszTable,
@@ -318,7 +318,7 @@ For related information, see the topic "CreateRelation Method" in DAO Help.
 
 Call this member function to delete the specified querydef — saved query — from the `CDaoDatabase` object's QueryDefs collection.
 
-```
+```cpp
 void DeleteQueryDef(LPCTSTR lpszName);
 ```
 
@@ -337,7 +337,7 @@ For information about creating querydef objects, see class [CDaoQueryDef](../../
 
 Call this member function to delete an existing relation from the database object's Relations collection.
 
-```
+```cpp
 void DeleteRelation(LPCTSTR lpszName);
 ```
 
@@ -356,7 +356,7 @@ For related information, see the topic "Delete Method" in DAO Help.
 
 Call this member function to delete the specified table and all of its data from the `CDaoDatabase` object's TableDefs collection.
 
-```
+```cpp
 void DeleteTableDef(LPCTSTR lpszName);
 ```
 
@@ -380,7 +380,7 @@ For related information, see the topic "Delete Method" in DAO Help.
 
 Call this member function to run an action query or execute a SQL statement on the database.
 
-```
+```cpp
 void Execute(
     LPCTSTR lpszSQL,
     int nOptions = dbFailOnError);
@@ -499,7 +499,7 @@ The number of queries defined in the database.
 
 Call this member function to obtain various kinds of information about a query defined in the database.
 
-```
+```cpp
 void GetQueryDefInfo(
     int nIndex,
     CDaoQueryDefInfo& querydefinfo,
@@ -597,7 +597,7 @@ To illustrate the concept of a relation, consider a Suppliers table and a Produc
 
 Call this member function to obtain information about a specified relation in the database's Relations collection.
 
-```
+```cpp
 void GetRelationInfo(
     int nIndex,
     CDaoRelationInfo& relinfo,
@@ -656,7 +656,7 @@ The number of tabledefs defined in the database.
 
 Call this member function to obtain various kinds of information about a table defined in the database.
 
-```
+```cpp
 void GetTableDefInfo(
     int nIndex,
     CDaoTableDefInfo& tabledefinfo,
@@ -813,7 +813,7 @@ You can also use the connection string for multiple levels of login authorizatio
 
 Call this member function to override the default number of seconds to allow before subsequent operations on the connected database time out.
 
-```
+```cpp
 void SetQueryTimeout(short nSeconds);
 ```
 

--- a/docs/mfc/reference/cdaoexception-class.md
+++ b/docs/mfc/reference/cdaoexception-class.md
@@ -118,7 +118,7 @@ This information is useful for looping through the Errors collection to retrieve
 
 Returns error information about a particular error object in the Errors collection.
 
-```
+```cpp
 void GetErrorInfo(int nIndex);
 ```
 

--- a/docs/mfc/reference/cdaofieldexchange-class.md
+++ b/docs/mfc/reference/cdaofieldexchange-class.md
@@ -120,7 +120,7 @@ Contains a pointer to the [CDaoRecordset](../../mfc/reference/cdaorecordset-clas
 
 Call `SetFieldType` in your `CDaoRecordset` class's `DoFieldExchange` override.
 
-```
+```cpp
 void SetFieldType(UINT nFieldType);
 ```
 

--- a/docs/mfc/reference/cdaoquerydef-class.md
+++ b/docs/mfc/reference/cdaoquerydef-class.md
@@ -342,7 +342,7 @@ The number of fields defined in the query.
 
 Call this member function to obtain various kinds of information about a field defined in the querydef.
 
-```
+```cpp
 void GetFieldInfo(
     int nIndex,
     CDaoFieldInfo& fieldinfo,
@@ -435,7 +435,7 @@ For related information, see the topics "Parameter Object", "Parameters Collecti
 
 Call this member function to obtain information about a parameter defined in the querydef.
 
-```
+```cpp
 void GetParameterInfo(
     int nIndex,
     CDaoParameterInfo& paraminfo,
@@ -646,7 +646,7 @@ Once the querydef is open, you can call its [Execute](#execute) member function 
 
 Call this member function to set the querydef object's connection string.
 
-```
+```cpp
 void SetConnect(LPCTSTR lpszConnect);
 ```
 
@@ -670,7 +670,7 @@ For more information about the connection string's structure and examples of con
 
 Call this member function if you want to change the name of a querydef that is not temporary.
 
-```
+```cpp
 void SetName(LPCTSTR lpszName);
 ```
 
@@ -687,7 +687,7 @@ Querydef names are unique, user-defined names. You can call `SetName` before the
 
 Call this member function to set the time limit before a query to an ODBC data source times out.
 
-```
+```cpp
 void SetODBCTimeout(short nODBCTimeout);
 ```
 
@@ -737,7 +737,7 @@ Specify the value to set as a `COleVariant` object. For information about settin
 
 Call this member function as part of the process of setting up a SQL pass-through query to an external database.
 
-```
+```cpp
 void SetReturnsRecords(BOOL bReturnsRecords);
 ```
 
@@ -754,7 +754,7 @@ In such a case, you must create the querydef and set its properties using other 
 
 Call this member function to set the SQL statement that the querydef executes.
 
-```
+```cpp
 void SetSQL(LPCTSTR lpszSQL);
 ```
 

--- a/docs/mfc/reference/cdaorecordset-class.md
+++ b/docs/mfc/reference/cdaorecordset-class.md
@@ -458,7 +458,7 @@ For related information, see the topics "AddNew Method", "Edit Method", "Delete 
 
 Call this member function to cache a specified number of records from the recordset.
 
-```
+```cpp
 void FillCache(
     long* pSize = NULL,
     COleVariant* pBookmark = NULL);
@@ -937,7 +937,7 @@ For related information, see the topic "Count Property" in DAO Help.
 
 Call this member function to obtain information about the fields in a recordset.
 
-```
+```cpp
 void GetFieldInfo(
     int nIndex,
     CDaoFieldInfo& fieldinfo,
@@ -1044,7 +1044,7 @@ For related information, see the topic "Attributes Property" in DAO Help.
 
 Call this member function to obtain various kinds of information about an index defined in the base table underlying a recordset.
 
-```
+```cpp
 void GetIndexInfo(
     int nIndex,
     CDaoIndexInfo& indexinfo,
@@ -1634,7 +1634,7 @@ For related information, see the topics "Move Method" and "MoveFirst, MoveLast, 
 
 Call this member function to make the first record in the recordset (if any) the current record.
 
-```
+```cpp
 void MoveFirst();
 ```
 
@@ -1664,7 +1664,7 @@ For related information, see the topics "Move Method" and "MoveFirst, MoveLast, 
 
 Call this member function to make the last record (if any) in the recordset the current record.
 
-```
+```cpp
 void MoveLast();
 ```
 
@@ -1690,7 +1690,7 @@ For related information, see the topics "Move Method" and "MoveFirst, MoveLast, 
 
 Call this member function to make the next record in the recordset the current record.
 
-```
+```cpp
 void MoveNext();
 ```
 
@@ -1716,7 +1716,7 @@ For related information, see the topics "Move Method" and "MoveFirst, MoveLast, 
 
 Call this member function to make the previous record in the recordset the current record.
 
-```
+```cpp
 void MovePrev();
 ```
 
@@ -1961,7 +1961,7 @@ For related information, see the topic "Seek Method" in DAO Help.
 
 Sets the relative record number of a recordset object's current record.
 
-```
+```cpp
 void SetAbsolutePosition(long lPosition);
 ```
 
@@ -1990,7 +1990,7 @@ For related information, see the topic "AbsolutePosition Property" in DAO Help.
 
 Call this member function to position the recordset on the record containing the specified bookmark.
 
-```
+```cpp
 void SetBookmark(COleVariant varBookmark);
 ```
 
@@ -2014,7 +2014,7 @@ For related information, see the topics "Bookmark Property" and Bookmarkable Pro
 
 Call this member function to set the number of records to be cached.
 
-```
+```cpp
 void SetCacheSize(long lSize);
 ```
 
@@ -2035,7 +2035,7 @@ For related information, see the topic "CacheSize, CacheStart Properties" in DAO
 
 Call this member function to specify the bookmark of the first record in the recordset to be cached.
 
-```
+```cpp
 void SetCacheStart(COleVariant varBookmark);
 ```
 
@@ -2062,7 +2062,7 @@ For related information, see the topic CacheSize, CacheStart Properties" in DAO 
 
 Call this member function to set an index on a table-type recordset.
 
-```
+```cpp
 void SetCurrentIndex(LPCTSTR lpszIndex);
 ```
 
@@ -2085,7 +2085,7 @@ For related information, see the topic "Index Object" and the definition "curren
 
 Call this member function to flag a field data member of the recordset as changed or as unchanged.
 
-```
+```cpp
 void SetFieldDirty(
     void* pv,
     BOOL bDirty = TRUE);
@@ -2128,7 +2128,7 @@ This means you cannot set all **param** fields to NULL, as you can with `outputC
 
 Call this member function to flag a field data member of the recordset as Null (specifically having no value) or as non-Null.
 
-```
+```cpp
 void SetFieldNull(
     void* pv,
     BOOL bNull = TRUE);
@@ -2211,7 +2211,7 @@ For related information, see the topics "Field Object" and "Value Property" in D
 
 Call this member function to set the field to a Null value.
 
-```
+```cpp
 void SetFieldValueNull(int nIndex);
 void SetFieldValueNull(LPCTSTR lpszName);
 ```
@@ -2234,7 +2234,7 @@ For related information, see the topics "Field Object" and "Value Property" in D
 
 Call this member function to set the type of locking for the recordset.
 
-```
+```cpp
 void SetLockingMode(BOOL bPessimistic);
 ```
 
@@ -2290,7 +2290,7 @@ Specify the value to set as a `COleVariant` object. For information about settin
 
 Call this member function to set the parameter to a Null value.
 
-```
+```cpp
 void SetParamValueNull(int nIndex);
 void SetParamValueNull(LPCTSTR lpszName);
 ```
@@ -2311,7 +2311,7 @@ C++ NULL is not the same as Null, which, in database terminology, means "having 
 
 Call this member function to set a value that changes the approximate location of the current record in the recordset object based on a percentage of the records in the recordset.
 
-```
+```cpp
 void SetPercentPosition(float fPosition);
 ```
 

--- a/docs/mfc/reference/cdaotabledef-class.md
+++ b/docs/mfc/reference/cdaotabledef-class.md
@@ -226,7 +226,7 @@ For related information, see the topic "CreateTableDef Method" in DAO Help.
 
 Call this member function to add a field to the table.
 
-```
+```cpp
 void CreateField(
     LPCTSTR lpszName,
     short nType,
@@ -299,7 +299,7 @@ For related information, see the topic "CreateField Method" in DAO Help.
 
 Call this function to add an index to a table.
 
-```
+```cpp
 void CreateIndex(CDaoIndexInfo& indexinfo);
 ```
 
@@ -328,7 +328,7 @@ The remaining members will be ignored if set to FALSE. In addition, the `m_lDist
 
 Call this member function to remove a field and make it inaccessible.
 
-```
+```cpp
 void DeleteField(LPCTSTR lpszName);
 void DeleteField(int nIndex);
 ```
@@ -351,7 +351,7 @@ For related information, see the topic "Delete Method" in DAO Help.
 
 Call this member function to delete an index in an underlying table.
 
-```
+```cpp
 void DeleteIndex(LPCTSTR lpszName);
 void DeleteIndex(int nIndex);
 ```
@@ -483,7 +483,7 @@ For related information, see the topic "Count Property" in DAO Help.
 
 Call this member function to obtain various kinds of information about a field defined in the tabledef.
 
-```
+```cpp
 void GetFieldInfo(
     int nIndex,
     CDaoFieldInfo& fieldinfo,
@@ -545,7 +545,7 @@ For related information, see the topic "Count Property" in DAO Help.
 
 Call this member function to obtain various kinds of information about an index defined in the tabledef.
 
-```
+```cpp
 void GetIndexInfo(
     int nIndex,
     CDaoIndexInfo& indexinfo,
@@ -722,7 +722,7 @@ A pointer to a string that specifies a table name.
 
 Call this member function to update the connection information for an attached table.
 
-```
+```cpp
 void RefreshLink();
 ```
 
@@ -738,7 +738,7 @@ For related information, see the topic "RefreshLink Method" in DAO Help.
 
 Sets a value that indicates one or more characteristics of a `CDaoTableDef` object.
 
-```
+```cpp
 void SetAttributes(long lAttributes);
 ```
 
@@ -768,7 +768,7 @@ For related information, see the topic "Attributes Property" in DAO Help.
 
 For a `CDaoTableDef` object that represents an attached table, the string object consists of one or two parts (a database type specifier and a path to the database).
 
-```
+```cpp
 void SetConnect(LPCTSTR lpszConnect);
 ```
 
@@ -820,7 +820,7 @@ For related information, see the topic "Connect Property" in DAO Help.
 
 Call this member function to set a user-defined name for a table.
 
-```
+```cpp
 void SetName(LPCTSTR lpszName);
 ```
 
@@ -839,7 +839,7 @@ For related information, see the topic "Name Property" in DAO Help.
 
 Call this member function to specify the name of an attached table or the name of the base table on which the `CDaoTableDef` object is based, as it exists in the original source of the data.
 
-```
+```cpp
 void SetSourceTableName(LPCTSTR lpszSrcTableName);
 ```
 
@@ -858,7 +858,7 @@ For related information, see the topic "SourceTableName Property" in DAO Help.
 
 Call this member function to set a validation rule for a tabledef.
 
-```
+```cpp
 void SetValidationRule(LPCTSTR lpszValidationRule);
 ```
 
@@ -883,7 +883,7 @@ For related information, see the topic "ValidationRule Property" in DAO Help.
 
 Call this member function to set the exception text of a validation rule for a `CDaoTableDef` object with an underlying base table supported by the Microsoft Jet database engine.
 
-```
+```cpp
 void SetValidationText(LPCTSTR lpszValidationText);
 ```
 

--- a/docs/mfc/reference/cdaoworkspace-class.md
+++ b/docs/mfc/reference/cdaoworkspace-class.md
@@ -149,7 +149,7 @@ For related information, see the topic "Append Method" in DAO Help.
 
 Call this member function to initiate a transaction.
 
-```
+```cpp
 void BeginTrans();
 ```
 
@@ -208,7 +208,7 @@ For related information, see the topic "Close Method" in DAO Help.
 
 Call this member function to commit a transaction — save a group of edits and updates to one or more databases in the workspace.
 
-```
+```cpp
 void CommitTrans();
 ```
 
@@ -373,7 +373,7 @@ The number of open databases in the workspace.
 
 Call this member function to obtain various kinds of information about a database open in the workspace.
 
-```
+```cpp
 void GetDatabaseInfo(
     int nIndex,
     CDaoDatabaseInfo& dbinfo,
@@ -543,7 +543,7 @@ This count does not include any open workspaces not appended to the collection. 
 
 Call this member function to obtain various kinds of information about a workspace open in the session.
 
-```
+```cpp
 void GetWorkspaceInfo(
     int nIndex,
     CDaoWorkspaceInfo& wkspcinfo,
@@ -690,7 +690,7 @@ For more information about repairing databases, see the topic "RepairDatabase Me
 
 Call this member function to end the current transaction and restore all databases in the workspace to their condition before the transaction was begun.
 
-```
+```cpp
 void Rollback();
 ```
 
@@ -788,7 +788,7 @@ You can use this mechanism to configure the database engine with user-provided r
 
 Call this member function to set the value of the DAO IsolateODBCTrans property for the workspace.
 
-```
+```cpp
 void SetIsolateODBCTrans(BOOL bIsolateODBCTrans);
 ```
 

--- a/docs/mfc/reference/cdatabase-class.md
+++ b/docs/mfc/reference/cdatabase-class.md
@@ -134,7 +134,7 @@ In your override, call `SQLBindParameters` and related ODBC functions to bind th
 
 Call this member function to request that the data source cancel either an asynchronous operation in progress or a process from a second thread.
 
-```
+```cpp
 void Cancel();
 ```
 
@@ -242,7 +242,7 @@ For more information about transactions, see the article [Transaction (ODBC)](..
 
 Call this member function when you need to execute a SQL command directly.
 
-```
+```cpp
 void ExecuteSQL(LPCTSTR lpszSQL);
 ```
 
@@ -554,7 +554,7 @@ After a rollback, the record that was current before the rollback remains curren
 
 Call this member function — before you call `OpenEx` or `Open` — to override the default number of seconds allowed before an attempted data source connection times out.
 
-```
+```cpp
 void SetLoginTimeout(DWORD dwSeconds);
 ```
 
@@ -573,7 +573,7 @@ The default value for login timeouts is 15 seconds. Not all data sources support
 
 Call this member function to override the default number of seconds to allow before subsequent operations on the connected data source time out.
 
-```
+```cpp
 void SetQueryTimeout(DWORD dwSeconds);
 ```
 

--- a/docs/mfc/reference/cdataexchange-class.md
+++ b/docs/mfc/reference/cdataexchange-class.md
@@ -85,7 +85,7 @@ Construct a `CDataExchange` object yourself to store extra information in the da
 
 The framework calls this member function when a dialog data validation (DDV) operation fails.
 
-```
+```cpp
 void Fail();
 ```
 

--- a/docs/mfc/reference/cdatapathproperty-class.md
+++ b/docs/mfc/reference/cdatapathproperty-class.md
@@ -171,7 +171,7 @@ Opening should be restarted. Derived classes can override this function for diff
 
 Call this member function to associate an asynchronous OLE control with the `CDataPathProperty` object.
 
-```
+```cpp
 void SetControl(COleControl* pControl);
 ```
 
@@ -184,7 +184,7 @@ A pointer to the asynchronous OLE control to be associated with the property.
 
 Call this member function to set the pathname of the property.
 
-```
+```cpp
 void SetPath(LPCTSTR lpszPath);
 ```
 

--- a/docs/mfc/reference/cdatetimectrl-class.md
+++ b/docs/mfc/reference/cdatetimectrl-class.md
@@ -78,7 +78,7 @@ CDateTimeCtrl();
 
 Closes the current date and time picker control.
 
-```
+```cpp
 void CloseMonthCal() const;
 ```
 
@@ -432,7 +432,7 @@ This member function implements the behavior of the Win32 message [DTM_SETMCCOLO
 
 Sets the font that the date and time picker control's child month calendar control will use.
 
-```
+```cpp
 void SetMonthCalFont(
     HFONT hFont,
     BOOL bRedraw = TRUE);

--- a/docs/mfc/reference/cdbvariant-class.md
+++ b/docs/mfc/reference/cdbvariant-class.md
@@ -83,7 +83,7 @@ Sets the [m_dwType](#m_dwtype) data member to DBVT_NULL.
 
 Call this member function to clear the `CDBVariant` object.
 
-```
+```cpp
 void Clear();
 ```
 

--- a/docs/mfc/reference/cdc-class.md
+++ b/docs/mfc/reference/cdc-class.md
@@ -950,7 +950,7 @@ A Windows device context.
 
 Use this function when you give HIMETRIC sizes to OLE, converting pixels to HIMETRIC.
 
-```
+```cpp
 void DPtoHIMETRIC(LPSIZE lpSize) const;
 ```
 
@@ -967,7 +967,7 @@ If the mapping mode of the device context object is MM_LOENGLISH, MM_HIENGLISH, 
 
 Converts device units into logical units.
 
-```
+```cpp
 void DPtoLP(
     LPPOINT lpPoints,
     int nCount = 1) const;
@@ -998,7 +998,7 @@ The function maps the coordinates of each point, or dimension of a size, from th
 
 Call this member function to draw a three-dimensional rectangle.
 
-```
+```cpp
 void Draw3dRect(
     LPCRECT lpRect,
     COLORREF clrTopLeft,
@@ -1048,7 +1048,7 @@ The rectangle will be drawn with the top and left sides in the color specified b
 
 Call this member function repeatedly to redraw a drag rectangle.
 
-```
+```cpp
 void DrawDragRect(
     LPCRECT lpRect,
     SIZE size,
@@ -1144,7 +1144,7 @@ When an application calls `DrawEscape`, the data identified by *nInputSize* and 
 
 Draws a rectangle in the style used to indicate that the rectangle has the focus.
 
-```
+```cpp
 void DrawFocusRect(LPCRECT lpRect);
 ```
 
@@ -1941,7 +1941,7 @@ After its interior is filled, the path is discarded from the device context.
 
 Call this member function to fill a given rectangle using the specified brush.
 
-```
+```cpp
 void FillRect(
     LPCRECT lpRect,
     CBrush* pBrush);
@@ -1999,7 +1999,7 @@ The brush must either be created using the `CBrush` member functions `CreateHatc
 
 Call this member function to fill the given rectangle with the specified solid color.
 
-```
+```cpp
 void FillSolidRect(
     LPCRECT lpRect,
     COLORREF clr);
@@ -2088,7 +2088,7 @@ The `ExtFloodFill` function provides similar capability but greater flexibility.
 
 Draws a border around the rectangle specified by *lpRect*.
 
-```
+```cpp
 void FrameRect(
     LPCRECT lpRect,
     CBrush* pBrush);
@@ -3719,7 +3719,7 @@ When the framework is in preview mode, a call to the `GrayString` member functio
 
 Use this function when you convert HIMETRIC sizes from OLE to pixels.
 
-```
+```cpp
 void HIMETRICtoDP(LPSIZE lpSize) const;
 ```
 
@@ -3736,7 +3736,7 @@ If the mapping mode of the device context object is MM_LOENGLISH, MM_HIENGLISH, 
 
 Call this function to convert HIMETRIC units into logical units.
 
-```
+```cpp
 void HIMETRICtoLP(LPSIZE lpSize) const;
 ```
 
@@ -3802,7 +3802,7 @@ GDI clips all subsequent output to fit within the new boundary. The width and he
 
 Inverts the contents of the given rectangle.
 
-```
+```cpp
 void InvertRect(LPCRECT lpRect);
 ```
 
@@ -3893,7 +3893,7 @@ The line is drawn with the selected pen. The current position is set to *x*, *y*
 
 Converts logical units into device units.
 
-```
+```cpp
 void LPtoDP(
     LPPOINT lpPoints,
     int nCount = 1) const;
@@ -3926,7 +3926,7 @@ The x- and y-coordinates of points are 2-byte signed integers in the range -32,7
 
 Call this function to convert logical units into HIMETRIC units.
 
-```
+```cpp
 void LPtoHIMETRIC(LPSIZE lpSize) const;
 ```
 
@@ -6625,7 +6625,7 @@ For more information, see [TransparentBlt](/windows/win32/api/wingdi/nf-wingdi-t
 
 Updates the client area of the device context by matching the current colors in the client area to the system palette on a pixel-by-pixel basis.
 
-```
+```cpp
 void UpdateColors();
 ```
 

--- a/docs/mfc/reference/cdcrendertarget-class.md
+++ b/docs/mfc/reference/cdcrendertarget-class.md
@@ -61,7 +61,7 @@ class CDCRenderTarget : public CRenderTarget;
 
 Attaches existing render target interface to the object
 
-```
+```cpp
 void Attach(ID2D1DCRenderTarget* pTarget);
 ```
 

--- a/docs/mfc/reference/cdhtmldialog-class.md
+++ b/docs/mfc/reference/cdhtmldialog-class.md
@@ -230,7 +230,7 @@ You can override this member function to return an instance of your own control 
 
 Exchanges data between a member variable and the property value of an ActiveX control on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_AxControl(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -269,7 +269,7 @@ The data member, of type VARIANT, [COleVariant](../../mfc/reference/colevariant-
 
 Exchanges data between a member variable and a check box on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_CheckBox(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -295,7 +295,7 @@ The value being exchanged.
 
 Exchanges data between a member variable and any HTML element property on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_ElementText(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -357,7 +357,7 @@ The value being exchanged.
 
 Exchanges data between a member variable and a radio button on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_Radio(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -379,7 +379,7 @@ The value being exchanged.
 
 Gets or sets the index of a list box on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_SelectIndex(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -401,7 +401,7 @@ The value being exchanged.
 
 Gets or sets the display text of a list box entry (based on the current index) on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_SelectString(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -423,7 +423,7 @@ The value being exchanged.
 
 Gets or sets the value of a list box entry (based on the current index) on an HTML page.
 
-```
+```cpp
 void DDX_DHtml_SelectValue(
     CDataExchange* pDX,
     LPCTSTR szId,
@@ -449,7 +449,7 @@ The value being exchanged.
 
 Detaches a modeless dialog box from the `CDHtmlDialog` object and destroys the object.
 
-```
+```cpp
 void DestroyModeless();
 ```
 
@@ -566,7 +566,7 @@ The overloads are listed from least efficient at the top to most efficient at th
 
 Retrieves the Uniform Resource Locator (URL) associated with the current document.
 
-```
+```cpp
 void GetCurrentUrl(CString& szUrl);
 ```
 
@@ -949,7 +949,7 @@ LPTSTR m_szHtmlResID;
 
 Navigates to the resource identified by the URL that is specified by *lpszURL*.
 
-```
+```cpp
 void Navigate(
     LPCTSTR lpszURL,
     DWORD dwFlags = 0,
@@ -1125,7 +1125,7 @@ Returns E_NOTIMPL.
 
 Sets the property of an ActiveX control to a new value.
 
-```
+```cpp
 void SetControlProperty(
     LPCTSTR szElementId,
     DISPID dispId,
@@ -1163,7 +1163,7 @@ String containing the name of the property to set.
 
 Sets the `innerHTML` property of an HTML element.
 
-```
+```cpp
 void SetElementHtml(
     LPCTSTR szElementId,
     BSTR bstrText);
@@ -1188,7 +1188,7 @@ The `IUnknown` pointer of an HTML element.
 
 Sets a property of an HTML element.
 
-```
+```cpp
 void SetElementProperty(
     LPCTSTR szElementId,
     DISPID dispId,
@@ -1210,7 +1210,7 @@ The new value of the property.
 
 Sets the `innerText` property of an HTML element.
 
-```
+```cpp
 void SetElementText(
     LPCTSTR szElementId,
     BSTR bstrText);
@@ -1235,7 +1235,7 @@ The `IUnknown` pointer of an HTML element.
 
 Sets the host's `IDispatch` interface.
 
-```
+```cpp
 void SetExternalDispatch(IDispatch* pdispExternal);
 ```
 
@@ -1248,7 +1248,7 @@ The new `IDispatch` interface.
 
 Sets the host UI flags.
 
-```
+```cpp
 void SetHostFlags(DWORD dwFlags);
 ```
 

--- a/docs/mfc/reference/cdialog-class.md
+++ b/docs/mfc/reference/cdialog-class.md
@@ -253,7 +253,7 @@ If the user clicks one of the pushbuttons in the dialog box, such as OK or Cance
 
 Call this member function to terminate a modal dialog box.
 
-```
+```cpp
 void EndDialog(int nResult);
 ```
 
@@ -296,7 +296,7 @@ This is usually an OK button.
 
 Moves the focus to the specified control in the dialog box.
 
-```
+```cpp
 void GotoDlgCtrl(CWnd* pWndCtrl);
 ```
 
@@ -356,7 +356,7 @@ Dialog boxes that contain ActiveX controls require additional information provid
 
 Call to convert the dialog-box units of a rectangle to screen units.
 
-```
+```cpp
 void MapDialogRect(LPRECT lpRect) const;
 ```
 
@@ -377,7 +377,7 @@ The `MapDialogRect` member function replaces the dialog-box units in *lpRect* wi
 
 Moves the focus to the next control in the dialog box.
 
-```
+```cpp
 void NextDlgCtrl() const;
 ```
 
@@ -480,7 +480,7 @@ The dialog editor typically sets the dialog-box font as part of the dialog-box t
 
 Sets the focus to the previous control in the dialog box.
 
-```
+```cpp
 void PrevDlgCtrl() const;
 ```
 
@@ -492,7 +492,7 @@ If the focus is at the first control in the dialog box, it moves to the last con
 
 Changes the default pushbutton control for a dialog box.
 
-```
+```cpp
 void SetDefID(UINT nID);
 ```
 
@@ -505,7 +505,7 @@ Specifies the ID of the pushbutton control that will become the default.
 
 Sets a context-sensitive help ID for the dialog box.
 
-```
+```cpp
 void SetHelpID(UINT nIDR);
 ```
 

--- a/docs/mfc/reference/cdialogex-class.md
+++ b/docs/mfc/reference/cdialogex-class.md
@@ -91,7 +91,7 @@ CDialogEx(
 
 Sets the background color of the dialog box.
 
-```
+```cpp
 void SetBackgroundColor(
     COLORREF color,
     BOOL bRepaint=TRUE);
@@ -111,7 +111,7 @@ void SetBackgroundColor(
 
 Sets the background image of the dialog box.
 
-```
+```cpp
 void SetBackgroundImage(
     HBITMAP hBitmap,
     BackgroundLocation location=BACKGR_TILE,

--- a/docs/mfc/reference/cdockablepane-class.md
+++ b/docs/mfc/reference/cdockablepane-class.md
@@ -747,7 +747,7 @@ Override this method in a derived class to customize the appearance of the capti
 
 Enables or disables autohide mode for this pane and for other panes in the container.
 
-```
+```cpp
 void EnableAutohideAll(BOOL bEnable = TRUE);
 ```
 
@@ -1304,7 +1304,7 @@ Override this method in a derived class to implement custom autohide effects.
 
 The framework calls this method when a pane is being undocked.
 
-```
+```cpp
 void RemoveFromDefaultPaneDividier();
 ```
 
@@ -1342,7 +1342,7 @@ TRUE if the replacement is successful; otherwise, FALSE.
 
 When a pane is deserialized, the framework calls this method to restore the default pane divider.
 
-```
+```cpp
 void RestoreDefaultPaneDivider();
 ```
 
@@ -1390,7 +1390,7 @@ Call this method to switch a dockable pane to autohide mode programmatically. Th
 
 Sets the auto-hide button and auto-hide toolbar for the pane.
 
-```
+```cpp
 void SetAutoHideParents(
     CMFCAutoHideBar* pToolBar,
     CMFCAutoHideButton* pBtn);
@@ -1408,7 +1408,7 @@ void SetAutoHideParents(
 
 Sets the percentage of space that a pane occupies in its container.
 
-```
+```cpp
 void SetLastPercentInPaneContainer(int n);
 ```
 
@@ -1425,7 +1425,7 @@ The framework adjusts the pane to use the new value when the layout is recalcula
 
 Sets the restored default pane divider.
 
-```
+```cpp
 void SetRestoredDefaultPaneDivider(HWND hRestoredSlider);
 ```
 
@@ -1442,7 +1442,7 @@ A restored default pane divider is obtained when a pane is deserialized. For mor
 
 Sets the runtime class information for a tabbed window that is created when two panes dock together.
 
-```
+```cpp
 void SetTabbedPaneRTC(CRuntimeClass* pRTC);
 ```
 

--- a/docs/mfc/reference/cdockingmanager-class.md
+++ b/docs/mfc/reference/cdockingmanager-class.md
@@ -170,7 +170,7 @@ TRUE if the dock pane was created successfully; FALSE otherwise.
 
 Adds a handle to a bar pane to the list of hidden MDI tabbed bar panes.
 
-```
+```cpp
 void AddHiddenMDITabbedBar(CDockablePane* pBar);
 ```
 
@@ -293,7 +293,7 @@ The *dwAlignment* parameter can have one of the following values:
 
 Resizes a docking pane in autohide mode so that it takes the full width or height of the frame’s client area surrounded by dock sites.
 
-```
+```cpp
 void AlignAutoHidePane(
     CPaneDivider* pDefaultSlider,
     BOOL bIsVisible = TRUE);
@@ -333,7 +333,7 @@ NULL if the auto hide toolbar was not created; otherwise a pointer to the new to
 
 Brings the docked bars that have the specified alignment to the top.
 
-```
+```cpp
 void BringBarsToTop(
     DWORD dwAlignment = 0,
     BOOL bExcludeDockedBars = TRUE);
@@ -351,7 +351,7 @@ void BringBarsToTop(
 
 Adds names of docking panes and toolbars to a menu.
 
-```
+```cpp
 void BuildPanesMenu(
     CMenu& menu,
     BOOL bToolbarsOnly);
@@ -369,7 +369,7 @@ void BuildPanesMenu(
 
 Calculates the expected rectangle of a docked window.
 
-```
+```cpp
 void CalcExpectedDockedRect(
     CWnd* pWnd,
     CPoint ptMouse,
@@ -469,7 +469,7 @@ The docking status can be one of the following values:
 
 Enables or disables loading of docking layout from the registry.
 
-```
+```cpp
 void DisableRestoreDockState(BOOL bDisable = TRUE);
 ```
 
@@ -486,7 +486,7 @@ Call this method when you must preserve the current layout of docking panes and 
 
 Docks a pane to another pane or to a frame window.
 
-```
+```cpp
 void DockPane(
     CBasePane* pBar,
     UINT nDockBarID = 0,
@@ -591,7 +591,7 @@ By default, this menu is not displayed.
 
 Tells the library to display a special context menu that has a list of application toolbars and docking panes when the user clicks the right mouse button and the library is processing the WM_CONTEXTMENU message.
 
-```
+```cpp
 void EnablePaneContextMenu(
     BOOL bEnable,
     UINT uiCustomizeCmd,
@@ -811,7 +811,7 @@ A rectangle that contains the outer edges of the frame.
 
 Returns a list of panes that belong to the docking manager. This includes all floating panes.
 
-```
+```cpp
 void GetPaneList(
     CObList& lstBars,
     BOOL bIncludeAutohide = FALSE,
@@ -881,7 +881,7 @@ The class that contains the smart docking parameters for the current docking man
 
 Hides a pane that is in autohide mode.
 
-```
+```cpp
 void HideAutoHidePanes(
     CDockablePane* pBarToExclude = NULL,
     BOOL bImmediately = FALSE);
@@ -1059,7 +1059,7 @@ TRUE if the docking manager state was loaded successfully; otherwise FALSE.
 
 Locks the given window.
 
-```
+```cpp
 void LockUpdate(BOOL bLock);
 ```
 
@@ -1149,7 +1149,7 @@ virtual void OnActivateFrame(BOOL bActivate);
 
 Called by the framework when an active pop-up menu processes a WM_DESTROY message.
 
-```
+```cpp
 void OnClosePopupMenu();
 ```
 
@@ -1178,7 +1178,7 @@ TRUE if the method succeeds; otherwise FALSE.
 
 Called by the framework when it builds a menu that has a list of panes.
 
-```
+```cpp
 void OnPaneContextMenu(CPoint point);
 ```
 
@@ -1286,7 +1286,7 @@ virtual void RecalcLayout(BOOL bNotify = TRUE);
 
 Releases the empty pane containers.
 
-```
+```cpp
 void ReleaseEmptyPaneContainers();
 ```
 
@@ -1294,7 +1294,7 @@ void ReleaseEmptyPaneContainers();
 
 Removes the specified hidden bar pane.
 
-```
+```cpp
 void RemoveHiddenMDITabbedBar(CDockablePane* pBar);
 ```
 
@@ -1324,7 +1324,7 @@ TRUE if the specified frame is removed; FALSE otherwise.
 
 Unregisters a pane and removes it from the list in the docking manager.
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pWnd,
     BOOL bDestroy,
@@ -1376,7 +1376,7 @@ TRUE if the pane is successfully replaced; FALSE otherwise.
 
 Resorts the frames in the list of mini frames.
 
-```
+```cpp
 void ResortMiniFramesForZOrder();
 ```
 
@@ -1436,7 +1436,7 @@ TRUE always.
 
 Writes the docking manager to an archive.
 
-```
+```cpp
 void Serialize(CArchive& ar);
 ```
 
@@ -1453,7 +1453,7 @@ Writing the docking manager to an archive involves determining the number of doc
 
 Sets the size, width, and height of the control bars and the specified pane.
 
-```
+```cpp
 void SetAutohideZOrder(CDockablePane* pAHDockingBar);
 ```
 
@@ -1504,7 +1504,7 @@ virtual void SetDockState();
 
 Sets the print preview mode of the bars that are displayed in the print preview.
 
-```
+```cpp
 void SetPrintPreviewMode(
     BOOL bPreview,
     CPrintPreviewState* pState);
@@ -1541,7 +1541,7 @@ To use the default look for smart docking markers, pass an uninitialized instanc
 
 Shows or hides the windows of the mini frames.
 
-```
+```cpp
 void ShowDelayShowMiniFrames(BOOL bshow);
 ```
 
@@ -1571,7 +1571,7 @@ Always FALSE.
 
 Starts the smart docking of the specified window according to the alignment of the smart docking manager.
 
-```
+```cpp
 void StartSDocking(CWnd* pDockingWnd);
 ```
 
@@ -1584,7 +1584,7 @@ void StartSDocking(CWnd* pDockingWnd);
 
 Stops smart docking.
 
-```
+```cpp
 void StopSDocking();
 ```
 

--- a/docs/mfc/reference/cdockingpanesrow-class.md
+++ b/docs/mfc/reference/cdockingpanesrow-class.md
@@ -201,7 +201,7 @@ virtual BOOL Create();
 
 ## <a name="expandstretchedpanes"></a> CDockingPanesRow::ExpandStretchedPanes
 
-```
+```cpp
 void ExpandStretchedPanes();
 ```
 
@@ -209,7 +209,7 @@ void ExpandStretchedPanes();
 
 ## <a name="expandstretchedpanesrect"></a> CDockingPanesRow::ExpandStretchedPanesRect
 
-```
+```cpp
 void ExpandStretchedPanesRect();
 ```
 
@@ -217,7 +217,7 @@ void ExpandStretchedPanesRect();
 
 ## <a name="fixupvirtualrects"></a> CDockingPanesRow::FixupVirtualRects
 
-```
+```cpp
 void FixupVirtualRects(
     bool bMoveBackToVirtualRect,
     CPane* pBarToExclude = NULL);
@@ -259,7 +259,7 @@ virtual void GetAvailableSpace(CRect& rect);
 
 ## <a name="getclientrect"></a> CDockingPanesRow::GetClientRect
 
-```
+```cpp
 void GetClientRect(CRect& rect) const;
 ```
 
@@ -291,7 +291,7 @@ int GetExtraSpace() const;
 
 ## <a name="getgroupfrompane"></a> CDockingPanesRow::GetGroupFromPane
 
-```
+```cpp
 void GetGroupFromPane(
     CPane* pBar,
     CObList& lst);
@@ -391,7 +391,7 @@ virtual int GetVisibleCount();
 
 ## <a name="getwindowrect"></a> CDockingPanesRow::GetWindowRect
 
-```
+```cpp
 void GetWindowRect(CRect& rect) const;
 ```
 
@@ -469,7 +469,7 @@ virtual void Move(int nOffset);
 
 ## <a name="movepane"></a> CDockingPanesRow::MovePane
 
-```
+```cpp
 void MovePane(
     CPane* pControlBar,
     CPoint ptOffset,
@@ -527,7 +527,7 @@ virtual void OnResizePane(CBasePane* pControlBar);
 
 ## <a name="redrawall"></a> CDockingPanesRow::RedrawAll
 
-```
+```cpp
 void RedrawAll();
 ```
 
@@ -615,7 +615,7 @@ virtual int ResizeByPaneDivider(int /*ignored*/);
 
 ## <a name="screentoclient"></a> CDockingPanesRow::ScreenToClient
 
-```
+```cpp
 void ScreenToClient(CRect& rect) const;
 ```
 
@@ -627,7 +627,7 @@ void ScreenToClient(CRect& rect) const;
 
 ## <a name="setextra"></a> CDockingPanesRow::SetExtra
 
-```
+```cpp
 void SetExtra(
     int nExtraSpace,
     AFX_ROW_ALIGNMENT rowExtraAlign);

--- a/docs/mfc/reference/cdocksite-class.md
+++ b/docs/mfc/reference/cdocksite-class.md
@@ -124,7 +124,7 @@ virtual void AdjustLayout();
 
 ## <a name="aligndocksite"></a> CDockSite::AlignDockSite
 
-```
+```cpp
 void AlignDockSite(
     const CRect& rectToAlignBy,
     CRect& rectResult,
@@ -593,7 +593,7 @@ virtual void RemovePane(
 
 ## <a name="removerow"></a> CDockSite::RemoveRow
 
-```
+```cpp
 void RemoveRow(CDockingPanesRow* pRow);
 ```
 
@@ -635,7 +635,7 @@ virtual void RepositionPanes(CRect& rectNewClientArea);
 
 ## <a name="resizedocksite"></a> CDockSite::ResizeDockSite
 
-```
+```cpp
 void ResizeDockSite(
     int nNewWidth,
     int nNewHeight);
@@ -706,7 +706,7 @@ Call this method to show or hide docked panes. Normally, you do not have to call
 
 ## <a name="showrow"></a> CDockSite::ShowRow
 
-```
+```cpp
 void ShowRow(
     CDockingPanesRow* pRow,
     BOOL bShow,
@@ -725,7 +725,7 @@ void ShowRow(
 
 ## <a name="swaprows"></a> CDockSite::SwapRows
 
-```
+```cpp
 void SwapRows(
     CDockingPanesRow* pFirstRow,
     CDockingPanesRow* pSecondRow);

--- a/docs/mfc/reference/cdockstate-class.md
+++ b/docs/mfc/reference/cdockstate-class.md
@@ -56,7 +56,7 @@ For more information on docking control bars, see the articles [Control Bars](..
 
 Call this function to clear all docking information stored in the `CDockState` object.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -84,7 +84,7 @@ Version support enables a revised bar to add new persistent properties and still
 
 Call this function to retrieve state information from the registry or .INI file.
 
-```
+```cpp
 void LoadState(LPCTSTR lpszProfileName);
 ```
 
@@ -109,7 +109,7 @@ CPtrArray m_arrBarInfo;
 
 Call this function to save the state information to the registry or .INI file.
 
-```
+```cpp
 void SaveState(LPCTSTR lpszProfileName);
 ```
 

--- a/docs/mfc/reference/cdocobjectserver-class.md
+++ b/docs/mfc/reference/cdocobjectserver-class.md
@@ -63,7 +63,7 @@ For further information on DocObjects, see [CDocObjectServerItem](../../mfc/refe
 
 Call this function to activate (but not show) the document object server.
 
-```
+```cpp
 void ActivateDocObject();
 ```
 

--- a/docs/mfc/reference/cdoctemplate-class.md
+++ b/docs/mfc/reference/cdoctemplate-class.md
@@ -463,7 +463,7 @@ Non-zero if successful; otherwise 0.
 
 Determines the resources for OLE containers when editing an in-place OLE item.
 
-```
+```cpp
 void SetContainerInfo(UINT nIDOleInPlaceContainer);
 ```
 
@@ -499,7 +499,7 @@ For information on the default title, see the description of `CDocTemplate::docN
 
 Determines the resources and classes when the server document is embedded or edited in-place.
 
-```
+```cpp
 void SetServerInfo(
     UINT nIDOleEmbedding,
     UINT nIDOleInPlaceServer = 0,
@@ -555,7 +555,7 @@ A valid pointer to a `CFrameWnd` object, or NULL if the creation fails.
 
 Sets up the out of process preview handler.
 
-```
+```cpp
 void SetPreviewInfo(
     UINT nIDPreviewFrame,
     CRuntimeClass* pPreviewFrameClass = NULL,

--- a/docs/mfc/reference/cdocument-class.md
+++ b/docs/mfc/reference/cdocument-class.md
@@ -138,7 +138,7 @@ For more information on `CDocument`, see [Serialization](../../mfc/serialization
 
 Call this function to attach a view to the document.
 
-```
+```cpp
 void AddView(CView* pView);
 ```
 
@@ -643,7 +643,7 @@ Specifies a bounding rectangle of the area where the thumbnail should be drawn.
 
 Sends a message via the resident mail host (if any) with the document as an attachment.
 
-```
+```cpp
 void OnFileSendMail();
 ```
 
@@ -857,7 +857,7 @@ virtual void OnUnloadHandler();
 
 Enables the ID_FILE_SEND_MAIL command if mail support (MAPI) is present.
 
-```
+```cpp
 void OnUpdateFileSendMail(CCmdUI* pCmdUI);
 ```
 
@@ -960,7 +960,7 @@ Specifies the PID of a chunk to be removed.
 
 Call this function to detach a view from a document.
 
-```
+```cpp
 void RemoveView(CView* pView);
 ```
 
@@ -1102,7 +1102,7 @@ Calling this function updates the titles of all frame windows that display the d
 
 Call this function after the document has been modified.
 
-```
+```cpp
 void UpdateAllViews(
     CView* pSender,
     LPARAM lHint = 0L,

--- a/docs/mfc/reference/cdrawingmanager-class.md
+++ b/docs/mfc/reference/cdrawingmanager-class.md
@@ -116,7 +116,7 @@ For more information about how to create a DIB bitmap, see [CreateDIBSection](/w
 
 Displays bitmaps that have transparent or semitransparent pixels.
 
-```
+```cpp
 void DrawAlpha(
     CDC* pDstDC,
     const CRect& rectDst,
@@ -146,7 +146,7 @@ This method performs alpha-blending for two bitmaps. For more information about 
 
 Draws an ellipse with the supplied fill and border colors.
 
-```
+```cpp
 void DrawEllipse(
     const CRect& rect,
     COLORREF clrFill,
@@ -218,7 +218,7 @@ The rectangle defined by *rect* must be at least 5 pixels wide and 5 pixels high
 
 Draws a line.
 
-```
+```cpp
 void DrawLine(
     int x1,
     int y1,
@@ -253,7 +253,7 @@ This method fails if *clrLine* equals -1.
 
 Draws a rectangle with the supplied fill and border colors.
 
-```
+```cpp
 void DrawRect(
     const CRect& rect,
     COLORREF clrFill,
@@ -339,7 +339,7 @@ The following example demonstrates how to use the `DrawShadow` method of the `CD
 
 Fills a rectangular area with two color gradients.
 
-```
+```cpp
 void Fill4ColorsGradient(
     CRect rect,
     COLORREF colorStart1,
@@ -383,7 +383,7 @@ This method generates an assertion failure if *nPercentage* is less than 0 or mo
 
 Fills a rectangular area with the specified color gradient.
 
-```
+```cpp
 void FillGradient(
     CRect rect,
     COLORREF colorStart,
@@ -423,7 +423,7 @@ The following example demonstrates how to use the `FillGradient` method of the `
 
 Fills a rectangular area with a specified color gradient.
 
-```
+```cpp
 void FillGradient2 (
     CRect rect,
     COLORREF colorStart,
@@ -679,7 +679,7 @@ To convert a HSV or HSL color to a RGB representation, call one of the following
 
 Flips a rectangular area.
 
-```
+```cpp
 void MirrorRect(
     CRect rect,
     BOOL bHorz = TRUE);
@@ -954,7 +954,7 @@ The weighted ratio is calculated with the following formula:                    
 
 Rotates a source DC content inside the given rectangle by 90 degrees.
 
-```
+```cpp
 void DrawRotated(
     CRect rectDest,
     CDC& dcSrc,

--- a/docs/mfc/reference/cdumpcontext-class.md
+++ b/docs/mfc/reference/cdumpcontext-class.md
@@ -125,7 +125,7 @@ Call this member function to dump the item of the specified type as a hexadecima
 
 Forces any data remaining in buffers to be written to the file attached to the dump context.
 
-```
+```cpp
 void Flush();
 ```
 
@@ -153,7 +153,7 @@ The depth of the dump as set by `SetDepth`.
 
 Dumps an array of bytes formatted as hexadecimal numbers.
 
-```
+```cpp
 void HexDump(
     LPCTSTR lpszLine,
     BYTE* pby,
@@ -229,7 +229,7 @@ If you use the IMPLEMENT_DYNAMIC or IMPLEMENT_SERIAL macro in the implementation
 
 Sets the depth for the dump.
 
-```
+```cpp
 void SetDepth(int nNewDepth);
 ```
 

--- a/docs/mfc/reference/cedit-class.md
+++ b/docs/mfc/reference/cedit-class.md
@@ -203,7 +203,7 @@ For more information, see [EM_CHARFROMPOS](/windows/win32/Controls/em-charfrompo
 
 Call this function to delete (clear) the current selection (if any) in the edit control.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -223,7 +223,7 @@ For more information, see [WM_CLEAR](/windows/win32/dataxchg/wm-clear) in the Wi
 
 Call this function to coy the current selection (if any) in the edit control to the Clipboard in CF_TEXT format.
 
-```
+```cpp
 void Copy();
 ```
 
@@ -293,7 +293,7 @@ Apply the following [window styles](styles-used-by-mfc.md#window-styles) to an e
 
 Call this function to delete (cut) the current selection (if any) in the edit control and copy the deleted text to the Clipboard in CF_TEXT format.
 
-```
+```cpp
 void Cut();
 ```
 
@@ -313,7 +313,7 @@ For more information, see [WM_CUT](/windows/win32/dataxchg/wm-cut) in the Window
 
 Call this function to reset (clear) the undo flag of an edit control.
 
-```
+```cpp
 void EmptyUndoBuffer();
 ```
 
@@ -624,7 +624,7 @@ This method sends the [EM_GETPASSWORDCHAR](/windows/win32/Controls/em-getpasswor
 
 Call this function to get the formatting rectangle of an edit control.
 
-```
+```cpp
 void GetRect(LPRECT lpRect) const;
 ```
 
@@ -697,7 +697,7 @@ This function sends the [EM_HIDEBALLOONTIP](/windows/win32/Controls/em-hideballo
 
 Call this function to limit the length of the text that the user may enter into an edit control.
 
-```
+```cpp
 void LimitText(int nChars = 0);
 ```
 
@@ -814,7 +814,7 @@ This method is supported by the [EM_LINELENGTH](/windows/win32/Controls/em-linel
 
 Call this function to scroll the text of a multiple-line edit control.
 
-```
+```cpp
 void LineScroll(
     int nLines,
     int nChars = 0);
@@ -846,7 +846,7 @@ For more information, see [EM_LINESCROLL](/windows/win32/Controls/em-linescroll)
 
 Call this function to insert the data from the Clipboard into the `CEdit` at the insertion point.
 
-```
+```cpp
 void Paste();
 ```
 
@@ -894,7 +894,7 @@ For more information, see [EM_POSFROMCHAR](/windows/win32/Controls/em-posfromcha
 
 Call this function to replace the current selection in an edit control with the text specified by *lpszNewText*.
 
-```
+```cpp
 void ReplaceSel(LPCTSTR lpszNewText, BOOL bCanUndo = FALSE);
 ```
 
@@ -960,7 +960,7 @@ The following example demonstrates the [CEdit::SetCueBanner](#setcuebanner) meth
 
 Call this function to set the handle to the local memory that will be used by a multiple-line edit control.
 
-```
+```cpp
 void SetHandle(HLOCAL hBuffer);
 ```
 
@@ -994,7 +994,7 @@ For more information, see [EM_SETHANDLE](/windows/win32/Controls/em-sethandle), 
 
 Highlights a range of text that is displayed in the current edit control.
 
-```
+```cpp
 void SetHighlight(
     int ichStart,
     int ichEnd);
@@ -1015,7 +1015,7 @@ This method sends the [EM_SETHILITE](/windows/win32/Controls/em-sethilite) messa
 
 Call this member function to set the text limit for this `CEdit` object.
 
-```
+```cpp
 void SetLimitText(UINT nMax);
 ```
 
@@ -1042,7 +1042,7 @@ For more information, see [EM_SETLIMITTEXT](/windows/win32/Controls/em-setlimitt
 
 Call this method to set the left and right margins of this edit control.
 
-```
+```cpp
 void SetMargins(
     UINT nLeft,
     UINT nRight);
@@ -1071,7 +1071,7 @@ For more information, see [EM_SETMARGINS](/windows/win32/Controls/em-setmargins)
 
 Call this function to set or clear the modified flag for an edit control.
 
-```
+```cpp
 void SetModify(BOOL bModified = TRUE);
 ```
 
@@ -1094,7 +1094,7 @@ For more information, see [EM_SETMODIFY](/windows/win32/Controls/em-setmodify) i
 
 Call this function to set or remove a password character displayed in an edit control when the user types text.
 
-```
+```cpp
 void SetPasswordChar(TCHAR ch);
 ```
 
@@ -1150,7 +1150,7 @@ For more information, see [EM_SETREADONLY](/windows/win32/Controls/em-setreadonl
 
 Call this function to set the dimensions of a rectangle using the specified coordinates.
 
-```
+```cpp
 void SetRect(LPCRECT lpRect);
 ```
 
@@ -1179,7 +1179,7 @@ For more information, see [EM_SETRECT](/windows/win32/Controls/em-setrect) in th
 
 Call this function to set the formatting rectangle of a multiple-line edit control.
 
-```
+```cpp
 void SetRectNP(LPCRECT lpRect);
 ```
 
@@ -1210,7 +1210,7 @@ For more information, see [EM_SETRECTNP](/windows/win32/Controls/em-setrectnp) i
 
 Call this function to select a range of characters in an edit control.
 
-```
+```cpp
 void SetSel(
     DWORD dwSelection,
     BOOL bNoScroll = FALSE);
@@ -1247,7 +1247,7 @@ For more information, see [EM_SETSEL](/windows/win32/Controls/em-setsel) in the 
 
 Call this function to set the tab stops in a multiple-line edit control.
 
-```
+```cpp
 void SetTabStops();
 BOOL SetTabStops(const int& cxEachStop);
 

--- a/docs/mfc/reference/ceditview-class.md
+++ b/docs/mfc/reference/ceditview-class.md
@@ -217,7 +217,7 @@ Use this function to determine the current printer font. If it is not the desire
 
 Call `GetSelectedText` to copy the selected text into a `CString` object, up to the end of the selection or the character preceding the first carriage-return character in the selection.
 
-```
+```cpp
 void GetSelectedText(CString& strResult) const;
 ```
 
@@ -381,7 +381,7 @@ The `rect.bottom` element of the *rectLayout* object is changed so that the rect
 
 Call `SerializeRaw` to have a `CArchive` object read or write the text in the `CEditView` object to a text file.
 
-```
+```cpp
 void SerializeRaw(CArchive& ar);
 ```
 
@@ -398,7 +398,7 @@ Reference to the `CArchive` object that stores the serialized text.
 
 Call `SetPrinterFont` to set the printer font to the font specified by *pFont*.
 
-```
+```cpp
 void SetPrinterFont(CFont* pFont);
 ```
 
@@ -415,7 +415,7 @@ If you want your view to always use a particular font for printing, include a ca
 
 Call this function to set the tab stops used for display and printing.
 
-```
+```cpp
 void SetTabStops(int nTabStops);
 ```
 
@@ -440,7 +440,7 @@ This code fragment sets the tab stops in the control to every fourth character b
 
 Call this member function to unlock the buffer.
 
-```
+```cpp
 void UnlockBuffer() const;
 ```
 

--- a/docs/mfc/reference/cexception-class.md
+++ b/docs/mfc/reference/cexception-class.md
@@ -91,7 +91,7 @@ You would normally never need to call this constructor directly. A function that
 
 This function checks to see if the `CException` object was created on the heap, and if so, it calls the **delete** operator on the object.
 
-```
+```cpp
 void Delete();
 ```
 

--- a/docs/mfc/reference/cfieldexchange-class.md
+++ b/docs/mfc/reference/cfieldexchange-class.md
@@ -78,7 +78,7 @@ Follow the model of the existing RFX functions.
 
 You need a call to `SetFieldType` in your recordset class's [DoFieldExchange](../../mfc/reference/crecordset-class.md#dofieldexchange) or [DoBulkFieldExchange](../../mfc/reference/crecordset-class.md#dobulkfieldexchange) override.
 
-```
+```cpp
 void SetFieldType(UINT nFieldType);
 ```
 

--- a/docs/mfc/reference/cfile-class.md
+++ b/docs/mfc/reference/cfile-class.md
@@ -689,7 +689,7 @@ The exception handler for this method must delete the exception object after the
 
 Sets the value of the file pointer to the beginning of the file.
 
-```
+```cpp
 void SeekToBegin();
 ```
 

--- a/docs/mfc/reference/cfiledialog-class.md
+++ b/docs/mfc/reference/cfiledialog-class.md
@@ -275,7 +275,7 @@ The menu name.
 
 Adds a folder to the list of places available for the user to open or save items.
 
-```
+```cpp
 void AddPlace(
     LPCWSTR lpszFolder,
     FDAP fdap = FDAP_TOP) throw();
@@ -372,7 +372,7 @@ The text name.
 
 Updates the current state of the [CFileDialog](../../mfc/reference/cfiledialog-class.md) based on the values stored in the `m_ofn` data structure.
 
-```
+```cpp
 void ApplyOFNToShellDialog();
 ```
 
@@ -895,7 +895,7 @@ A POSITION value that can be used for iteration; NULL if the list is empty.
 
 Call this member function to hide the specified control in an Explorer-style Open or Save As common dialog box.
 
-```
+```cpp
 void HideControl(int nID);
 ```
 
@@ -1331,7 +1331,7 @@ One or more values from the CDCONTROLSTATE enumeration that indicate the current
 
 Call this method to set the text for the specified control in an Explorer-style **Open** or **Save As** dialog box.
 
-```
+```cpp
 void SetControlText(
     int nID,
     LPCSTR lpsz);
@@ -1359,7 +1359,7 @@ To use this method, you must create the dialog box with the OFN_EXPLORER style. 
 
 Call this function to set the default file name extension for an Explorer-style Open or Save As common dialog box.
 
-```
+```cpp
 void SetDefExt(LPCSTR lpsz);
 ```
 
@@ -1431,7 +1431,7 @@ The ID of the item that the user selected in the control.
 
 Sets the dialog box template for the [CFileDialog](../../mfc/reference/cfiledialog-class.md) object.
 
-```
+```cpp
 void SetTemplate(
     UINT nWin3ID,
     UINT nWin4ID);
@@ -1486,7 +1486,7 @@ The group name.
 
 Updates the `m_ofn` data structure of the [CFileDialog](../../mfc/reference/cfiledialog-class.md) based on the current state of the internal object.
 
-```
+```cpp
 void UpdateOFNFromShellDialog();
 ```
 

--- a/docs/mfc/reference/cfilefind-class.md
+++ b/docs/mfc/reference/cfilefind-class.md
@@ -108,7 +108,7 @@ Pointer to CAtlTransactionManager object
 
 Call this member function to end the search, reset the context, and release all resources.
 
-```
+```cpp
 void Close();
 ```
 

--- a/docs/mfc/reference/cfontdialog-class.md
+++ b/docs/mfc/reference/cfontdialog-class.md
@@ -160,7 +160,7 @@ If `DoModal` returns IDOK, you can call other member functions to retrieve the s
 
 Retrieves the character formatting of the selected font.
 
-```
+```cpp
 void GetCharFormat(CHARFORMAT& cf) const;
 ```
 
@@ -189,7 +189,7 @@ The color of the selected font.
 
 Call this function to assign the characteristics of the currently selected font to the members of a [LOGFONT](/windows/win32/api/wingdi/ns-wingdi-logfontw) structure.
 
-```
+```cpp
 void GetCurrentFont(LPLOGFONT lplf);
 ```
 

--- a/docs/mfc/reference/cfontholder-class.md
+++ b/docs/mfc/reference/cfontholder-class.md
@@ -142,7 +142,7 @@ The version with no parameters returns a handle to a font sized correctly for th
 
 Initializes a `CFontHolder` object.
 
-```
+```cpp
 void InitializeFont(
     const FONTDESC* pFontDesc = NULL,
     LPDISPATCH pFontDispAmbient = NULL);
@@ -176,7 +176,7 @@ LPFONT m_pFont;
 
 Retrieves information on the physical font represented by the `CFontHolder` object.
 
-```
+```cpp
 void QueryTextMetrics(LPTEXTMETRIC lptm);
 ```
 
@@ -189,7 +189,7 @@ A pointer to a [TEXTMETRIC](/windows/win32/api/wingdi/ns-wingdi-textmetricw) str
 
 This function disconnects the `CFontHolder` object from its `IFont` interface.
 
-```
+```cpp
 void ReleaseFont();
 ```
 
@@ -227,7 +227,7 @@ See [GetFontHandle](#getfonthandle) for a discussion of the *cyLogical* and *cyH
 
 Releases any existing font and connects the `CFontHolder` object to an `IFont` interface.
 
-```
+```cpp
 void SetFont(LPFONT pNewFont);
 ```
 

--- a/docs/mfc/reference/cframewnd-class.md
+++ b/docs/mfc/reference/cframewnd-class.md
@@ -276,7 +276,7 @@ Use this member function to create "views" that are not `CView`-derived within a
 
 Causes a control bar to be docked to the frame window.
 
-```
+```cpp
 void DockControlBar(
     CControlBar* pBar,
     UINT nDockBarID = 0,
@@ -312,7 +312,7 @@ The control bar will be docked to one of the sides of the frame window specified
 
 Call this function to enable dockable control bars in a frame window.
 
-```
+```cpp
 void EnableDocking(DWORD dwDockStyle);
 ```
 
@@ -355,7 +355,7 @@ virtual void EndModalState();
 
 Call this function to cause a control bar to not be docked to the frame window.
 
-```
+```cpp
 void FloatControlBar(
     CControlBar* pBar,
     CPoint point,
@@ -462,7 +462,7 @@ The *nID* parameter refers to the unique identifier passed to the `Create` metho
 
 Call this member function to store state information about the frame window's control bars in a `CDockState` object.
 
-```
+```cpp
 void GetDockState(CDockState& state) const;
 ```
 
@@ -567,7 +567,7 @@ A [CString](../../atl-mfc-shared/reference/cstringt-class.md) object containing 
 
 Call `IntitialUpdateFrame` after creating a new frame with `Create`.
 
-```
+```cpp
 void InitialUpdateFrame(
     CDocument* pDoc,
     BOOL bMakeVisible);
@@ -640,7 +640,7 @@ If you call `LoadFrame` to create the frame window, the framework loads an accel
 
 Call this function to restore the settings of each control bar owned by the frame window.
 
-```
+```cpp
 void LoadBarState(LPCTSTR lpszProfileName);
 ```
 
@@ -906,7 +906,7 @@ static AFX_DATA const CRect rectDefault;
 
 Call this function to store information about each control bar owned by the frame window.
 
-```
+```cpp
 void SaveBarState(LPCTSTR lpszProfileName) const;
 ```
 
@@ -923,7 +923,7 @@ This information can be read from the initialization file using [LoadBarState](#
 
 Designates the specified view to be the active view for Rich Preview.
 
-```
+```cpp
 void SetActivePreviewView(CView* pViewNew);
 ```
 
@@ -938,7 +938,7 @@ A pointer to a view to be activated.
 
 Call this member function to set the active view.
 
-```
+```cpp
 void SetActiveView(
     CView* pViewNew,
     BOOL bNotify = TRUE);
@@ -960,7 +960,7 @@ The framework will call this function automatically as the user changes the focu
 
 Call this member function to apply state information stored in a `CDockState` object to the frame window's control bars.
 
-```
+```cpp
 void SetDockState(const CDockState& state);
 ```
 
@@ -1019,7 +1019,7 @@ This method affects the state of menus in applications written for Windows Vista
 
 Call this function to place a string in the status-bar pane that has an ID of 0.
 
-```
+```cpp
 void SetMessageText(LPCTSTR lpszText);
 void SetMessageText(UINT nID);
 ```
@@ -1040,7 +1040,7 @@ This is typically the leftmost, and longest, pane of the status bar.
 
 Sets the current position for the Windows 7 progress bar displayed on the taskbar.
 
-```
+```cpp
 void SetProgressBarPosition(int nProgressPos);
 ```
 
@@ -1055,7 +1055,7 @@ Specifies the position to set. It must be within the range set by `SetProgressBa
 
 Sets the range for the Windows 7 progress bar displayed on the taskbar.
 
-```
+```cpp
 void SetProgressBarRange(
     int nRangeMin,
     int nRangeMax);
@@ -1075,7 +1075,7 @@ Maximal value.
 
 Sets the type and state of the progress indicator displayed on a taskbar button.
 
-```
+```cpp
 void SetProgressBarState(TBPFLAG tbpFlags);
 ```
 
@@ -1121,7 +1121,7 @@ TRUE if successful; FALSE if OS version is less than Windows 7 or if an error oc
 
 Sets the title of the window object.
 
-```
+```cpp
 void SetTitle(LPCTSTR lpszTitle);
 ```
 
@@ -1134,7 +1134,7 @@ A pointer to a character string containing the title of the window object.
 
 Call this member function to show or hide the control bar.
 
-```
+```cpp
 void ShowControlBar(
     CControlBar* pBar,
     BOOL bShow,
@@ -1156,7 +1156,7 @@ If TRUE, delay showing the control bar. If FALSE, show the control bar immediate
 
 Call this member function to show all windows that are descendants of the `CFrameWnd` object.
 
-```
+```cpp
 void ShowOwnedWindows(BOOL bShow);
 ```
 

--- a/docs/mfc/reference/cframewndex-class.md
+++ b/docs/mfc/reference/cframewndex-class.md
@@ -136,7 +136,7 @@ The following example demonstrates how to inherit a class from the `CFrameWndEx`
 
 Adjusts the layout of the OLE client item and the frame's client area.
 
-```
+```cpp
 void ActiveItemRecalcLayout();
 ```
 
@@ -200,7 +200,7 @@ virtual void DelayUpdateFrameMenu(HMENU hMenuAlt);
 
 Docks the specified pane to the frame window.
 
-```
+```cpp
 void DockPane(
     CBasePane* pBar,
     UINT nDockBarID=0,
@@ -318,7 +318,7 @@ The *dwDockStyle* parameter can have one of the following values:
 
 Shows or hides the main menu in a full screen mode.
 
-```
+```cpp
 void EnableFullScreenMainMenu(BOOL bEnableMenu);
 ```
 
@@ -331,7 +331,7 @@ void EnableFullScreenMainMenu(BOOL bEnableMenu);
 
 Enables the full-screen mode for the frame window.
 
-```
+```cpp
 void EnableFullScreenMode(UINT uiFullScreenCmd);
 ```
 
@@ -352,7 +352,7 @@ If you want to keep the main menu on the screen, call [CFrameWndEx::EnableFullSc
 
 Enables or disables the loading of the docking state.
 
-```
+```cpp
 void EnableLoadDockState(BOOL bEnable=TRUE);
 ```
 
@@ -365,7 +365,7 @@ void EnableLoadDockState(BOOL bEnable=TRUE);
 
 Enables or disables the automatic handling of the pane menu.
 
-```
+```cpp
 void EnablePaneMenu(
     BOOL bEnable,
     UINT uiCustomizeCmd,
@@ -1532,7 +1532,7 @@ afx_msg void OnSizing(
 
 Called by the framework when the system colors change.
 
-```
+```cpp
 void OnSysColorChange();
 ```
 
@@ -1783,7 +1783,7 @@ This method is called when the size of the frame window has changed or when cont
 
 Unregisters a pane and removes it from the docking manager.
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pControlBar,
     BOOL bDestroy,
@@ -1819,7 +1819,7 @@ The [CDockingManager Class](../../mfc/reference/cdockingmanager-class.md) handle
 
 Restores the docking layout to the docking state stored in the registry.
 
-```
+```cpp
 void SetDockState(const CDockState& state);
 ```
 
@@ -1832,7 +1832,7 @@ The docking state. This parameter is ignored.
 
 Sets the print preview frame window.
 
-```
+```cpp
 void SetPrintPreviewFrame(CFrameWnd* pWnd);
 ```
 
@@ -1847,7 +1847,7 @@ void SetPrintPreviewFrame(CFrameWnd* pWnd);
 
 Inserts user-defined commands into a toolbar menu.
 
-```
+```cpp
 void SetupToolbarMenu(
     CMenu& menu,
     const UINT uiViewUserToolbarCmdFirst,
@@ -1873,7 +1873,7 @@ The framework stores user-defined commands in a list. Use *uiViewUserToolbarCmdF
 
 Switches the main frame between full-screen mode and regular mode.
 
-```
+```cpp
 void ShowFullScreen();
 ```
 
@@ -1881,7 +1881,7 @@ void ShowFullScreen();
 
 Shows or hides the specified pane.
 
-```
+```cpp
 void ShowPane(
     CBasePane* pBar,
     BOOL bShow,
@@ -1907,7 +1907,7 @@ void ShowPane(
 
 Called by the framework to update the window frame caption.
 
-```
+```cpp
 void UpdateCaption();
 ```
 

--- a/docs/mfc/reference/cglobalutils-class.md
+++ b/docs/mfc/reference/cglobalutils-class.md
@@ -50,7 +50,7 @@ class CGlobalUtils
 
 ## <a name="adjustrecttoworkarea"></a> CGlobalUtils::AdjustRectToWorkArea
 
-```
+```cpp
 void AdjustRectToworkArea(
     CRect& rect,
     CRect* pRectDelta = NULL);
@@ -65,7 +65,7 @@ void AdjustRectToworkArea(
 
 ## <a name="calcexpecteddockedrect"></a> CGlobalUtils::CalcExpectedDockedRect
 
-```
+```cpp
 void CalcExpectedDockedRect(
     CPaneContainerManager& barContainerManager,
     CWnd* pWndTodock,
@@ -193,7 +193,7 @@ BOOL DecimalFromString(
 
 ## <a name="fliprect"></a> CGlobalUtils::FlipRect
 
-```
+```cpp
 void FlipRect(
     CRect& rect,
     int nDegrees);
@@ -208,7 +208,7 @@ void FlipRect(
 
 ## <a name="forceadjustlayout"></a> CGlobalUtils::ForceAdjustLayout
 
-```
+```cpp
 void ForceAdjustLayout(
     CDockingManager* pDockManager,
     BOOL bForce = FALSE,
@@ -299,7 +299,7 @@ HICON GetWndIcon(CWnd* pWnd);
 
 ## <a name="setnewparent"></a> CGlobalUtils::SetNewParent
 
-```
+```cpp
 void SetNewParent(
     CObList& lstControlBars,
     CWnd* pNewParent,

--- a/docs/mfc/reference/chotkeyctrl-class.md
+++ b/docs/mfc/reference/chotkeyctrl-class.md
@@ -230,7 +230,7 @@ The key name that this function returns comes from the keyboard driver, so you c
 
 Sets the keyboard shortcut for a hot key control.
 
-```
+```cpp
 void SetHotKey(
     WORD wVirtualKeyCode,
     WORD wModifiers);
@@ -261,7 +261,7 @@ The virtual key code and the modifier keys together define the keyboard shortcut
 
 Call this function to define the invalid combinations and the default modifier combination for a hot key control.
 
-```
+```cpp
 void SetRules(
     WORD wInvalidComb,
     WORD wModifiers);

--- a/docs/mfc/reference/chtmlview-class.md
+++ b/docs/mfc/reference/chtmlview-class.md
@@ -273,7 +273,7 @@ A standard HRESULT value. For a complete listing of possible values, see [IOleCo
 
 Call this member function to execute a command in the WebBrowser or Internet Explorer.
 
-```
+```cpp
 void ExecWB(
     OLECMDID cmdID,
     OLECMDEXECOPT cmdexecopt,
@@ -764,7 +764,7 @@ The current width of the window, in pixels.
 
 Navigates backward one item in the history list.
 
-```
+```cpp
 void GoBack();
 ```
 
@@ -776,7 +776,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Navigates forward one item in the history list.
 
-```
+```cpp
 void GoForward();
 ```
 
@@ -784,7 +784,7 @@ void GoForward();
 
 Navigates to the current home or start page specified in the Internet Explorer Internet Options dialog box or the Internet Properties dialog box, accessed from the Control Panel.
 
-```
+```cpp
 void GoHome();
 ```
 
@@ -796,7 +796,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Navigates to the current search page, as specified in the Internet Explorer Internet Options dialog box or the Internet Properties dialog box, accessed from the Control Panel.
 
-```
+```cpp
 void GoSearch();
 ```
 
@@ -833,7 +833,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to navigate to the resource identified by a URL.
 
-```
+```cpp
 void Navigate(
     LPCTSTR URL,
     DWORD dwFlags = 0,
@@ -871,7 +871,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to navigate to the resource identified by a URL, or to the file identified by a full path.
 
-```
+```cpp
 void Navigate2(
     LPITEMIDLIST pIDL,
     DWORD dwFlags = 0,
@@ -1629,7 +1629,7 @@ This allows the object control host window to behave the same way the Internet E
 
 Call this member function to set the property associated with a given object.
 
-```
+```cpp
 void PutProperty(
     LPCTSTR lpszProperty,
     const VARIANT& vtValue);
@@ -1739,7 +1739,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Reloads the URL or file that the web browser is currently displaying.
 
-```
+```cpp
 void Refresh();
 ```
 
@@ -1753,7 +1753,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Reloads the file that Internet Explorer is currently displaying.
 
-```
+```cpp
 void Refresh2(int nLevel);
 ```
 
@@ -1772,7 +1772,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to show or hide the Internet Explorer object's address bar.
 
-```
+```cpp
 void SetAddressBar(BOOL bNewValue);
 ```
 
@@ -1789,7 +1789,7 @@ Applies to Internet Explorer. If you use this call with a WebBrowser control, it
 
 Call this member function to set Internet Explorer to either full-screen or normal window mode.
 
-```
+```cpp
 void SetFullScreen(BOOL bNewValue);
 ```
 
@@ -1808,7 +1808,7 @@ Applies to Internet Explorer. If you use this call with a WebBrowser control, it
 
 Call this member function to set the height of the Internet Explorer main window.
 
-```
+```cpp
 void SetHeight(long nNewValue);
 ```
 
@@ -1825,7 +1825,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Sets the horizontal position of the Internet Explorer main window.
 
-```
+```cpp
 void SetLeft(long nNewValue);
 ```
 
@@ -1838,7 +1838,7 @@ The screen coordinate of the left edge of the main window.
 
 Call this member function to show or hide the Internet Explorer menu bar.
 
-```
+```cpp
 void SetMenuBar(BOOL bNewValue);
 ```
 
@@ -1855,7 +1855,7 @@ Applies to Internet Explorer. If you use this call with a WebBrowser control, it
 
 Call this member function to set a value indicating whether the WebBrowser control is currently operating in offline mode.
 
-```
+```cpp
 void SetOffline(BOOL bNewValue);
 ```
 
@@ -1874,7 +1874,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to set a value indicating whether the WebBrowser control is registered as a top-level browser for target name resolution.
 
-```
+```cpp
 void SetRegisterAsBrowser(BOOL bNewValue);
 ```
 
@@ -1893,7 +1893,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to set a value indicating whether the WebBrowser control is registered as a drop target for navigation.
 
-```
+```cpp
 void SetRegisterAsDropTarget(BOOL bNewValue);
 ```
 
@@ -1910,7 +1910,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to set a value indicating whether any dialog boxes can be shown.
 
-```
+```cpp
 void SetSilent(BOOL bNewValue);
 ```
 
@@ -1927,7 +1927,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to display the status bar.
 
-```
+```cpp
 void SetStatusBar(BOOL bNewValue);
 ```
 
@@ -1944,7 +1944,7 @@ Applies to Internet Explorer. If you use this call with a WebBrowser control, it
 
 Call this member function to set a value indicating whether the WebBrowser control is in theater mode.
 
-```
+```cpp
 void SetTheaterMode(BOOL bNewValue);
 ```
 
@@ -1963,7 +1963,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to show or hide the Internet Explorer toolbar.
 
-```
+```cpp
 void SetToolBar(int nNewValue);
 ```
 
@@ -1980,7 +1980,7 @@ Applies to Internet Explorer. If you use this call with a WebBrowser control, it
 
 Call this member function to set the distance between the internal top edge of the WebBrowser control and the top edge of its container
 
-```
+```cpp
 void SetTop(long nNewValue);
 ```
 
@@ -1997,7 +1997,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Call this member function to set the visibility state of the WebBrowser control.
 
-```
+```cpp
 void SetVisible(BOOL bNewValue);
 ```
 
@@ -2014,7 +2014,7 @@ Applies to Internet Explorer and WebBrowser.
 
 Sets the width of the Internet Explorer main window.
 
-```
+```cpp
 void SetWidth(long nNewValue);
 ```
 
@@ -2027,7 +2027,7 @@ The width, in pixels, of the Internet Explorer main window.
 
 Call this member function to cancel any pending navigation or download operation and stop any dynamic page elements, such as background sounds and animations.
 
-```
+```cpp
 void Stop();
 ```
 

--- a/docs/mfc/reference/chwndrendertarget-class.md
+++ b/docs/mfc/reference/chwndrendertarget-class.md
@@ -64,7 +64,7 @@ class CHwndRenderTarget : public CRenderTarget;
 
 Attaches existing render target interface to the object
 
-```
+```cpp
 void Attach(ID2D1HwndRenderTarget* pTarget);
 ```
 

--- a/docs/mfc/reference/cinterpolatorbase-class.md
+++ b/docs/mfc/reference/cinterpolatorbase-class.md
@@ -189,7 +189,7 @@ If the method succeeds, it returns S_OK. It returns E_FAIL if CCustomInterpolato
 
 Stores a pointer to custom interpolator, which will be handling events.
 
-```
+```cpp
 void SetCustomInterpolator(CCustomInterpolator* pInterpolator);
 ```
 

--- a/docs/mfc/reference/cipaddressctrl-class.md
+++ b/docs/mfc/reference/cipaddressctrl-class.md
@@ -70,7 +70,7 @@ CIPAddressCtrl();
 
 Clears the contents of the IP Address Control.
 
-```
+```cpp
 void ClearAddress();
 ```
 
@@ -222,7 +222,7 @@ This member function implements the behavior of the Win32 message [IPM_ISBLANK](
 
 Sets the address values for all four fields in the IP Address Control.
 
-```
+```cpp
 void SetAddress(
     BYTE nField0,
     BYTE nField1,
@@ -264,7 +264,7 @@ This member function implements the behavior of the Win32 message [IPM_SETADDRES
 
 Sets the keyboard focus to the specified field in the IP Address Control.
 
-```
+```cpp
 void SetFieldFocus(WORD nField);
 ```
 
@@ -281,7 +281,7 @@ This member function implements the behavior of the Win32 message [IPM_SETFOCUS]
 
 Sets the range in the specified field in the IP Address Control.
 
-```
+```cpp
 void SetFieldRange(
     int nField,
     BYTE nLower,

--- a/docs/mfc/reference/cjumplist-class.md
+++ b/docs/mfc/reference/cjumplist-class.md
@@ -61,7 +61,7 @@ Destroys a `CJumpList` object.
 
 Aborts a list-building transaction without committing.
 
-```
+```cpp
 void AbortList();
 ```
 
@@ -218,7 +218,7 @@ If this parameter is FALSE the list is not automatically committed in  destructo
 
 Removes all tasks and destinations that have been added to the current instance of `CJumpList` so far.
 
-```
+```cpp
 void ClearAll();
 ```
 
@@ -230,7 +230,7 @@ This method clears and releases all data and internal interfaces.
 
 Removes all destinations that have been added to the current instance of CJumpList so far.
 
-```
+```cpp
 void ClearAllDestinations();
 ```
 
@@ -312,7 +312,7 @@ You don't need to call this method explicitly unless you wish to retrieve a poin
 
 Sets the Application User Model ID for the list that will be built.
 
-```
+```cpp
 void SetAppID(LPCTSTR strAppID);
 ```
 

--- a/docs/mfc/reference/ckeyboardmanager-class.md
+++ b/docs/mfc/reference/ckeyboardmanager-class.md
@@ -224,7 +224,7 @@ If you do not specify a default window, the main frame window of your applicatio
 
 Reloads the shortcut key tables from the application resource.
 
-```
+```cpp
 void ResetAll();
 ```
 

--- a/docs/mfc/reference/clist-class.md
+++ b/docs/mfc/reference/clist-class.md
@@ -531,7 +531,7 @@ Nonzero if this list is empty; otherwise 0.
 
 Removes all the elements from this list and frees the associated memory.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -547,7 +547,7 @@ No error is generated if the list is already empty.
 
 Removes the specified element from this list.
 
-```
+```cpp
 void RemoveAt(POSITION position);
 ```
 
@@ -618,7 +618,7 @@ You must ensure that the list is not empty before calling `RemoveTail`. If the l
 
 A variable of type POSITION is a key for the list.
 
-```
+```cpp
 void SetAt(POSITION pos, ARG_TYPE newElement);
 ```
 

--- a/docs/mfc/reference/clistbox-class.md
+++ b/docs/mfc/reference/clistbox-class.md
@@ -613,7 +613,7 @@ The doubleword value was the *dwItemData* parameter of a [SetItemData](#setitemd
 
 Retrieves the application-supplied 32-bit value associated with the specified list-box item as a pointer (**void** <strong>\*</strong>).
 
-```
+```cpp
 void* GetItemDataPtr(int nIndex) const;
 ```
 
@@ -983,7 +983,7 @@ See [CWnd::OnMeasureItem](../../mfc/reference/cwnd-class.md#onmeasureitem) for a
 
 Removes all items from a list box.
 
-```
+```cpp
 void ResetContent();
 ```
 
@@ -1065,7 +1065,7 @@ Use this member function only with multiple-selection list boxes. If you need to
 
 Sets the anchor in a multiple-selection list box to begin an extended selection.
 
-```
+```cpp
 void SetAnchorIndex(int nIndex);
 ```
 
@@ -1116,7 +1116,7 @@ If the item is not visible, it is scrolled into view.
 
 Sets the width in pixels of all columns in a multicolumn list box (created with the [LBS_MULTICOLUMN](../../mfc/reference/styles-used-by-mfc.md#list-box-styles) style).
 
-```
+```cpp
 void SetColumnWidth(int cxWidth);
 ```
 
@@ -1162,7 +1162,7 @@ To set or remove a selection in a multiple-selection list box, use [CListBox::Se
 
 Sets the width, in pixels, by which a list box can be scrolled horizontally.
 
-```
+```cpp
 void SetHorizontalExtent(int cxExtent);
 ```
 
@@ -1330,7 +1330,7 @@ To select an item from a single-selection list box, use [CListBox::SetCurSel](#s
 
 Sets the tab-stop positions in a list box.
 
-```
+```cpp
 void SetTabStops();
 BOOL SetTabStops(const int& cxEachStop);
 

--- a/docs/mfc/reference/clistctrl-class.md
+++ b/docs/mfc/reference/clistctrl-class.md
@@ -318,7 +318,7 @@ The *nCode* parameter specifies the alignment style.
 
 Cancels item text editing operation.
 
-```
+```cpp
 void CancelEditLabel();
 ```
 
@@ -1147,7 +1147,7 @@ The following code example demonstrates the `GetGroupInfoByIndex` method. In an 
 
 Retrieves the metrics of a group.
 
-```
+```cpp
 void GetGroupMetrics(PLVGROUPMETRICS pGroupMetrics) const;
 ```
 
@@ -2280,7 +2280,7 @@ The list view must be in icon view or small icon view.
 
 Retrieves the current working areas of a list view control.
 
-```
+```cpp
 void GetWorkAreas(
     int nWorkAreas,
     LPRECT pRect) const;
@@ -2742,7 +2742,7 @@ This member function emulates the functionality of the [LVM_MOVEGROUP](/windows/
 
 Moves the specified item into the specified group.
 
-```
+```cpp
 void MoveItemToGroup(
     int idItemFrom,
     int idGroupTo);
@@ -2793,7 +2793,7 @@ The specified items are not actually repainted until the list view window receiv
 
 Removes all groups from a list view control.
 
-```
+```cpp
 void RemoveAllGroups();
 ```
 
@@ -3121,7 +3121,7 @@ This method sends the [LVM_SETGROUPINFO](/windows/win32/Controls/lvm-setgroupinf
 
 Sets the group metrics of a list view control.
 
-```
+```cpp
 void SetGroupMetrics(PLVGROUPMETRICS pGroupMetrics);
 ```
 
@@ -3427,7 +3427,7 @@ See the example for [CListCtrl::HitTest](#hittest).
 
 Prepares a list view control for adding a large number of items.
 
-```
+```cpp
 void SetItemCount(int nItems);
 ```
 
@@ -3890,7 +3890,7 @@ This member function emulates the functionality of the [LVM_SETVIEW](/windows/wi
 
 Sets the area where icons can be displayed in a list view control.
 
-```
+```cpp
 void SetWorkAreas(
     int nWorkAreas,
     LPRECT lpRect);

--- a/docs/mfc/reference/clistview-class.md
+++ b/docs/mfc/reference/clistview-class.md
@@ -85,7 +85,7 @@ A reference to the list control associated with the view.
 
 Removes the specified image list from the list view.
 
-```
+```cpp
 void RemoveImageList(int nImageList);
 ```
 

--- a/docs/mfc/reference/cmap-class.md
+++ b/docs/mfc/reference/cmap-class.md
@@ -171,7 +171,7 @@ The number of elements in the hash table.
 
 Retrieves the map element at `rNextPosition`, then updates `rNextPosition` to refer to the next element in the map.
 
-```
+```cpp
 void GetNextAssoc(
     POSITION& rNextPosition,
     KEY& rKey,
@@ -249,7 +249,7 @@ See the example for [CMap::SetAt](#setat).
 
 Initializes the hash table.
 
-```
+```cpp
 void InitHashTable(UINT hashSize, BOOL  bAllocNow = TRUE);
 ```
 
@@ -426,7 +426,7 @@ Call this method to search for a map element with a key that exactly matches the
 
 Removes all the values from this map by calling the global helper function `DestructElements`.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -470,7 +470,7 @@ See the example for [CMap::SetAt](#setat).
 
 The primary means to insert an element in a map.
 
-```
+```cpp
 void SetAt(ARG_KEY key, ARG_VALUE newValue);
 ```
 

--- a/docs/mfc/reference/cmapstringtoob-class.md
+++ b/docs/mfc/reference/cmapstringtoob-class.md
@@ -165,7 +165,7 @@ The following table shows other member functions that are similar to `CMapString
 
 Retrieves the map element at *rNextPosition*, then updates *rNextPosition* to refer to the next element in the map.
 
-```
+```cpp
 void GetNextAssoc(
     POSITION& rNextPosition,
     CString& rKey,
@@ -317,7 +317,7 @@ The following table shows other member functions that are similar to `CMapString
 
 Initializes the hash table.
 
-```
+```cpp
 void InitHashTable(
     UINT hashSize,
     BOOL bAllocNow = TRUE);
@@ -498,7 +498,7 @@ Operator [] example: A CMapStringToOb with 2 elements
 
 Removes all the elements from this map and destroys the `CString` key objects.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -576,7 +576,7 @@ RemoveKey example: A CMapStringToOb with 3 elements
 
 The primary means to insert an element in a map.
 
-```
+```cpp
 void SetAt(
     LPCTSTR key,
     CObject* newValue);

--- a/docs/mfc/reference/cmdichildwnd-class.md
+++ b/docs/mfc/reference/cmdichildwnd-class.md
@@ -183,7 +183,7 @@ The frame returned is two parents removed from the `CMDIChildWnd` and is the par
 
 Call this member function to activate an MDI child window independently of the MDI frame window.
 
-```
+```cpp
 void MDIActivate();
 ```
 
@@ -199,7 +199,7 @@ When the frame becomes active, the child window that was last activated will be 
 
 Call this member function to destroy an MDI child window.
 
-```
+```cpp
 void MDIDestroy();
 ```
 
@@ -215,7 +215,7 @@ The member function removes the title of the child window from the frame window 
 
 Call this member function to maximize an MDI child window.
 
-```
+```cpp
 void MDIMaximize();
 ```
 
@@ -231,7 +231,7 @@ When a child window is maximized, Windows resizes it to make its client area fil
 
 Call this member function to restore an MDI child window from maximized or minimized size.
 
-```
+```cpp
 void MDIRestore();
 ```
 
@@ -243,7 +243,7 @@ void MDIRestore();
 
 Sets the handles for menu and accelerator resources.
 
-```
+```cpp
 void SetHandles(
     HMENU hMenu,
     HACCEL hAccel);

--- a/docs/mfc/reference/cmdichildwndex-class.md
+++ b/docs/mfc/reference/cmdichildwndex-class.md
@@ -135,7 +135,7 @@ TRUE if the pane was successfully registered with the docking manager; otherwise
 
 Adds a tabbed pane.
 
-```
+```cpp
 void AddTabbedPane(CDockablePane* pControlBar);
 ```
 
@@ -187,7 +187,7 @@ Override this method in a derived class and return FALSE if the window should no
 
 Docks a pane.
 
-```
+```cpp
 void DockPane(
     CBasePane* pBar,
     UINT nDockBarID = 0,
@@ -614,7 +614,7 @@ virtual void RecalcLayout(BOOL bNotify = TRUE);
 
 Removes a pane from the docking manager.
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pControlBar,
     BOOL bDestroy,
@@ -642,7 +642,7 @@ void RemovePaneFromDockManager(
 
 ## <a name="setrelatedtabgroup"></a> CMDIChildWndEx::SetRelatedTabGroup
 
-```
+```cpp
 void SetRelatedTabGroup(CMFCTabCtrl* p);
 ```
 
@@ -654,7 +654,7 @@ void SetRelatedTabGroup(CMFCTabCtrl* p);
 
 ## <a name="showpane"></a> CMDIChildWndEx::ShowPane
 
-```
+```cpp
 void ShowPane(
     CBasePane* pBar,
     BOOL bShow,
@@ -693,7 +693,7 @@ A handle to an icon to display on the Windows 7 taskbar tab.
 
 Removes the MDI child from Windows 7 taskbar tabs.
 
-```
+```cpp
 void UnregisterTaskbarTab(BOOL bCheckRegisteredMDIChildCount = TRUE);
 ```
 
@@ -727,7 +727,7 @@ TRUE if successful; otherwise FALSE.
 
 Sets properties for a Windows 7 taskbar tab.
 
-```
+```cpp
 void SetTaskbarTabProperties(DWORD dwFlags);
 ```
 
@@ -742,7 +742,7 @@ A combination of STPFLAG values. For more information, see [ITaskbarList4::SetTa
 
 Inserts the MDI child before the specified window on Windows 7 taskbar tabs.
 
-```
+```cpp
 void SetTaskbarTabOrder(CMDIChildWndEx* pWndBefore = NULL);
 ```
 
@@ -757,7 +757,7 @@ A pointer to the MDI child window whose thumbnail is inserted to the left. This 
 
 Activates the corresponding Windows 7 taskbar tab.
 
-```
+```cpp
 void SetTaskbarTabActive();
 ```
 
@@ -1032,7 +1032,7 @@ A pointer to a `CMDITabProxyWnd` object, which is registered with Windows 7 task
 
 Enables or disables automatic selection of a portion of a window's client area to display as that window's thumbnail in the taskbar.
 
-```
+```cpp
 void EnableTaskbarThumbnailClipRect(BOOL bEnable = TRUE);
 ```
 

--- a/docs/mfc/reference/cmdiframewnd-class.md
+++ b/docs/mfc/reference/cmdiframewnd-class.md
@@ -206,7 +206,7 @@ Override this member function if you have a Window menu that does not use the st
 
 Activates a different MDI child window.
 
-```
+```cpp
 void MDIActivate(CWnd* pWndActivate);
 ```
 
@@ -232,7 +232,7 @@ See the example for [CMDIFrameWnd::GetWindowMenuPopup](#getwindowmenupopup).
 
 Arranges all the MDI child windows in a cascade format.
 
-```
+```cpp
 void MDICascade();
 void MDICascade(int nType);
 ```
@@ -275,7 +275,7 @@ See the example for [CMDIChildWnd::MDIMaximize](../../mfc/reference/cmdichildwnd
 
 Arranges all minimized document child windows.
 
-```
+```cpp
 void MDIIconArrange();
 ```
 
@@ -291,7 +291,7 @@ See the example for [CMDIFrameWnd::MDICascade](#mdicascade).
 
 Maximizes the specified MDI child window.
 
-```
+```cpp
 void MDIMaximize(CWnd* pWnd);
 ```
 
@@ -314,7 +314,7 @@ See the example for [CMDIChildWnd::MDIMaximize](../../mfc/reference/cmdichildwnd
 
 Activates the child window immediately behind the currently active child window and places the currently active child window behind all other child windows.
 
-```
+```cpp
 void MDINext();
 ```
 
@@ -330,7 +330,7 @@ If the currently active MDI child window is maximized, the member function resto
 
 Activates the previous child window and places the currently active child window immediately behind it.
 
-```
+```cpp
 void MDIPrev();
 ```
 
@@ -342,7 +342,7 @@ If the currently active MDI child window is maximized, the member function resto
 
 Restores an MDI child window from maximized or minimized size.
 
-```
+```cpp
 void MDIRestore(CWnd* pWnd);
 ```
 
@@ -397,7 +397,7 @@ Do not call this member function if you use the framework to manage your MDI chi
 
 Arranges all child windows in a tiled format.
 
-```
+```cpp
 void MDITile();
 void MDITile(int nType);
 ```

--- a/docs/mfc/reference/cmdiframewndex-class.md
+++ b/docs/mfc/reference/cmdiframewndex-class.md
@@ -138,7 +138,7 @@ The following example derives a class from `CMDIFrameWndEx`. This code snippet c
 
 Recalculates the layout of the active item.
 
-```
+```cpp
 void ActiveItemRecalcLayout();
 ```
 
@@ -323,7 +323,7 @@ A pointer to the new window.
 
 Docks the specified pane to the frame window.
 
-```
+```cpp
 void DockPane(
     CBasePane* pBar,
     UINT nDockBarID=0,
@@ -445,7 +445,7 @@ The following example shows how the `EnableDocking` method is used in the [Visua
 
 Shows or hides the main menu in full-screen mode.
 
-```
+```cpp
 void EnableFullScreenMainMenu(BOOL bEnableMenu);
 ```
 
@@ -460,7 +460,7 @@ void EnableFullScreenMainMenu(BOOL bEnableMenu);
 
 Enables full-screen mode for the frame window.
 
-```
+```cpp
 void EnableFullScreenMode(UINT uiFullScreenCmd);
 ```
 
@@ -477,7 +477,7 @@ In full-screen mode, all docking control bars, toolbars and menus are hidden and
 
 Enables or disables the loading of the docking state.
 
-```
+```cpp
 void EnableLoadDockState(BOOL bEnable = TRUE);
 ```
 
@@ -492,7 +492,7 @@ void EnableLoadDockState(BOOL bEnable = TRUE);
 
 Enables or disables the MDI tabbed groups feature for the frame window.
 
-```
+```cpp
 void EnableMDITabbedGroups(
     BOOL bEnable,
     const CMDITabInfo& params);
@@ -536,7 +536,7 @@ The following example shows how `EnableMDITabbedGroups` is used in the [VisualSt
 
 Enables or disables the MDI Tabs feature for the MDI frame window. When enabled, the frame window displays a tab for each MDI child window.
 
-```
+```cpp
 void EnableMDITabs(
     BOOL bEnable=TRUE,
     BOOL bIcons=TRUE,
@@ -588,7 +588,7 @@ The following example shows how `EnableMDITabs` is used in the [MDITabsDemo Samp
 
 Specifies whether the last active tab should be opened when the user closes the current tab.
 
-```
+```cpp
 void EnableMDITabsLastActiveActivation(BOOL bLastActiveTab=TRUE);
 ```
 
@@ -613,7 +613,7 @@ Use `EnableMDITabsLastActiveActivation` to enable the second way of tab activati
 
 Enables or disables automatic creation and management of the pop-up pane menu, which displays a list of application panes.
 
-```
+```cpp
 void EnablePaneMenu(
     BOOL bEnable,
     UINT uiCustomizeCmd,
@@ -657,7 +657,7 @@ The following example shows how `EnablePaneMenu` is used in the [VisualStudioDem
 
 Inserts a menu item whose command ID calls a [CMFCWindowsManagerDialog](../../mfc/reference/cmfcwindowsmanagerdialog-class.md) dialog box.
 
-```
+```cpp
 void EnableWindowsDialog(
     UINT uiMenuId,
     LPCTSTR lpszMenuText,
@@ -1074,7 +1074,7 @@ The following example shows how `LoadMDIState` is used in the [VisualStudioDemo 
 
 Moves the active tab from the currently active tabbed window to the next or previous tabbed group.
 
-```
+```cpp
 void MDITabMoveToNextGroup(BOOL bNext=TRUE);
 ```
 
@@ -1087,7 +1087,7 @@ void MDITabMoveToNextGroup(BOOL bNext=TRUE);
 
 Creates a new tabbed group that has a single window.
 
-```
+```cpp
 void MDITabNewGroup(BOOL bVert=TRUE);
 ```
 
@@ -1631,7 +1631,7 @@ This method overrides [CFrameWnd::RecalcLayout](../../mfc/reference/cframewnd-cl
 
 Unregisters a pane and removes it from the docking manager.
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pControlBar,
     BOOL bDestroy,
@@ -1706,7 +1706,7 @@ The following example shows how `SaveMDIState` is used in the [VisualStudioDemo 
 
 Sets the print preview frame window.
 
-```
+```cpp
 void SetPrintPreviewFrame(CFrameWnd* pWnd);
 ```
 
@@ -1721,7 +1721,7 @@ void SetPrintPreviewFrame(CFrameWnd* pWnd);
 
 Modifies a toolbar object by replacing dummy items with user-defined items.
 
-```
+```cpp
 void SetupToolbarMenu(
     CMenu& menu,
     const UINT uiViewUserToolbarCmdFirst,
@@ -1743,7 +1743,7 @@ void SetupToolbarMenu(
 
 Switches the main frame from regular mode to full-screen mode.
 
-```
+```cpp
 void ShowFullScreen();
 ```
 
@@ -1753,7 +1753,7 @@ void ShowFullScreen();
 
 Shows or hides the specified pane.
 
-```
+```cpp
 void ShowPane(
     CBasePane* pBar,
     BOOL bShow,
@@ -1789,7 +1789,7 @@ The following example shows how `ShowPane` is used in the [VisualStudioDemo Samp
 
 Creates a [CMFCWindowsManagerDialog](../../mfc/reference/cmfcwindowsmanagerdialog-class.md) box and opens it.
 
-```
+```cpp
 void ShowWindowsDialog();
 ```
 
@@ -1830,7 +1830,7 @@ The following example shows how `TabbedDocumentToControlBar` is used in the [Vis
 
 Called by the framework to update the window frame caption.
 
-```
+```cpp
 void UpdateCaption();
 ```
 
@@ -1840,7 +1840,7 @@ void UpdateCaption();
 
 Sets the icon for each MDI tabbed pane.
 
-```
+```cpp
 void UpdateMDITabbedBarsIcons();
 ```
 

--- a/docs/mfc/reference/cmditabinfo-class.md
+++ b/docs/mfc/reference/cmditabinfo-class.md
@@ -208,7 +208,7 @@ Apply to the tabs one of the following location flags:
 
 Reads or writes this object from an archive or to an archive.
 
-```
+```cpp
 void Serialize(CArchive& ar);
 ```
 

--- a/docs/mfc/reference/cmemfile-class.md
+++ b/docs/mfc/reference/cmemfile-class.md
@@ -97,7 +97,7 @@ The default implementation uses the run-time library function [malloc](../../c-r
 
 Call this function to attach a block of memory to `CMemFile`.
 
-```
+```cpp
 void Attach(
     BYTE* lpBuffer,
     UINT nBufferSize,

--- a/docs/mfc/reference/cmemorystate-structure.md
+++ b/docs/mfc/reference/cmemorystate-structure.md
@@ -69,7 +69,7 @@ For more information about how to use `CMemoryState` and other diagnostics, see 
 
 Takes a snapshot summary of memory and stores it in this `CMemoryState` object.
 
-```
+```cpp
 void Checkpoint();
 ```
 
@@ -127,7 +127,7 @@ Nonzero if the two memory states are different; otherwise 0.
 
 Calls the `Dump` function for all objects of a type derived from class `CObject` that were allocated (and are still allocated) since the last [Checkpoint](#checkpoint) call for this `CMemoryState` object.
 
-```
+```cpp
 void DumpAllObjectsSince() const;
 ```
 
@@ -143,7 +143,7 @@ Calling `DumpAllObjectsSince` with an uninitialized `CMemoryState` object will d
 
 Prints a concise memory statistics report from a `CMemoryState` object that is filled by the [Difference](#difference) member function.
 
-```
+```cpp
 void DumpStatistics() const;
 ```
 

--- a/docs/mfc/reference/cmenutearoffmanager-class.md
+++ b/docs/mfc/reference/cmenutearoffmanager-class.md
@@ -60,7 +60,7 @@ The following example demonstrates how to construct and initialize a `CMenuTearO
 
 ## <a name="build"></a> CMenuTearOffManager::Build
 
-```
+```cpp
 void Build(
     UINT uiTearOffBarID,
     CString& strText);
@@ -156,7 +156,7 @@ UINT Parse(CString& str);
 
 ## <a name="reset"></a> CMenuTearOffManager::Reset
 
-```
+```cpp
 void Reset(HMENU hmenu);
 ```
 
@@ -168,7 +168,7 @@ void Reset(HMENU hmenu);
 
 ## <a name="setinuse"></a> CMenuTearOffManager::SetInUse
 
-```
+```cpp
 void SetInUse(
     UINT uiCmdId,
     BOOL bUse = TRUE);
@@ -184,7 +184,7 @@ void SetInUse(
 
 ## <a name="setuptearoffmenus"></a> CMenuTearOffManager::SetupTearOffMenus
 
-```
+```cpp
 void SetupTearOffMenus(HMENU hMenu);
 ```
 

--- a/docs/mfc/reference/cmfcacceleratorkey-class.md
+++ b/docs/mfc/reference/cmfcacceleratorkey-class.md
@@ -74,7 +74,7 @@ If you do not provide a shortcut key when you create a `CMFCAccleratorKey`, use 
 
 Translates the ACCEL structure to its associated string value.
 
-```
+```cpp
 void Format(CString& str) const;
 ```
 
@@ -91,7 +91,7 @@ This method retrieves the string format of the associated shortcut key. You can 
 
 Sets the shortcut key for the [CMFCAcceleratorKey](../../mfc/reference/cmfcacceleratorkey-class.md) object.
 
-```
+```cpp
 void SetAccelerator(LPACCEL lpAccel);
 ```
 

--- a/docs/mfc/reference/cmfcacceleratorkeyassignctrl-class.md
+++ b/docs/mfc/reference/cmfcacceleratorkeyassignctrl-class.md
@@ -133,7 +133,7 @@ virtual BOOL PreTranslateMessage(MSG* pMsg);
 
 Resets the shortcut key.
 
-```
+```cpp
 void ResetKey();
 ```
 

--- a/docs/mfc/reference/cmfcautohidebar-class.md
+++ b/docs/mfc/reference/cmfcautohidebar-class.md
@@ -277,7 +277,7 @@ See [CPane::SetActiveInGroup](../../mfc/reference/cpane-class.md#setactiveingrou
 
 ## <a name="setrecentvisiblestate"></a> CMFCAutoHideBar::SetRecentVisibleState
 
-```
+```cpp
 void SetRecentVisibleState(BOOL bState);
 ```
 
@@ -346,7 +346,7 @@ Derived classes can override this method to customize the behavior.
 
 Disables auto-hide mode for a group of auto-hide bars.
 
-```
+```cpp
 void UnSetAutoHideMode(CDockablePane* pFirstBarInGroup)
 ```
 
@@ -361,7 +361,7 @@ A pointer to the first auto-hide bar in the group.
 
 Called by the framework when the auto-hide bar needs to be redrawn.
 
-```
+```cpp
 void UpdateVisibleState();
 ```
 

--- a/docs/mfc/reference/cmfcautohidebutton-class.md
+++ b/docs/mfc/reference/cmfcautohidebutton-class.md
@@ -70,7 +70,7 @@ The following example demonstrates how to construct a `CMFCAutoHideButton` objec
 
 ## <a name="bringtotop"></a> CMFCAutoHideButton::BringToTop
 
-```
+```cpp
 void BringToTop();
 ```
 
@@ -327,7 +327,7 @@ If you want to customize the background for auto-hide buttons in your applicatio
 
 Shows or hides the associated [CDockablePane Class](../../mfc/reference/cdockablepane-class.md).
 
-```
+```cpp
 void ShowAttachedWindow(BOOL bShow);
 ```
 
@@ -351,7 +351,7 @@ virtual void ShowButton(BOOL bShow);
 
 ## <a name="move"></a> CMFCAutoHideButton::Move
 
-```
+```cpp
 void Move(int nOffset);
 ```
 
@@ -363,7 +363,7 @@ void Move(int nOffset);
 
 ## <a name="replacepane"></a> CMFCAutoHideButton::ReplacePane
 
-```
+```cpp
 void ReplacePane(CDockablePane* pNewBar);
 ```
 

--- a/docs/mfc/reference/cmfcbasetabctrl-class.md
+++ b/docs/mfc/reference/cmfcbasetabctrl-class.md
@@ -185,7 +185,7 @@ The following tips pertain to the `CMFCBaseTabCtrl Class` and any classes that i
 
 Adds an icon to the list of icons in the protected `CMap m_mapAddedIcons` member.
 
-```
+```cpp
 void AddIcon(
     HICON hIcon,
     int iIcon);
@@ -254,7 +254,7 @@ virtual void ApplyRestoredTabInfo(BOOL bUseTabIndexes = FALSE);
 
 ## <a name="autodestroywindow"></a> CMFCBaseTabCtrl::AutoDestroyWindow
 
-```
+```cpp
 void AutoDestroyWindow(BOOL bAutoDestroy = TRUE);
 ```
 
@@ -358,7 +358,7 @@ If the tab specified by *nTabNum* is non-detachable, this function fails and ret
 
 ## <a name="enableactivatelastactive"></a> CMFCBaseTabCtrl::EnableActivateLastActive
 
-```
+```cpp
 void EnableActivateLastActive(BOOL bLastActive = TRUE);
 ```
 
@@ -372,7 +372,7 @@ void EnableActivateLastActive(BOOL bLastActive = TRUE);
 
 Controls whether the framework uses the automatic background colors when drawing a tab.
 
-```
+```cpp
 void EnableAutoColor(BOOL bEnable = TRUE);
 ```
 
@@ -455,7 +455,7 @@ TRUE if successful; otherwise FALSE.
 
 Enables the user to change the tab order using a mouse.
 
-```
+```cpp
 void EnableTabSwap(BOOL bEnable);
 ```
 
@@ -493,7 +493,7 @@ By default, this method is not supported by the `CMFCBaseTabCtrl Class`. You sho
 
 ## <a name="enterdragmode"></a> CMFCBaseTabCtrl::EnterDragMode
 
-```
+```cpp
 void EnterDragMode();
 ```
 
@@ -1169,7 +1169,7 @@ If the object indicated by *pNewWnd* is not derived from the [CDockablePane Clas
 
 ## <a name="invalidatetab"></a> CMFCBaseTabCtrl::InvalidateTab
 
-```
+```cpp
 void InvalidateTab(int iTab);
 ```
 
@@ -1704,7 +1704,7 @@ virtual BOOL RenameTab();
 
 Resets the image list for an instance of the [CMFCBaseTabCtrl Class](../../mfc/reference/cmfcbasetabctrl-class.md).
 
-```
+```cpp
 void ResetImageList();
 ```
 
@@ -1779,7 +1779,7 @@ By default, the framework obtains the text color from [GetSysColor](/windows/win
 
 Sets the colors of the tab control that the framework uses in automatic color mode.
 
-```
+```cpp
 void SetAutoColors(const CArray<COLORREF,COLORREF>& arColors);
 ```
 
@@ -1798,7 +1798,7 @@ To enable autocolor mode, use the [CMFCBaseTabCtrl::EnableAutoColor](#enableauto
 
 Sets the wrapper class that is used for any objects that are not derived from the [CDockablePane Class](../../mfc/reference/cdockablepane-class.md).
 
-```
+```cpp
 void SetDockingBarWrapperRTC(CRuntimeClass* pRTC);
 ```
 
@@ -1815,7 +1815,7 @@ You add tabs to a tab control by using the methods [CMFCBaseTabCtrl::AddTab](#ad
 
 Enables and disables the processing of prefix characters in tab labels.
 
-```
+```cpp
 void SetDrawNoPrefix(
     BOOL bNoPrefix,
     BOOL bRedraw = TRUE);

--- a/docs/mfc/reference/cmfcbasevisualmanager-class.md
+++ b/docs/mfc/reference/cmfcbasevisualmanager-class.md
@@ -71,7 +71,7 @@ Because it is a base class for all visual managers, you can just call [CMFCVisua
 
 Calls `CloseThemeData` for all handles obtained in `UpdateSystemColors`.
 
-```
+```cpp
 void CleanUpThemes();
 ```
 
@@ -370,7 +370,7 @@ The currently selected Windows Theme color. Can be one of the following enumerat
 
 Calls `OpenThemeData` to obtain handles for drawing various controls: windows, toolbars, buttons, and so on.
 
-```
+```cpp
 void UpdateSystemColors();
 ```
 

--- a/docs/mfc/reference/cmfcbutton-class.md
+++ b/docs/mfc/reference/cmfcbutton-class.md
@@ -133,7 +133,7 @@ virtual void CleanUp();
 
 Specifies whether to display the full text of a tooltip in a large tooltip window or a truncated version of the text in a small tooltip window.
 
-```
+```cpp
 void EnableFullTextTooltip(BOOL bOn=TRUE);
 ```
 
@@ -148,7 +148,7 @@ void EnableFullTextTooltip(BOOL bOn=TRUE);
 
 Specifies whether the button text font is the same as the application menu font.
 
-```
+```cpp
 void EnableMenuFont(
     BOOL bOn=TRUE,
     BOOL bRedraw=TRUE);
@@ -618,7 +618,7 @@ Override this method to use your own code to retrieve the font.
 
 Sets a button to auto-repeat mode.
 
-```
+```cpp
 void SetAutorepeatMode(int nTimeDelay=500);
 ```
 
@@ -635,7 +635,7 @@ This method causes the button to constantly send WM_COMMAND messages to the pare
 
 Sets the image for a checked button.
 
-```
+```cpp
 void SetCheckedImage(
     HICON hIcon,
     BOOL bAutoDestroy=TRUE,
@@ -700,7 +700,7 @@ void SetCheckedImage(
 
 Sets the background color for the button text.
 
-```
+```cpp
 void SetFaceColor(
     COLORREF crFace,
     BOOL bRedraw=TRUE);
@@ -722,7 +722,7 @@ Use this method to define a new fill color for the button background (face). Not
 
 Sets the image for a button.
 
-```
+```cpp
 void SetImage(
     HICON hIcon,
     BOOL bAutoDestroy=TRUE,
@@ -794,7 +794,7 @@ The following example demonstrates how to use various versions of the `SetImage`
 
 Sets the cursor image.
 
-```
+```cpp
 void SetMouseCursor(HCURSOR hcursor);
 ```
 
@@ -818,7 +818,7 @@ The following example demonstrates how to use the `SetMouseCursor` method in the
 
 Sets the cursor to the image of a hand.
 
-```
+```cpp
 void SetMouseCursorHand();
 ```
 
@@ -830,7 +830,7 @@ Use this method to associate the cursor image of a hand with the button. The cur
 
 Uses a `CMenuImages` object to set the button image.
 
-```
+```cpp
 void SetStdImage(
     CMenuImages::IMAGES_IDS id,
     CMenuImages::IMAGE_STATE state=CMenuImages::ImageBlack,
@@ -854,7 +854,7 @@ void SetStdImage(
 
 Sets the color of the button text for a button that is not selected.
 
-```
+```cpp
 void SetTextColor(COLORREF clrText);
 ```
 
@@ -869,7 +869,7 @@ void SetTextColor(COLORREF clrText);
 
 Sets the color of the button text for a button that is selected.
 
-```
+```cpp
 void SetTextHotColor(COLORREF clrTextHot);
 ```
 
@@ -884,7 +884,7 @@ void SetTextHotColor(COLORREF clrTextHot);
 
 Associates a tooltip with a button.
 
-```
+```cpp
 void SetTooltip(LPCTSTR lpszToolTipText);
 ```
 

--- a/docs/mfc/reference/cmfccaptionbar-class.md
+++ b/docs/mfc/reference/cmfccaptionbar-class.md
@@ -159,7 +159,7 @@ Returns FALSE unless overridden.
 
 Enables or disables the button on the caption bar.
 
-```
+```cpp
 void EnableButton(BOOL bEnable=TRUE);
 ```
 
@@ -405,7 +405,7 @@ Override this method in a `CMFCCaptionBar` derived class to customize the appear
 
 Removes the bitmap image from the caption bar.
 
-```
+```cpp
 void RemoveBitmap();
 ```
 
@@ -413,7 +413,7 @@ void RemoveBitmap();
 
 Removes the button from the caption bar.
 
-```
+```cpp
 void RemoveButton();
 ```
 
@@ -425,7 +425,7 @@ The layout of caption bar elements are adjusted automatically.
 
 Removes the icon from the caption bar.
 
-```
+```cpp
 void RemoveIcon();
 ```
 
@@ -433,7 +433,7 @@ void RemoveIcon();
 
 Removes the text label from the caption bar.
 
-```
+```cpp
 void RemoveText();
 ```
 
@@ -441,7 +441,7 @@ void RemoveText();
 
 Sets the bitmap image for the caption bar.
 
-```
+```cpp
 void SetBitmap(
     HBITMAP hBitmap,
     COLORREF clrTransparent,
@@ -489,7 +489,7 @@ The bitmap is aligned as specified by the *bmpAlignment* parameter.  This parame
 
 Sets the border size of the caption bar.
 
-```
+```cpp
 void SetBorderSize(int nSize);
 ```
 
@@ -502,7 +502,7 @@ void SetBorderSize(int nSize);
 
 Sets the button for the caption bar.
 
-```
+```cpp
 void SetButton(
     LPCTSTR lpszLabel,
     UINT uiCmdUI,
@@ -528,7 +528,7 @@ TRUE if the button displays a drop down arrow, FALSE otherwise.
 
 Specifies whether the button stays pressed.
 
-```
+```cpp
 void SetButtonPressed(BOOL bPresed=TRUE);
 ```
 
@@ -541,7 +541,7 @@ TRUE if the button keeps its pressed state, FALSE otherwise.
 
 Sets the tooltip for the button.
 
-```
+```cpp
 void SetButtonToolTip(
     LPCTSTR lpszToolTip,
     LPCTSTR lpszDescription=NULL);
@@ -559,7 +559,7 @@ void SetButtonToolTip(
 
 Sets the border style of the caption bar.
 
-```
+```cpp
 void SetFlatBorder(BOOL bFlat=TRUE);
 ```
 
@@ -572,7 +572,7 @@ void SetFlatBorder(BOOL bFlat=TRUE);
 
 Sets the icon for a caption bar.
 
-```
+```cpp
 void SetIcon(
     HICON hIcon,
     BarElementAlignment iconAlignment=ALIGN_RIGHT);
@@ -604,7 +604,7 @@ The icon is aligned according to the *iconAlignment* parameter. It can be one of
 
 Sets the tooltip for the image in the caption bar.
 
-```
+```cpp
 void SetImageToolTip(
     LPCTSTR lpszToolTip,
     LPCTSTR lpszDescription=NULL);
@@ -622,7 +622,7 @@ void SetImageToolTip(
 
 Sets the distance between the edge of the caption bar element and the edge of the caption bar control.
 
-```
+```cpp
 void SetMargin(int nMargin);
 ```
 
@@ -635,7 +635,7 @@ void SetMargin(int nMargin);
 
 Sets the text label for the caption bar.
 
-```
+```cpp
 void SetText(
     const CString& strText,
     BarElementAlignment textAlignment=ALIGN_RIGHT);

--- a/docs/mfc/reference/cmfccaptionbutton-class.md
+++ b/docs/mfc/reference/cmfccaptionbutton-class.md
@@ -200,7 +200,7 @@ TRUE if the caption is set to mini size; otherwise FALSE.
 
 Sets the button draw location and window show state.
 
-```
+```cpp
 void Move(
     const CPoint& ptTo,
     BOOL bHide = FALSE);
@@ -252,7 +252,7 @@ The *bMaximized* parameter is used when the button is a maximize or minimize but
 
 Sets the mini size of the title bar.
 
-```
+```cpp
 void SetMiniFramebutton(BOOL bSet = TRUE);
 ```
 

--- a/docs/mfc/reference/cmfccmdusagecount-class.md
+++ b/docs/mfc/reference/cmfccmdusagecount-class.md
@@ -68,7 +68,7 @@ You can persist `CMFCCmdUsageCount` class data between runs of your program. Use
 
 Increments by one the counter that is associated with the given command.
 
-```
+```cpp
 void AddCmd(UINT uiCmd);
 ```
 
@@ -157,7 +157,7 @@ This method returns 0 if the total command usage, `m_nTotalUsage`, is 0. Otherwi
 
 Clears the usage count of all commands.
 
-```
+```cpp
 void Reset();
 ```
 

--- a/docs/mfc/reference/cmfccolorbar-class.md
+++ b/docs/mfc/reference/cmfccolorbar-class.md
@@ -304,7 +304,7 @@ The standard label for the other button is **More Colors...**.
 
 Calculates the vertical and horizontal margins that are required to contain the buttons on the color bar control, and adjusts the location of those buttons.
 
-```
+```cpp
 void ContextToSize(
     BOOL bSquareButtons = TRUE,
     BOOL bCenterButtons = TRUE);
@@ -428,7 +428,7 @@ TRUE if this method is successful; otherwise, FALSE.
 
 Shows or hides the automatic button.
 
-```
+```cpp
 void EnableAutomaticButton(
     LPCTSTR lpszLabel,
     COLORREF colorAutomatic,
@@ -456,7 +456,7 @@ The text label of the automatic button is deleted if the *lpszLabel* parameter i
 
 Enables or disables the display of a dialog box that lets the user select more colors.
 
-```
+```cpp
 void EnableOtherButton(
     LPCTSTR lpszLabel,
     BOOL bAltColorDlg=TRUE,
@@ -726,7 +726,7 @@ Pointer to the palette that is replaced by the palette of the parent button of t
 
 Sets the color that is currently selected.
 
-```
+```cpp
 void SetColor(COLORREF color);
 ```
 
@@ -761,7 +761,7 @@ This method changes the name of the specified color in all `CMFCColorBar` object
 
 Sets a new command ID for a color bar control.
 
-```
+```cpp
 void SetCommandID(UINT nCommandID);
 ```
 
@@ -778,7 +778,7 @@ Call this method to modify the command ID of a color bar control and to notify t
 
 Sets the list of colors that are used in the current document.
 
-```
+```cpp
 void SetDocumentColors(
     LPCTSTR lpszCaption,
     CList<COLORREF,COLORREF>& lstDocColors,
@@ -804,7 +804,7 @@ void SetDocumentColors(
 
 Sets the horizontal margin, which is the space between the left or right color cell and the boundary of the client area.
 
-```
+```cpp
 void SetHorzMargin(int nHorzMargin);
 ```
 
@@ -821,7 +821,7 @@ By default, the [CMFCColorBar::CMFCColorBar](#cmfccolorbar) constructor sets the
 
 Sets the `m_pWndPropList` protected data member to the specified pointer to a property grid control.
 
-```
+```cpp
 void SetPropList(CMFCPropertyGridCtrl* pWndList);
 ```
 
@@ -835,7 +835,7 @@ void SetPropList(CMFCPropertyGridCtrl* pWndList);
 
 Sets the vertical margin, which is the space between the top or bottom color cell and the client area boundary.
 
-```
+```cpp
 void SetVertMargin(int nVertMargin);
 ```
 

--- a/docs/mfc/reference/cmfccolorbutton-class.md
+++ b/docs/mfc/reference/cmfccolorbutton-class.md
@@ -101,7 +101,7 @@ CMFCColorButton();
 
 Enable or disable the "automatic" button of a color picker control and set the automatic (default) color.
 
-```
+```cpp
 void EnableAutomaticButton(
     LPCTSTR lpszLabel,
     COLORREF colorAutomatic,
@@ -125,7 +125,7 @@ void EnableAutomaticButton(
 
 Enable or disable the "other" button, which appears below regular color buttons.
 
-```
+```cpp
 void EnableOtherButton(
     LPCTSTR lpszLabel,
     BOOL bAltColorDlg=TRUE,
@@ -289,7 +289,7 @@ virtual void OnShowColorPopup();
 
 Initializes the `m_pPalette` protected data member to the specified palette or the default system palette.
 
-```
+```cpp
 void RebuildPalette(CPalette* pPal);
 ```
 
@@ -303,7 +303,7 @@ void RebuildPalette(CPalette* pPal);
 
 Specifies the color of the button.
 
-```
+```cpp
 void SetColor(COLORREF color);
 ```
 
@@ -340,7 +340,7 @@ The list of color names is global per application. Consequently, this method tra
 
 Defines the number of columns that are displayed in the table of colors that is presented to the user during the user's color selection process.
 
-```
+```cpp
 void SetColumnsNumber(int nColumns);
 ```
 
@@ -357,7 +357,7 @@ The user can select a color from a popup color bar that displays a table of pred
 
 Specifies a set of colors and the set's name. The set of colors is displayed using a [CMFCColorBar Class](../../mfc/reference/cmfccolorbar-class.md) object.
 
-```
+```cpp
 void SetDocumentColors(
     LPCTSTR lpszLabel,
     CList<COLORREF,COLORREF>& lstColors);
@@ -379,7 +379,7 @@ A `CMFCColorButton` object maintains a list of RGB values that are transferred t
 
 Specifies the standard colors to display on the popup color bar.
 
-```
+```cpp
 void SetPalette(CPalette* pPalette);
 ```
 

--- a/docs/mfc/reference/cmfccolordialog-class.md
+++ b/docs/mfc/reference/cmfccolordialog-class.md
@@ -150,7 +150,7 @@ The color palette specifies the colors that the user can choose.
 
 Derives a palette from the system palette.
 
-```
+```cpp
 void RebuildPalette();
 ```
 
@@ -158,7 +158,7 @@ void RebuildPalette();
 
 Sets the current color of the dialog box.
 
-```
+```cpp
 void SetCurrentColor(COLORREF rgb);
 ```
 
@@ -173,7 +173,7 @@ void SetCurrentColor(COLORREF rgb);
 
 Sets the current color to the color in the current palette that is most similar.
 
-```
+```cpp
 void SetNewColor(COLORREF rgb);
 ```
 
@@ -188,7 +188,7 @@ void SetNewColor(COLORREF rgb);
 
 Explicitly specifies the red, green, and blue components of a selected color on the first property page of a color dialog.
 
-```
+```cpp
 void SetPageOne(
     BYTE R,
     BYTE G,
@@ -212,7 +212,7 @@ void SetPageOne(
 
 Explicitly specifies the red, green, and blue components of a selected color on the second property page of a color dialog.
 
-```
+```cpp
 void SetPageTwo(
     BYTE R,
     BYTE G,

--- a/docs/mfc/reference/cmfccolormenubutton-class.md
+++ b/docs/mfc/reference/cmfccolormenubutton-class.md
@@ -147,7 +147,7 @@ This method is called by the framework when the user presses a color menu button
 
 Enables and disables an "automatic" button that is positioned above the regular color buttons. (The standard system automatic button is labeled **Automatic**.)
 
-```
+```cpp
 void EnableAutomaticButton(
     LPCTSTR lpszLabel,
     COLORREF colorAutomatic,
@@ -173,7 +173,7 @@ The automatic button applies the current default color.
 
 Enables the display of document-specific colors instead of system colors.
 
-```
+```cpp
 void EnableDocumentColors(
     LPCTSTR lpszLabel,
     BOOL bEnable=TRUE);
@@ -195,7 +195,7 @@ Use this method to display the current document colors or the system palette col
 
 Enables and disables an "other" button that is positioned below the regular color buttons. (The standard system "other" button is labeled **More Colors**.)
 
-```
+```cpp
 void EnableOtherButton(
     LPCTSTR lpszLabel,
     BOOL bAltColorDlg=TRUE,
@@ -219,7 +219,7 @@ void EnableOtherButton(
 
 Enables the ability to tear off a color pane.
 
-```
+```cpp
 void EnableTearOff(
     UINT uiID,
     int nVertDockColumns=-1,
@@ -487,7 +487,7 @@ static void SetColorName(
 
 Sets the number of columns to display in a color selection control ( [CMFCColorBar](../../mfc/reference/cmfccolorbar-class.md) object).
 
-```
+```cpp
 void SetColumnsNumber(int nColumns);
 ```
 

--- a/docs/mfc/reference/cmfccolorpickerctrl-class.md
+++ b/docs/mfc/reference/cmfccolorpickerctrl-class.md
@@ -142,7 +142,7 @@ The RGB value of the selected color.
 
 Retrieves the hue, luminance and saturation values of the color that the user selects.
 
-```
+```cpp
 void GetHLS(
     double* hue,
     double* luminance,
@@ -208,7 +208,7 @@ The saturation component of the selected color.
 
 Sets the current color to the color defined by the specified RGB color components or the specified cell hexagon.
 
-```
+```cpp
 void SelectCellHexagon(
     BYTE R,
     BYTE G,
@@ -250,7 +250,7 @@ The second overload of this method sets the current color to the color of the ce
 
 Sets the current color to the specified RGB color value.
 
-```
+```cpp
 void SetColor(COLORREF Color);
 ```
 
@@ -265,7 +265,7 @@ void SetColor(COLORREF Color);
 
 Sets the current color to the specified HLS color value.
 
-```
+```cpp
 void SetHLS(
     double hue,
     double luminance,
@@ -293,7 +293,7 @@ void SetHLS(
 
 Changes the hue of the currently selected color.
 
-```
+```cpp
 void SetHue(double Hue);
 ```
 
@@ -308,7 +308,7 @@ void SetHue(double Hue);
 
 Changes the luminance of the currently selected color.
 
-```
+```cpp
 void SetLuminance(double Luminance);
 ```
 
@@ -323,7 +323,7 @@ void SetLuminance(double Luminance);
 
 Sets the width of the luminance bar in the color picker control.
 
-```
+```cpp
 void SetLuminanceBarWidth(int w);
 ```
 
@@ -340,7 +340,7 @@ Use this method to resize the luminance bar, which is on the **Custom** tab of t
 
 Sets the initial selected color.
 
-```
+```cpp
 void SetOriginalColor(COLORREF ref);
 ```
 
@@ -357,7 +357,7 @@ Call this method when the color picker control is initialized.
 
 Sets the current color palette.
 
-```
+```cpp
 void SetPalette(CPalette* pPalette);
 ```
 
@@ -374,7 +374,7 @@ The color palette defines the array of colors that is presented in the color pic
 
 Changes the saturation of the currently selected color.
 
-```
+```cpp
 void SetSaturation(double Saturation);
 ```
 
@@ -389,7 +389,7 @@ void SetSaturation(double Saturation);
 
 Sets the type of color picker control to display.
 
-```
+```cpp
 void SetType(COLORTYPE colorType);
 ```
 

--- a/docs/mfc/reference/cmfccolorpopupmenu-class.md
+++ b/docs/mfc/reference/cmfccolorpopupmenu-class.md
@@ -215,7 +215,7 @@ The color pop-up menu has an embedded [CMFCPopupMenuBar Class](../../mfc/referen
 
 Sets the property grid control object of the embedded `CMFCColorBar` object.
 
-```
+```cpp
 void SetPropList(CMFCPropertyGridCtrl* pWndList);
 ```
 

--- a/docs/mfc/reference/cmfccustomcolorspropertypage-class.md
+++ b/docs/mfc/reference/cmfccustomcolorspropertypage-class.md
@@ -65,7 +65,7 @@ The following example demonstrates how to construct a `CMFCCustomColorsPropertyP
 
 Sets the color components of the property page.
 
-```
+```cpp
 void Setup(
     BYTE R,
     BYTE G,

--- a/docs/mfc/reference/cmfcdesktopalertwnd-class.md
+++ b/docs/mfc/reference/cmfcdesktopalertwnd-class.md
@@ -345,7 +345,7 @@ BOOL ProcessCommand(HWND hwnd);
 
 Sets the new animation speed.
 
-```
+```cpp
 void SetAnimationSpeed(UINT nSpeed);
 ```
 
@@ -362,7 +362,7 @@ Call this method to set the animation speed for the alert window. The default an
 
 Sets the animation type.
 
-```
+```cpp
 void SetAnimationType(CMFCPopupMenu::ANIMATION_TYPE type);
 ```
 
@@ -389,7 +389,7 @@ Call this method to set animation type. You can specify one of the following val
 
 Sets the auto-close time out.
 
-```
+```cpp
 void SetAutoCloseTime(int nTime);
 ```
 
@@ -406,7 +406,7 @@ The alert window is automatically closed after the specified time if the user do
 
 Switches between small and regular-size captions.
 
-```
+```cpp
 void SetSmallCaption(BOOL bSmallCaption = TRUE);
 ```
 
@@ -423,7 +423,7 @@ Call this method to display the small or regular-size caption. By default, the s
 
 Sets the transparency level of the popup window.
 
-```
+```cpp
 void SetTransparency(BYTE nTransparency);
 ```
 

--- a/docs/mfc/reference/cmfcdisablemenuanimation-class.md
+++ b/docs/mfc/reference/cmfcdisablemenuanimation-class.md
@@ -65,7 +65,7 @@ The following example shows how to use the stack to temporarily disable menu ani
 
 Restores the previous animation that the framework used to display a pop-up menu.
 
-```
+```cpp
 void Restore ();
 ```
 

--- a/docs/mfc/reference/cmfcdragframeimpl-class.md
+++ b/docs/mfc/reference/cmfcdragframeimpl-class.md
@@ -32,7 +32,7 @@ You can control the thickness of the drag rectangle by using [AFX_GLOBAL_DATA::m
 
 ## <a name="enddrawdragframe"></a> CMFCDragFrameImpl::EndDrawDragFrame
 
-```
+```cpp
 void EndDrawDragFrame(BOOL bClearInternalRects = TRUE);
 ```
 
@@ -44,7 +44,7 @@ void EndDrawDragFrame(BOOL bClearInternalRects = TRUE);
 
 ## <a name="init"></a> CMFCDragFrameImpl::Init
 
-```
+```cpp
 void Init(CWnd* pDraggedWnd);
 ```
 
@@ -56,7 +56,7 @@ void Init(CWnd* pDraggedWnd);
 
 ## <a name="movedragframe"></a> CMFCDragFrameImpl::MoveDragFrame
 
-```
+```cpp
 void MoveDragFrame(BOOL bForceMove = FALSE);
 ```
 
@@ -68,7 +68,7 @@ void MoveDragFrame(BOOL bForceMove = FALSE);
 
 ## <a name="placetabpredocking"></a> CMFCDragFrameImpl::PlaceTabPreDocking
 
-```
+```cpp
 void PlaceTabPreDocking(
     CBaseTabbedPane* pTabbedBar,
     BOOL bFirstTime);
@@ -88,7 +88,7 @@ void PlaceTabPreDocking(CWnd* pCBarToPlaceOn);
 
 ## <a name="removetabpredocking"></a> CMFCDragFrameImpl::RemoveTabPreDocking
 
-```
+```cpp
 void RemoveTabPreDocking(CDockablePane* pOldTargetBar = NULL);
 ```
 
@@ -100,7 +100,7 @@ void RemoveTabPreDocking(CDockablePane* pOldTargetBar = NULL);
 
 ## <a name="resetstate"></a> CMFCDragFrameImpl::ResetState
 
-```
+```cpp
 void ResetState();
 ```
 

--- a/docs/mfc/reference/cmfcdropdownframe-class.md
+++ b/docs/mfc/reference/cmfcdropdownframe-class.md
@@ -155,7 +155,7 @@ The framework calls this method when the drop-down frame is created or the paren
 
 Sets whether the child drop-down toolbar window is destroyed automatically.
 
-```
+```cpp
 void SetAutoDestroy(BOOL bAutoDestroy = TRUE);
 ```
 

--- a/docs/mfc/reference/cmfcdropdowntoolbarbutton-class.md
+++ b/docs/mfc/reference/cmfcdropdowntoolbarbutton-class.md
@@ -481,7 +481,7 @@ This method extends the base class implementation ( [CMFCToolBarButton::Serializ
 
 Sets the default command that the framework uses when a user clicks the button.
 
-```
+```cpp
 void SetDefaultCommand(UINT uiCmd);
 ```
 

--- a/docs/mfc/reference/cmfcdynamiclayout-class.md
+++ b/docs/mfc/reference/cmfcdynamiclayout-class.md
@@ -105,7 +105,7 @@ The position and size of a child control is changed dynamically when a hosting w
 
 Adds a child window, typically a control, to the list of windows that are controlled by the dynamic layout manager.
 
-```
+```cpp
 void Adjust();
 ```
 
@@ -168,7 +168,7 @@ The position and size of a child control is changed dynamically when a hosting w
 
 Retrieves the rectangle for the window's current client area.
 
-```
+```cpp
 void GetHostWndRect(CRect& rect,);
 ```
 
@@ -365,7 +365,7 @@ A [MoveSettings](#movesettings_structure) value that encapsulates the requested 
 
 Sets the window size below which layout is not adjusted.
 
-```
+```cpp
 void SetMinSize(const CSize& size);
 ```
 

--- a/docs/mfc/reference/cmfceditbrowsectrl-class.md
+++ b/docs/mfc/reference/cmfceditbrowsectrl-class.md
@@ -105,7 +105,7 @@ The following example demonstrates how to use two methods in the `CMFCEditBrowse
 
 Displays or does not display the browse button on the current edit browse control.
 
-```
+```cpp
 void EnableBrowseButton(
     BOOL bEnable=TRUE,
     LPCTSTR szLabel=_T("..."));
@@ -129,7 +129,7 @@ If the *bEnable* parameter is TRUE, the browse mode of the control is `BrowseMod
 
 Displays the browse button on the current edit browse control and puts the control in *file browse* mode.
 
-```
+```cpp
 void EnableFileBrowseButton(
     LPCTSTR lpszDefExt=NULL,
     LPCTSTR lpszFilter=NULL,
@@ -157,7 +157,7 @@ For a full list of available flags, see [OPENFILENAME structure](/windows/win32/
 
 Displays the browse button on the current edit browse control and puts the control in *folder browse* mode.
 
-```
+```cpp
 void EnableFolderBrowseButton();
 ```
 
@@ -260,7 +260,7 @@ Override this function in a derived class to customize the appearance of the bro
 
 Sets a custom image on the browse button of the edit browse control.
 
-```
+```cpp
 void SetBrowseButtonImage(
     HICON hIcon,
     BOOL bAutoDestroy= TRUE);

--- a/docs/mfc/reference/cmfcfilterchunkvalueimpl-class.md
+++ b/docs/mfc/reference/cmfcfilterchunkvalueimpl-class.md
@@ -81,7 +81,7 @@ hr = chunk.SetFileTimeValue(PKEY_ItemDate, ftLastModified);
 
 Clears the ChunkValue.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -130,7 +130,7 @@ S_OK if successful; otherwise an error code.
 
 Initializes this chunk value from the other value.
 
-```
+```cpp
 void CopyFrom (IFilterChunkValue* pValue);
 ```
 

--- a/docs/mfc/reference/cmfcheaderctrl-class.md
+++ b/docs/mfc/reference/cmfcheaderctrl-class.md
@@ -98,7 +98,7 @@ This constructor initializes the following member variables to the specified val
 
 Enables or disables *multiple column sort* mode for the current header control.
 
-```
+```cpp
 void EnableMultipleSort(BOOL bEnable=TRUE);
 ```
 
@@ -263,7 +263,7 @@ virtual void OnFillBackground(CDC* pDC);
 
 Removes the specified column from the list of sort columns.
 
-```
+```cpp
 void RemoveSortColumn(int iColumn);
 ```
 
@@ -276,7 +276,7 @@ void RemoveSortColumn(int iColumn);
 
 Sets the sort order of a specified column in a header control.
 
-```
+```cpp
 void SetSortColumn(
     int iColumn,
     BOOL bAscending=TRUE,

--- a/docs/mfc/reference/cmfcimagepaintarea-class.md
+++ b/docs/mfc/reference/cmfcimagepaintarea-class.md
@@ -94,7 +94,7 @@ An [IMAGE_EDIT_MODE](cmfcimagepaintarea-image-edit-mode-enumeration.md) value th
 
 Sets the bitmap image for the picture area.
 
-```
+```cpp
 void SetBitmap(CBitmap* pBitmap);
 ```
 
@@ -113,7 +113,7 @@ If *pBitmap* is NULL, this method sets the size of the modifiable paint area to 
 
 Sets the current drawing color.
 
-```
+```cpp
 void SetColor(COLORREF color);
 ```
 
@@ -134,7 +134,7 @@ The drawing color is used by the image editor dialog box for all drawing modes e
 
 Sets the current drawing mode.
 
-```
+```cpp
 void SetMode(IMAGE_EDIT_MODE mode);
 ```
 

--- a/docs/mfc/reference/cmfclinkctrl-class.md
+++ b/docs/mfc/reference/cmfclinkctrl-class.md
@@ -86,7 +86,7 @@ Override this method when you want to use your own code to draw the button's foc
 
 Displays a specified URL as the button text.
 
-```
+```cpp
 void SetURL(LPCTSTR lpszURL);
 ```
 
@@ -101,7 +101,7 @@ void SetURL(LPCTSTR lpszURL);
 
 Sets the implicit protocol (for example, "http:") of the URL.
 
-```
+```cpp
 void SetURLPrefix(LPCTSTR lpszPrefix);
 ```
 

--- a/docs/mfc/reference/cmfclistctrl-class.md
+++ b/docs/mfc/reference/cmfclistctrl-class.md
@@ -64,7 +64,7 @@ The following example demonstrates how to use various methods in the `CMFCListCt
 
 Marks the sorted columns with a different background color.
 
-```
+```cpp
 void EnableMarkSortedColumn(
     BOOL bMark = TRUE,
     BOOL bRedraw = TRUE);
@@ -86,7 +86,7 @@ void EnableMarkSortedColumn(
 
 Enables sorting the rows of data in the list control by multiple columns.
 
-```
+```cpp
 void EnableMultipleSort(BOOL bEnable = TRUE);
 ```
 
@@ -247,7 +247,7 @@ By default, this method calls `GetTextColor` regardless of input parameters. The
 
 Removes a sort column from the list of sorted columns.
 
-```
+```cpp
 void RemoveSortColumn(int iColumn);
 ```
 
@@ -264,7 +264,7 @@ This method removes a sort column from the header control. It calls [CMFCHeaderC
 
 Sets the current sorted column and the sort order.
 
-```
+```cpp
 void SetSortColumn(
     int iColumn,
     BOOL bAscending = TRUE,

--- a/docs/mfc/reference/cmfcmaskededit-class.md
+++ b/docs/mfc/reference/cmfcmaskededit-class.md
@@ -87,7 +87,7 @@ The following example demonstrates how to set up a mask (for example a phone num
 
 Disables validating user input.
 
-```
+```cpp
 void DisableMask();
 ```
 
@@ -99,7 +99,7 @@ If user input validation is disabled, the masked edit control behaves like the s
 
 Specifies whether the `GetWindowText` method retrieves only masked characters.
 
-```
+```cpp
 void EnableGetMaskedCharsOnly(BOOL bEnable=TRUE);
 ```
 
@@ -116,7 +116,7 @@ Use this method to enable retrieving masked characters. Then create a masked edi
 
 Initializes the masked edit control.
 
-```
+```cpp
 void EnableMask(
     LPCTSTR lpszMask,
     LPCTSTR lpszInputTemplate,
@@ -159,7 +159,7 @@ The following table list the default mask characters:
 
 Specifies whether the masked edit control allows the user to select particular groups input, or all input.
 
-```
+```cpp
 void EnableSelectByGroup(BOOL bEnable=TRUE);
 ```
 
@@ -193,7 +193,7 @@ If selection by group is enabled, the user can retrieve only the "425", "555", o
 
 Specifies whether the text is validated against only the masked characters, or against the whole mask.
 
-```
+```cpp
 void EnableSetMaskedCharsOnly(BOOL bEnable=TRUE);
 ```
 
@@ -265,7 +265,7 @@ Override this method to validate input characters on your own. For more informat
 
 Specifies a string of valid characters that the user can enter.
 
-```
+```cpp
 void SetValidChars(LPCTSTR lpszValid=NULL);
 ```
 
@@ -295,7 +295,7 @@ m_wndMaskEdit.SetValidChars(_T("1234567890ABCDEFabcdef"));m_wndMaskEdit.SetWindo
 
 Displays a prompt in the masked edit control.
 
-```
+```cpp
 void SetWindowText(LPCTSTR lpszString);
 ```
 

--- a/docs/mfc/reference/cmfcmenubar-class.md
+++ b/docs/mfc/reference/cmfcmenubar-class.md
@@ -322,7 +322,7 @@ Use this method if you want a menu control to have the same menu items as a menu
 
 Enables a **Help** combo box that is located on the right side of the menu bar.
 
-```
+```cpp
 void EnableHelpCombobox(
     UINT uiID,
     LPCTSTR lpszPrompt = NULL,
@@ -846,7 +846,7 @@ The saved information includes the menu items, the dock state, and the position 
 
 Sets the default menu for a [CMFCMenuBar](../../mfc/reference/cmfcmenubar-class.md) object based on the resource ID.
 
-```
+```cpp
 void SetDefaultMenuResId(UINT uiResId);
 ```
 
@@ -863,7 +863,7 @@ Use the [CMFCMenuBar::GetDefaultMenuResId](#getdefaultmenuresid) method to retri
 
 ## <a name="setforcedownarrows"></a> CMFCMenuBar::SetForceDownArrows
 
-```
+```cpp
 void SetForceDownArrows(BOOL bValue);
 ```
 
@@ -877,7 +877,7 @@ void SetForceDownArrows(BOOL bValue);
 
 The framework calls this method when a MDI changes its display mode and the menu bar must be updated.
 
-```
+```cpp
 void SetMaximizeMode(
     BOOL bMax,
     CWnd* pWnd = NULL,
@@ -903,7 +903,7 @@ When an MDI child window is maximized, a menu bar attached to the MDI main frame
 
 Sets the runtime class information that the framework uses when the user creates menu buttons.
 
-```
+```cpp
 void SetMenuButtonRTC(CRuntimeClass* pMenuButtonRTC);
 ```
 

--- a/docs/mfc/reference/cmfcoutlookbarpane-class.md
+++ b/docs/mfc/reference/cmfcoutlookbarpane-class.md
@@ -190,7 +190,7 @@ virtual BOOL CanBeAttached() const;
 
 Frees the resources used by the images on the Outlook bar pane.
 
-```
+```cpp
 void ClearAll();
 ```
 
@@ -269,7 +269,7 @@ The default implementation checks the customization mode ( [CMFCToolBar::IsCusto
 
 Specifies whether the scroll arrows on the Outlook bar pane advance the list of buttons page by page, or button by button.
 
-```
+```cpp
 void EnablePageScrollMode(BOOL bPageScroll=TRUE);
 ```
 
@@ -353,7 +353,7 @@ TRUE if the button was successfully removed; FALSE if the specified command ID i
 
 Sets the background color of the Outlook bar.
 
-```
+```cpp
 void SetBackColor(COLORREF color);
 ```
 
@@ -370,7 +370,7 @@ Call this function to set the current background color for the Outlook bar. The 
 
 Sets the background image.
 
-```
+```cpp
 void SetBackImage(UINT uiImageID);
 ```
 
@@ -387,7 +387,7 @@ Call this method to set the Outlook bar's background image. The list of backgrou
 
 Resets the Outlook bar pane to the original set of buttons.
 
-```
+```cpp
 void SetDefaultState();
 ```
 
@@ -399,7 +399,7 @@ This method restores the Outlook bar buttons to the original set. This method is
 
 Sets the number of pixels of padding used around buttons in the Outlook bar pane.
 
-```
+```cpp
 void SetExtraSpace()
 ```
 
@@ -407,7 +407,7 @@ void SetExtraSpace()
 
 Sets the colors of regular and highlighted text in the Outlook bar pane.
 
-```
+```cpp
 void SetTextColor(
     COLORREF clrRegText,
     COLORREF clrSelText=0);
@@ -425,7 +425,7 @@ void SetTextColor(
 
 Sets the transparent color for the Outlook bar pane.
 
-```
+```cpp
 void SetTransparentColor(COLORREF color);
 ```
 

--- a/docs/mfc/reference/cmfcoutlookbartabctrl-class.md
+++ b/docs/mfc/reference/cmfcoutlookbartabctrl-class.md
@@ -89,7 +89,7 @@ The following example demonstrates how to initialize a `CMFCOutlookBarTabCtrl` o
 
 Adds a Windows control as a new tab in the Outlook bar.
 
-```
+```cpp
 void AddControl(
     CWnd* pWndCtrl,
     LPCTSTR lpszName,
@@ -231,7 +231,7 @@ Call this function to enable or disable in-place editing of text  labels on tab 
 
 Called by the framework to enable scroll handles that allow the user to scroll through buttons on the Outlook bar pane.
 
-```
+```cpp
 void EnableScrollButtons(
     BOOL bEnable = TRUE,
     BOOL bIsUp = TRUE,
@@ -370,7 +370,7 @@ The visual effect of setting the active tab depends on whether you have enabled 
 
 Sets the border size of the Outlook tab control.
 
-```
+```cpp
 void SetBorderSize(int nBorderSize);
 ```
 
@@ -387,7 +387,7 @@ Sets the new border size and recalculates the outlook window layout.
 
 Sets the alignment of the text labels on the tab buttons of the Outlook bar.
 
-```
+```cpp
 void SetPageButtonTextAlign(
     UINT uiAlign,
     BOOL bRedraw=TRUE);
@@ -449,7 +449,7 @@ This method should not be called if not in Microsoft Office 2003 mode. For more 
 
 ## <a name="setvisiblepagebuttons"></a> CMFCOutlookBarTabCtrl::SetVisiblePageButtons
 
-```
+```cpp
 void SetVisiblePageButtons(int nVisiblePageButtons);
 ```
 

--- a/docs/mfc/reference/cmfcpopupmenu-class.md
+++ b/docs/mfc/reference/cmfcpopupmenu-class.md
@@ -213,7 +213,7 @@ A MENUAREA_TYPE parameter can have any one of the following values.
 
 ## <a name="closemenu"></a> CMFCPopupMenu::CloseMenu
 
-```
+```cpp
 void CloseMenu(BOOL bSetFocusToBar = FALSE);
 ```
 
@@ -326,7 +326,7 @@ virtual BOOL DefaultMouseClickOnClose() const;
 
 Initializes the logo for a pop-up menu.
 
-```
+```cpp
 void EnableMenuLogo(
     int iLogoSize,
     LOGO_LOCATION nLogoLocation = MENU_LOGO_LEFT);
@@ -365,7 +365,7 @@ If you enable sound, the framework calls the [PlaySound](/windows/win32/api/shob
 
 ## <a name="enableresize"></a> CMFCPopupMenu::EnableResize
 
-```
+```cpp
 void EnableResize(CSize sizeMinResize);
 ```
 
@@ -377,7 +377,7 @@ void EnableResize(CSize sizeMinResize);
 
 ## <a name="enablescrolling"></a> CMFCPopupMenu::EnableScrolling
 
-```
+```cpp
 void EnableScrolling(BOOL = TRUE);
 ```
 
@@ -389,7 +389,7 @@ void EnableScrolling(BOOL = TRUE);
 
 ## <a name="enablevertresize"></a> CMFCPopupMenu::EnableVertResize
 
-```
+```cpp
 void EnableVertResize(int nMinResize);
 ```
 
@@ -927,7 +927,7 @@ TRUE if a pop-up menu is visible; otherwise FALSE.
 
 ## <a name="moveto"></a> CMFCPopupMenu::MoveTo
 
-```
+```cpp
 void MoveTo(const CPoint& pt);
 ```
 
@@ -1026,7 +1026,7 @@ virtual void RecalcLayout(BOOL bNotify = TRUE);
 
 Clears all the items from a pop-up menu.
 
-```
+```cpp
 void RemoveAllItems();
 ```
 
@@ -1097,7 +1097,7 @@ See [CMFCPopupMenu::GetAnimationType](#getanimationtype) for a list of valid val
 
 ## <a name="setautodestroy"></a> CMFCPopupMenu::SetAutoDestroy
 
-```
+```cpp
 void SetAutoDestroy(BOOL bAutoDestroy = TRUE);
 ```
 
@@ -1111,7 +1111,7 @@ void SetAutoDestroy(BOOL bAutoDestroy = TRUE);
 
 Sets the default command for the pop-up menu.
 
-```
+```cpp
 void SetDefaultItem(UINT uiCmd);
 ```
 
@@ -1162,7 +1162,7 @@ When you call this method, it sets a global flag in your application. This flag 
 
 Set the maximum width for the pop-up menu.
 
-```
+```cpp
 void SetMaxWidth(int iMaxWidth);
 ```
 
@@ -1177,7 +1177,7 @@ If the text associated with a menu command will not fit in the maximum width, it
 
 ## <a name="setmessagewnd"></a> CMFCPopupMenu::SetMessageWnd
 
-```
+```cpp
 void SetMessageWnd(CWnd* pMsgWnd);
 ```
 
@@ -1189,7 +1189,7 @@ void SetMessageWnd(CWnd* pMsgWnd);
 
 ## <a name="setparentribbonelement"></a> CMFCPopupMenu::SetParentRibbonElement
 
-```
+```cpp
 void SetParentRibbonElement(CMFCRibbonBaseElement* pElem);
 ```
 
@@ -1201,7 +1201,7 @@ void SetParentRibbonElement(CMFCRibbonBaseElement* pElem);
 
 ## <a name="setquickcustomizetype"></a> CMFCPopupMenu::SetQuickCustomizeType
 
-```
+```cpp
 void SetQuickCustomizeType(QUICK_CUSTOMIZE_TYPE Type);
 ```
 
@@ -1213,7 +1213,7 @@ void SetQuickCustomizeType(QUICK_CUSTOMIZE_TYPE Type);
 
 ## <a name="setquickmode"></a> CMFCPopupMenu::SetQuickMode
 
-```
+```cpp
 void SetQuickMode();
 ```
 
@@ -1223,7 +1223,7 @@ void SetQuickMode();
 
 Sets the menu alignment for pop-up menus.
 
-```
+```cpp
 void SetRightAlign(BOOL bRightAlign = TRUE);
 ```
 
@@ -1257,7 +1257,7 @@ This is a global option for all the pop-up menus in an application. If it is ena
 
 Forces the pop-up menu to display all commands.
 
-```
+```cpp
 void ShowAllCommands();
 ```
 
@@ -1267,7 +1267,7 @@ This is not a global setting and affects only the current pop-up menu.
 
 ## <a name="triggerresize"></a> CMFCPopupMenu::TriggerResize
 
-```
+```cpp
 void TriggerResize();
 ```
 
@@ -1294,7 +1294,7 @@ This method is useful when pop-up menus are displayed over animated controls or 
 
 Updates the shadow for the pop-up menu.
 
-```
+```cpp
 void UpdateShadow(LPRECT lprectScreen = NULL);
 ```
 

--- a/docs/mfc/reference/cmfcpopupmenubar-class.md
+++ b/docs/mfc/reference/cmfcpopupmenubar-class.md
@@ -363,7 +363,7 @@ virtual void SetButtonStyle(
 
 Sets the row offset of the popup menu bar.
 
-```
+```cpp
 void SetOffset(int iOffset);
 ```
 
@@ -378,7 +378,7 @@ void SetOffset(int iOffset);
 
 Starts the timer for a specified delayed popup menu button.
 
-```
+```cpp
 void StartPopupMenuTimer(
     CMFCToolBarMenuButton* pMenuButton,
     int nDelayFactor = 1);

--- a/docs/mfc/reference/cmfcpreviewctrlimpl-class.md
+++ b/docs/mfc/reference/cmfcpreviewctrlimpl-class.md
@@ -213,7 +213,7 @@ Called by the preview handler to create a relationship between the document impl
 
 ### Syntax
 
-```
+```cpp
 void SetDocument(
    IDocument* pDocument
 );

--- a/docs/mfc/reference/cmfcpropertygridcolorproperty-class.md
+++ b/docs/mfc/reference/cmfcpropertygridcolorproperty-class.md
@@ -97,7 +97,7 @@ CMFCPropertyGridColorProperty(
 
 Enables the *automatic* button on the color selection dialog box. (The standard automatic button is labeled **Automatic**.)
 
-```
+```cpp
 void EnableAutomaticButton(
     LPCTSTR lpszLabel,
     COLORREF colorAutomatic,
@@ -121,7 +121,7 @@ void EnableAutomaticButton(
 
 Enables the *other* button on the color selection dialog box. (The standard other button is labeled **More Colors**.)
 
-```
+```cpp
 void EnableOtherButton(
     LPCTSTR lpszLabel,
     BOOL bAltColorDlg = TRUE,
@@ -159,7 +159,7 @@ An RGB color value.
 
 Sets a new color for the property.
 
-```
+```cpp
 void SetColor(COLORREF color);
 ```
 
@@ -174,7 +174,7 @@ void SetColor(COLORREF color);
 
 Specifies the number of columns in the current color property grid.
 
-```
+```cpp
 void SetColumnsNumber(int nColumnsNumber);
 ```
 

--- a/docs/mfc/reference/cmfcpropertygridctrl-class.md
+++ b/docs/mfc/reference/cmfcpropertygridctrl-class.md
@@ -228,7 +228,7 @@ This method recalculates how to draw the entire property grid control and its pr
 
 ## <a name="alwaysshowusertooltip"></a> CMFCPropertyGridCtrl::AlwaysShowUserToolTip
 
-```
+```cpp
 void AlwaysShowUserToolTip(BOOL bShow = TRUE);
 ```
 
@@ -400,7 +400,7 @@ TRUE if method is successful; otherwise, FALSE.
 
 Enables or disables the description area that is displayed underneath the list of properties in the property grid control.
 
-```
+```cpp
 void EnableDescriptionArea(BOOL bEnable=TRUE);
 ```
 
@@ -417,7 +417,7 @@ The description area is displayed at the bottom of the property grid control. By
 
 Enables or disables the header control at the top of the property grid control.
 
-```
+```cpp
 void EnableHeaderCtrl(
     BOOL bEnable=TRUE,
     LPCTSTR lpszLeftColumn=_T("Property"),
@@ -458,7 +458,7 @@ TRUE if the edit operation ends successfully; FALSE if the modified property dat
 
 Scrolls a property grid control and expands property items until the specified property is visible.
 
-```
+```cpp
 void EnsureVisible(
     CMFCPropertyGridProperty* pProp,
     BOOL bExpandParents=FALSE);
@@ -478,7 +478,7 @@ void EnsureVisible(
 
 Expands or collapses all property grid control nodes.
 
-```
+```cpp
 void ExpandAll(BOOL bExpand=TRUE);
 ```
 
@@ -656,7 +656,7 @@ A pointer to the property object that corresponds to the selected item in the pr
 
 Retrieves the custom colors that are currently defined for property grid control elements.
 
-```
+```cpp
 void GetCustomColors(
     COLORREF& clrBackground,
     COLORREF& clrText,
@@ -1073,7 +1073,7 @@ Use the [CMFCPropertyGridCtrl::SetVSDotNetLook](#setvsdotnetlook) method to set 
 
 Specifies how to display modified properties.
 
-```
+```cpp
 void MarkModifiedProperties(
     BOOL bMark=TRUE,
     BOOL bRedraw=TRUE);
@@ -1224,7 +1224,7 @@ By default, this method sends the [AFX_WM_PROPERTY_CHANGED](../../mfc/reference/
 
 Called by the framework when a property that contains a combo box control is selected.
 
-```
+```cpp
 void OnSelectCombo();
 ```
 
@@ -1234,7 +1234,7 @@ void OnSelectCombo();
 
 Removes all property objects from a property grid control.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -1244,7 +1244,7 @@ void RemoveAll();
 
 Restores the original values of all properties.
 
-```
+```cpp
 void ResetOriginalValues(BOOL bRedraw=TRUE);
 ```
 
@@ -1259,7 +1259,7 @@ void ResetOriginalValues(BOOL bRedraw=TRUE);
 
 Sets or resets alphabetic mode.
 
-```
+```cpp
 void SetAlphabeticMode(BOOL bSet=TRUE);
 ```
 
@@ -1276,7 +1276,7 @@ When the property grid control is in alphabetic mode, the control sorts all the 
 
 Specifies the text of Boolean labels.
 
-```
+```cpp
 void SetBoolLabels(
     LPCTSTR lpszTrue,
     LPCTSTR lpszFalse);
@@ -1296,7 +1296,7 @@ void SetBoolLabels(
 
 Selects a property in a property grid control.
 
-```
+```cpp
 void SetCurSel(
     CMFCPropertyGridProperty* pProp,
     BOOL bRedraw=TRUE);
@@ -1318,7 +1318,7 @@ Use this method to cancel the selection of the current item in the property grid
 
 Specifies custom colors for various elements of the property grid control.
 
-```
+```cpp
 void SetCustomColors(
     COLORREF clrBackground,
     COLORREF clrText,
@@ -1362,7 +1362,7 @@ To customize the appearance of a specific property, derive a class from the [CMF
 
 Specifies the number of rows to display in the description section of the current property grid control.
 
-```
+```cpp
 void SetDescriptionRows(int nDescRows);
 ```
 
@@ -1375,7 +1375,7 @@ void SetDescriptionRows(int nDescRows);
 
 Specifies whether to display the full width of the category name for a group of properties in the current property grid control.
 
-```
+```cpp
 void SetGroupNameFullWidth(
     BOOL bGroupNameFullWidth = TRUE,
     BOOL bRedraw = TRUE);
@@ -1399,7 +1399,7 @@ The terms *group name* and *category name* are used interchangeably in this meth
 
 Defines a character that is used as a delimiter in a list of property values.
 
-```
+```cpp
 void SetListDelimiter(TCHAR c);
 ```
 
@@ -1418,7 +1418,7 @@ By default, the [CMFCPropertyGridCtrl::CMFCPropertyGridCtrl](#cmfcpropertygridct
 
 Specifies whether the framework redraws the name and value columns of the current property grid control when a user resizes the columns.
 
-```
+```cpp
 void SetShowDragContext(BOOL bShowDragContext = TRUE);
 ```
 
@@ -1435,7 +1435,7 @@ The user can resize the name and value columns of a property grid control by dra
 
 Sets the appearance of the property grid control to the style that is used in Visual Studio .NET.
 
-```
+```cpp
 void SetVSDotNetLook(BOOL bSet=TRUE);
 ```
 

--- a/docs/mfc/reference/cmfcpropertygridproperty-class.md
+++ b/docs/mfc/reference/cmfcpropertygridproperty-class.md
@@ -232,7 +232,7 @@ The value area of a property consists of a text box and possibly an *option butt
 
 Makes a property either editable or read-only.
 
-```
+```cpp
 void AllowEdit(BOOL bAllow=TRUE);
 ```
 
@@ -371,7 +371,7 @@ Call the [CMFCPropertyGridProperty::EnableSpinControl](#enablespincontrol) metho
 
 Enables or disables a property.
 
-```
+```cpp
 void Enable(BOOL bEnable=TRUE);
 ```
 
@@ -386,7 +386,7 @@ void Enable(BOOL bEnable=TRUE);
 
 Enables or disables a spin button control that is used to modify a property value.
 
-```
+```cpp
 void EnableSpinControl(
     BOOL bEnable=TRUE,
     int nMin=0,
@@ -414,7 +414,7 @@ The property type, which is specified by the *varValue* parameter of the [CMFCPr
 
 Expands or collapses a property that contains sub-properties.
 
-```
+```cpp
 void Expand(BOOL bExpand=TRUE);
 ```
 
@@ -744,7 +744,7 @@ The following table lists the values that can be returned to the *pnArea* parame
 
 Called by the framework to initialize a property object.
 
-```
+```cpp
 void Init();
 ```
 
@@ -1388,7 +1388,7 @@ This method supports a property that is either a list of values or one of the fo
 
 Redraws the property.
 
-```
+```cpp
 void Redraw();
 ```
 
@@ -1398,7 +1398,7 @@ void Redraw();
 
 Removes all options (items) from a property.
 
-```
+```cpp
 void RemoveAllOptions();
 ```
 
@@ -1444,7 +1444,7 @@ virtual void ResetOriginalValue();
 
 Associates a DWORD value with a property.
 
-```
+```cpp
 void SetData(DWORD_PTR dwData);
 ```
 
@@ -1461,7 +1461,7 @@ Use the [CMFCPropertyGridProperty::GetData](#getdata) method to retrieve the DWO
 
 Specifies the text that describes the current property.
 
-```
+```cpp
 void SetDescription(const CString& strDescr);
 ```
 
@@ -1476,7 +1476,7 @@ void SetDescription(const CString& strDescr);
 
 Sets the name of a property.
 
-```
+```cpp
 void SetName(
     LPCTSTR lpszName,
     BOOL bRedraw=TRUE);
@@ -1528,7 +1528,7 @@ virtual void SetValue(const _variant_t& varValue);
 
 Shows or hides a property.
 
-```
+```cpp
 void Show(
     BOOL bShow=TRUE,
     BOOL bAdjustLayout=TRUE);

--- a/docs/mfc/reference/cmfcpropertygridtooltipctrl-class.md
+++ b/docs/mfc/reference/cmfcpropertygridtooltipctrl-class.md
@@ -93,7 +93,7 @@ TRUE if the window was successfully created; otherwise, FALSE.
 
 Deactivates and hides the tooltip control.
 
-```
+```cpp
 void Deactivate();
 ```
 
@@ -105,7 +105,7 @@ This method sets the last position and text to empty values, so that future call
 
 Returns the coordinates of the last position of the tooltip control.
 
-```
+```cpp
 void GetLastRect(CRect& rect) const;
 ```
 
@@ -118,7 +118,7 @@ void GetLastRect(CRect& rect) const;
 
 Hides the tooltip control.
 
-```
+```cpp
 void Hide();
 ```
 
@@ -126,7 +126,7 @@ void Hide();
 
 Sets the spacing between the tooltip text and the border of the tooltip window.
 
-```
+```cpp
 void SetTextMargin(int nTextMargin);
 ```
 
@@ -139,7 +139,7 @@ void SetTextMargin(int nTextMargin);
 
 Displays the tooltip control.
 
-```
+```cpp
 void Track(
     CRect rect,
     const CString& strText);

--- a/docs/mfc/reference/cmfcpropertysheet-class.md
+++ b/docs/mfc/reference/cmfcpropertysheet-class.md
@@ -100,7 +100,7 @@ The following illustration depicts a property sheet that is in the style of a tr
 
 Adds a page to the property sheet.
 
-```
+```cpp
 void AddPage(CPropertyPage* pPage);
 ```
 
@@ -119,7 +119,7 @@ If the property sheet is in the style of Microsoft Outlook, the framework displa
 
 Adds a new property page to the tree control.
 
-```
+```cpp
 void AddPageToTree(
     CMFCPropertySheetCategoryInfo* pCategory,
     CMFCPropertyPage* pPage,
@@ -219,7 +219,7 @@ For more information, see the parameters for the [CPropertySheet::CPropertySheet
 
 Reserves space at the top of each page to draw a custom header.
 
-```
+```cpp
 void EnablePageHeader(int nHeaderHeight);
 ```
 
@@ -372,7 +372,7 @@ TRUE if this method is successful; otherwise, FALSE.
 
 Removes a node from the tree control.
 
-```
+```cpp
 void RemoveCategory(CMFCPropertySheetCategoryInfo* pCategory);
 ```
 
@@ -389,7 +389,7 @@ Use this method to remove a node, which is also referred to as a category, from 
 
 Removes a property page from the property sheet.
 
-```
+```cpp
 void RemovePage(CPropertyPage* pPage);
 void RemovePage(int nPage);
 ```
@@ -446,7 +446,7 @@ For more information about the methods that support this method, see [CImageList
 
 Specifies the appearance of the property sheet.
 
-```
+```cpp
 void SetLook(
     PropSheetLook look,
     int nNavControlWidth=100);

--- a/docs/mfc/reference/cmfcrebar-class.md
+++ b/docs/mfc/reference/cmfcrebar-class.md
@@ -180,7 +180,7 @@ virtual BOOL CanFloat() const;
 
 ## <a name="enabledocking"></a> CMFCReBar::EnableDocking
 
-```
+```cpp
 void EnableDocking(DWORD dwDockStyle);
 ```
 

--- a/docs/mfc/reference/cmfcribbonapplicationbutton-class.md
+++ b/docs/mfc/reference/cmfcribbonapplicationbutton-class.md
@@ -78,7 +78,7 @@ The ribbon application button is a special button that is located in the upper-l
 
 Assigns an image to the application button.
 
-```
+```cpp
 void SetImage(UINT uiBmpResID);
 void SetImage(HBITMAP hBmp);
 ```

--- a/docs/mfc/reference/cmfcribbonbar-class.md
+++ b/docs/mfc/reference/cmfcribbonbar-class.md
@@ -391,7 +391,7 @@ The quick access toolbar ribbon category is only used on the quick access toolba
 
 Adds the specified ribbon element to the tabs row of the ribbon bar.
 
-```
+```cpp
 void AddToTabs(CMFCRibbonBaseElement* pElement);
 ```
 
@@ -489,7 +489,7 @@ TRUE if the window was created; otherwise FALSE.
 
 Closes all keytip controls on the ribbon bar.
 
-```
+```cpp
 void DeactivateKeyboardFocus(BOOL bSetFocus = TRUE);
 ```
 
@@ -542,7 +542,7 @@ virtual void DWMCompositionChanged();
 
 Enables or disables the keytip feature for the ribbon bar.
 
-```
+```cpp
 void EnableKeyTips(BOOL bEnable = TRUE);
 ```
 
@@ -559,7 +559,7 @@ When you enable this feature, key tips are displayed when the user presses the A
 
 Enables or disables the **Print Preview** feature.
 
-```
+```cpp
 void EnablePrintPreview(BOOL bEnable = TRUE);
 ```
 
@@ -578,7 +578,7 @@ By default the **Print Preview** feature is enabled.
 
 Enables or disables tooltips and optional tooltip descriptions on the ribbon bar.
 
-```
+```cpp
 void EnableToolTips(
     BOOL bEnable = TRUE,
     BOOL bEnableDescr = TRUE);
@@ -675,7 +675,7 @@ The zero-based index of a ribbon category if the method was successful; otherwis
 
 Adjusts the layout of all items in the ribbon bar and parent window and redraws the whole window.
 
-```
+```cpp
 void ForceRecalcLayout();
 ```
 
@@ -827,7 +827,7 @@ The ribbon element that is currently dropped down; or NULL if no ribbon element 
 
 Retrieves an array of pointers to all ribbon elements that have a specific command ID.
 
-```
+```cpp
 void GetElementsByID(
     UINT uiCmdID,
     CArray<CMFCRibbonBaseElement*,CMFCRibbonBaseElement*>& arButtons);
@@ -870,7 +870,7 @@ The following table lists the possible combination of flags for the return value
 
 Retrieves the command IDs for the specified collection of ribbon elements on the ribbon bar.
 
-```
+```cpp
 void GetItemIDsList(CList<UINT, UINT>& lstItems,
     BOOL bHiddenOnly = FALSE) const;
 ```
@@ -987,7 +987,7 @@ A pointer to the ribbon element on the quick access toolbar that has its pop-up 
 
 Retrieves a list of command IDs for the ribbon elements on the quick access toolbar.
 
-```
+```cpp
 void GetQuickAccessCommands(CList<UINT,UINT>& lstCommands);
 ```
 
@@ -1096,7 +1096,7 @@ If a context category is active, the active category is reset to the first visib
 
 Hides all keytips on the ribbon bar.
 
-```
+```cpp
 void HideKeyTips();
 ```
 
@@ -1446,7 +1446,7 @@ TRUE if the keystroke event was processed; otherwise FALSE.
 
 Removes a tooltip from view.
 
-```
+```cpp
 void PopTooltip();
 ```
 
@@ -1487,7 +1487,7 @@ After layout adjustment, the display of the ribbon bar is updated.
 
 Deletes all ribbon categories from the ribbon bar.
 
-```
+```cpp
 void RemoveAllCategories();
 ```
 
@@ -1499,7 +1499,7 @@ This method deletes all ribbon categories from memory and from the category list
 
 Removes all ribbon elements from the tab area.
 
-```
+```cpp
 void RemoveAllFromTabs();
 ```
 
@@ -1560,7 +1560,7 @@ If the category specified by *pCategory* is not displayed, it cannot be set as t
 
 Associates the system buttons on the ribbon bar that belong to a multiple-document interface (MDI) child window to the specified MDI child window.
 
-```
+```cpp
 void SetActiveMDIChild(CWnd* pWnd);
 ```
 
@@ -1575,7 +1575,7 @@ void SetActiveMDIChild(CWnd* pWnd);
 
 Assigns an application ribbon button to the ribbon bar.
 
-```
+```cpp
 void SetApplicationButton(
     CMFCRibbonApplicationButton* pButton,
     CSize sizeButton);
@@ -1633,7 +1633,7 @@ The optional menu keytip is for ribbon elements with a split button that opens a
 
 Sets the keyboard navigation level as the user presses the keytips that are contained on the ribbon bar.
 
-```
+```cpp
 void SetKeyboardNavigationLevel(
     CObject* pLevel,
     BOOL bSetFocus = TRUE);
@@ -1655,7 +1655,7 @@ Keyboard navigation of the ribbon bar starts when the user presses the ALT or F1
 
 Adjusts the ribbon bar when the window size of a multiple-document interface (MDI) child window enters or leaves the maximized state.
 
-```
+```cpp
 void SetMaximizeMode(
     BOOL bMax,
     CWnd* pWnd = NULL);
@@ -1677,7 +1677,7 @@ The ribbon bar displays system buttons for an MDI child window in the tab row wh
 
 Adds one or more ribbon elements to the Quick Access Toolbar.
 
-```
+```cpp
 void SetQuickAccessCommands(
     const CList<UINT,UINT>& lstCommands,
     BOOL bRecalcLayout=TRUE);
@@ -1701,7 +1701,7 @@ The following example demonstrates how to use the `SetQuickAccessCommands` metho
 
 Sets the quick access toolbar to the default state.
 
-```
+```cpp
 void SetQuickAccessDefaultState(const CMFCRibbonQuickAccessToolBarDefaultState& state);
 ```
 
@@ -1724,7 +1724,7 @@ The following example demonstrates how to use the `SetQuickAccessDefaultState` m
 
 Positions the quick access toolbar above or below the ribbon bar.
 
-```
+```cpp
 void SetQuickAccessToolbarOnTop(BOOL bOnTop);
 ```
 
@@ -1737,7 +1737,7 @@ void SetQuickAccessToolbarOnTop(BOOL bOnTop);
 
 Sets the regular and large sizes of tooltip fixed widths for the ribbon bar.
 
-```
+```cpp
 void SetTooltipFixedWidth(
     int nWidthRegular,
     int nWidthLargeImage);
@@ -1759,7 +1759,7 @@ Setting a parameter to 0 causes the corresponding width to vary.
 
 Shows or hides the specified ribbon category.
 
-```
+```cpp
 void ShowCategory(
     int nIndex,
     BOOL bShow=TRUE);
@@ -1777,7 +1777,7 @@ void ShowCategory(
 
 Shows or hides the context categories that have the specified ID.
 
-```
+```cpp
 void ShowContextCategories(
     UINT uiContextID,
     BOOL bShow=TRUE);
@@ -1795,7 +1795,7 @@ void ShowContextCategories(
 
 Shows the keytips for each ribbon element on the ribbon bar.
 
-```
+```cpp
 void ShowKeyTips();
 ```
 
@@ -1805,7 +1805,7 @@ void ShowKeyTips();
 
 Toggles the ribbon bar between the minimized and maximized states.
 
-```
+```cpp
 void ToggleMimimizeState();
 ```
 
@@ -1942,7 +1942,7 @@ TRUE if successful; otherwise FALSE.
 
 Enables or disables Windows 7 look (small rectangular application button) for the Ribbon.
 
-```
+```cpp
 void SetWindows7Look(
     BOOL bWindows7Look,
     BOOL bRecalc = TRUE);

--- a/docs/mfc/reference/cmfcribbonbaseelement-class.md
+++ b/docs/mfc/reference/cmfcribbonbaseelement-class.md
@@ -1659,7 +1659,7 @@ This method notifies the parent window of the ribbon bar that the ribbon element
 
 Closes the pop-up menu for the ribbon element and sends a close message to the parent menu.
 
-```
+```cpp
 void PostMenuCommand(UINT uiCmdId);
 ```
 
@@ -1738,7 +1738,7 @@ The following table summarizes the logic for this method.
 
 Associates a data item with the ribbon element.
 
-```
+```cpp
 void SetData(DWORD_PTR dwData);
 ```
 
@@ -1751,7 +1751,7 @@ void SetData(DWORD_PTR dwData);
 
 Sets the ribbon element to appear as a pop-up command.
 
-```
+```cpp
 void SetDefaultMenuLook(BOOL bIsDefaultMenuLook = TRUE);
 ```
 
@@ -1895,7 +1895,7 @@ virtual void SetParentRibbonBar(CMFCRibbonBar* pRibbonBar);
 
 Sets the dimensions of the display rectangle for the ribbon element.
 
-```
+```cpp
 void SetRect(CRect rect);
 ```
 
@@ -1966,7 +1966,7 @@ virtual void SetToolTipText(LPCTSTR lpszText);
 
 Sets the visibility of the ribbon element.
 
-```
+```cpp
 void SetVisible(BOOL bIsVisible);
 ```
 

--- a/docs/mfc/reference/cmfcribbonbutton-class.md
+++ b/docs/mfc/reference/cmfcribbonbutton-class.md
@@ -134,7 +134,7 @@ pPanel->Add (new CMFCRibbonButton (ID_EDIT_PAINT, _T("Paint"), 9));
 
 Adds a menu item to the pop-up menu that is associated with the button.
 
-```
+```cpp
 void AddSubItem(
     CMFCRibbonBaseElement* pSubItem,
     int nIndex=-1);
@@ -687,7 +687,7 @@ virtual COLORREF OnFillBackground(CDC* pDC);
 
 Removes all menu items from the pop-up menu.
 
-```
+```cpp
 void RemoveAllSubItems();
 ```
 
@@ -736,7 +736,7 @@ Returns TRUE if successful; otherwise FALSE.
 
 Specifies whether the button displays a large or a small image when the user collapses the button.
 
-```
+```cpp
 void SetAlwaysLargeImage(BOOL bSet=TRUE);
 ```
 
@@ -749,7 +749,7 @@ void SetAlwaysLargeImage(BOOL bSet=TRUE);
 
 Enables the default command for the ribbon button.
 
-```
+```cpp
 void SetDefaultCommand(BOOL bSet=TRUE);
 ```
 
@@ -778,7 +778,7 @@ virtual void SetDescription(LPCTSTR lpszText);
 
 Assigns an index to the image of the button.
 
-```
+```cpp
 void SetImageIndex(
     int nIndex,
     BOOL bLargeImage);
@@ -796,7 +796,7 @@ void SetImageIndex(
 
 Assigns a pop-up menu to the ribbon button.
 
-```
+```cpp
 void SetMenu(
     HMENU hMenu,
     BOOL bIsDefaultCommand=FALSE,
@@ -842,7 +842,7 @@ virtual void SetParentCategory(CMFCRibbonCategory* pParent);
 
 Aligns the pop-up menu to the edge of the button.
 
-```
+```cpp
 void SetRightAlignMenu(BOOL bSet=TRUE);
 ```
 

--- a/docs/mfc/reference/cmfcribbonbuttonsgroup-class.md
+++ b/docs/mfc/reference/cmfcribbonbuttonsgroup-class.md
@@ -65,7 +65,7 @@ The following example demonstrates how to use various methods in the `CMFCRibbon
 
 Adds a button to a group.
 
-```
+```cpp
 void AddButton(CMFCRibbonBaseElement* pButton);
 ```
 
@@ -78,7 +78,7 @@ void AddButton(CMFCRibbonBaseElement* pButton);
 
 Adds a list of buttons to a group.
 
-```
+```cpp
 void AddButtons(
     const CList<CMFCRibbonBaseElement*,CMFCRibbonBaseElement*>& lstButtons);
 ```
@@ -214,7 +214,7 @@ virtual void OnDrawImage(
 
 Removes all buttons from the `CMFCRibbonButtonsGroup` object.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -224,7 +224,7 @@ void RemoveAll();
 
 Assigns images to the group of ribbon buttons.
 
-```
+```cpp
 void SetImages(
     CMFCToolBarImages* pImages,
     CMFCToolBarImages* pHotImages,

--- a/docs/mfc/reference/cmfcribboncategory-class.md
+++ b/docs/mfc/reference/cmfcribboncategory-class.md
@@ -128,7 +128,7 @@ The following diagram shows a figure of the Home category from the RibbonApp sam
 
 Adds the specified ribbon element to the array of ribbon elements that are displayed on the customization dialog box.
 
-```
+```cpp
 void AddHidden(CMFCRibbonBaseElement* pElem);
 ```
 
@@ -343,7 +343,7 @@ Pointer to a ribbon element if the method was successful; otherwise NULL.
 
 Retrieves all ribbon elements in the ribbon category.
 
-```
+```cpp
 void GetElements(
     CArray <CMFCRibbonBaseElement*, CMFCRibbonBaseElement*>& arElements);
 ```
@@ -361,7 +361,7 @@ Ribbon elements that are designed for use on the quick access toolbar are includ
 
 Retrieves all ribbon elements that are associated with the specified command ID.
 
-```
+```cpp
 void GetElementsByID(
     UINT uiCmdID,
     CArray <CMFCRibbonBaseElement*, CMFCRibbonBaseElement*>& arElements);
@@ -465,7 +465,7 @@ The size retrieved includes the global image scale factor.
 
 Retrieves the command IDs for the ribbon elements that are contained in the ribbon category.
 
-```
+```cpp
 void GetItemIDsList(
     CList<UINT, UINT>& lstItems,
     BOOL bHiddenOnly = FALSE) const;
@@ -749,7 +749,7 @@ The vertical location of text, in pixels, on ribbon buttons that display large i
 
 Retrieves all visible elements that belong to the ribbon category.
 
-```
+```cpp
 void GetVisibleElements(
     CArray <CMFCRibbonBaseElement*,
     CMFCRibbonBaseElement*>& arElements);
@@ -1204,7 +1204,7 @@ virtual void ReposPanels(CDC* pDC);
 
 Defines the order in which the ribbon panels of the ribbon category collapse.
 
-```
+```cpp
 void SetCollapseOrder(const CArray<int,int>& arCollapseOrder);
 ```
 
@@ -1231,7 +1231,7 @@ The following example demonstrates how to use the `SetCollapseOrder` method in t
 
 Sets the user-defined data to be associated with the ribbon category.
 
-```
+```cpp
 void SetData(DWORD_PTR dwData);
 ```
 
@@ -1244,7 +1244,7 @@ void SetData(DWORD_PTR dwData);
 
 Assigns a keytip to the ribbon category.
 
-```
+```cpp
 void SetKeys(LPCTSTR lpszKeys);
 ```
 
@@ -1261,7 +1261,7 @@ Keytips are displayed when the user presses the Alt key or the F10 key.
 
 Assigns a name and keytip to the ribbon category.
 
-```
+```cpp
 void SetName(LPCTSTR lpszName);
 ```
 
@@ -1278,7 +1278,7 @@ To set the keytip for the ribbon category, append a newline escape sequence foll
 
 Sets the color of the ribbon category.
 
-```
+```cpp
 void SetTabColor(AFX_RibbonCategoryColor color);
 ```
 

--- a/docs/mfc/reference/cmfcribboncolorbutton-class.md
+++ b/docs/mfc/reference/cmfcribboncolorbutton-class.md
@@ -74,7 +74,7 @@ The following example demonstrates how to use various methods in the `CMFCRibbon
 
 Adds a group of colors to the regular color area.
 
-```
+```cpp
 void AddColorsGroup(
     LPCTSTR lpszName,
     const CList<COLORREF,COLORREF>& lstColors,
@@ -146,7 +146,7 @@ CMFCRibbonColorButton(
 
 Specifies whether the **Automatic** button is enabled.
 
-```
+```cpp
 void EnableAutomaticButton(
     LPCTSTR lpszLabel,
     COLORREF colorAutomatic,
@@ -180,7 +180,7 @@ void EnableAutomaticButton(
 
 Enables the **Other** button.
 
-```
+```cpp
 void EnableOtherButton(
     LPCTSTR lpszLabel,
     LPCTSTR lpszToolTip=NULL);
@@ -268,7 +268,7 @@ The color of currently selected element on the pop-up color palette.
 
 Removes all color groups from the regular color area.
 
-```
+```cpp
 void RemoveAllColorGroups();
 ```
 
@@ -276,7 +276,7 @@ void RemoveAllColorGroups();
 
 Selects a color from the regular color area.
 
-```
+```cpp
 void SetColor(COLORREF color);
 ```
 
@@ -289,7 +289,7 @@ void SetColor(COLORREF color);
 
 Sets the size of all the color elements that appear on the color bar.
 
-```
+```cpp
 void SetColorBoxSize(CSize sizeBox);
 ```
 
@@ -324,7 +324,7 @@ Because it calls `CMFCColorBar::SetColorName`, this method changes the name of t
 
 Sets the number of columns displayed in the table of colors that is presented to the user during the user's color selection process.
 
-```
+```cpp
 void SetColumns(int nColumns);
 ```
 
@@ -339,7 +339,7 @@ void SetColumns(int nColumns);
 
 Specifies a list of RGB values to display in the document color area.
 
-```
+```cpp
 void SetDocumentColors(
     LPCTSTR lpszLabel,
     CList<COLORREF,COLORREF>& lstColors);
@@ -357,7 +357,7 @@ void SetDocumentColors(
 
 Specifies the standard colors to display in the color table that the color button displays.
 
-```
+```cpp
 void SetPalette(CPalette* pPalette);
 ```
 
@@ -372,7 +372,7 @@ void SetPalette(CPalette* pPalette);
 
 Called by the framework when the user selects a color from the color table displayed when the user clicks the color button.
 
-```
+```cpp
 void UpdateColor(COLORREF color);
 ```
 

--- a/docs/mfc/reference/cmfcribboncustomizepropertypage-class.md
+++ b/docs/mfc/reference/cmfcribboncustomizepropertypage-class.md
@@ -69,7 +69,7 @@ The following example demonstrates how to construct a `CMFCRibbonCustomizeProper
 
 Adds a custom category to the **Commands** combo box.
 
-```
+```cpp
 void AddCustomCategory(
     LPCTSTR lpszName,
     const CList<UINT, UINT>& lstIDS);

--- a/docs/mfc/reference/cmfcribbonfontcombobox-class.md
+++ b/docs/mfc/reference/cmfcribbonfontcombobox-class.md
@@ -69,7 +69,7 @@ After you create a `CMFCRibbonFontComboBox` object, add it to a ribbon panel by 
 
 Populates the combo box on the ribbon with fonts.
 
-```
+```cpp
 void BuildFonts(
     int nFontType = DEVICE_FONTTYPE | RASTER_FONTTYPE | TRUETYPE_FONTTYPE,
     BYTE nCharSet = DEFAULT_CHARSET,
@@ -143,7 +143,7 @@ const CMFCFontInfo* GetFontDesc(int iIndex = -1) const;
 
 Populates the combo box on the ribbon with fonts of a previously specified font type, character set, and pitch and family.
 
-```
+```cpp
 void RebuildFonts();
 ```
 

--- a/docs/mfc/reference/cmfcribbonlinkctrl-class.md
+++ b/docs/mfc/reference/cmfcribbonlinkctrl-class.md
@@ -225,7 +225,7 @@ Opens a webpage using the hyperlink associated with the `CMFCRibbonLinkCtrl` obj
 
 Sets the value of the hyperlink.
 
-```
+```cpp
 void SetLink(LPCTSTR lpszLink);
 ```
 

--- a/docs/mfc/reference/cmfcribbonmainpanel-class.md
+++ b/docs/mfc/reference/cmfcribbonmainpanel-class.md
@@ -79,7 +79,7 @@ Adds a ribbon element to the panel. Elements added using this method will be loc
 
 Adds a text string to the recent files list menu.
 
-```
+```cpp
 void AddRecentFilesList(
     LPCTSTR lpszLabel,
     int nWidth = 300);
@@ -99,7 +99,7 @@ Specifies the width, in pixels, of the recent files list panel.
 
 Adds a ribbon element to the bottom pane of the ribbon application panel.
 
-```
+```cpp
 void AddToBottom(CMFCRibbonMainPanelButton* pElem);
 ```
 
@@ -114,7 +114,7 @@ void AddToBottom(CMFCRibbonMainPanelButton* pElem);
 
 Adds a ribbon element to the right pane of the application button panel.
 
-```
+```cpp
 void AddToRight(
     CMFCRibbonBaseElement* pElem,
     int nWidth = 300);

--- a/docs/mfc/reference/cmfcribbonminitoolbar-class.md
+++ b/docs/mfc/reference/cmfcribbonminitoolbar-class.md
@@ -68,7 +68,7 @@ The mini toolbar becomes transparent when the mouse pointer is out of the bounds
 
 Sets the list of commands to be displayed on the toolbar.
 
-```
+```cpp
 void SetCommands(
     CMFCRibbonBar* pRibbonBar,
     const CList<UINT,UINT>& lstCommands);

--- a/docs/mfc/reference/cmfcribbonpanel-class.md
+++ b/docs/mfc/reference/cmfcribbonpanel-class.md
@@ -316,7 +316,7 @@ A valid pointer to the base ribbon element located at position *nIndex* in the r
 
 Retrieves all ribbon elements that are contained in the ribbon panel.
 
-```
+```cpp
 void GetElements(CArray<CMFCRibbonBaseElement*, CMFCRibbonBaseElement*>& arElements);
 ```
 
@@ -331,7 +331,7 @@ void GetElements(CArray<CMFCRibbonBaseElement*, CMFCRibbonBaseElement*>& arEleme
 
 Adds ribbon elements that have the specified command ID to the specified array.
 
-```
+```cpp
 void GetElementsByID(
 UINT uiCmdID,
 CArray<CMFCRibbonBaseElement*, CMFCRibbonBaseElement*>& arElements);
@@ -386,7 +386,7 @@ Zero-based index of the specified ribbon element if the method was successful; o
 
 Retrieves the command IDs for all ribbon elements in the ribbon panel.
 
-```
+```cpp
 void GetItemIDsList(CList<UINT, UINT>& lstItems) const;
 ```
 
@@ -775,7 +775,7 @@ Call this method to remove an element from the ribbon panel.
 
 Deletes all ribbon elements from the ribbon panel.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -839,7 +839,7 @@ To replace a ribbon element based on position, call [CMFCRibbonPanel::Replace](#
 
 Enables or disables the centering of the vertical positions of ribbon elements within their display rectangle.
 
-```
+```cpp
 void SetCenterColumnVert(BOOL bSet = TRUE);
 ```
 
@@ -854,7 +854,7 @@ void SetCenterColumnVert(BOOL bSet = TRUE);
 
 Associates user-defined data with the ribbon panel.
 
-```
+```cpp
 void SetData(DWORD_PTR dwData);
 ```
 
@@ -992,7 +992,7 @@ pColorButton->EnableAutomaticButton(_T("Automatic"),
 
 Enables or disables the adjustment of the width of ribbon elements in the same column.
 
-```
+```cpp
 void SetJustifyColumns(BOOL bSet = TRUE);
 ```
 
@@ -1009,7 +1009,7 @@ When this feature is enabled in a ribbon panel, the widths of ribbon elements in
 
 Sets the keytip for the default button of the ribbon panel.
 
-```
+```cpp
 void SetKeys(LPCTSTR lpszKeys);
 ```
 
@@ -1047,7 +1047,7 @@ The pop-up menu for the ribbon panel is only available when the display of the r
 
 Sets focus to the specified Ribbon element.
 
-```
+```cpp
 void SetFocused(CMFCRibbonBaseElement* pNewFocus);
 ```
 
@@ -1062,7 +1062,7 @@ A pointer to a Ribbon element that receives focus.
 
 Scrolls the gallery to make the specified Ribbon element visible.
 
-```
+```cpp
 void MakeGalleryItemVisible(CMFCRibbonBaseElement* pItem);
 ```
 
@@ -1091,7 +1091,7 @@ TRUE if the parent ribbon has Windows 7 look; otherwise FALSE.
 
 Retrieves an array of visible elements.
 
-```
+```cpp
 void GetVisibleElements(
 CArray<CMFCRibbonBaseElement*,
 CMFCRibbonBaseElement*>& arElements);

--- a/docs/mfc/reference/cmfcribbonprogressbar-class.md
+++ b/docs/mfc/reference/cmfcribbonprogressbar-class.md
@@ -175,7 +175,7 @@ virtual void OnDraw(CDC* pDC);
 
 Sets the progress bar to work in infinite mode.
 
-```
+```cpp
 void SetInfiniteMode(BOOL bSet = TRUE);
 ```
 
@@ -192,7 +192,7 @@ Usually, if the progress bar is in infinite mode, it is telling the user that an
 
 Sets the current position of the progress bar.
 
-```
+```cpp
 void SetPos(
     int nPos,
     BOOL bRedraw = TRUE);
@@ -214,7 +214,7 @@ The range being set must be within the range specified by the [CMFCRibbonProgres
 
 Sets the minimum and maximum values for the progress bar.
 
-```
+```cpp
 void SetRange(
     int nMin,
     int nMax);

--- a/docs/mfc/reference/cmfcribbonquickaccesstoolbardefaultstate-class.md
+++ b/docs/mfc/reference/cmfcribbonquickaccesstoolbardefaultstate-class.md
@@ -53,7 +53,7 @@ The following example demonstrates how to construct an object of the `CMFCRibbon
 
 Adds a command to the default state for the Quick Access Toolbar.
 
-```
+```cpp
 void AddCommand(
     UINT uiCmd,
     BOOL bIsVisible=TRUE);
@@ -75,7 +75,7 @@ Adding a command to the CMFCRibbonQuickAccessToolBarDefaultState accomplishes th
 
 Copies the properties of one Quick Access Toolbar to another.
 
-```
+```cpp
 void CopyFrom(const CMFCRibbonQuickAccessToolBarDefaultState& src);
 ```
 
@@ -104,7 +104,7 @@ By default, the list of commands that the new instance of [CMFRibbonQuickAccessT
 
 Clears the list of default commands in the Quick Access Toolbar.
 
-```
+```cpp
 void RemoveAll();
 ```
 

--- a/docs/mfc/reference/cmfcribbonslider-class.md
+++ b/docs/mfc/reference/cmfcribbonslider-class.md
@@ -181,7 +181,7 @@ virtual void OnDraw(CDC* pDC);
 
 Set the current position of the slider control.
 
-```
+```cpp
 void SetPos(
     int nPos,
     BOOL bRedraw=TRUE);
@@ -199,7 +199,7 @@ void SetPos(
 
 Set the range of values for the slider control.
 
-```
+```cpp
 void SetRange(
     int nMin,
     int nMax);
@@ -221,7 +221,7 @@ Specifies the range of values for the slider control by setting the minimum and 
 
 Display or hide zoom buttons.
 
-```
+```cpp
 void SetZoomButtons(BOOL bSet=TRUE);
 ```
 
@@ -234,7 +234,7 @@ TRUE to display zoom buttons; FALSE to hide them.
 
 Set the zoom increment for the slider control.
 
-```
+```cpp
 void SetZoomIncrement(int nZoomIncrement);
 ```
 

--- a/docs/mfc/reference/cmfcribbonstatusbar-class.md
+++ b/docs/mfc/reference/cmfcribbonstatusbar-class.md
@@ -88,7 +88,7 @@ The following example demonstrates how to use various methods in the `CMFCRibbon
 
 Adds a dynamic element to the ribbon status bar.
 
-```
+```cpp
 void AddDynamicElement(CMFCRibbonBaseElement* pElement);
 ```
 
@@ -105,7 +105,7 @@ Unlike regular elements, dynamic elements are not customizable and the customize
 
 Adds a new ribbon element to the ribbon status bar.
 
-```
+```cpp
 void AddElement(
     CMFCRibbonBaseElement* pElement,
     LPCTSTR lpszLabel,
@@ -127,7 +127,7 @@ void AddElement(
 
 Adds a ribbon element to the extended area of the ribbon status bar.
 
-```
+```cpp
 void AddExtendedElement(
     CMFCRibbonBaseElement* pElement,
     LPCTSTR lpszLabel,
@@ -153,7 +153,7 @@ The extended area is on the right side of the status bar control.
 
 Adds a separator to the ribbon status bar.
 
-```
+```cpp
 void AddSeparator();
 ```
 
@@ -425,7 +425,7 @@ virtual void RecalcLayout();
 
 Removes all elements from the ribbon status bar.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -450,7 +450,7 @@ TRUE if an element with the specified *uiID* is removed. FALSE otherwise.
 
 Enables or disables the information mode for the ribbon status bar.
 
-```
+```cpp
 void SetInformation(LPCTSTR lpszInfo);
 ```
 

--- a/docs/mfc/reference/cmfcribbonstatusbarpane-class.md
+++ b/docs/mfc/reference/cmfcribbonstatusbarpane-class.md
@@ -225,7 +225,7 @@ virtual void OnFinishAnimation();
 
 Define the longest text that can be displayed in the status bar pane without truncation.
 
-```
+```cpp
 void SetAlmostLargeText(LPCTSTR lpszAlmostLargeText);
 ```
 
@@ -242,7 +242,7 @@ The library calculates the size of text that *lpszAlmostLargeText* specifies and
 
 Attaches to the status bar pane an image list that can be used for animation.
 
-```
+```cpp
 void SetAnimationList(
     HBITMAP hBmpAnimationList,
     int cxAnimation=16,
@@ -276,7 +276,7 @@ TRUE if the image list is successfully attached to the status bar pane; FALSE ot
 
 Sets the text alignment of the label of the status bar pane.
 
-```
+```cpp
 void SetTextAlign(int nAlign);
 ```
 
@@ -299,7 +299,7 @@ void SetTextAlign(int nAlign);
 
 Starts the animation that you assign to the pane.
 
-```
+```cpp
 void StartAnimation(
     UINT nFrameDelay=500,
     UINT nDuration=-1);
@@ -321,7 +321,7 @@ You must specify a handle to an image list before you call `StartAnimation` by u
 
 Stops the animation that you assigned to the status bar pane.
 
-```
+```cpp
 void StopAnimation();
 ```
 

--- a/docs/mfc/reference/cmfcribbonundobutton-class.md
+++ b/docs/mfc/reference/cmfcribbonundobutton-class.md
@@ -62,7 +62,7 @@ The following example demonstrates how to construct an object of the `CMFCRibbon
 
 Adds a new action to the list of actions.
 
-```
+```cpp
 void AddUndoAction(LPCTSTR lpszLabel);
 ```
 
@@ -75,7 +75,7 @@ void AddUndoAction(LPCTSTR lpszLabel);
 
 Clears the action list, which is the drop-down list.
 
-```
+```cpp
 void CleanUpUndoList();
 ```
 

--- a/docs/mfc/reference/cmfcshelllistctrl-class.md
+++ b/docs/mfc/reference/cmfcshelllistctrl-class.md
@@ -109,7 +109,7 @@ S_OK if successful; E_FAIL otherwise.
 
 Enables the shortcut menu.
 
-```
+```cpp
 void EnableShellContextMenu(BOOL bEnable = TRUE);
 ```
 
@@ -399,7 +399,7 @@ Call this method to refresh the list of items displayed by the `CMFCShellListCtr
 
 Sets the type of items that are listed in the [CMFCShellListCtrl](../../mfc/reference/cmfcshelllistctrl-class.md) object.
 
-```
+```cpp
 void SetItemTypes(SHCONTF nTypes);
 ```
 

--- a/docs/mfc/reference/cmfcshelltreectrl-class.md
+++ b/docs/mfc/reference/cmfcshelltreectrl-class.md
@@ -66,7 +66,7 @@ The following example demonstrates how to create an object of the `CMFCShellTree
 
 Enables the shortcut menu.
 
-```
+```cpp
 void EnableShellContextMenu(BOOL bEnable = TRUE);
 ```
 
@@ -191,7 +191,7 @@ virtual CString OnGetItemText(LPAFX_SHELLITEMINFO pItem);
 
 Refreshes and repaints the [CMFCShellTreeCtrl](../../mfc/reference/cmfcshelltreectrl-class.md).
 
-```
+```cpp
 void Refresh();
 ```
 
@@ -224,7 +224,7 @@ S_OK if successful; E_FAIL otherwise.
 
 Sets flags to filter the tree context.
 
-```
+```cpp
 void SetFlags(
     DWORD dwFlags,
     BOOL bRefresh = TRUE);
@@ -246,7 +246,7 @@ The `CMFCShellTreeCtrl` passes all set flags to [IShellFolder::EnumObjects](/win
 
 Associates a [CMFCShellListCtrl](../../mfc/reference/cmfcshelllistctrl-class.md) object with a [CMFCShellTreeCtrl](../../mfc/reference/cmfcshelltreectrl-class.md) object.
 
-```
+```cpp
 void SetRelatedList(CMFCShellListCtrl* pShellList);
 ```
 

--- a/docs/mfc/reference/cmfcstatusbar-class.md
+++ b/docs/mfc/reference/cmfcstatusbar-class.md
@@ -195,7 +195,7 @@ virtual BOOL DoesAllowDynInsertBefore() const;
 
 Enables or disables the handling of mouse double-clicks on the status bar.
 
-```
+```cpp
 void EnablePaneDoubleClick(BOOL bEnable=TRUE);
 ```
 
@@ -212,7 +212,7 @@ If the status bar is enabled to process double clicks, Windows sends the WM_COMM
 
 Display a progress bar on the specified pane.
 
-```
+```cpp
 void EnablePaneProgressBar(
     int nIndex,
     long nTotal=100,
@@ -302,7 +302,7 @@ UINT GetItemID(int nIndex) const;
 
 ## <a name="getitemrect"></a> CMFCStatusBar::GetItemRect
 
-```
+```cpp
 void GetItemRect(
     int nIndex,
     LPRECT lpRect) const;
@@ -317,7 +317,7 @@ void GetItemRect(
 
 ## <a name="getpaneinfo"></a> CMFCStatusBar::GetPaneInfo
 
-```
+```cpp
 void GetPaneInfo(
     int nIndex,
     UINT& nID,
@@ -364,7 +364,7 @@ UINT GetPaneStyle(int nIndex) const;
 
 ## <a name="getpanetext"></a> CMFCStatusBar::GetPaneText
 
-```
+```cpp
 void GetPaneText(
     int nIndex,
     CString& s) const;
@@ -419,7 +419,7 @@ The tooltip text of the status-bar pane that *nIndex* specifies. Otherwise, the 
 
 Invalidate the status bar pane and redraw its content.
 
-```
+```cpp
 void InvalidatePaneContent(int nIndex);
 ```
 
@@ -472,7 +472,7 @@ virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
 
 ## <a name="setdrawextendedarea"></a> CMFCStatusBar::SetDrawExtendedArea
 
-```
+```cpp
 void SetDrawExtendedArea(BOOL bSet = TRUE);
 ```
 
@@ -503,7 +503,7 @@ BOOL SetIndicators(
 
 Assigns an animation to the specified pane.
 
-```
+```cpp
 void SetPaneAnimation(
     int nIndex,
     HIMAGELIST hImageList,
@@ -533,7 +533,7 @@ If you want to disable the current animation, call `SetPaneAnimation` with `hIma
 
 Sets the background color of the status bar pane.
 
-```
+```cpp
 void SetPaneBackgroundColor(
     int nIndex,
     COLORREF clrBackground=(COLORREF)-1,
@@ -555,7 +555,7 @@ void SetPaneBackgroundColor(
 
 Set the icon of the status bar pane.
 
-```
+```cpp
 void SetPaneIcon(
     int nIndex,
     HICON hIcon,
@@ -593,7 +593,7 @@ If there is any running animation that [CMFCStatusBar::SetPaneAnimation](#setpan
 
 ## <a name="setpaneinfo"></a> CMFCStatusBar::SetPaneInfo
 
-```
+```cpp
 void SetPaneInfo(
     int nIndex,
     UINT nID,
@@ -614,7 +614,7 @@ void SetPaneInfo(
 
 Set the current progress indicator of the progress bar for the specified pane.
 
-```
+```cpp
 void SetPaneProgress(
     int nIndex,
     long nCurr,
@@ -640,7 +640,7 @@ To use this function for the given pane, you must call [CMFCStatusBar::EnablePan
 
 ## <a name="setpanestyle"></a> CMFCStatusBar::SetPaneStyle
 
-```
+```cpp
 void SetPaneStyle(
     int nIndex,
     UINT nStyle);
@@ -676,7 +676,7 @@ virtual BOOL SetPaneText(
 
 Sets the text color of the specified pane.
 
-```
+```cpp
 void SetPaneTextColor(
     int nIndex,
     COLORREF clrText=(COLORREF)-1,
@@ -698,7 +698,7 @@ void SetPaneTextColor(
 
 Set the width of the status bar pane.
 
-```
+```cpp
 void SetPaneWidth(
     int nIndex,
     int cx);
@@ -716,7 +716,7 @@ void SetPaneWidth(
 
 Set the tooltip text of a status bar pane.
 
-```
+```cpp
 void SetTipText(
     int nIndex,
     LPCTSTR pszTipText);

--- a/docs/mfc/reference/cmfctabctrl-class.md
+++ b/docs/mfc/reference/cmfctabctrl-class.md
@@ -150,7 +150,7 @@ The following example demonstrates how to use various methods in the `CMFCTabCtr
 
 Displays the specified tab of the current tab control and sets the focus on that tab.
 
-```
+```cpp
 void ActivateMDITab(int nTab = -1);
 ```
 
@@ -177,7 +177,7 @@ Always TRUE.
 
 Specifies whether the framework is to resize the client area of all tab control windows when a user interface element of the tab control changes.
 
-```
+```cpp
 void AutoSizeWindow(BOOL bAutoSize = TRUE);
 ```
 
@@ -275,7 +275,7 @@ This method is called when you change the label of a tab. This method deflates t
 
 Shows or hides a Close button ( **X**) on the active tab.
 
-```
+```cpp
 void EnableActiveTabCloseButton(BOOL bEnable=TRUE);
 ```
 
@@ -303,7 +303,7 @@ virtual void EnableInPlaceEdit(BOOL bEnable);
 
 Toggles between a user interface that uses two buttons to scroll the window tabs and an interface that displays a pop-up menu of tabbed windows.
 
-```
+```cpp
 void EnableTabDocumentsMenu(BOOL bEnable=TRUE);
 ```
 
@@ -402,7 +402,7 @@ Use this method to access the tab control's embedded scroll bar. A scroll bar ob
 
 Retrieves the bounding rectangle of the tab label area at the top or bottom of the tab control.
 
-```
+```cpp
 void GetTabArea(
     CRect& rectTabAreaTop,
     CRect& rectTabAreaBottom) const;
@@ -465,7 +465,7 @@ virtual void GetTabsRect(CRect& rect) const;
 
 Retrieves the boundary of the client area of the current tab control.
 
-```
+```cpp
 void GetWndArea(CRect& rect) const;
 ```
 
@@ -480,7 +480,7 @@ void GetWndArea(CRect& rect) const;
 
 Hides the horizontal scroll bar, if any, in the active window.
 
-```
+```cpp
 void HideActiveWindowHorzScrollBar();
 ```
 
@@ -492,7 +492,7 @@ Use this method to prevent the tab control from blinking when the user switches 
 
 Specifies whether the framework displays inactive tab control windows.
 
-```
+```cpp
 void HideInactiveWindow(BOOL bHide = TRUE);
 ```
 
@@ -507,7 +507,7 @@ void HideInactiveWindow(BOOL bHide = TRUE);
 
 Enables or disables drawing of the tab area if there are no visible tabs.
 
-```
+```cpp
 void HideNoTabs(BOOL bHide=TRUE);
 ```
 
@@ -832,7 +832,7 @@ virtual void OnShowTabDocumentsMenu(CPoint point);
 
 Sets the current tab of a tab control as the active tab in a multiple document interface tab group.
 
-```
+```cpp
 void SetActiveInMDITabGroup(BOOL bActive);
 ```
 
@@ -872,7 +872,7 @@ The `SetActiveTab` method automatically calls the [CMFCTabCtrl::HideActiveWindow
 
 Enables or disables use of a bold font on active tabs.
 
-```
+```cpp
 void SetActiveTabBoldFont(BOOL bIsBold=TRUE);
 ```
 
@@ -887,7 +887,7 @@ void SetActiveTabBoldFont(BOOL bIsBold=TRUE);
 
 Specifies whether a frame rectangle is drawn around an embedded bar.
 
-```
+```cpp
 void SetDrawFrame(BOOL bDraw=TRUE);
 ```
 
@@ -902,7 +902,7 @@ void SetDrawFrame(BOOL bDraw=TRUE);
 
 Specifies whether to draw a flat or a 3D frame around the tab area.
 
-```
+```cpp
 void SetFlatFrame(
     BOOL bFlat=TRUE,
     BOOL bRepaint=TRUE);
@@ -959,7 +959,7 @@ Use the [CMFCBaseTabCtrl::AddTab](../../mfc/reference/cmfcbasetabctrl-class.md#a
 
 Specifies how the current tab control can be resized and then redisplays the control.
 
-```
+```cpp
 void SetResizeMode(ResizeMode resizeMode);
 ```
 
@@ -982,7 +982,7 @@ The *resizeMode* parameter can be one of the following `ResizeMode` enumeration 
 
 Specifies the maximum tab width in a tabbed window.
 
-```
+```cpp
 void SetTabMaxWidth(int nTabMaxWidth);
 ```
 
@@ -999,7 +999,7 @@ Use this method to limit the width of each tab in a tabbed window. This method i
 
 Terminates the current resize operation on the tab control.
 
-```
+```cpp
 void StopResize(BOOL bCancel);
 ```
 

--- a/docs/mfc/reference/cmfctaskspane-class.md
+++ b/docs/mfc/reference/cmfctaskspane-class.md
@@ -395,7 +395,7 @@ CMFCTasksPane();
 
 ## <a name="collapseallgroups"></a> CMFCTasksPane::CollapseAllGroups
 
-```
+```cpp
 void CollapseAllGroups(BOOL bCollapse = TRUE);
 
 void CollapseAllGroups(
@@ -479,7 +479,7 @@ The pop-up menu  that this method creates contains the list of pages in the task
 
 Enables or disables the animation that occurs when a task group expands or collapses.
 
-```
+```cpp
 void EnableAnimation(BOOL bEnable = TRUE);
 ```
 
@@ -496,7 +496,7 @@ By default, the animation that occurs when a task group expands or collapses is 
 
 Specifies whether a user can collapse task groups.
 
-```
+```cpp
 void EnableGroupCollapse(BOOL bEnable);
 ```
 
@@ -513,7 +513,7 @@ A task group that is collapsed displays only the group caption; the list of task
 
 Enables drop-down menus on the **Next** and **Previous** navigation buttons.
 
-```
+```cpp
 void EnableHistoryMenuButtons(BOOL bEnable = TRUE);
 ```
 
@@ -532,7 +532,7 @@ The menus contain the history of tasks pages that the user used.
 
 Enables or disables the navigation toolbar.
 
-```
+```cpp
 void EnableNavigationToolbar(
     BOOL bEnable = TRUE,
     UINT uiToolbarBmpRes = 0,
@@ -564,7 +564,7 @@ By default, the framework does not display the navigation toolbar. If the naviga
 
 ## <a name="enableoffsetcustomcontrols"></a> CMFCTasksPane::EnableOffsetCustomControls
 
-```
+```cpp
 void EnableOffsetCustomControls(BOOL bEnable);
 ```
 
@@ -578,7 +578,7 @@ void EnableOffsetCustomControls(BOOL bEnable);
 
 Enables scroll buttons instead of a scroll bar.
 
-```
+```cpp
 void EnableScrollButtons(BOOL bEnable = TRUE);
 ```
 
@@ -595,7 +595,7 @@ By default, the framework displays scroll buttons in the task pane.
 
 Enables or disables word wrapping for the text in labels.
 
-```
+```cpp
 void EnableWrapLabels(BOOL bEnable = TRUE);
 ```
 
@@ -612,7 +612,7 @@ By default, the framework does not wrap the text in labels. When word wrapping i
 
 Enables or disables word wrapping for the text in tasks.
 
-```
+```cpp
 void EnableWrapTasks(BOOL bEnable = TRUE);
 ```
 
@@ -741,7 +741,7 @@ The default spacing between a task pane and the edge of the client area is 12 pi
 
 ## <a name="getnextpages"></a> CMFCTasksPane::GetNextPages
 
-```
+```cpp
 void GetNextPages(CStringList& lstNextPages) const;
 ```
 
@@ -787,7 +787,7 @@ The number of pages in the task pane.
 
 ## <a name="getpreviouspages"></a> CMFCTasksPane::GetPreviousPages
 
-```
+```cpp
 void GetPreviousPages(CStringList& lstPrevPages) const;
 ```
 
@@ -1272,7 +1272,7 @@ virtual BOOL PreTranslateMessage(MSG* pMsg);
 
 ## <a name="recalclayout"></a> CMFCTasksPane::RecalcLayout
 
-```
+```cpp
 void RecalcLayout(BOOL bRedraw = TRUE);
 ```
 
@@ -1286,7 +1286,7 @@ void RecalcLayout(BOOL bRedraw = TRUE);
 
 Removes all groups on the specified page.
 
-```
+```cpp
 void RemoveAllGroups(int nPageIdx = 0);
 ```
 
@@ -1303,7 +1303,7 @@ Removes all groups on the page specified by *nPageIdx*, or all groups if there i
 
 Removes all pages from the task pane except the default (first) page.
 
-```
+```cpp
 void RemoveAllPages();
 ```
 
@@ -1311,7 +1311,7 @@ void RemoveAllPages();
 
 Removes all tasks from the specified group.
 
-```
+```cpp
 void RemoveAllTasks(int nGroup);
 ```
 
@@ -1324,7 +1324,7 @@ void RemoveAllTasks(int nGroup);
 
 Removes a group.
 
-```
+```cpp
 void RemoveGroup(int nGroup);
 ```
 
@@ -1343,7 +1343,7 @@ When the framework removes a group, all tasks and user windows associated with i
 
 Removes a specified page from the task pane.
 
-```
+```cpp
 void RemovePage(int nPageIdx);
 ```
 
@@ -1413,7 +1413,7 @@ virtual void Serialize(CArchive& ar);
 
 Makes the specified page in the task pane active.
 
-```
+```cpp
 void SetActivePage(int nPageIdx);
 ```
 
@@ -1430,7 +1430,7 @@ This method asserts if the *nPageIdx* is invalid.
 
 Sets the caption name of a task pane.
 
-```
+```cpp
 void SetCaption(LPCTSTR lpszName);
 ```
 
@@ -1447,7 +1447,7 @@ If a task pane has multiple pages, the default page has the caption that was set
 
 Sets the height of a group caption.
 
-```
+```cpp
 void SetGroupCaptionHeight(int n = -1);
 ```
 
@@ -1466,7 +1466,7 @@ If *n* is -1, the framework determines the margin value by using the visual mana
 
 Sets the horizontal offset of a group caption.
 
-```
+```cpp
 void SetGroupCaptionHorzOffset(int n = -1);
 ```
 
@@ -1479,7 +1479,7 @@ void SetGroupCaptionHorzOffset(int n = -1);
 
 Sets the vertical offset of a group caption.
 
-```
+```cpp
 void SetGroupCaptionVertOffset(int n = -1);
 ```
 
@@ -1540,7 +1540,7 @@ TRUE if the group text color was successfully changed; otherwise, FALSE.
 
 Sets the vertical offset for a group.
 
-```
+```cpp
 void SetGroupVertOffset(int n = -1);
 ```
 
@@ -1559,7 +1559,7 @@ Call this method to customize the margins of task pane elements. If *n* is -1, t
 
 Sets the horizontal margin.
 
-```
+```cpp
 void SetHorzMargin(int n = -1);
 ```
 
@@ -1611,7 +1611,7 @@ This method associates an image list with the task pane control. To set the icon
 
 Sets the caption text for a task pane page.
 
-```
+```cpp
 void SetPageCaption(
     int nPageIdx,
     LPCTSTR lpszName);
@@ -1659,7 +1659,7 @@ TRUE if the task name was successfully set; otherwise, FALSE.
 
 Sets the horizontal offset for tasks.
 
-```
+```cpp
 void SetTasksHorzOffset(int n = -1);
 ```
 
@@ -1678,7 +1678,7 @@ The default horizontal offset is 12 pixels.
 
 ## <a name="settasksiconhorzoffset"></a> CMFCTasksPane::SetTasksIconHorzOffset
 
-```
+```cpp
 void SetTasksIconHorzOffset(int n = -1);
 ```
 
@@ -1690,7 +1690,7 @@ void SetTasksIconHorzOffset(int n = -1);
 
 ## <a name="settasksiconvertoffset"></a> CMFCTasksPane::SetTasksIconVertOffset
 
-```
+```cpp
 void SetTasksIconVertOffset(int n = -1);
 ```
 
@@ -1734,7 +1734,7 @@ TRUE if the text color for the task was successfully set; otherwise, FALSE.
 
 Sets the vertical margin.
 
-```
+```cpp
 void SetVertMargin(int n = -1);
 ```
 

--- a/docs/mfc/reference/cmfctoolbar-class.md
+++ b/docs/mfc/reference/cmfctoolbar-class.md
@@ -339,7 +339,7 @@ Override this method to provide your own dynamic layout in classes that you deri
 
 Recalculates the size of the toolbar.
 
-```
+```cpp
 void AdjustSize();
 ```
 
@@ -607,7 +607,7 @@ The framework calls this method when an application shuts down.
 
 Frees the system resources allocated for locked toolbar images.
 
-```
+```cpp
 void CleanUpLockedImages();
 ```
 
@@ -826,7 +826,7 @@ Override this method in a class derived from [CMFCToolBar](../../mfc/reference/c
 
 Enables or disables the Customize button that appears on the toolbar.
 
-```
+```cpp
 void EnableCustomizeButton(
     BOOL bEnable,
     int iCustomizeCmd,
@@ -886,7 +886,7 @@ This method extends the base class implementation, [CBasePane::EnableDocking](..
 
 Enables or disables large icons on toolbar buttons.
 
-```
+```cpp
 void EnableLargeIcons(BOOL bEnable);
 ```
 
@@ -916,7 +916,7 @@ static void EnableQuickCustomization(BOOL bEnable=TRUE);
 
 Enables or disables command reflection.
 
-```
+```cpp
 void EnableReflections(BOOL bEnable = TRUE);
 ```
 
@@ -935,7 +935,7 @@ For more information about command reflection, see [TN062: Message Reflection fo
 
 Enables or disables text labels under toolbar button images.
 
-```
+```cpp
 void EnableTextLabels(BOOL bEnable=TRUE);
 ```
 
@@ -1030,7 +1030,7 @@ A pointer to the toolbar button if it exists; or NULL if there is no such button
 
 Returns the command ID, style, and image index of the button at a specified index.
 
-```
+```cpp
 void GetButtonInfo(
     int nIndex,
     UINT& nID,
@@ -2898,7 +2898,7 @@ See the Explorer sample for an example that uses this method.
 
 Sets the command ID, style, and image ID of a toolbar button.
 
-```
+```cpp
 void SetButtonInfo(
     int nIndex,
     UINT nID,
@@ -3061,7 +3061,7 @@ This method adjusts the layout of and redraws each toolbar in the application. C
 
 Specifies whether unavailable buttons on the toolbar are dimmed, or whether button-unavailable images are used.
 
-```
+```cpp
 void SetGrayDisabledButtons(BOOL bGrayDisabledButtons);
 ```
 
@@ -3078,7 +3078,7 @@ By default, unavailable buttons are dimmed.
 
 Sets the height of the toolbar.
 
-```
+```cpp
 void SetHeight(int cyHeight);
 ```
 
@@ -3121,7 +3121,7 @@ BOOL SetHot(CMFCToolBarButton* pMenuButton);
 
 Specifies whether toolbar buttons are hot-tracked.
 
-```
+```cpp
 void SetHotBorder(BOOL bShowHotBorder);
 ```
 
@@ -3155,7 +3155,7 @@ For more information about hot-tracked toolbar buttons, see [CMFCToolBar::GetHot
 
 ## <a name="setignoresettext"></a> CMFCToolBar::SetIgnoreSetText
 
-```
+```cpp
 void SetIgnoreSetText(BOOL bValue);
 ```
 
@@ -3190,7 +3190,7 @@ For more information about the **Customize** dialog box, see [CMFCToolBarsCustom
 
 Sets the sizes of locked buttons and locked images on the toolbar.
 
-```
+```cpp
 void SetLockedSizes(
     SIZE sizeButton,
     SIZE sizeImage,
@@ -3216,7 +3216,7 @@ Call the [CMFCToolBar::GetLockedImageSize](#getlockedimagesize) method to retrie
 
 ## <a name="setmaskmode"></a> CMFCToolBar::SetMaskMode
 
-```
+```cpp
 void SetMaskMode(BOOL bMasked);
 ```
 
@@ -3275,7 +3275,7 @@ This method clears the previous list of non-permitted commands. By default, the 
 
 Positions the toolbar and its sibling on the same row.
 
-```
+```cpp
 void SetOneRowWithSibling();
 ```
 
@@ -3289,7 +3289,7 @@ The framework calls the [CMFCToolBar::SetTwoRowsWithSibling](#settworowswithsibl
 
 ## <a name="setorigbuttons"></a> CMFCToolBar::SetOrigButtons
 
-```
+```cpp
 void SetOrigButtons(const CObList& lstOrigButtons);
 ```
 
@@ -3303,7 +3303,7 @@ void SetOrigButtons(const CObList& lstOrigButtons);
 
 Specifies whether a user can close the toolbar.
 
-```
+```cpp
 void SetPermament(BOOL bPermament=TRUE);
 ```
 
@@ -3322,7 +3322,7 @@ Call the [CMFCToolBar::CanBeClosed](#canbeclosed) method to determine whether a 
 
 Specifies whether the parent frame or the owner sends commands to the toolbar.
 
-```
+```cpp
 void SetRouteCommandsViaFrame(BOOL bValue);
 ```
 
@@ -3358,7 +3358,7 @@ Call the [CMFCToolBar::GetShowTooltips](#getshowtooltips) method to determine wh
 
 Specifies the sibling of the toolbar.
 
-```
+```cpp
 void SetSiblingToolBar(CMFCToolBar* pBrotherToolbar);
 ```
 
@@ -3403,7 +3403,7 @@ Call the [CMFCToolBar::GetImageSize](#getimagesize) method to retrieve the size 
 
 Specifies properties of a button on the toolbar.
 
-```
+```cpp
 void SetToolBarBtnText(
     UINT nBtnIndex,
     LPCTSTR szText=NULL,
@@ -3435,7 +3435,7 @@ In Debug builds, this method generates an assertion failure if *nBtnIndex* does 
 
 Positions the toolbar and its sibling on separate rows.
 
-```
+```cpp
 void SetTwoRowsWithSibling();
 ```
 
@@ -3527,7 +3527,7 @@ The framework calls this method when a key is pressed together with the Alt key.
 
 Updates the state of the specified button.
 
-```
+```cpp
 void UpdateButton(int nIndex);
 ```
 

--- a/docs/mfc/reference/cmfctoolbarbutton-class.md
+++ b/docs/mfc/reference/cmfctoolbarbutton-class.md
@@ -1521,7 +1521,7 @@ The default implementation of this method does nothing. Override this method to 
 
 Sets the bounding rectangle of the button.
 
-```
+```cpp
 void SetRect(const CRect rect);
 ```
 
@@ -1555,7 +1555,7 @@ The default implementation sets the [CMFCToolBarButton::m_nStyle](#m_nstyle) dat
 
 Specifies whether the button is visible.
 
-```
+```cpp
 void SetVisible(BOOL bShow=TRUE);
 ```
 
@@ -1572,7 +1572,7 @@ Use this function to hide or show a particular toolbar button. Call the [CPane::
 
 Shows or hides the button.
 
-```
+```cpp
 void Show(BOOL bShow);
 ```
 

--- a/docs/mfc/reference/cmfctoolbarcomboboxbutton-class.md
+++ b/docs/mfc/reference/cmfctoolbarcomboboxbutton-class.md
@@ -1050,7 +1050,7 @@ TRUE if the method handles the event; otherwise, FALSE.
 
 Deletes all items from the list and edit boxes.
 
-```
+```cpp
 void RemoveAllItems();
 ```
 
@@ -1189,7 +1189,7 @@ By default, combo box buttons are aligned to the top.
 
 Sets the shortcut menu resource ID for the combo box button.
 
-```
+```cpp
 void SetContextMenuID(UINT uiResID);
 ```
 
@@ -1202,7 +1202,7 @@ void SetContextMenuID(UINT uiResID);
 
 Sets the height of the list box when it is dropped down.
 
-```
+```cpp
 void SetDropDownHeight(int nHeight);
 ```
 
@@ -1253,7 +1253,7 @@ For a list of toolbar button styles see [ToolBar Control Styles](../../mfc/refer
 
 Sets the text in the edit box of the combo box button.
 
-```
+```cpp
 void SetText(LPCTSTR lpszText);
 ```
 

--- a/docs/mfc/reference/cmfctoolbareditboxbutton-class.md
+++ b/docs/mfc/reference/cmfctoolbareditboxbutton-class.md
@@ -584,7 +584,7 @@ Nonzero if the text was set; 0 if the `CMFCToolBarEditBoxButton` control with th
 
 Specifies the resource ID of the shortcut menu that is associated with the button.
 
-```
+```cpp
 void SetContextMenuID(UINT uiResID);
 ```
 

--- a/docs/mfc/reference/cmfctoolbarfontsizecombobox-class.md
+++ b/docs/mfc/reference/cmfctoolbarfontsizecombobox-class.md
@@ -83,7 +83,7 @@ If the return value is positive, it is the font size in twips. It is -1 if the t
 
 Fills a font size combo box with all valid sizes of the given font.
 
-```
+```cpp
 void RebuildFontSizes(const CString& strFontName);
 ```
 
@@ -100,7 +100,7 @@ Call this function when you want to synchronize between selection in a font comb
 
 Rounds the specified size (in twips) to the nearest size in points, and then sets the selected size in the combo box to that value.
 
-```
+```cpp
 void SetTwipSize(int nSize);
 ```
 

--- a/docs/mfc/reference/cmfctoolbarimages-class.md
+++ b/docs/mfc/reference/cmfctoolbarimages-class.md
@@ -128,7 +128,7 @@ The following example demonstrates how to configure a `CMFCToolBarImages` object
 
 ## <a name="adaptcolors"></a> CMFCToolBarImages::AdaptColors
 
-```
+```cpp
 void AdaptColors(
     COLORREF clrBase,
     COLORREF clrTone);
@@ -207,7 +207,7 @@ static void __stdcall CleanUp();
 
 Frees the system resources that the [CMFCToolbarImages](../../mfc/reference/cmfctoolbarimages-class.md) object allocated.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -403,7 +403,7 @@ static void __stdcall EnableRTL(BOOL bIsRTL = TRUE);
 
 Frees system resources that [CMFCToolBarImages::PrepareDrawImage](#preparedrawimage) allocated after you draw a toolbar image by calling [CMFCToolBarImages::Draw](#draw).
 
-```
+```cpp
 void EndDrawImage(CAfxDrawState& ds);
 ```
 
@@ -926,7 +926,7 @@ BOOL MirrorVert();
 
 ## <a name="onsyscolorchange"></a> CMFCToolBarImages::OnSysColorChange
 
-```
+```cpp
 void OnSysColorChange();
 ```
 
@@ -1019,7 +1019,7 @@ Call this method to store the user-defined images into a disk file. If *lpszBmpF
 
 ## <a name="setalwayslight"></a> CMFCToolBarImages::SetAlwaysLight
 
-```
+```cpp
 void SetAlwaysLight(BOOL bAlwaysLight = TRUE);
 ```
 
@@ -1062,7 +1062,7 @@ static void __stdcall SetFadedImageAlpha(BYTE nValue);
 
 Sets the size of each toolbar image (source size).
 
-```
+```cpp
 void SetImageSize(
     SIZE sizeImage,
     BOOL bUpdateCount=FALSE);
@@ -1079,7 +1079,7 @@ By default the size of the toolbar image is 16x15 pixels. Call this method if yo
 
 ## <a name="setlightpercentage"></a> CMFCToolBarImages::SetLightPercentage
 
-```
+```cpp
 void SetLightPercentage(int nValue);
 ```
 
@@ -1091,7 +1091,7 @@ void SetLightPercentage(int nValue);
 
 ## <a name="setmapto3dcolors"></a> CMFCToolBarImages::SetMapTo3DColors
 
-```
+```cpp
 void SetMapTo3DColors(BOOL bMapTo3DColors);
 ```
 
@@ -1103,7 +1103,7 @@ void SetMapTo3DColors(BOOL bMapTo3DColors);
 
 ## <a name="setpremultiplyautocheck"></a> CMFCToolBarImages::SetPreMultiplyAutoCheck
 
-```
+```cpp
 void SetPreMultiplyAutoCheck(BOOL bAuto = TRUE);
 ```
 
@@ -1115,7 +1115,7 @@ void SetPreMultiplyAutoCheck(BOOL bAuto = TRUE);
 
 ## <a name="setsingleimage"></a> CMFCToolBarImages::SetSingleImage
 
-```
+```cpp
 void SetSingleImage();
 ```
 

--- a/docs/mfc/reference/cmfctoolbarmenubutton-class.md
+++ b/docs/mfc/reference/cmfctoolbarmenubutton-class.md
@@ -234,7 +234,7 @@ The default implementation just constructs and returns a new `CMFCPopupMenu` obj
 
 Draws a document icon on the menu button.
 
-```
+```cpp
 void DrawDocumentIcon(
     CDC* pDC,
     const CRect& rectImage,
@@ -258,7 +258,7 @@ This method takes a document icon and draws it on the menu button, centered in t
 
 ## <a name="enablequickcustomize"></a> CMFCToolBarMenuButton::EnableQuickCustomize
 
-```
+```cpp
 void EnableQuickCustomize();
 ```
 
@@ -334,7 +334,7 @@ A toolbar menu button can display a submenu. You can provide the list of command
 
 Retrieves the bounding rectangle for the button image.
 
-```
+```cpp
 void GetImageRect(CRect& rectImage);
 ```
 
@@ -700,7 +700,7 @@ By default this method sets the accessibility data for the ribbon element and al
 
 Specifies whether the button is drawn as a menu button or a split button when it has both a valid command ID and a submenu.
 
-```
+```cpp
 void SetMenuOnly(BOOL bMenuOnly);
 ```
 
@@ -717,7 +717,7 @@ Typically, when a toolbar menu button has both a submenu and a command ID, the m
 
 Specifies whether the drop-down menu is in palette mode.
 
-```
+```cpp
 void SetMenuPaletteMode(
     BOOL bMenuPaletteMode=TRUE,
     int nPaletteRows=1);
@@ -737,7 +737,7 @@ In the palette mode, all menu items are displayed as a multicolumn palette. You 
 
 ## <a name="setmessagewnd"></a> CMFCToolBarMenuButton::SetMessageWnd
 
-```
+```cpp
 void SetMessageWnd(CWnd* pWndMessage);
 ```
 

--- a/docs/mfc/reference/cmfctoolbarscustomizedialog-class.md
+++ b/docs/mfc/reference/cmfctoolbarscustomizedialog-class.md
@@ -94,7 +94,7 @@ The following example demonstrates how to use various methods in the `CMFCToolBa
 
 Inserts a toolbar button into the list of commands on the **Commands** page.
 
-```
+```cpp
 void AddButton(
     UINT uiCategoryId,
     const CMFCToolBarButton& button,
@@ -161,7 +161,7 @@ In the call to `AddMenuCommands`, *bPopup* is FALSE. As a result, that method do
 
 Adds items to the list of commands in the **Commands** page to represent all the items in the specified menu.
 
-```
+```cpp
 void AddMenuCommands(
     const CMenu* pMenu,
     BOOL bPopup,
@@ -325,7 +325,7 @@ Call the `Create` method only after you fully initialize the class.
 
 Enables or disables creating new toolbars by using the **Customize** dialog box.
 
-```
+```cpp
 void EnableUserDefinedToolbars(BOOL bEnable=TRUE);
 ```
 
@@ -365,7 +365,7 @@ The `CMFCMousePropertyPage` class uses this method to populate the double-click 
 
 Populates the provided `CComboBox` object with the name of each command category in the **Customize** dialog box.
 
-```
+```cpp
 void FillCategoriesComboBox(
     CComboBox& wndCategory,
     BOOL bAddEmpty = TRUE) const;
@@ -393,7 +393,7 @@ The `CMFCToolBarsKeyboardPropertyPage` and `CMFCKeyMapDialog` classes use this m
 
 Populates the provided `CListBox` object with the name of each command category in the **Customize** dialog box.
 
-```
+```cpp
 void FillCategoriesListBox(
     CListBox& wndCategory,
     BOOL bAddEmpty = TRUE) const;
@@ -679,7 +679,7 @@ The category name must be unique.
 
 Replaces a toolbar button in the list box of commands on the **Commands** page.
 
-```
+```cpp
 void ReplaceButton(
     UINT uiCmd,
     const CMFCToolBarButton& button);

--- a/docs/mfc/reference/cmfcvisualmanager-class.md
+++ b/docs/mfc/reference/cmfcvisualmanager-class.md
@@ -315,7 +315,7 @@ static void __stdcall DestroyInstance(BOOL bAutoDestroyOnly = FALSE);
 
 ## <a name="dodrawheadersortarrow"></a> CMFCVisualManager::DoDrawHeaderSortArrow
 
-```
+```cpp
 void DoDrawHeaderSortArrow(
     CDC* pDC,
     CRect rect,
@@ -419,7 +419,7 @@ virtual BOOL DrawTextOnGlass(
 
 ## <a name="enabletoolbarbuttonfill"></a> CMFCVisualManager::EnableToolbarButtonFill
 
-```
+```cpp
 void EnableToolbarButtonFill(BOOL bEnable = TRUE);
 ```
 
@@ -4665,7 +4665,7 @@ Use this method to change the visual manager that your application uses.
 
 Enables or disables the embossed mode for disabled toolbar images.
 
-```
+```cpp
 void SetEmbossDisabledImage (BOOL bEmboss = TRUE);
 ```
 
@@ -4682,7 +4682,7 @@ Use the function [CMFCVisualManager::IsEmbossDisabledImage](#isembossdisabledima
 
 Enables or disables the lighting effect for inactive images on a menu or toolbar.
 
-```
+```cpp
 void SetFadeInactiveImage(BOOL bFade = TRUE);
 ```
 
@@ -4699,7 +4699,7 @@ This feature controls whether inactive images appear faded on a menu or toolbar.
 
 Sets a flag that indicates whether the menu buttons appear flat. Otherwise, they appear three-dimensional.
 
-```
+```cpp
 void SetMenuFlatLook(BOOL bMenuFlatLook = TRUE);
 ```
 
@@ -4716,7 +4716,7 @@ By default, this feature is not enabled.
 
 Sets the width and height of the menu shadow.
 
-```
+```cpp
 void SetMenuShadowDepth(int nDepth);
 ```
 
@@ -4733,7 +4733,7 @@ The height and width of the menu shadow must be identical. The default value is 
 
 Sets a flag that indicates whether the [CMFCVisualManager](../../mfc/reference/cmfcvisualmanager-class.md) displays shadows for highlighted images.
 
-```
+```cpp
 void SetShadowHighlightedImage(BOOL bShadow = TRUE);
 ```
 

--- a/docs/mfc/reference/cmfcvisualmanagerwindows-class.md
+++ b/docs/mfc/reference/cmfcvisualmanagerwindows-class.md
@@ -1335,7 +1335,7 @@ virtual void OnUpdateSystemColors();
 
 ## <a name="setofficestylemenus"></a> CMFCVisualManagerWindows::SetOfficeStyleMenus
 
-```
+```cpp
 void SetOfficeStyleMenus(BOOL bOn = TRUE);
 ```
 

--- a/docs/mfc/reference/cmonthcalctrl-class.md
+++ b/docs/mfc/reference/cmonthcalctrl-class.md
@@ -716,7 +716,7 @@ This method sends the [MCM_GETCURRENTVIEW](/windows/win32/Controls/mcm-getcurren
 
 Sets the width of the border of the current month calendar control.
 
-```
+```cpp
 void SetCalendarBorder(int cxyBorder);
 ```
 
@@ -748,7 +748,7 @@ The following code example sets the border width of the month calendar control t
 
 Sets the default width of the border of the current month calendar control.
 
-```
+```cpp
 void SetCalendarBorderDefault();
 ```
 
@@ -1127,7 +1127,7 @@ This member function implements the behavior of the Win32 message [MCM_SETSELRAN
 
 Sets the calendar control for the current day.
 
-```
+```cpp
 void SetToday(const COleDateTime& refDateTime);
 void SetToday(const CTime* pDateTime);
 void SetToday(const LPSYSTEMTIME pDateTime);

--- a/docs/mfc/reference/cmousemanager-class.md
+++ b/docs/mfc/reference/cmousemanager-class.md
@@ -160,7 +160,7 @@ This method searches through views registered by using [CMouseManager::AddView](
 
 Retrieves a list of all the registered view names.
 
-```
+```cpp
 void GetViewNames(CStringList& listOfNames) const;
 ```
 
@@ -223,7 +223,7 @@ In most cases, you do not have to call this function directly. It is called as a
 
 Associates a custom command with a view that is first registered with the mouse manager.
 
-```
+```cpp
 void SetCommandForDblClk(
     int iViewId,
     UINT uiCmd);

--- a/docs/mfc/reference/cmultipaneframewnd-class.md
+++ b/docs/mfc/reference/cmultipaneframewnd-class.md
@@ -498,7 +498,7 @@ virtual void SetDockState(CDockingManager* pDockManager);
 
 ## <a name="setlastfocusedpane"></a> CMultiPaneFrameWnd::SetLastFocusedPane
 
-```
+```cpp
 void SetLastFocusedPane(HWND hwnd);
 ```
 

--- a/docs/mfc/reference/cobarray-class.md
+++ b/docs/mfc/reference/cobarray-class.md
@@ -175,7 +175,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 Call this member function to overwrite the elements of the given array with the elements of another array of the same type.
 
-```
+```cpp
 void Copy(const CObArray& src);
 ```
 
@@ -272,7 +272,7 @@ The following table shows other member functions that are similar to `CObArray::
 
 Frees any extra memory that was allocated while the array was grown.
 
-```
+```cpp
 void FreeExtra();
 ```
 
@@ -472,7 +472,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 Inserts an element (or all the elements in another array) at a specified index.
 
-```
+```cpp
 void InsertAt(
     INT_PTR nIndex,
     CObject* newElement,
@@ -582,7 +582,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 Removes all the pointers from this array but does not actually delete the `CObject` objects.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -613,7 +613,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 Removes one or more elements starting at a specified index in an array.
 
-```
+```cpp
 void RemoveAt(
     INT_PTR nIndex,
     INT_PTR nCount = 1);
@@ -663,7 +663,7 @@ RemoveAt example: A CObArray with 1 elements
 
 Sets the array element at the specified index.
 
-```
+```cpp
 void SetAt(
     INT_PTR nIndex,
     CObject* newElement);
@@ -712,7 +712,7 @@ SetAt example: A CObArray with 2 elements
 
 Sets the array element at the specified index.
 
-```
+```cpp
 void SetAtGrow(
     INT_PTR nIndex,
     CObject* newElement);
@@ -761,7 +761,7 @@ SetAtGrow example: A CObArray with 4 elements
 
 Establishes the size of an empty or existing array; allocates memory if necessary.
 
-```
+```cpp
 void SetSize(
     INT_PTR nNewSize,
     INT_PTR nGrowBy = -1);

--- a/docs/mfc/reference/cobject-class.md
+++ b/docs/mfc/reference/cobject-class.md
@@ -253,7 +253,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 For the Release version of the library, operator **delete** frees the memory allocated by operator **new**.
 
-```
+```cpp
 void PASCAL operator delete(void* p);
 
 void PASCAL operator delete(
@@ -290,7 +290,7 @@ See [CObList::CObList](../../mfc/reference/coblist-class.md#coblist) for a listi
 
 For the Release version of the library, operator **new** performs an optimal memory allocation in a manner similar to `malloc`.
 
-```
+```cpp
 void* PASCAL operator new(size_t nSize);
 void* PASCAL operator new(size_t, void* p);
 

--- a/docs/mfc/reference/coblist-class.md
+++ b/docs/mfc/reference/coblist-class.md
@@ -697,7 +697,7 @@ The following table shows other member functions that are similar to `CObList::I
 
 Removes all the elements from this list and frees the associated `CObList` memory.
 
-```
+```cpp
 void RemoveAll();
 ```
 
@@ -724,7 +724,7 @@ See [CObList::CObList](#coblist) for a listing of the `CAge` class.
 
 Removes the specified element from this list.
 
-```
+```cpp
 void RemoveAt(POSITION position);
 ```
 
@@ -824,7 +824,7 @@ See [CObList::CObList](#coblist) for a listing of the `CAge` class.
 
 Sets the element at a given position.
 
-```
+```cpp
 void SetAt(
     POSITION pos,
     CObject* newElement);

--- a/docs/mfc/reference/coleclientitem-class.md
+++ b/docs/mfc/reference/coleclientitem-class.md
@@ -144,7 +144,7 @@ For more information about using the container interface, see the articles [Cont
 
 Call this function to execute the specified verb instead of [DoVerb](#doverb) so that you can do your own processing when an exception is thrown.
 
-```
+```cpp
 void Activate(
     LONG nVerb,
     CView* pView,
@@ -214,7 +214,7 @@ This is called automatically by [COleConvertDialog::DoConvert](../../mfc/referen
 
 Call this function to initialize a [COleDataObject](../../mfc/reference/coledataobject-class.md) for accessing the data in the OLE item.
 
-```
+```cpp
 void AttachDataObject(COleDataObject& rDataObject) const;
 ```
 
@@ -327,7 +327,7 @@ For more information, see [OleGetClipboard](/windows/win32/api/ole2/nf-ole2-oleg
 
 Call this function to change the state of an OLE item from the running state to the loaded state, that is, loaded with its handler in memory but with the server not running.
 
-```
+```cpp
 void Close(OLECLOSE dwCloseOption = OLECLOSE_SAVEIFDIRTY);
 ```
 
@@ -412,7 +412,7 @@ This is called automatically by [COleConvertDialog](../../mfc/reference/coleconv
 
 Call this function to copy the OLE item to the Clipboard.
 
-```
+```cpp
 void CopyToClipboard(BOOL bIncludeLink = FALSE);
 ```
 
@@ -770,7 +770,7 @@ For more information, see [OleCreateStaticFromData](/windows/win32/api/ole2/nf-o
 
 Call this function to deactivate the OLE item and free any associated resources.
 
-```
+```cpp
 void Deactivate();
 ```
 
@@ -786,7 +786,7 @@ For more information, see [IOleInPlaceObject::InPlaceDeactivate](/windows/win32/
 
 Call this function when the user deactivates an item that was activated in place.
 
-```
+```cpp
 void DeactivateUI();
 ```
 
@@ -802,7 +802,7 @@ For more information, see [IOleInPlaceObject::InPlaceDeactivate](/windows/win32/
 
 Call this function to delete the OLE item from the container document.
 
-```
+```cpp
 void Delete(BOOL bAutoDelete = TRUE);
 ```
 
@@ -987,7 +987,7 @@ For more information, see [IViewObject2::GetExtent](/windows/win32/api/oleidl/nf
 
 Returns the class ID of the item into the memory pointed to by *pClassID*.
 
-```
+```cpp
 void GetClassID(CLSID* pClassID) const;
 ```
 
@@ -1006,7 +1006,7 @@ For more information, see [IPersist::GetClassID](/windows/win32/api/objidl/nf-ob
 
 Call this function to get a `COleDataSource` object containing all the data that would be placed on the Clipboard by a call to the [CopyToClipboard](#copytoclipboard) member function.
 
-```
+```cpp
 void GetClipboardData(
     COleDataSource* pDataSource,
     BOOL bIncludeLink = FALSE,
@@ -1234,7 +1234,7 @@ An unsigned integer with one of the following values:
 
 Call this function to get the user-visible string describing the OLE item's type, such as "Word document."
 
-```
+```cpp
 void GetUserType(
     USERCLASSTYPE nUserClassType,
     CString& rString);
@@ -1811,7 +1811,7 @@ Call the `Reload` function after activating the item as an item of another type 
 
 Runs the application associated with this item.
 
-```
+```cpp
 void Run();
 ```
 
@@ -1850,7 +1850,7 @@ This function is called automatically by the Change Icon (and other dialogs that
 
 Call this function to specify how much space is available to the OLE item.
 
-```
+```cpp
 void SetExtent(
     const CSize& size,
     DVASPECT nDrawAspect = DVASPECT_CONTENT);
@@ -1874,7 +1874,7 @@ For more information, see [IOleObject::SetExtent](/windows/win32/api/oleidl/nf-o
 
 Call this function to specify the name of the container application and the container's name for an embedded OLE item.
 
-```
+```cpp
 void SetHostNames(
     LPCTSTR lpszHost,
     LPCTSTR lpszHostObj);
@@ -1951,7 +1951,7 @@ For more information, see [IOleInPlaceObject::SetObjectRects](/windows/win32/api
 
 Call this function to set the link-update option for the presentation of the specified linked item.
 
-```
+```cpp
 void SetLinkUpdateOptions(OLEUPDATE dwUpdateOpt);
 ```
 

--- a/docs/mfc/reference/colecontrol-class.md
+++ b/docs/mfc/reference/colecontrol-class.md
@@ -445,7 +445,7 @@ For example, a container might set this to FALSE in design mode.
 
 Signals that the bound property value has changed.
 
-```
+```cpp
 void BoundPropertyChanged(DISPID dispid);
 ```
 
@@ -542,7 +542,7 @@ This function is normally not called directly. Instead the OLE control is usuall
 
 Call this function when the set of mnemonics supported by the control has changed.
 
-```
+```cpp
 void ControlInfoChanged();
 ```
 
@@ -590,7 +590,7 @@ Override this function to customize how errors are displayed.
 
 Simulates a mouse click action on the control.
 
-```
+```cpp
 void DoClick();
 ```
 
@@ -623,7 +623,7 @@ If Control Wizard has been used to create the OLE control project, the overridde
 
 Redraws an OLE control that has been subclassed from a Windows control.
 
-```
+```cpp
 void DoSuperclassPaint(
     CDC* pDC,
     const CRect& rcBounds);
@@ -647,7 +647,7 @@ For more information on this function and subclassing a Windows control, see the
 
 Called by the framework when the control's appearance needs to be updated.
 
-```
+```cpp
 void DrawContent(
     CDC* pDC,
     CRect& rc);
@@ -669,7 +669,7 @@ This function directly calls the overridable `OnDraw` function.
 
 Called by the framework when the metafile device context is being used.
 
-```
+```cpp
 void DrawMetafile(
     CDC* pDC,
     CRect& rc);
@@ -687,7 +687,7 @@ Rectangular area to be drawn in.
 
 Enables the simple frame characteristic for an OLE control.
 
-```
+```cpp
 void EnableSimpleFrame();
 ```
 
@@ -720,7 +720,7 @@ This function is normally called by the default implementation of `COleControl::
 
 Serializes or initializes the state of the control's stock properties.
 
-```
+```cpp
 void ExchangeStockProps(CPropExchange* pPX);
 ```
 
@@ -769,7 +769,7 @@ For more information on persistence and versioning, see the article [ActiveX Con
 
 Called by the framework when the mouse is clicked over an active control.
 
-```
+```cpp
 void FireClick();
 ```
 
@@ -783,7 +783,7 @@ For automatic firing of a Click event to occur, the control's Event map must hav
 
 Called by the framework when the mouse is double-clicked over an active control.
 
-```
+```cpp
 void FireDblClick();
 ```
 
@@ -797,7 +797,7 @@ For automatic firing of a DblClick event to occur, the control's Event map must 
 
 Fires the stock Error event.
 
-```
+```cpp
 void FireError(
     SCODE scode,
     LPCTSTR lpszDescription,
@@ -829,7 +829,7 @@ To fix this, manually change the SCODE parameter in the control's .ODL file to a
 
 Fires a user-defined event from your control with any number of optional arguments,.
 
-```
+```cpp
 void AFX_CDECL FireEvent(
     DISPID dispid,
     BYTE* pbParams,
@@ -874,7 +874,7 @@ The *pbParams* argument is a space-separated list of **VTS_**. One or more of th
 
 Called by the framework when a key is pressed while the control is UI active.
 
-```
+```cpp
 void FireKeyDown(
     USHORT* pnChar,
     short nShiftState);
@@ -904,7 +904,7 @@ For automatic firing of a KeyDown event to occur, the control's Event map must h
 
 Called by the framework when a key is pressed and released while the custom control is UI Active within the container.
 
-```
+```cpp
 void FireKeyPress(USHORT* pnChar);
 ```
 
@@ -925,7 +925,7 @@ For automatic firing of a KeyPress event to occur, the control's Event map must 
 
 Called by the framework when a key is released while the custom control is UI Active within the container.
 
-```
+```cpp
 void FireKeyUp(
     USHORT* pnChar,
     short nShiftState);
@@ -955,7 +955,7 @@ For automatic firing of a KeyUp event to occur, the control's Event map must hav
 
 Called by the framework when a mouse button is pressed over an active custom control.
 
-```
+```cpp
 void FireMouseDown(
     short nButton,
     short nShiftState,
@@ -999,7 +999,7 @@ For automatic firing of a MouseDown event to occur, the control's Event map must
 
 Called by the framework when the cursor is moved over an active custom control.
 
-```
+```cpp
 void FireMouseMove(
     short nButton,
     short nShiftState,
@@ -1043,7 +1043,7 @@ For automatic firing of a MouseMove event to occur, the control's Event map must
 
 Called by the framework when a mouse button is released over an active custom control.
 
-```
+```cpp
 void FireMouseUp(
     short nButton,
     short nShiftState,
@@ -1087,7 +1087,7 @@ For automatic firing of a MouseUp event to occur, the control's Event map must h
 
 Fires an event with the current value of the ready state of control.
 
-```
+```cpp
 void FireReadyStateChange();
 ```
 
@@ -1360,7 +1360,7 @@ For more information about `GetControlFlags` and other optimizations of OLE cont
 
 Retrieves the size of the OLE control window.
 
-```
+```cpp
 void GetControlSize(
     int* pcx,
     int* pcy);
@@ -1478,7 +1478,7 @@ Note that the caller must release the object when finished. Within the implement
 
 Measures the text metrics for any `CFontHolder` object owned by the control.
 
-```
+```cpp
 void GetFontTextMetrics(
     LPTEXTMETRIC lptm,
     CFontHolder& fontHolder);
@@ -1548,7 +1548,7 @@ This can be used to obtain a message for display in a status bar while the menu 
 
 Prevents access to a control's property value by the user.
 
-```
+```cpp
 void GetNotSupported();
 ```
 
@@ -1605,7 +1605,7 @@ The rectangle is only valid if the control is in-place active.
 
 Measures the text metrics for the control's stock Font property, which can be selected with the [SelectStockFont](#selectstockfont) function.
 
-```
+```cpp
 void GetStockTextMetrics(LPTEXTMETRIC lptm);
 ```
 
@@ -1661,7 +1661,7 @@ Normally, this would require that the control's window be registered as a drop t
 
 Informs the base class of the IIDs the control will use.
 
-```
+```cpp
 void InitializeIIDs(
     const IID* piidPrimary,
     const IID* piidEvents);
@@ -1707,7 +1707,7 @@ A reference to the control text string.
 
 Sets the readiness state of the control.
 
-```
+```cpp
 void InternalSetReadyState(long lNewReadyState);
 ```
 
@@ -1732,7 +1732,7 @@ Most simple controls never need to differentiate between LOADED and INTERACTIVE.
 
 Forces the control to redraw itself.
 
-```
+```cpp
 void InvalidateControl(
     LPCRECT lpRect = NULL,
     BOOL bErase = TRUE);
@@ -1754,7 +1754,7 @@ If *lpRect* has a NULL value, the entire control will be redrawn. If *lpRect* is
 
 Invalidates the container window's client area within the given region.
 
-```
+```cpp
 void InvalidateRgn(CRgn* pRgn, BOOL bErase = TRUE);
 ```
 
@@ -1866,7 +1866,7 @@ You must override this function and return TRUE if your OLE control subclasses a
 
 Resets any previous data loaded asynchronously and initiates a new loading of the control's asynchronous property.
 
-```
+```cpp
 void Load(LPCTSTR strNewPath, CDataPathProperty& prop);
 ```
 
@@ -3177,7 +3177,7 @@ On input *pPoint* is relative to the origin of the parent (upper left corner of 
 
 Notifies the container that a modal dialog box has been closed.
 
-```
+```cpp
 void PostModalDialog(HWND hWndParent = NULL);
 ```
 
@@ -3194,7 +3194,7 @@ Call this function after displaying any modal dialog box. You must call this fun
 
 Notifies the container that a modal dialog box is about to be displayed.
 
-```
+```cpp
 void PreModalDialog(HWND hWndParent = NULL);
 ```
 
@@ -3211,7 +3211,7 @@ Call this function before displaying any modal dialog box. You must call this fu
 
 Destroys and re-creates the control's window.
 
-```
+```cpp
 void RecreateControlWindow();
 ```
 
@@ -3223,7 +3223,7 @@ This may be necessary if you need to change the window's style bits.
 
 Forces a repaint of the OLE control.
 
-```
+```cpp
 void Refresh();
 ```
 
@@ -3294,7 +3294,7 @@ Call this function to reset the parent of the control window.
 
 Initializes the state of the `COleControl` stock properties to their default values.
 
-```
+```cpp
 void ResetStockProps();
 ```
 
@@ -3312,7 +3312,7 @@ You can improve a control's binary initialization performance by using `ResetSto
 
 Initializes the version number to specified value.
 
-```
+```cpp
 void ResetVersion(DWORD dwVersionDefault);
 ```
 
@@ -3329,7 +3329,7 @@ You can improve a control's binary initialization performance by using `ResetVer
 
 Allows a windowless OLE object to scroll an area within its in-place active image on the screen.
 
-```
+```cpp
 void ScrollWindow(
     int xAmount,
     int yAmount,
@@ -3394,7 +3394,7 @@ A pointer to the previously selected `CFont` object. You should use [CDC::Select
 
 Serializes or initializes the state of the display space allotted to the control.
 
-```
+```cpp
 void SerializeExtent(CArchive& ar);
 ```
 
@@ -3415,7 +3415,7 @@ You can improve a control's binary persistence performance by using `SerializeEx
 
 Serializes or initializes the state of the `COleControl` stock properties: Appearance, BackColor, BorderStyle, Caption, Enabled, Font, ForeColor, and Text.
 
-```
+```cpp
 void SerializeStockProps(CArchive& ar);
 ```
 
@@ -3464,7 +3464,7 @@ You can improve a control's binary persistence performance by using `SerializeVe
 
 Sets the stock Appearance property value of your control.
 
-```
+```cpp
 void SetAppearance (short sAppearance);
 ```
 
@@ -3481,7 +3481,7 @@ For more about stock properties, see [ActiveX Controls: Properties](../../mfc/mf
 
 Sets the stock BackColor property value of your control.
 
-```
+```cpp
 void SetBackColor(OLE_COLOR dwBackColor);
 ```
 
@@ -3498,7 +3498,7 @@ For more information on using this property and other related properties, see th
 
 Sets the stock BorderStyle property value of your control.
 
-```
+```cpp
 void SetBorderStyle(short sBorderStyle);
 ```
 
@@ -3557,7 +3557,7 @@ Note that all coordinates for control windows are relative to the upper-left cor
 
 Sets the stock Enabled property value of your control.
 
-```
+```cpp
 void SetEnabled(BOOL bEnabled);
 ```
 
@@ -3592,7 +3592,7 @@ If the control is not windowless, this function causes the control itself to tak
 
 Sets the stock Font property of your control.
 
-```
+```cpp
 void SetFont(LPFONTDISP pFontDisp);
 ```
 
@@ -3605,7 +3605,7 @@ A pointer to a Font dispatch interface.
 
 Sets the stock ForeColor property value of your control.
 
-```
+```cpp
 void SetForeColor(OLE_COLOR dwForeColor);
 ```
 
@@ -3634,7 +3634,7 @@ The default implementation specifies two formats: CF_METAFILEPICT and the persis
 
 Sets the size of an OLE control when first displayed in a container.
 
-```
+```cpp
 void SetInitialSize(
     int cx,
     int cy);
@@ -3656,7 +3656,7 @@ Call this function in your constructor to set the initial size of your control. 
 
 Changes the modified state of a control.
 
-```
+```cpp
 void SetModifiedFlag(BOOL bModified = TRUE);
 ```
 
@@ -3673,7 +3673,7 @@ Call this function whenever a change occurs that would affect your control's per
 
 Indicates that an edit request has failed.
 
-```
+```cpp
 void SetNotPermitted();
 ```
 
@@ -3685,7 +3685,7 @@ Call this function when `BoundPropertyRequestEdit` fails. This function throws a
 
 Prevents modification to a control's property value by the user.
 
-```
+```cpp
 void SetNotSupported();
 ```
 
@@ -3718,7 +3718,7 @@ If the control is open, it is resized; otherwise the container's `OnPosRectChang
 
 Sets the value of your control's stock Caption or Text property.
 
-```
+```cpp
 void SetText(LPCTSTR pszText);
 ```
 
@@ -3735,7 +3735,7 @@ Note that the stock Caption and Text properties are both mapped to the same valu
 
 Signals the occurrence of an error in your control.
 
-```
+```cpp
 void ThrowError(
     SCODE sc,
     UINT nDescriptionID,
@@ -3769,7 +3769,7 @@ This function should only be called from within a Get or Set function for an OLE
 
 Transforms coordinate values between HIMETRIC units and the container's native units.
 
-```
+```cpp
 void TransformCoords(
     POINTL* lpptlHimetric,
     POINTF* lpptfContainer,

--- a/docs/mfc/reference/colecontrolcontainer-class.md
+++ b/docs/mfc/reference/colecontrolcontainer-class.md
@@ -285,7 +285,7 @@ Use the second overload to create default-sized controls.
 
 Creates an OLE font.
 
-```
+```cpp
 void CreateOleFont(CFont* pFont);
 ```
 
@@ -315,7 +315,7 @@ A pointer to the custom site of the specified item.
 
 Determines if the container will ignore events from the attached control sites or accept them.
 
-```
+```cpp
 void FreezeAllEvents(BOOL bFreeze);
 ```
 

--- a/docs/mfc/reference/colecontrolsite-class.md
+++ b/docs/mfc/reference/colecontrolsite-class.md
@@ -346,7 +346,7 @@ Nonzero if the window was previously disabled, otherwise 0.
 
 Specifies whether the control site will handle or ignore events fired from a control.
 
-```
+```cpp
 void FreezeEvents(BOOL bFreeze);
 ```
 
@@ -366,7 +366,7 @@ If *bFreeze* is TRUE, the control site requests the control to stop fring events
 
 Retrieves information about a control's keyboard mnemonics and keyboard behavior.
 
-```
+```cpp
 void GetControlInfo();
 ```
 
@@ -909,7 +909,7 @@ Nonzero if successful; otherwise zero.
 
 Sets the control as the default button.
 
-```
+```cpp
 void SetDefaultButton(BOOL bDefault);
 ```
 

--- a/docs/mfc/reference/colecurrency-class.md
+++ b/docs/mfc/reference/colecurrency-class.md
@@ -495,7 +495,7 @@ BOOL operator>=(const COleCurrency& cur) const;
 
 Call this member function to set the units and fractional part of this `COleCurrency` object.
 
-```
+```cpp
 void SetCurrency(
     long nUnits,
     long nFractionalUnits);
@@ -520,7 +520,7 @@ Note that the units and fractional part are specified by signed long values. The
 
 Call this member function to set the status (validity) of this `COleCurrency` object.
 
-```
+```cpp
 void SetStatus(CurrencyStatus  status  );
 ```
 

--- a/docs/mfc/reference/coledataobject-class.md
+++ b/docs/mfc/reference/coledataobject-class.md
@@ -62,7 +62,7 @@ For more information about using data objects in your application, see the artic
 
 Call this function to associate the `COleDataObject` object with an OLE data object.
 
-```
+```cpp
 void Attach(
     LPDATAOBJECT lpDataObject,
     BOOL bAutoRelease = TRUE);
@@ -101,7 +101,7 @@ Nonzero if successful; otherwise 0.
 
 Call this function to prepare for subsequent calls to `GetNextFormat` for retrieving a list of data formats from the item.
 
-```
+```cpp
 void BeginEnumFormats();
 ```
 
@@ -298,7 +298,7 @@ For more information, see [RegisterClipboardFormat](/windows/win32/api/winuser/n
 
 Call this function to release ownership of the [IDataObject](/windows/win32/api/objidl/nn-objidl-idataobject) object that was previously associated with the `COleDataObject` object.
 
-```
+```cpp
 void Release();
 ```
 

--- a/docs/mfc/reference/coledatasource-class.md
+++ b/docs/mfc/reference/coledatasource-class.md
@@ -66,7 +66,7 @@ For more information about data sources and data transfer, see the article [Data
 
 Call this function to specify a format in which data is offered during data transfer operations.
 
-```
+```cpp
 void CacheData(
     CLIPFORMAT cfFormat,
     LPSTGMEDIUM lpStgMedium,
@@ -102,7 +102,7 @@ For more information, see [RegisterClipboardFormat](/windows/win32/api/winuser/n
 
 Call this function to specify a format in which data is offered during data transfer operations.
 
-```
+```cpp
 void CacheGlobalData(
     CLIPFORMAT cfFormat,
     HGLOBAL hGlobal,
@@ -142,7 +142,7 @@ COleDataSource();
 
 Call this function to specify a format in which data is offered during data transfer operations.
 
-```
+```cpp
 void DelayRenderData(
     CLIPFORMAT cfFormat,
     LPFORMATETC lpFormatEtc = NULL);
@@ -172,7 +172,7 @@ For more information, see [RegisterClipboardFormat](/windows/win32/api/winuser/n
 
 Call this function to specify a format in which data is offered during data transfer operations.
 
-```
+```cpp
 void DelayRenderFileData(
     CLIPFORMAT cfFormat,
     LPFORMATETC lpFormatEtc = NULL);
@@ -202,7 +202,7 @@ For more information, see [RegisterClipboardFormat](/windows/win32/api/winuser/n
 
 Call this function to support changing the contents of the data source.
 
-```
+```cpp
 void DelaySetData(
     CLIPFORMAT cfFormat,
     LPFORMATETC lpFormatEtc = NULL);
@@ -278,7 +278,7 @@ For more information, see the article [OLE drag and drop](../../mfc/drag-and-dro
 
 Call this function to empty the `COleDataSource` object of data.
 
-```
+```cpp
 void Empty();
 ```
 
@@ -444,7 +444,7 @@ For more information, see the [STGMEDIUM](/windows/win32/api/objidl/ns-objidl-us
 
 Puts the data contained in the `COleDataSource` object on the Clipboard after calling one of the following functions: [CacheData](#cachedata), [CacheGlobalData](#cacheglobaldata), [DelayRenderData](#delayrenderdata), or [DelayRenderFileData](#delayrenderfiledata).
 
-```
+```cpp
 void SetClipboard();
 ```
 

--- a/docs/mfc/reference/coledispatchdriver-class.md
+++ b/docs/mfc/reference/coledispatchdriver-class.md
@@ -75,7 +75,7 @@ For more information on using `COleDispatchDriver`, see the following articles:
 
 Call the `AttachDispatch` member function to attach an `IDispatch` pointer to the `COleDispatchDriver` object. For more information, see [Implementing the IDispatch Interface](/previous-versions/windows/desktop/automat/implementing-the-idispatch-interface).
 
-```
+```cpp
 void AttachDispatch(
     LPDISPATCH lpDispatch,
     BOOL bAutoRelease = TRUE);
@@ -189,7 +189,7 @@ For more information about the LPDISPATCH type, see [Implementing the IDispatch 
 
 Gets the object property specified by *dwDispID*.
 
-```
+```cpp
 void GetProperty(
     DISPID dwDispID,
     VARTYPE vtProp,
@@ -215,7 +215,7 @@ Address of the variable that will receive the property value. It must match the 
 
 Calls the object method or property specified by *dwDispID*, in the context specified by *wFlags*.
 
-```
+```cpp
 void AFX_CDECL InvokeHelper(
     DISPID dwDispID,
     WORD wFlags,
@@ -341,7 +341,7 @@ operator LPDISPATCH();
 
 Releases the `IDispatch` connection. For more information, see [Implementing the IDispatch Interface](/previous-versions/windows/desktop/automat/implementing-the-idispatch-interface)
 
-```
+```cpp
 void ReleaseDispatch();
 ```
 
@@ -357,7 +357,7 @@ If auto release has been set for this connection, this function calls `IDispatch
 
 Sets the OLE object property specified by *dwDispID*.
 
-```
+```cpp
 void AFX_CDECL SetProperty(
     DISPID dwDispID,
     VARTYPE vtProp, ...);

--- a/docs/mfc/reference/coledocument-class.md
+++ b/docs/mfc/reference/coledocument-class.md
@@ -141,7 +141,7 @@ COleDocument();
 
 Call this function if you want to store the document using the compound-file format.
 
-```
+```cpp
 void EnableCompoundFile(BOOL bEnable = TRUE);
 ```
 

--- a/docs/mfc/reference/coleipframewndex-class.md
+++ b/docs/mfc/reference/coleipframewndex-class.md
@@ -98,7 +98,7 @@ The following example demonstrates how to subclass an instance of the `COleIPFra
 
 ## <a name="adddocksite"></a> COleIPFrameWndEx::AddDockSite
 
-```
+```cpp
 void AddDockSite();
 ```
 
@@ -135,7 +135,7 @@ virtual void AdjustDockingLayout(HDWP hdwp = NULL);
 
 ## <a name="dockpane"></a> COleIPFrameWndEx::DockPane
 
-```
+```cpp
 void DockPane(
     CBasePane* pBar,
     UINT nDockBarID = 0,
@@ -206,7 +206,7 @@ BOOL EnableDocking(DWORD dwDockStyle);
 
 ## <a name="enablepanemenu"></a> COleIPFrameWndEx::EnablePaneMenu
 
-```
+```cpp
 void EnablePaneMenu(
     BOOL bEnable,
     UINT uiCustomizeCmd,
@@ -375,7 +375,7 @@ Override this function to customize the display of tooltips on toolbar buttons.
 
 Specifies a range of control IDs that the framework assigns to the user-defined toolbars.
 
-```
+```cpp
 void InitUserToolbars(
     LPCTSTR lpszRegEntry,
     UINT uiUserToolbarFirst,
@@ -783,7 +783,7 @@ virtual void RecalcLayout(BOOL bNotify = TRUE);
 
 ## <a name="removepanefromdockmanager"></a> COleIPFrameWndEx::RemovePaneFromDockManager
 
-```
+```cpp
 void RemovePaneFromDockManager(
     CBasePane* pControlBar,
     BOOL bDestroy,
@@ -806,7 +806,7 @@ void RemovePaneFromDockManager(
 
 Applies the specified docking state to panes that belong to the frame window.
 
-```
+```cpp
 void SetDockState(const CDockState& state);
 ```
 
@@ -823,7 +823,7 @@ Use this function to specify a new docking state for panes that belong to the `C
 
 Modifies a toolbar object by searching for dummy items and replacing them with the specified user-defined items.
 
-```
+```cpp
 void SetupToolbarMenu(
     CMenu& menu,
     const UINT uiViewUserToolbarCmdFirst,
@@ -845,7 +845,7 @@ void SetupToolbarMenu(
 
 ## <a name="showpane"></a> COleIPFrameWndEx::ShowPane
 
-```
+```cpp
 void ShowPane(
     CBasePane* pBar,
     BOOL bShow,

--- a/docs/mfc/reference/colelinkingdoc-class.md
+++ b/docs/mfc/reference/colelinkingdoc-class.md
@@ -163,7 +163,7 @@ If you are using `COleTemplateServer` in your application, `Register` is called 
 
 Informs the OLE system DLLs that the document is no longer open.
 
-```
+```cpp
 void Revoke();
 ```
 

--- a/docs/mfc/reference/colemessagefilter-class.md
+++ b/docs/mfc/reference/colemessagefilter-class.md
@@ -90,7 +90,7 @@ COleMessageFilter();
 
 Enables and disables the busy dialog box, which is displayed when the message-pending delay expires (see [SetRetryReply](#setretryreply)) during an OLE call.
 
-```
+```cpp
 void EnableBusyDialog(BOOL bEnableBusy = TRUE);
 ```
 
@@ -103,7 +103,7 @@ Specifies whether the "busy" dialog box is enabled or disabled.
 
 Enables and disables the "not responding" dialog box, which is displayed if a keyboard or mouse message is pending during an OLE call and the call has timed out.
 
-```
+```cpp
 void EnableNotRespondingDialog(BOOL bEnableNotResponding = TRUE);
 ```
 
@@ -173,7 +173,7 @@ The framework's default message filter is automatically registered during initia
 
 Revokes a previous registration performed by a call to [Register](#register).
 
-```
+```cpp
 void Revoke();
 ```
 
@@ -187,7 +187,7 @@ The default message filter, which is created and registered automatically by the
 
 This function sets the application's "busy reply."
 
-```
+```cpp
 void SetBusyReply(SERVERCALL nBusyReply);
 ```
 
@@ -214,7 +214,7 @@ By default, the busy reply is SERVERCALL_RETRYLATER. This reply causes the calli
 
 Determines how long the calling application waits for a response from the called application before taking further action.
 
-```
+```cpp
 void SetMessagePendingDelay(DWORD nTimeout = 5000);
 ```
 
@@ -231,7 +231,7 @@ This function works in concert with [SetRetryReply](#setretryreply).
 
 Determines the calling application's action when it receives a busy response from a called application.
 
-```
+```cpp
 void SetRetryReply(DWORD nRetryReply = 0);
 ```
 

--- a/docs/mfc/reference/coleobjectfactory-class.md
+++ b/docs/mfc/reference/coleobjectfactory-class.md
@@ -243,7 +243,7 @@ This function is usually called by [CWinApp::InitInstance](../../mfc/reference/c
 
 Revokes this object factory's registration with the OLE system DLLs.
 
-```
+```cpp
 void Revoke();
 ```
 
@@ -279,7 +279,7 @@ TRUE if successful; otherwise FALSE.
 
 Registers all of the application's object factories with the OLE system registry.
 
-```
+```cpp
 void UpdateRegistry(LPCTSTR lpszProgID = NULL);
 virtual BOOL UpdateRegistry(BOOL bRegister);
 ```

--- a/docs/mfc/reference/colepastespecialdialog-class.md
+++ b/docs/mfc/reference/colepastespecialdialog-class.md
@@ -75,7 +75,7 @@ For more information regarding OLE-specific dialog boxes, see the article [Dialo
 
 Call this function to add new formats to the list of formats your application can support in a Paste Special operation.
 
-```
+```cpp
 void AddFormat(
     const FORMATETC& formatEtc,
     LPTSTR lpszFormat,
@@ -148,7 +148,7 @@ An [OLEUIPASTEFLAG](/windows/win32/api/oledlg/ne-oledlg-oleuipasteflag) structur
 
 Call this function to add the following Clipboard formats to the list of formats your application can support in a Paste Special operation:
 
-```
+```cpp
 void AddStandardFormats(BOOL bEnableLink = TRUE);
 ```
 

--- a/docs/mfc/reference/colepropertypage-class.md
+++ b/docs/mfc/reference/colepropertypage-class.md
@@ -147,7 +147,7 @@ Controls and containers cooperate so that users can browse and edit control prop
 
 Determines which controls do not enable the Apply button.
 
-```
+```cpp
 void IgnoreApply(UINT nID);
 ```
 
@@ -286,7 +286,7 @@ If the status of a property page control is dirty when the property page is clos
 
 Sets the property page's dialog resource.
 
-```
+```cpp
 void SetDialogResource(HGLOBAL hDialog);
 ```
 
@@ -299,7 +299,7 @@ Handle to the property page's dialog resource.
 
 Specifies tooltip information, the help filename, and the help context for your property page.
 
-```
+```cpp
 void SetHelpInfo(
     LPCTSTR lpszDocString,
     LPCTSTR lpszHelpFile = NULL,
@@ -321,7 +321,7 @@ Help context for the property page.
 
 Indicates whether the user has modified the property page.
 
-```
+```cpp
 void SetModifiedFlag(BOOL bModified = TRUE);
 ```
 
@@ -334,7 +334,7 @@ Specifies the new value for the property page's modified flag.
 
 Sets the property page's name, which the property frame will typically display on the page's tab.
 
-```
+```cpp
 void SetPageName(LPCTSTR lpszPageName);
 ```
 

--- a/docs/mfc/reference/colesafearray-class.md
+++ b/docs/mfc/reference/colesafearray-class.md
@@ -82,7 +82,7 @@ class COleSafeArray : public tagVARIANT
 
 Retrieves a pointer to the array data.
 
-```
+```cpp
 void AccessData(void** ppvData);
 ```
 
@@ -103,7 +103,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Allocates memory for a safe array.
 
-```
+```cpp
 void AllocData();
 ```
 
@@ -115,7 +115,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Allocates memory for the descriptor of a safe array.
 
-```
+```cpp
 void AllocDescriptor(DWORD dwDims);
 ```
 
@@ -132,7 +132,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Gives control of the data in an existing `VARIANT` array to the `COleSafeArray` object.
 
-```
+```cpp
 void Attach(VARIANT& varSrc);
 ```
 
@@ -153,7 +153,7 @@ The source `VARIANT`'s type is set to VT_EMPTY. This function clears the current
 
 Clears the safe array.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -209,7 +209,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Creates a copy of an existing safe array.
 
-```
+```cpp
 void Copy(LPSAFEARRAY* ppsa);
 ```
 
@@ -226,7 +226,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Allocates and initializes the data for the array.
 
-```
+```cpp
 void Create(
     VARTYPE vtSrc,
     DWORD dwDims,
@@ -264,7 +264,7 @@ This function will clear the current array data if necessary. On error, the func
 
 Creates a new one-dimensional `COleSafeArray` object.
 
-```
+```cpp
 void CreateOneDim(
     VARTYPE vtSrc,
     DWORD dwElements,
@@ -300,7 +300,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Destroys an existing array descriptor and all the data in the array.
 
-```
+```cpp
 void Destroy();
 ```
 
@@ -312,7 +312,7 @@ If objects are stored in the array, each object is released. On error, the funct
 
 Destroys all the data in a safe array.
 
-```
+```cpp
 void DestroyData();
 ```
 
@@ -324,7 +324,7 @@ If objects are stored in the array, each object is released. On error, the funct
 
 Destroys a descriptor of a safe array.
 
-```
+```cpp
 void DestroyDescriptor();
 ```
 
@@ -358,7 +358,7 @@ On error, the function throws a [COleException](../../mfc/reference/coleexceptio
 
 Copies the contents of the safe array into a `CByteArray`.
 
-```
+```cpp
 void GetByteArray(CByteArray& bytes);
 ```
 
@@ -387,7 +387,7 @@ The number of dimensions in the safe array.
 
 Retrieves a single element of the safe array.
 
-```
+```cpp
 void GetElement(
     long* rgIndices,
     void* pvData);
@@ -427,7 +427,7 @@ The size, in bytes, of the elements of a safe array.
 
 Returns the lower bound for any dimension of a `COleSafeArray` object.
 
-```
+```cpp
 void GetLBound(
     DWORD dwDim,
     long* pLBound);
@@ -469,7 +469,7 @@ The number of elements in the one-dimensional safe array.
 
 Returns the upper bound for any dimension of a safe array.
 
-```
+```cpp
 void GetUBound(
     DWORD dwDim,
     long* pUBound);
@@ -495,7 +495,7 @@ On error, the function throws a [COleException](../../mfc/reference/coleexceptio
 
 Increments the lock count of an array and place a pointer to the array data in the array descriptor.
 
-```
+```cpp
 void Lock();
 ```
 
@@ -578,7 +578,7 @@ CDumpContext& AFXAPI operator<<(
 
 Returns a pointer to the element specified by the index values.
 
-```
+```cpp
 void PtrOfIndex(
     long* rgIndices,
     void** ppvData);
@@ -596,7 +596,7 @@ On return, pointer to the element identified by the values in *rgIndices*.
 
 Assigns a single element into the array.
 
-```
+```cpp
 void PutElement(
     long* rgIndices,
     void* pvData);
@@ -626,7 +626,7 @@ On error, the function throws a [CMemoryException](../../mfc/reference/cmemoryex
 
 Changes the least significant (rightmost) bound of a safe array.
 
-```
+```cpp
 void Redim(SAFEARRAYBOUND* psaboundNew);
 ```
 
@@ -643,7 +643,7 @@ On error, the function throws a [COleException](../../mfc/reference/coleexceptio
 
 Changes the number of elements in a one-dimensional `COleSafeArray` object.
 
-```
+```cpp
 void ResizeOneDim(DWORD dwElements);
 ```
 
@@ -664,7 +664,7 @@ On error, the function throws a [COleException](../../mfc/reference/coleexceptio
 
 Decrements the lock count of an array and invalidates the pointer retrieved by `AccessData`.
 
-```
+```cpp
 void UnaccessData();
 ```
 
@@ -680,7 +680,7 @@ On error, the function throws a [COleException](../../mfc/reference/coleexceptio
 
 Decrements the lock count of an array so it can be freed or resized.
 
-```
+```cpp
 void Unlock();
 ```
 

--- a/docs/mfc/reference/coleserverdoc-class.md
+++ b/docs/mfc/reference/coleserverdoc-class.md
@@ -108,7 +108,7 @@ For more information on servers, see the article [Servers: Implementing a Server
 
 Activates the associated DocObject document.
 
-```
+```cpp
 void ActivateDocObject();
 ```
 
@@ -275,7 +275,7 @@ It calls [COleServerDoc::OnGetEmbeddedItem](#ongetembeddeditem), a virtual funct
 
 Call the `GetItemClipRect` member function to get the clipping-rectangle coordinates of the item that is being edited in place.
 
-```
+```cpp
 void GetItemClipRect(LPRECT lpClipRect) const;
 ```
 
@@ -294,7 +294,7 @@ Drawing should not occur outside the clipping rectangle. Usually, drawing is aut
 
 Call the `GetItemPosition` member function to get the coordinates of the item being edited in place.
 
-```
+```cpp
 void GetItemPosition(LPRECT lpPosRect) const;
 ```
 
@@ -385,7 +385,7 @@ Nonzero if the `COleServerDoc` object is active in place; otherwise 0.
 
 Call this function to notify all linked items connected to the document that the document has changed.
 
-```
+```cpp
 void NotifyChanged();
 ```
 
@@ -400,7 +400,7 @@ Typically, you call this function after the user changes some global attribute s
 
 Call this function to notify the container(s) that the document has been closed.
 
-```
+```cpp
 void NotifyClosed();
 ```
 
@@ -412,7 +412,7 @@ When the user chooses the Close command from the File menu, `NotifyClosed` is ca
 
 Call this function after the user renames the server document.
 
-```
+```cpp
 void NotifyRename(LPCTSTR lpszNewName);
 ```
 
@@ -429,7 +429,7 @@ When the user chooses the Save As command from the File menu, `NotifyRename` is 
 
 Call this function after the user saves the server document.
 
-```
+```cpp
 void NotifySaved();
 ```
 
@@ -771,7 +771,7 @@ The default implementation calls the [COleServerDoc::NotifySaved](#notifysaved) 
 
 Call this member function to have the container application change the item's position.
 
-```
+```cpp
 void RequestPositionChange(LPCRECT lpPosRect);
 ```
 
@@ -788,7 +788,7 @@ This function is usually called (in conjunction with `UpdateAllItems`) when the 
 
 Call this function to tell the container application to save the embedded object.
 
-```
+```cpp
 void SaveEmbedding();
 ```
 
@@ -821,7 +821,7 @@ Positive values indicate scrolling down and to the right; negative values indica
 
 Call this function to notify all linked items connected to the document that the document has changed.
 
-```
+```cpp
 void UpdateAllItems(
     COleServerItem* pSender,
     LPARAM lHint = 0L,

--- a/docs/mfc/reference/coleserveritem-class.md
+++ b/docs/mfc/reference/coleserveritem-class.md
@@ -99,7 +99,7 @@ For more information about servers and related topics, see the article [Servers:
 
 Call this function to place the presentation and conversion formats for the OLE item in the specified `COleDataSource` object.
 
-```
+```cpp
 void AddOtherClipboardData(COleDataSource* pDataSource);
 ```
 
@@ -134,7 +134,7 @@ Flag indicating whether the object can be deleted when a link to it is released.
 
 Call this function to copy the OLE item to the Clipboard.
 
-```
+```cpp
 void CopyToClipboard(BOOL bIncludeLink = FALSE);
 ```
 
@@ -199,7 +199,7 @@ For more information about how drag delay information is stored in either the re
 
 Call this function to fill the specified [COleDataSource](../../mfc/reference/coledatasource-class.md) object with all the data that would be copied to the Clipboard if you called [CopyToClipboard](#copytoclipboard) (the same data would also be transferred if you called [DoDragDrop](#dodragdrop)).
 
-```
+```cpp
 void GetClipboardData(
     COleDataSource* pDataSource,
     BOOL bIncludeLink = FALSE,
@@ -263,7 +263,7 @@ This allows access to the server document that you passed as an argument to the 
 
 Call this function to get the CF_EMBEDSOURCE data for an OLE item.
 
-```
+```cpp
 void GetEmbedSourceData(LPSTGMEDIUM lpStgMedium);
 ```
 
@@ -325,7 +325,7 @@ For more information, see [STGMEDIUM](/windows/win32/api/objidl/ns-objidl-ustgme
 
 Call this function to get the CF_OBJECTDESCRIPTOR data for an OLE item.
 
-```
+```cpp
 void GetObjectDescriptorData(
     LPPOINT lpOffset,
     LPSIZE lpSize,
@@ -399,7 +399,7 @@ The default implementation of [OnSetExtent](#onsetextent) sets this member.
 
 Call this function after the linked item has been changed.
 
-```
+```cpp
 void NotifyChanged(DVASPECT nDrawAspect = DVASPECT_CONTENT);
 ```
 
@@ -906,7 +906,7 @@ The default implementation calls [UpdateLink](../../mfc/reference/coleclientitem
 
 Call this function when you create a linked item to set its name.
 
-```
+```cpp
 void SetItemName(LPCTSTR lpszItemName);
 ```
 

--- a/docs/mfc/reference/colestreamfile-class.md
+++ b/docs/mfc/reference/colestreamfile-class.md
@@ -60,7 +60,7 @@ For more information, see [IStream](/windows/win32/api/objidl/nn-objidl-istream)
 
 Associates the supplied OLE stream with the `COleStreamFile` object.
 
-```
+```cpp
 void Attach(LPSTREAM lpStream);
 ```
 

--- a/docs/mfc/reference/coletemplateserver-class.md
+++ b/docs/mfc/reference/coletemplateserver-class.md
@@ -69,7 +69,7 @@ For a brief description of the use of the `COleTemplateServer` class, see the [C
 
 Connects the document template pointed to by *pDocTemplate* to the underlying [COleObjectFactory](../../mfc/reference/coleobjectfactory-class.md) object.
 
-```
+```cpp
 void ConnectTemplate(
     REFCLSID clsid,
     CDocTemplate* pDocTemplate,
@@ -111,7 +111,7 @@ EnterRemarks
 
 Loads file-type information from the document-template string and places that information in the OLE system registry.
 
-```
+```cpp
 void UpdateRegistry(
     OLE_APPTYPE nAppType = OAT_INPLACE_SERVER,
     LPCTSTR* rglpszRegister = NULL,

--- a/docs/mfc/reference/colevariant-class.md
+++ b/docs/mfc/reference/colevariant-class.md
@@ -71,7 +71,7 @@ For more information on the `COleVariant` class and its use in OLE automation, s
 
 Call this function to attach the given [VARIANT](/windows/win32/api/oaidl/ns-oaidl-variant) object to the current `COleVariant` object.
 
-```
+```cpp
 void Attach(VARIANT& varSrc);
 ```
 
@@ -191,7 +191,7 @@ For more information on SCODE, see [Structure of COM Error Codes](/windows/win32
 
 Converts the type of variant value in this `COleVariant` object.
 
-```
+```cpp
 void ChangeType(VARTYPE vartype, LPVARIANT pSrc = NULL);
 ```
 
@@ -211,7 +211,7 @@ For more information, see the [VARIANT](/windows/win32/api/oaidl/ns-oaidl-varian
 
 Clears the `VARIANT`.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -242,7 +242,7 @@ For more information, see the [VARIANT](/windows/win32/api/oaidl/ns-oaidl-varian
 
 Retrieves a byte array from an existing variant array
 
-```
+```cpp
 void GetByteArrayFromVariantArray(CByteArray& bytes);
 ```
 
@@ -360,7 +360,7 @@ The `COleVariant` insertion (**\<\<**) operator supports diagnostic dumping and 
 
 Sets the string to a particular type.
 
-```
+```cpp
 void SetString(LPCTSTR lpszSrc, VARTYPE vtSrc);
 ```
 

--- a/docs/mfc/reference/cpagerctrl-class.md
+++ b/docs/mfc/reference/cpagerctrl-class.md
@@ -152,7 +152,7 @@ To create a pager control, declare a `CPagerCtrl` variable, then call the [CPage
 
 Enables or disables forwarding [WM_MOUSEMOVE](/windows/win32/inputdev/wm-mousemove) messages to the window that is contained in the current pager control.
 
-```
+```cpp
 void ForwardMouse(BOOL bForward);
 ```
 
@@ -412,7 +412,7 @@ This method sends the [PGM_GETBUTTONSTATE](/windows/win32/Controls/pgm-getbutton
 
 Causes the current pager control to recalculate the size of the contained window.
 
-```
+```cpp
 void RecalcSize();
 ```
 
@@ -522,7 +522,7 @@ The following example creates a pager control, then uses the [CPagerCtrl::SetChi
 
 Sets the contained window for the current pager control.
 
-```
+```cpp
 void SetChild(HWND hwndChild);
 ```
 
@@ -548,7 +548,7 @@ The following example creates a pager control, then uses the [CPagerCtrl::SetChi
 
 Sets the scroll position of the current pager control.
 
-```
+```cpp
 void SetScrollPos(int iPos);
 ```
 

--- a/docs/mfc/reference/cpagesetupdialog-class.md
+++ b/docs/mfc/reference/cpagesetupdialog-class.md
@@ -221,7 +221,7 @@ Use a pointer to the `CString` object returned by `GetDriverName` as the value o
 
 Call this function after a call to `DoModal` to retrieve the margins of the printer device driver.
 
-```
+```cpp
 void GetMargins(
     LPRECT lpRectMargins,
     LPRECT lpRectMinMargins) const;

--- a/docs/mfc/reference/cpalette-class.md
+++ b/docs/mfc/reference/cpalette-class.md
@@ -67,7 +67,7 @@ For more information on using `CPalette`, see [Graphic Objects](../../mfc/graphi
 
 Replaces entries in the logical palette attached to the `CPalette` object.
 
-```
+```cpp
 void AnimatePalette(
     UINT nStartIndex,
     UINT nNumEntries,

--- a/docs/mfc/reference/cpane-class.md
+++ b/docs/mfc/reference/cpane-class.md
@@ -205,7 +205,7 @@ The difference in width and height between *rectRequired* and the current window
 
 Calculates the inside rectangle of a pane, including the borders and grippers.
 
-```
+```cpp
 void CalcInsideRect(
     CRect& rect,
     BOOL bHorz) const;
@@ -227,7 +227,7 @@ This method is called by the framework when it has to recalculate the layout for
 
 Calculates the recently docked rectangle.
 
-```
+```cpp
 void CalcRecentDockedRect();
 ```
 
@@ -755,7 +755,7 @@ The pane title is displayed in the caption area when the pane is docked or float
 
 Retrieves the *virtual rectangle* of the pane.
 
-```
+```cpp
 void GetVirtualRect(CRect& rectVirtual) const;
 ```
 
@@ -1246,7 +1246,7 @@ If `CMFCAutoHideButton::m_bOverlappingTabs` is FALSE, or if the pane is not loca
 
 Sets the border values of the pane.
 
-```
+```cpp
 void SetBorders(
     int cxLeft = 0,
     int cyTop = 0,
@@ -1281,7 +1281,7 @@ Call this function to set the sizes of the pane's borders.
 
 Sets the *hot spot* for the pane.
 
-```
+```cpp
 void SetClientHotSpot(const CPoint& ptNew);
 ```
 
@@ -1336,7 +1336,7 @@ By default, all toolbars have exclusive row mode disabled and the menu bar has e
 
 Sets the minimum allowed size for the pane.
 
-```
+```cpp
 void SetMinSize(const CSize& size);
 ```
 
@@ -1351,7 +1351,7 @@ void SetMinSize(const CSize& size);
 
 Sets the *virtual rectangle* of the pane.
 
-```
+```cpp
 void SetVirtualRect(
     const CRect& rect,
     BOOL bMapToParent = TRUE);
@@ -1375,7 +1375,7 @@ Do not call methods that are related to virtual rectangles unless you are moving
 
 Sets the runtime class information for the default mini-frame window.
 
-```
+```cpp
 void SetMiniFrameRTC(CRuntimeClass* pClass);
 ```
 
@@ -1447,7 +1447,7 @@ Use this method to programmatically undock a pane.
 
 Updates the virtual rectangle.
 
-```
+```cpp
 void UpdateVirtualRect();
 void UpdateVirtualRect(CPoint ptOffset);
 void UpdateVirtualRect(CSize sizeNew);

--- a/docs/mfc/reference/cpanecontainer-class.md
+++ b/docs/mfc/reference/cpanecontainer-class.md
@@ -123,7 +123,7 @@ CDockablePane* AddPane(CDockablePane* pBar);
 
 ## <a name="addref"></a> CPaneContainer::AddRef
 
-```
+```cpp
 void AddRef();
 ```
 
@@ -186,7 +186,7 @@ virtual CSize CalcAvailableSpace(
 
 ## <a name="calculaterecentsize"></a> CPaneContainer::CalculateRecentSize
 
-```
+```cpp
 void CalculateRecentSize();
 ```
 
@@ -194,7 +194,7 @@ void CalculateRecentSize();
 
 ## <a name="checkpanedividervisibility"></a> CPaneContainer::CheckPaneDividerVisibility
 
-```
+```cpp
 void CheckPaneDividerVisibility();
 ```
 
@@ -570,7 +570,7 @@ virtual void Move(CPoint ptNewLeftTop);
 
 ## <a name="ondeletehidepane"></a> CPaneContainer::OnDeleteHidePane
 
-```
+```cpp
 void OnDeleteHidePane(
     CDockablePane* pBar,
     BOOL bHide);
@@ -627,7 +627,7 @@ DWORD Release();
 
 ## <a name="releaseemptypanecontainer"></a> CPaneContainer::ReleaseEmptyPaneContainer
 
-```
+```cpp
 void ReleaseEmptyPaneContainer();
 ```
 
@@ -635,7 +635,7 @@ void ReleaseEmptyPaneContainer();
 
 ## <a name="removenonvalidpanes"></a> CPaneContainer::RemoveNonValidPanes
 
-```
+```cpp
 void RemoveNonValidPanes();
 ```
 
@@ -712,7 +712,7 @@ virtual void ResizePartOfPaneContainer(
 
 ## <a name="serialize"></a> CPaneContainer::Serialize
 
-```
+```cpp
 void Serialize(CArchive& ar);
 ```
 
@@ -724,7 +724,7 @@ void Serialize(CArchive& ar);
 
 ## <a name="setpane"></a> CPaneContainer::SetPane
 
-```
+```cpp
 void SetPane(
     CDockablePane* pBar,
     BOOL bLeft);
@@ -739,7 +739,7 @@ void SetPane(
 
 ## <a name="setpanecontainer"></a> CPaneContainer::SetPaneContainer
 
-```
+```cpp
 void SetPaneContainer(
     CPaneContainer* pContainer,
     BOOL bLeft);
@@ -754,7 +754,7 @@ void SetPaneContainer(
 
 ## <a name="setpanedivider"></a> CPaneContainer::SetPaneDivider
 
-```
+```cpp
 void SetPaneDivider(CPaneDivider* pSlider);
 ```
 
@@ -766,7 +766,7 @@ void SetPaneDivider(CPaneDivider* pSlider);
 
 ## <a name="setparentpanecontainer"></a> CPaneContainer::SetParentPaneContainer
 
-```
+```cpp
 void SetParentPaneContainer(CPaneContainer* p);
 ```
 
@@ -778,7 +778,7 @@ void SetParentPaneContainer(CPaneContainer* p);
 
 ## <a name="setrecentpercent"></a> CPaneContainer::SetRecentPercent
 
-```
+```cpp
 void SetRecentPercent(int nRecentPercent);
 ```
 

--- a/docs/mfc/reference/cpanecontainermanager-class.md
+++ b/docs/mfc/reference/cpanecontainermanager-class.md
@@ -152,7 +152,7 @@ virtual BOOL AddPaneContainerManagerToDockablePane(
 
 ## <a name="addpanestolist"></a> CPaneContainerManager::AddPanesToList
 
-```
+```cpp
 void AddPanesToList(
     CObList* plstControlBars,
     CObList* plstSliders);
@@ -167,7 +167,7 @@ void AddPanesToList(
 
 ## <a name="addpanetolist"></a> CPaneContainerManager::AddPaneToList
 
-```
+```cpp
 void AddPaneToList(CDockablePane* pControlBarToAdd);
 ```
 
@@ -196,7 +196,7 @@ virtual CDockablePane* AddPaneToRecentPaneContainer(
 
 ## <a name="calcrects"></a> CPaneContainerManager::CalcRects
 
-```
+```cpp
 void CalcRects(
     CRect& rectOriginal,
     CRect& rectInserted,
@@ -550,7 +550,7 @@ virtual BOOL IsRootPaneContainerVisible() const;
 
 ## <a name="notifypanedivider"></a> CPaneContainerManager::NotifyPaneDivider
 
-```
+```cpp
 void NotifyPaneDivider();
 ```
 
@@ -619,7 +619,7 @@ virtual CDockablePane* PaneFromPoint(
 
 ## <a name="releaseemptypanecontainers"></a> CPaneContainerManager::ReleaseEmptyPaneContainers
 
-```
+```cpp
 void ReleaseEmptyPaneContainers();
 ```
 
@@ -627,7 +627,7 @@ void ReleaseEmptyPaneContainers();
 
 ## <a name="removeallpanesandpanedividers"></a> CPaneContainerManager::RemoveAllPanesAndPaneDividers
 
-```
+```cpp
 void RemoveAllPanesAndPaneDividers();
 ```
 
@@ -635,7 +635,7 @@ void RemoveAllPanesAndPaneDividers();
 
 ## <a name="removenonvalidpanes"></a> CPaneContainerManager::RemoveNonValidPanes
 
-```
+```cpp
 void RemoveNonValidPanes();
 ```
 
@@ -710,7 +710,7 @@ virtual void ResizePaneContainers(
 
 ## <a name="serialize"></a> CPaneContainerManager::Serialize
 
-```
+```cpp
 void Serialize(CArchive& ar);
 ```
 
@@ -722,7 +722,7 @@ void Serialize(CArchive& ar);
 
 ## <a name="setdefaultpanedividerforpanes"></a> CPaneContainerManager::SetDefaultPaneDividerForPanes
 
-```
+```cpp
 void SetDefaultPaneDividerForPanes(CPaneDivider* pSlider);
 ```
 
@@ -734,7 +734,7 @@ void SetDefaultPaneDividerForPanes(CPaneDivider* pSlider);
 
 ## <a name="setpanecontainerrtc"></a> CPaneContainerManager::SetPaneContainerRTC
 
-```
+```cpp
 void SetPaneContainerRTC(CRuntimeClass* pContainerRTC);
 ```
 

--- a/docs/mfc/reference/cpanedivider-class.md
+++ b/docs/mfc/reference/cpanedivider-class.md
@@ -108,7 +108,7 @@ The following example demonstrates how to get a `CPaneDivider` object from a `CW
 
 ## <a name="setautohidemode"></a> CPaneDivider::SetAutoHideMode
 
-```
+```cpp
 void SetAutoHideMode(BOOL bMode);
 ```
 
@@ -120,7 +120,7 @@ void SetAutoHideMode(BOOL bMode);
 
 ## <a name="setpanecontainermanager"></a> CPaneDivider::SetPaneContainerManager
 
-```
+```cpp
 void SetPaneContainerManager(CPaneContainerManager* p);
 ```
 
@@ -347,7 +347,7 @@ const CBasePane* GetFirstPane() const;
 
 Returns the list of pane dividers that reside in the [CPaneContainer Class](../../mfc/reference/cpanecontainer-class.md). This method should be called only for default pane dividers.
 
-```
+```cpp
 void GetPaneDividers(CObList& lstSliders);
 ```
 
@@ -374,7 +374,7 @@ DWORD GetPaneDividerStyle() const;
 
 Returns the list of panes that reside in the [CPaneContainer Class](../../mfc/reference/cpanecontainer-class.md). This method should be called only to retrieve default pane dividers.
 
-```
+```cpp
 void GetPanes(CObList& lstBars);
 ```
 
@@ -409,7 +409,7 @@ int GetWidth() const;
 
 ## <a name="init"></a> CPaneDivider::Init
 
-```
+```cpp
 void Init(
     BOOL bDefaultSlider = FALSE,
     CWnd* pParent = NULL);
@@ -546,7 +546,7 @@ virtual void OnShowPane(
 
 ## <a name="releaseemptypanecontainers"></a> CPaneDivider::ReleaseEmptyPaneContainers
 
-```
+```cpp
 void ReleaseEmptyPaneContainers();
 ```
 
@@ -598,7 +598,7 @@ virtual void RepositionPanes(
 
 ## <a name="serialize"></a> CPaneDivider::Serialize
 
-```
+```cpp
 void Serialize(CArchive& ar);
 ```
 
@@ -610,7 +610,7 @@ void Serialize(CArchive& ar);
 
 ## <a name="showwindow"></a> CPaneDivider::ShowWindow
 
-```
+```cpp
 void ShowWindow(int nCmdShow);
 ```
 
@@ -622,7 +622,7 @@ void ShowWindow(int nCmdShow);
 
 ## <a name="storerecentdocksiteinfo"></a> CPaneDivider::StoreRecentDockSiteInfo
 
-```
+```cpp
 void StoreRecentDockSiteInfo(CDockablePane* pBar);
 ```
 
@@ -634,7 +634,7 @@ void StoreRecentDockSiteInfo(CDockablePane* pBar);
 
 ## <a name="storerecenttabrelatedinfo"></a> CPaneDivider::StoreRecentTabRelatedInfo
 
-```
+```cpp
 void StoreRecentTabRelatedInfo(
     CDockablePane* pDockingBar,
     CDockablePane* pTabbedBar);

--- a/docs/mfc/reference/cpaneframewnd-class.md
+++ b/docs/mfc/reference/cpaneframewnd-class.md
@@ -681,7 +681,7 @@ By default, the framework checks whether the mouse pointer is inside the mini-fr
 
 Stops the docking timer.
 
-```
+```cpp
 void KillDockingTimer();
 ```
 
@@ -842,7 +842,7 @@ Called by the framework when a pane in the mini-frame window is shown or hidden.
 
 ## <a name="pin"></a> CPaneFrameWnd::Pin
 
-```
+```cpp
 void Pin(BOOL bPin = TRUE);
 ```
 
@@ -991,7 +991,7 @@ virtual void SetCaptionButtons(DWORD dwButtons);
 
 ## <a name="setdelayshow"></a> CPaneFrameWnd::SetDelayShow
 
-```
+```cpp
 void SetDelayShow(BOOL bDelayShow);
 ```
 
@@ -1003,7 +1003,7 @@ void SetDelayShow(BOOL bDelayShow);
 
 ## <a name="setdockingmanager"></a> CPaneFrameWnd::SetDockingManager
 
-```
+```cpp
 void SetDockingManager(CDockingManager* pManager);
 ```
 
@@ -1017,7 +1017,7 @@ void SetDockingManager(CDockingManager* pManager);
 
 Sets the docking timer.
 
-```
+```cpp
 void SetDockingTimer(UINT nTimeOut);
 ```
 
@@ -1041,7 +1041,7 @@ virtual void SetDockState(CDockingManager* pDockManager);
 
 ## <a name="sethotpoint"></a> CPaneFrameWnd::SetHotPoint
 
-```
+```cpp
 void SetHotPoint(CPoint& ptNew);
 ```
 

--- a/docs/mfc/reference/cpictureholder-class.md
+++ b/docs/mfc/reference/cpictureholder-class.md
@@ -257,7 +257,7 @@ LPPICTURE m_pPict;
 
 Renders the picture in the rectangle referenced by *rcRender*.
 
-```
+```cpp
 void Render(
     CDC* pDC,
     const CRect& rcRender,
@@ -279,7 +279,7 @@ A rectangle representing the bounding rectangle of the object rendering the pict
 
 Connects the `CPictureHolder` object to a `IPictureDisp` interface.
 
-```
+```cpp
 void SetPictureDispatch(LPPICTUREDISP pDisp);
 ```
 

--- a/docs/mfc/reference/cprintinfo-structure.md
+++ b/docs/mfc/reference/cprintinfo-structure.md
@@ -273,7 +273,7 @@ The framework uses "Page %u\nPages %u-%u\n" as the default value. If you want a 
 
 Call this function to specify the number of the last page of the document.
 
-```
+```cpp
 void SetMaxPage(UINT nMaxPage);
 ```
 
@@ -294,7 +294,7 @@ This value is stored in the `CPrintDialog` object referenced by the `m_pPD` memb
 
 Call this function to specify the number of the first page of the document.
 
-```
+```cpp
 void SetMinPage(UINT nMinPage);
 ```
 

--- a/docs/mfc/reference/cprogressctrl-class.md
+++ b/docs/mfc/reference/cprogressctrl-class.md
@@ -219,7 +219,7 @@ The position of the progress bar control is not the physical location on the scr
 
 Gets the current lower and upper limits, or range, of the progress bar control.
 
-```
+```cpp
 void GetRange(
     int& nLower,
     int& nUpper);
@@ -451,7 +451,7 @@ The position of the progress bar control is not the physical location on the scr
 
 Sets the upper and lower limits of the progress bar control's range and redraws the bar to reflect the new ranges.
 
-```
+```cpp
 void SetRange(
     short nLower,
     short nUpper);

--- a/docs/mfc/reference/cpropertypage-class.md
+++ b/docs/mfc/reference/cpropertypage-class.md
@@ -77,7 +77,7 @@ For more information on establishing a property sheet as a wizard, see [CPropert
 
 Call this function after an unrecoverable change has been made to the data in a page of a modal property sheet.
 
-```
+```cpp
 void CancelToClose();
 ```
 
@@ -95,7 +95,7 @@ The `CancelToClose` member function does nothing in a modeless property sheet, b
 
 Call this member function to construct a `CPropertyPage` object.
 
-```
+```cpp
 void Construct(
     UINT nIDTemplate,
     UINT nIDCaption = 0);
@@ -514,7 +514,7 @@ If a page returns a nonzero value, the property sheet does not send the message 
 
 Call this member function to enable or disable the Apply Now button, based on whether the settings in the property page should be applied to the appropriate external object.
 
-```
+```cpp
 void SetModified(BOOL bChanged = TRUE);
 ```
 

--- a/docs/mfc/reference/cpropertysheet-class.md
+++ b/docs/mfc/reference/cpropertysheet-class.md
@@ -111,7 +111,7 @@ For more information about how to use `CPropertySheet` objects, see the article 
 
 Adds the supplied page with the rightmost tab in the property sheet.
 
-```
+```cpp
 void AddPage(CPropertyPage* pPage);
 ```
 
@@ -140,7 +140,7 @@ If you call `AddPage` after displaying the property page, the tab row will refle
 
 Constructs a `CPropertySheet` object.
 
-```
+```cpp
 void Construct(
     UINT nIDCaption,
     CWnd* pParentWnd = NULL,
@@ -368,7 +368,7 @@ See the example for [CPropertySheet::AddPage](#addpage).
 
 Indicates whether to stack rows of tabs in a property sheet.
 
-```
+```cpp
 void EnableStackedTabs(BOOL bStacked);
 ```
 
@@ -391,7 +391,7 @@ You must call `EnableStackedTabs` when you create a modal or a modeless property
 
 Terminates the property sheet.
 
-```
+```cpp
 void EndDialog(int nEndID);
 ```
 
@@ -546,7 +546,7 @@ For more information on this structure, including a listing of its members, see 
 
 Converts the dialog-box units of a rectangle to screen units.
 
-```
+```cpp
 void MapDialogRect(LPRECT lpRect) const;
 ```
 
@@ -587,7 +587,7 @@ You do not need a message-map entry for this member function.
 
 Simulates the choice of the specified button in a property sheet.
 
-```
+```cpp
 void PressButton(int nButton);
 ```
 
@@ -624,7 +624,7 @@ A call to `PressButton` will not send the [PSN_APPLY](/windows/win32/Controls/ps
 
 Removes a page from the property sheet and destroys the associated window.
 
-```
+```cpp
 void RemovePage(CPropertyPage* pPage);
 void RemovePage(int nPage);
 ```
@@ -674,7 +674,7 @@ See the example for [CPropertySheet::GetActivePage](#getactivepage).
 
 Sets the text in the Finish command button.
 
-```
+```cpp
 void SetFinishText(LPCTSTR lpszText);
 ```
 
@@ -695,7 +695,7 @@ Call `SetFinishText` to display the text on the Finish command button and hide t
 
 Specifies the property sheet's caption (the text displayed in the title bar of a frame window).
 
-```
+```cpp
 void SetTitle(
     LPCTSTR lpszText,
     UINT nStyle = 0);
@@ -721,7 +721,7 @@ By default, a property sheet uses the caption parameter in the property sheet co
 
 Enables or disables the Back, Next, or Finish button in a wizard property sheet.
 
-```
+```cpp
 void SetWizardButtons(DWORD dwFlags);
 ```
 
@@ -758,7 +758,7 @@ A `CPropertySheet` has three wizard property pages: `CStylePage`, `CColorPage`, 
 
 Establishes a property page as a wizard.
 
-```
+```cpp
 void SetWizardMode();
 ```
 

--- a/docs/mfc/reference/crebarctrl-class.md
+++ b/docs/mfc/reference/crebarctrl-class.md
@@ -123,7 +123,7 @@ For more information, see [Using CReBarCtrl](../../mfc/using-crebarctrl.md).
 
 Implements the behavior of the Win32 message [RB_BEGINDRAG](/windows/win32/Controls/rb-begindrag), as described in the Windows SDK.
 
-```
+```cpp
 void BeginDrag(
     UINT uBand,
     DWORD dwPos = (DWORD)-1);
@@ -256,7 +256,7 @@ Nonzero if the band deleted successfully; otherwise zero.
 
 Implements the behavior of the Win32 message [RB_DRAGMOVE](/windows/win32/Controls/rb-dragmove), as described in the Windows SDK.
 
-```
+```cpp
 void DragMove(DWORD dwPos = (DWORD)-1);
 ```
 
@@ -269,7 +269,7 @@ A DWORD value that contains the new mouse coordinates. The horizontal coordinate
 
 Implements the behavior of the Win32 message [RB_ENDDRAG](/windows/win32/Controls/rb-enddrag), as described in the Windows SDK.
 
-```
+```cpp
 void EndDrag();
 ```
 
@@ -277,7 +277,7 @@ void EndDrag();
 
 Implements the behavior of the Win32 message [RB_GETBANDBORDERS](/windows/win32/Controls/rb-getbandborders), as described in the Windows SDK.
 
-```
+```cpp
 void GetBandBorders(
     UINT uBand,
     LPRECT prc) const;
@@ -329,7 +329,7 @@ Nonzero if successful; otherwise zero.
 
 Retrieves the margins of the band.
 
-```
+```cpp
 void GetBandMargins(PMARGINS pMargins);
 ```
 
@@ -623,7 +623,7 @@ Nonzero if successful; otherwise zero.
 
 Resizes a band in a rebar control to its largest size.
 
-```
+```cpp
 void MaximizeBand(UINT uBand);
 ```
 
@@ -644,7 +644,7 @@ Implements the behavior of the Win32 message [RB_MAXIMIZEBAND](/windows/win32/Co
 
 Resizes a band in a rebar control to its smallest size.
 
-```
+```cpp
 void MinimizeBand(UINT uBand);
 ```
 
@@ -687,7 +687,7 @@ Nonzero if successful; otherwise zero.
 
 Implements the behavior of the Win32 message [RB_PUSHCHEVRON](/windows/win32/Controls/rb-pushchevron), as described in the Windows SDK.
 
-```
+```cpp
 void PushChevron(
     UINT uBand,
     LPARAM lAppValue);
@@ -705,7 +705,7 @@ An application defined 32-bit value. See *lAppValue* in [RB_PUSHCHEVRON](/window
 
 Resizes a band in a rebar control to its ideal size.
 
-```
+```cpp
 void RestoreBand(UINT uBand);
 ```
 
@@ -831,7 +831,7 @@ See this topic for more information about when to set the background color, and 
 
 Sets the color scheme for the buttons on a rebar control.
 
-```
+```cpp
 void SetColorScheme(const COLORSCHEME* lpcs);
 ```
 
@@ -956,7 +956,7 @@ It is provided to support text color flexibility in a rebar control.
 
 Associates a tool tip control with a rebar control.
 
-```
+```cpp
 void SetToolTips(CToolTipCtrl* pToolTip);
 ```
 

--- a/docs/mfc/reference/crecentdocksiteinfo-class.md
+++ b/docs/mfc/reference/crecentdocksiteinfo-class.md
@@ -59,7 +59,7 @@ A `CRecentDockSiteInfo` object is created every time that a pane is created. Eac
 
 ## <a name="cleanup"></a> CRecentDockSiteInfo::CleanUp
 
-```
+```cpp
 void CleanUp();
 ```
 
@@ -159,7 +159,7 @@ CPaneContainer* GetRecentTabContainer(BOOL bForSlider);
 
 ## <a name="init"></a> CRecentDockSiteInfo::Init
 
-```
+```cpp
 void Init();
 ```
 
@@ -195,7 +195,7 @@ CRecentDockSiteInfo& operator=(CRecentDockSiteInfo& src);
 
 ## <a name="savelistofrecentpanes"></a> CRecentDockSiteInfo::SaveListOfRecentPanes
 
-```
+```cpp
 void SaveListOfRecentPanes(CList<HWND,
     HWND>& lstOrg,
     BOOL bForSlider);

--- a/docs/mfc/reference/crecordset-class.md
+++ b/docs/mfc/reference/crecordset-class.md
@@ -199,7 +199,7 @@ For more information about bookmarks and recordset navigation, see the articles 
 
 Requests that the data source cancel either an asynchronous operation in progress or a process from a second thread.
 
-```
+```cpp
 void Cancel();
 ```
 
@@ -211,7 +211,7 @@ Note that the MFC ODBC classes no longer use asynchronous processing; to perform
 
 Cancels any pending updates, caused by an [Edit](#edit) or [AddNew](#addnew) operation, before [Update](#update) is called.
 
-```
+```cpp
 void CancelUpdate();
 ```
 
@@ -511,7 +511,7 @@ The following code assumes that `COutParamRecordset` is a `CRecordset`-derived o
 
 Obtains the bookmark value for the current record.
 
-```
+```cpp
 void GetBookmark(CDBVariant& varBookmark);
 ```
 
@@ -579,7 +579,7 @@ For more information, see the article [Recordset: Declaring a Class for a Table 
 
 Retrieves field data in the current record.
 
-```
+```cpp
 void GetFieldValue(
     LPCTSTR lpszName,
     CDBVariant& varValue,
@@ -674,7 +674,7 @@ For more information about creating recordsets, see the article [Recordset: Crea
 
 Obtains information about the fields in the recordset.
 
-```
+```cpp
 void GetODBCFieldInfo(
     LPCTSTR lpszName,
     CODBCFieldInfo& fieldinfo);
@@ -800,7 +800,7 @@ For more information, see the ODBC API function `SQLExtendedFetch` in the Window
 
 Determines the index of the current record in the recordset and whether the last record has been seen.
 
-```
+```cpp
 void GetStatus(CRecordsetStatus& rStatus) const;
 ```
 
@@ -1206,7 +1206,7 @@ For more information about recordset navigation, see the articles [Recordset: Sc
 
 Makes the first record in the first rowset the current record.
 
-```
+```cpp
 void MoveFirst();
 ```
 
@@ -1238,7 +1238,7 @@ For more information about recordset navigation, see the articles [Recordset: Sc
 
 Makes the first record in the last complete rowset the current record.
 
-```
+```cpp
 void MoveLast();
 ```
 
@@ -1268,7 +1268,7 @@ For more information about recordset navigation, see the articles [Recordset: Sc
 
 Makes the first record in the next rowset the current record.
 
-```
+```cpp
 void MoveNext();
 ```
 
@@ -1298,7 +1298,7 @@ For more information about recordset navigation, see the articles [Recordset: Sc
 
 Makes the first record in the previous rowset the current record.
 
-```
+```cpp
 void MovePrev();
 ```
 
@@ -1486,7 +1486,7 @@ The following code examples show different forms of the `Open` call.
 
 Updates the data and the status for a row in the current rowset.
 
-```
+```cpp
 void RefreshRowset(
     WORD wRow,
     WORD wLockType = SQL_LOCK_NO_CHANGE);
@@ -1551,7 +1551,7 @@ This example rebuilds a recordset to apply a different sort order.
 
 Positions the recordset on the record corresponding to the specified record number.
 
-```
+```cpp
 void SetAbsolutePosition(long nRows);
 ```
 
@@ -1580,7 +1580,7 @@ For more information about recordset navigation and bookmarks, see the articles 
 
 Positions the recordset on the record containing the specified bookmark.
 
-```
+```cpp
 void SetBookmark(const CDBVariant& varBookmark);
 ```
 
@@ -1607,7 +1607,7 @@ For more information about bookmarks and recordset navigation, see the articles 
 
 Flags a field data member of the recordset as changed or as unchanged.
 
-```
+```cpp
 void SetFieldDirty(void* pv, BOOL bDirty = TRUE);
 ```
 
@@ -1647,7 +1647,7 @@ This means you cannot set all `param` fields to NULL, as you can with `outputCol
 
 Flags a field data member of the recordset as Null (specifically having no value) or as non-Null.
 
-```
+```cpp
 void SetFieldNull(void* pv, BOOL bNull = TRUE);
 ```
 
@@ -1692,7 +1692,7 @@ This means you cannot set all `param` fields to NULL, as you can with `outputCol
 
 Sets the locking mode to "optimistic" locking (the default) or "pessimistic" locking. Determines how records are locked for updates.
 
-```
+```cpp
 void SetLockingMode(UINT nMode);
 ```
 
@@ -1713,7 +1713,7 @@ Call this member function if you need to specify which of two record-locking str
 
 Flags a parameter as Null (specifically having no value) or as non-Null.
 
-```
+```cpp
 void SetParamNull(
     int nIndex,
     BOOL bNull = TRUE);
@@ -1737,7 +1737,7 @@ Unlike [SetFieldNull](#setfieldnull), you can call `SetParamNull` before you hav
 
 Moves the cursor to a row within the current rowset.
 
-```
+```cpp
 void SetRowsetCursorPosition(WORD wRow, WORD wLockType = SQL_LOCK_NO_CHANGE);
 ```
 

--- a/docs/mfc/reference/crecttracker-class.md
+++ b/docs/mfc/reference/crecttracker-class.md
@@ -134,7 +134,7 @@ The default constructor initializes the `CRectTracker` object with the values fr
 
 Call this function to draw the rectangle's outer lines and inner region.
 
-```
+```cpp
 void Draw(CDC* pDC) const;
 ```
 
@@ -207,7 +207,7 @@ Override this member function to hide or show the indicated resize handles.
 
 Call this function to retrieve the coordinates of the rectangle.
 
-```
+```cpp
 void GetTrueRect(LPRECT lpTrueRect) const;
 ```
 

--- a/docs/mfc/reference/crendertarget-class.md
+++ b/docs/mfc/reference/crendertarget-class.md
@@ -120,7 +120,7 @@ virtual ~CRenderTarget();
 
 Attaches existing render target interface to the object
 
-```
+```cpp
 void Attach(ID2D1RenderTarget* pRenderTarget);
 ```
 
@@ -133,7 +133,7 @@ Existing render target interface. Cannot be NULL
 
 Initiates drawing on this render target.
 
-```
+```cpp
 void BeginDraw();
 ```
 
@@ -141,7 +141,7 @@ void BeginDraw();
 
 Clears the drawing area to the specified color.
 
-```
+```cpp
 void Clear(D2D1_COLOR_F color);
 ```
 
@@ -246,7 +246,7 @@ Pointer to detached render target interface.
 
 Draws the formatted text described by the specified IDWriteTextLayout object.
 
-```
+```cpp
 void DrawBitmap(
     CD2DBitmap* pBitmap,
     const CD2DRectF& rectDest,
@@ -276,7 +276,7 @@ The size and position, in device-independent pixels in the bitmap's coordinate s
 
 Draws the outline of the specified ellipse using the specified stroke style.
 
-```
+```cpp
 void DrawEllipse(
     const CD2DEllipse& ellipse,
     CD2DBrush* pBrush,
@@ -302,7 +302,7 @@ The style of stroke to apply to the ellipse's outline, or NULL to paint a solid 
 
 Draws the outline of the specified geometry using the specified stroke style.
 
-```
+```cpp
 void DrawGeometry(
     CD2DGeometry* pGeometry,
     CD2DBrush* pBrush,
@@ -328,7 +328,7 @@ The style of stroke to apply to the geometry's outline, or NULL to paint a solid
 
 Draws the specified glyphs.
 
-```
+```cpp
 void DrawGlyphRun(
     const CD2DPointF& ptBaseLineOrigin,
     const DWRITE_GLYPH_RUN& glyphRun,
@@ -354,7 +354,7 @@ A value that indicates how glyph metrics are used to measure text when it is for
 
 Draws a line between the specified points using the specified stroke style.
 
-```
+```cpp
 void DrawLine(
     const CD2DPointF& ptFrom,
     const CD2DPointF& ptTo,
@@ -384,7 +384,7 @@ The style of stroke to paint, or NULL to paint a solid line.
 
 Draws the outline of a rectangle that has the specified dimensions and stroke style.
 
-```
+```cpp
 void DrawRectangle(
     const CD2DRectF& rectangle,
     CD2DBrush* pBrush,
@@ -410,7 +410,7 @@ The style of stroke to paint, or NULL to paint a solid stroke.
 
 Draws the outline of the specified rounded rectangle using the specified stroke style.
 
-```
+```cpp
 void DrawRoundedRectangle(
     const CD2DRoundedRect& rectRounded,
     CD2DBrush* pBrush,
@@ -436,7 +436,7 @@ The style of the rounded rectangle's stroke, or NULL to paint a solid stroke. Th
 
 Draws the specified text using the format information provided by an IDWriteTextFormat object.
 
-```
+```cpp
 void DrawText(
     const CString& strText,
     const CD2DRectF& rectangle,
@@ -470,7 +470,7 @@ A value that indicates how glyph metrics are used to measure text when it is for
 
 Draws the formatted text described by the specified IDWriteTextLayout object.
 
-```
+```cpp
 void DrawTextLayout(
     const CD2DPointF& ptOrigin,
     CD2DTextLayout* textLayout,
@@ -508,7 +508,7 @@ If the method succeeds, it returns S_OK. Otherwise, it returns an HRESULT error 
 
 Paints the interior of the specified ellipse.
 
-```
+```cpp
 void FillEllipse(
     const CD2DEllipse& ellipse,
     CD2DBrush* pBrush);
@@ -526,7 +526,7 @@ The brush used to paint the interior of the ellipse.
 
 Paints the interior of the specified geometry.
 
-```
+```cpp
 void FillGeometry(
     CD2DGeometry* pGeometry,
     CD2DBrush* pBrush,
@@ -548,7 +548,7 @@ The opacity mask to apply to the geometry;NULL for no opacity mask. If an opacit
 
 Paints the interior of the specified mesh.
 
-```
+```cpp
 void FillMesh(
     CD2DMesh* pMesh,
     CD2DBrush* pBrush);
@@ -566,7 +566,7 @@ The brush used to paint the mesh.
 
 Applies the opacity mask described by the specified bitmap to a brush and uses that brush to paint a region of the render target.
 
-```
+```cpp
 void FillOpacityMask(
     CD2DBitmap* pOpacityMask,
     CD2DBrush* pBrush,
@@ -596,7 +596,7 @@ The region of the bitmap to use as the opacity mask, in device-independent pixel
 
 Paints the interior of the specified rectangle.
 
-```
+```cpp
 void FillRectangle(
     const CD2DRectF& rectangle,
     CD2DBrush* pBrush);
@@ -614,7 +614,7 @@ The brush used to paint the rectangle's interior.
 
 Paints the interior of the specified rounded rectangle.
 
-```
+```cpp
 void FillRoundedRectangle(
     const CD2DRoundedRect& rectRounded,
     CD2DBrush* pBrush);
@@ -632,7 +632,7 @@ The brush used to paint the interior of the rounded rectangle.
 
 Executes all pending drawing commands.
 
-```
+```cpp
 void Flush(
     D2D1_TAG* tag1 = NULL,
     D2D1_TAG* tag2 = NULL);
@@ -734,7 +734,7 @@ The current size of the render target in device-independent pixels
 
 Gets the label for subsequent drawing operations.
 
-```
+```cpp
 void GetTags(
     D2D1_TAG* tag1 = NULL,
     D2D1_TAG* tag2 = NULL) const;
@@ -764,7 +764,7 @@ Current antialiasing mode for text and glyph drawing operations.
 
 Retrieves the render target's current text rendering options.
 
-```
+```cpp
 void GetTextRenderingParams(IDWriteRenderingParams** textRenderingParams);
 ```
 
@@ -777,7 +777,7 @@ When this method returns, textRenderingParamscontains the address of a pointer t
 
 Gets the current transform of the render target.
 
-```
+```cpp
 void GetTransform(D2D1_MATRIX_3X2_F* transform);
 ```
 
@@ -855,7 +855,7 @@ Pointer to an ID2D1RenderTarget interface or NULL if object is not initialized y
 
 Removes the last axis-aligned clip from the render target. After this method is called, the clip is no longer applied to subsequent drawing operations.
 
-```
+```cpp
 void PopAxisAlignedClip();
 ```
 
@@ -863,7 +863,7 @@ void PopAxisAlignedClip();
 
 Stops redirecting drawing operations to the layer that is specified by the last PushLayer call.
 
-```
+```cpp
 void PopLayer();
 ```
 
@@ -871,7 +871,7 @@ void PopLayer();
 
 Removes the last axis-aligned clip from the render target. After this method is called, the clip is no longer applied to subsequent drawing operations.
 
-```
+```cpp
 void PushAxisAlignedClip(
     const CD2DRectF& rectClip,
     D2D1_ANTIALIAS_MODE mode = D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
@@ -889,7 +889,7 @@ The antialiasing mode that is used to draw the edges of clip rectangles that hav
 
 Adds the specified layer to the render target so that it receives all subsequent drawing operations until PopLayer is called.
 
-```
+```cpp
 void PushLayer(
     const D2D1_LAYER_PARAMETERS& layerParameters,
     CD2DLayer& layer);
@@ -907,7 +907,7 @@ The layer that receives subsequent drawing operations.
 
 Sets the render target's drawing state to that of the specified ID2D1DrawingStateBlock.
 
-```
+```cpp
 void RestoreDrawingState(ID2D1DrawingStateBlock& drawingStateBlock);
 ```
 
@@ -920,7 +920,7 @@ The new drawing state of the render target.
 
 Saves the current drawing state to the specified ID2D1DrawingStateBlock.
 
-```
+```cpp
 void SaveDrawingState(ID2D1DrawingStateBlock& drawingStateBlock) const;
 ```
 
@@ -933,7 +933,7 @@ When this method returns, contains the current drawing state of the render targe
 
 Sets the antialiasing mode of the render target. The antialiasing mode applies to all subsequent drawing operations, excluding text and glyph drawing operations.
 
-```
+```cpp
 void SetAntialiasMode(D2D1_ANTIALIAS_MODE antialiasMode);
 ```
 
@@ -946,7 +946,7 @@ The antialiasing mode for future drawing operations.
 
 Sets the dots per inch (DPI) of the render target.
 
-```
+```cpp
 void SetDpi(const CD2DSizeF& sizeDPI);
 ```
 
@@ -959,7 +959,7 @@ A value greater than or equal to zero that specifies the horizontal/verticalDPI 
 
 Specifies a label for subsequent drawing operations.
 
-```
+```cpp
 void SetTags(
     D2D1_TAG tag1,
     D2D1_TAG tag2);
@@ -977,7 +977,7 @@ A label to apply to subsequent drawing operations.
 
 Specifies the antialiasing mode to use for subsequent text and glyph drawing operations.
 
-```
+```cpp
 void SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE textAntialiasMode);
 ```
 
@@ -990,7 +990,7 @@ The antialiasing mode to use for subsequent text and glyph drawing operations.
 
 Specifies text rendering options to be applied to all subsequent text and glyph drawing operations.
 
-```
+```cpp
 void SetTextRenderingParams(IDWriteRenderingParams* textRenderingParams = NULL);
 ```
 
@@ -1003,7 +1003,7 @@ The text rendering options to be applied to all subsequent text and glyph drawin
 
 Applies the specified transform to the render target, replacing the existing transformation. All subsequent drawing operations occur in the transformed space.
 
-```
+```cpp
 void SetTransform(const D2D1_MATRIX_3X2_F* transform);
 void SetTransform(const D2D1_MATRIX_3X2_F& transform);
 ```

--- a/docs/mfc/reference/crgn-class.md
+++ b/docs/mfc/reference/crgn-class.md
@@ -757,7 +757,7 @@ Nonzero if any part of the specified rectangle lies within the boundaries of the
 
 Creates a rectangular region.
 
-```
+```cpp
 void SetRectRgn(
     int x1,
     int y1,

--- a/docs/mfc/reference/cricheditcntritem-class.md
+++ b/docs/mfc/reference/cricheditcntritem-class.md
@@ -83,7 +83,7 @@ For more information, see the [REOBJECT](/windows/win32/api/richole/ns-richole-r
 
 Call this function to synchronize the device aspect, [DVASPECT](/windows/win32/api/wtypes/ne-wtypes-dvaspect), of this `CRichEditCntrltem` to that specified by *reo*.
 
-```
+```cpp
 void SyncToRichEditObject(REOBJECT& reo);
 ```
 

--- a/docs/mfc/reference/cricheditctrl-class.md
+++ b/docs/mfc/reference/cricheditctrl-class.md
@@ -223,7 +223,7 @@ For more information, see [EM_CHARFROMPOS](/windows/win32/Controls/em-charfrompo
 
 Deletes (clears) the current selection (if any) in the rich edit control.
 
-```
+```cpp
 void Clear();
 ```
 
@@ -243,7 +243,7 @@ For more information, see [WM_CLEAR](/windows/win32/dataxchg/wm-clear) in the Wi
 
 Copies the current selection (if any) in the rich edit control to the Clipboard.
 
-```
+```cpp
 void Copy();
 ```
 
@@ -371,7 +371,7 @@ Use [Create](#create) to construct the Windows rich edit control.
 
 Delete (cuts) the current selection (if any) in the rich edit control and copies the deleted text to the Clipboard.
 
-```
+```cpp
 void Cut();
 ```
 
@@ -418,7 +418,7 @@ For more information, see [EM_DISPLAYBAND](/windows/win32/Controls/em-displayban
 
 Resets (clear) the undo flag of this rich edit control.
 
-```
+```cpp
 void EmptyUndoBuffer();
 ```
 
@@ -812,7 +812,7 @@ This member function is available with only the Asian-language versions of the o
 
 Retrieves the formatting rectangle for this `CRichEditCtrl` object.
 
-```
+```cpp
 void GetRect(LPRECT lpRect) const;
 ```
 
@@ -851,7 +851,7 @@ The types of actions that can be undone or redone include typing, delete, drag-d
 
 Retrieves the bounds of the current selection in this `CRichEditCtrl` object.
 
-```
+```cpp
 void GetSel(CHARRANGE& cr) const;
 
 void GetSel(
@@ -1102,7 +1102,7 @@ This member function is available only for Asian-language versions of the operat
 
 Changes the visibility of the selection.
 
-```
+```cpp
 void HideSelection(
     BOOL bHide,
     BOOL bPerm);
@@ -1130,7 +1130,7 @@ For more information, see [EM_HIDESELECTION](/windows/win32/Controls/em-hidesele
 
 Limits the length of the text that the user can enter into an edit control.
 
-```
+```cpp
 void LimitText(long nChars = 0);
 ```
 
@@ -1237,7 +1237,7 @@ For more information, see [EM_LINELENGTH](/windows/win32/Controls/em-linelength)
 
 Scrolls the text of a multiple-line edit control.
 
-```
+```cpp
 void LineScroll(
     int nLines,
     int nChars = 0);
@@ -1267,7 +1267,7 @@ For more information, see [EM_LINESCROLL](/windows/win32/Controls/em-linescroll)
 
 Inserts the data from the Clipboard into the `CRichEditCtrl` at the insertion point, the location of the caret.
 
-```
+```cpp
 void Paste();
 ```
 
@@ -1285,7 +1285,7 @@ For more information, see [WM_PASTE](/windows/win32/dataxchg/wm-paste) in the Wi
 
 Pastes data in a specific Clipboard format into this `CRichEditCtrl` object.
 
-```
+```cpp
 void PasteSpecial(
     UINT nClipFormat,
     DWORD dvAspect = 0,
@@ -1354,7 +1354,7 @@ For more information, see [EM_REDO](/windows/win32/Controls/em-redo) in the Wind
 
 Replaces the current selection in this `CRichEditCtrl` object with the specified text.
 
-```
+```cpp
 void ReplaceSel(
     LPCTSTR lpszNewText,
     BOOL bCanUndo = FALSE);
@@ -1386,7 +1386,7 @@ For more information, see [EM_REPLACESEL](/windows/win32/Controls/em-replacesel)
 
 Forces this `CRichEditCtrl` object to send EN_REQUESTRESIZE notification messages to its parent window.
 
-```
+```cpp
 void RequestResize();
 ```
 
@@ -1513,7 +1513,7 @@ For more information, see [EM_SETEVENTMASK](/windows/win32/Controls/em-seteventm
 
 Sets or clears the modified flag for an edit control.
 
-```
+```cpp
 void SetModify(BOOL bModified = TRUE);
 ```
 
@@ -1559,7 +1559,7 @@ For more information, see [EM_SETOLECALLBACK](/windows/win32/Controls/em-setolec
 
 Sets the options for this `CRichEditCtrl` object.
 
-```
+```cpp
 void SetOptions(
     WORD wOp,
     DWORD dwFlags);
@@ -1694,7 +1694,7 @@ For more information, see [EM_SETREADONLY](/windows/win32/Controls/em-setreadonl
 
 Sets the formatting rectangle for this `CRichEditCtrl` object.
 
-```
+```cpp
 void SetRect(LPCRECT lpRect);
 ```
 
@@ -1717,7 +1717,7 @@ For more information, see [EM_SETRECT](/windows/win32/Controls/em-setrect) in th
 
 Sets the selection within this `CRichEditCtrl` object.
 
-```
+```cpp
 void SetSel(
     long nStartChar,
     long nEndChar);
@@ -1922,7 +1922,7 @@ This message is available only in Asian-language versions of the operating syste
 
 Stops the control from collecting additional typing actions into the current undo action.
 
-```
+```cpp
 void StopGroupTyping();
 ```
 

--- a/docs/mfc/reference/cricheditview-class.md
+++ b/docs/mfc/reference/cricheditview-class.md
@@ -116,7 +116,7 @@ For an example of using a rich edit view in an MFC application, see the [WORDPAD
 
 Call this function to move the given dialog box so that it does not obscure the current selection.
 
-```
+```cpp
 void AdjustDialogPosition(CDialog* pDlg);
 ```
 
@@ -149,7 +149,7 @@ CRichEditView();
 
 Call this function to paste the OLE item in *dataobj* into this rich edit document/view.
 
-```
+```cpp
 void DoPaste(
     COleDataObject& dataobj,
     CLIPFORMAT cf,
@@ -541,7 +541,7 @@ The number of characters or bytes in the edit control. If incompatible flags wer
 
 Call this function to insert the specified file (as a [CRichEditCntrItem](../../mfc/reference/cricheditcntritem-class.md) object) into a rich edit view.
 
-```
+```cpp
 void InsertFileAsObject(LPCTSTR lpszFileName);
 ```
 
@@ -643,7 +643,7 @@ One of the following values:
 
 Call this function to toggle the character formatting effects for the current selection.
 
-```
+```cpp
 void OnCharEffect(
     DWORD dwMask,
     DWORD dwEffect);
@@ -742,7 +742,7 @@ For more information, see [IStorage](/windows/win32/api/objidl/nn-objidl-istorag
 
 Call this function to change the paragraph alignment for the selected paragraphs.
 
-```
+```cpp
 void OnParaAlign(WORD wAlign);
 ```
 
@@ -873,7 +873,7 @@ For more information, see [MessageBeep](/windows/win32/api/winuser/nf-winuser-me
 
 The framework calls this function to update the command UI for character effect commands.
 
-```
+```cpp
 void OnUpdateCharEffect(
     CCmdUI* pCmdUI,
     DWORD dwMask,
@@ -905,7 +905,7 @@ For more information on the *dwMask* and *dwEffect* parameters and their potenti
 
 The framework calls this function to update the command UI for paragraph effect commands.
 
-```
+```cpp
 void OnUpdateParaAlign(
     CCmdUI* pCmdUI,
     WORD wAlign);
@@ -1051,7 +1051,7 @@ For more information on HRESULT and `IDataObject`, see [Structure of COM Error C
 
 Call this function to set the character formatting attributes for new text in this `CRichEditView` object.
 
-```
+```cpp
 void SetCharFormat(CHARFORMAT2 cf);
 ```
 
@@ -1074,7 +1074,7 @@ For more information, see [EM_SETCHARFORMAT](/windows/win32/Controls/em-setcharf
 
 Call this function to set the printing margins for this rich edit view.
 
-```
+```cpp
 void SetMargins(const CRect& rectMargin);
 ```
 
@@ -1097,7 +1097,7 @@ Note that the margins used by [PrintPage](#printpage) are relative to the physic
 
 Call this function to set the paper size for printing this rich edit view.
 
-```
+```cpp
 void SetPaperSize(CSize sizePaper);
 ```
 
@@ -1145,7 +1145,7 @@ For more information, see [EM_SETPARAFORMAT](/windows/win32/Controls/em-setparaf
 
 Call this function to reset the internal search state of the [CRichEditView](../../mfc/reference/cricheditview-class.md) control after a failed call to [FindText](#findtext).
 
-```
+```cpp
 void TextNotFound(LPCTSTR lpszFind);
 ```
 

--- a/docs/mfc/reference/cscrollbar-class.md
+++ b/docs/mfc/reference/cscrollbar-class.md
@@ -255,7 +255,7 @@ The current position is a relative value that depends on the current scrolling r
 
 Copies the current minimum and maximum scroll-bar positions for the given scroll bar to the locations specified by *lpMinPos* and *lpMaxPos*.
 
-```
+```cpp
 void GetScrollRange(
     LPINT lpMinPos,
     LPINT lpMaxPos) const;
@@ -343,7 +343,7 @@ Set *bRedraw* to FALSE whenever the scroll bar will be redrawn by a subsequent c
 
 Sets minimum and maximum position values for the given scroll bar.
 
-```
+```cpp
 void SetScrollRange(
     int nMinPos,
     int nMaxPos,
@@ -379,7 +379,7 @@ The difference between the values specified by *nMinPos* and *nMaxPos* must not 
 
 Shows or hides a scroll bar.
 
-```
+```cpp
 void ShowScrollBar(BOOL bShow = TRUE);
 ```
 

--- a/docs/mfc/reference/cscrollview-class.md
+++ b/docs/mfc/reference/cscrollview-class.md
@@ -94,7 +94,7 @@ For more information on using `CScrollView`, see [Document/View Architecture](..
 
 Call this member function to determine if the scroll view has horizontal and vertical bars.
 
-```
+```cpp
 void CheckScrollBars(
     BOOL& bHasHorzBar,
     BOOL& bHasVertBar) const;
@@ -124,7 +124,7 @@ You must call either `SetScrollSizes` or `SetScaleToFitSize` before the scroll v
 
 Call `FillOutsideRect` to fill the area of the view that appears outside of the scrolling area.
 
-```
+```cpp
 void FillOutsideRect(
     CDC* pDC,
     CBrush* pBrush);
@@ -168,7 +168,7 @@ This coordinate pair corresponds to the location in the document to which the up
 
 `GetDeviceScrollSizes` gets the current mapping mode, the total size, and the line and page sizes of the scrollable view.
 
-```
+```cpp
 void GetDeviceScrollSizes(
     int& nMapMode,
     SIZE& sizeTotal,
@@ -228,7 +228,7 @@ The total size of the scroll view in logical units. The horizontal size is in th
 
 Call `ResizeParentToFit` to let the size of your view dictate the size of its frame window.
 
-```
+```cpp
 void ResizeParentToFit(BOOL bShrinkOnly = TRUE);
 ```
 
@@ -249,7 +249,7 @@ This is recommended only for views in MDI child frame windows. Use `ResizeParent
 
 Call `ScrollToPosition` to scroll to a given point in the view.
 
-```
+```cpp
 void ScrollToPosition(POINT pt);
 ```
 
@@ -266,7 +266,7 @@ The view will be scrolled so that this point is at the upper-left corner of the 
 
 Call `SetScaleToFitSize` when you want to scale the viewport size to the current window size automatically.
 
-```
+```cpp
 void SetScaleToFitSize(SIZE sizeTotal);
 ```
 
@@ -291,7 +291,7 @@ You'll typically place the call to `SetScaleToFitSize` in your override of the v
 
 Call `SetScrollSizes` when the view is about to be updated.
 
-```
+```cpp
 void SetScrollSizes(
     int nMapMode,
     SIZE sizeTotal,

--- a/docs/mfc/reference/csharedfile-class.md
+++ b/docs/mfc/reference/csharedfile-class.md
@@ -96,7 +96,7 @@ You can reopen it by calling [SetHandle](#sethandle), using the handle returned 
 
 Call this function to attach a block of global memory to the `CSharedFile` object.
 
-```
+```cpp
 void SetHandle(
     HGLOBAL hGlobalMemory,
     BOOL bAllowGrow = TRUE);

--- a/docs/mfc/reference/cshellmanager-class.md
+++ b/docs/mfc/reference/cshellmanager-class.md
@@ -182,7 +182,7 @@ In most cases, you do not have to create a `CShellManager` directly. By default,
 
 Deletes an item list.
 
-```
+```cpp
 void FreeItem(LPITEMIDLIST pidl);
 ```
 

--- a/docs/mfc/reference/csliderctrl-class.md
+++ b/docs/mfc/reference/csliderctrl-class.md
@@ -93,7 +93,7 @@ For more information on using `CSliderCtrl`, see [Controls](../../mfc/controls-m
 
 Clears the current selection in a slider control.
 
-```
+```cpp
 void ClearSel(BOOL bRedraw = FALSE);
 ```
 
@@ -106,7 +106,7 @@ Redraw flag. If this parameter is TRUE, the slider is redrawn after the selectio
 
 Removes the current tick marks from a slider control.
 
-```
+```cpp
 void ClearTics(BOOL bRedraw = FALSE);
 ```
 
@@ -228,7 +228,7 @@ This member function implements the behavior of the Win32 message [TBM_GETBUDDY]
 
 Retrieves the size and position of the bounding rectangle for a slider control's channel.
 
-```
+```cpp
 void GetChannelRect(LPRECT lprc) const;
 ```
 
@@ -301,7 +301,7 @@ The current position.
 
 Retrieves the maximum and minimum positions for the slider in a slider control.
 
-```
+```cpp
 void GetRange(
     int& nMin,
     int& nMax) const;
@@ -347,7 +347,7 @@ The control's minimum position.
 
 Retrieves the starting and ending positions of the current selection in a slider control.
 
-```
+```cpp
 void GetSelection(
     int& nMin,
     int& nMax) const;
@@ -381,7 +381,7 @@ This method sends the [TBM_GETTHUMBLENGTH](/windows/win32/Controls/tbm-getthumbl
 
 Retrieves the size and position of the bounding rectangle for the slider (thumb) in a slider control.
 
-```
+```cpp
 void GetThumbRect(LPRECT lprc) const;
 ```
 
@@ -532,7 +532,7 @@ The page size affects how much the slider moves for the TB_PAGEUP and TB_PAGEDOW
 
 Sets the current position of the slider in a slider control.
 
-```
+```cpp
 void SetPos(int nPos);
 ```
 
@@ -545,7 +545,7 @@ Specifies the new slider position.
 
 Sets the range (minimum and maximum positions) for the slider in a slider control.
 
-```
+```cpp
 void SetRange(
     int nMin,
     int nMax,
@@ -567,7 +567,7 @@ The redraw flag. If this parameter is TRUE, the slider is redrawn after the rang
 
 Sets the maximum range for the slider in a slider control.
 
-```
+```cpp
 void SetRangeMax(
     int nMax,
     BOOL bRedraw = FALSE);
@@ -585,7 +585,7 @@ The redraw flag. If this parameter is TRUE, the slider is redrawn after the rang
 
 Sets the minimum range for the slider in a slider control.
 
-```
+```cpp
 void SetRangeMin(
     int nMin,
     BOOL bRedraw = FALSE);
@@ -603,7 +603,7 @@ The redraw flag. If this parameter is TRUE, the slider is redrawn after the rang
 
 Sets the starting and ending positions for the current selection in a slider control.
 
-```
+```cpp
 void SetSelection(
     int nMin,
     int nMax);
@@ -621,7 +621,7 @@ Ending position for the slider.
 
 Sets the length of the slider in the current trackbar control.
 
-```
+```cpp
 void SetThumbLength(int nLength);
 ```
 
@@ -670,7 +670,7 @@ Nonzero if the tick mark is set; otherwise 0.
 
 Sets the frequency with which tick marks are displayed in a slider.
 
-```
+```cpp
 void SetTicFreq(int nFreq);
 ```
 
@@ -710,7 +710,7 @@ This member function implements the behavior of the Win32 message TBM_SETTIPSIDE
 
 Assigns a tooltip control to a slider control.
 
-```
+```cpp
 void SetToolTips(CToolTipCtrl* pWndTip);
 ```
 

--- a/docs/mfc/reference/csmartdockinginfo-class.md
+++ b/docs/mfc/reference/csmartdockinginfo-class.md
@@ -81,7 +81,7 @@ The following illustration shows an example of smart docking markers that have b
 
 Copies the current smart docking parameters into the provided [CSmartDockingInfo](../../mfc/reference/csmartdockinginfo-class.md) object.
 
-```
+```cpp
 void CopyTo(CSmartDockingInfo& params);
 ```
 

--- a/docs/mfc/reference/csocket-class.md
+++ b/docs/mfc/reference/csocket-class.md
@@ -107,7 +107,7 @@ For more information, see [Windows Sockets: Using Sockets with Archives](../../m
 
 Call this member function to cancel a blocking call currently in progress.
 
-```
+```cpp
 void CancelBlockingCall();
 ```
 

--- a/docs/mfc/reference/cspinbuttonctrl-class.md
+++ b/docs/mfc/reference/cspinbuttonctrl-class.md
@@ -341,7 +341,7 @@ The previous position (16-bit precision for `SetPos`, 32-bit precision for `SetP
 
 Sets the upper and lower limits (range) for a spin button control.
 
-```
+```cpp
 void SetRange(
     short nLower,
     short nUpper);

--- a/docs/mfc/reference/csplitbutton-class.md
+++ b/docs/mfc/reference/csplitbutton-class.md
@@ -150,7 +150,7 @@ END_MESSAGE_MAP()
 
 Sets the drop-down menu that is displayed when a user clicks the drop-down arrow of the current split button control.
 
-```
+```cpp
 void SetDropDownMenu(
     UINT nMenuId,
     UINT nSubMenuId);

--- a/docs/mfc/reference/csplitterwnd-class.md
+++ b/docs/mfc/reference/csplitterwnd-class.md
@@ -545,7 +545,7 @@ Returns the current number of columns in the splitter. For a static splitter, th
 
 Returns information on the specified column.
 
-```
+```cpp
 void GetColumnInfo(
     int col,
     int& cxCur,
@@ -601,7 +601,7 @@ Returns the current number of rows in the splitter window. For a static splitter
 
 Returns information on the specified row.
 
-```
+```cpp
 void GetRowInfo(
     int row,
     int& cyCur,
@@ -822,7 +822,7 @@ Specify pane by providing either row and column, **or** by providing *pWnd*.
 
 Call to set the specified column information.
 
-```
+```cpp
 void SetColumnInfo(
     int col,
     int cxIdeal,
@@ -854,7 +854,7 @@ When the framework displays the splitter window, it lays out the panes in column
 
 Call to set the specified row information.
 
-```
+```cpp
 void SetRowInfo(
     int row,
     int cyIdeal,
@@ -882,7 +882,7 @@ When the framework displays the splitter window, it lays out the panes in column
 
 Specifies the new scroll style for the splitter window's shared scroll-bar support.
 
-```
+```cpp
 void SetScrollStyle(DWORD dwStyle);
 ```
 

--- a/docs/mfc/reference/cstatusbar-class.md
+++ b/docs/mfc/reference/cstatusbar-class.md
@@ -233,7 +233,7 @@ The ID of the indicator specified by *nIndex*.
 
 Copies the coordinates of the indicator specified by *nIndex* into the structure pointed to by *lpRect*.
 
-```
+```cpp
 void GetItemRect(
     int nIndex,
     LPRECT lpRect) const;
@@ -255,7 +255,7 @@ Coordinates are in pixels relative to the upper-left corner of the status bar.
 
 Sets *nID*, *nStyle*, and *cxWidth* to the ID, style, and width of the indicator pane at the location specified by *nIndex*.
 
-```
+```cpp
 void GetPaneInfo(
     int nIndex,
     UINT& nID,
@@ -368,7 +368,7 @@ Nonzero if successful; otherwise 0.
 
 Sets the specified indicator pane to a new ID, style, and width.
 
-```
+```cpp
 void SetPaneInfo(
     int nIndex,
     UINT nID,
@@ -408,7 +408,7 @@ The following indicator styles are supported:
 
 Call this member function to set the style of a status bar's pane.
 
-```
+```cpp
 void SetPaneStyle(
     int nIndex,
     UINT nStyle);

--- a/docs/mfc/reference/cstatusbarctrl-class.md
+++ b/docs/mfc/reference/cstatusbarctrl-class.md
@@ -484,7 +484,7 @@ This member function implements the behavior of the Win32 message [SB_SETICON](/
 
 Sets the minimum height of a status bar control's drawing area.
 
-```
+```cpp
 void SetMinHeight(int nMin);
 ```
 
@@ -586,7 +586,7 @@ The message invalidates the portion of the control that has changed, causing it 
 
 Sets the tooltip text for a pane in a status bar.
 
-```
+```cpp
 void SetTipText(
     int nPane,
     LPCTSTR pszTipText);

--- a/docs/mfc/reference/cstring-formatting-and-message-box-display.md
+++ b/docs/mfc/reference/cstring-formatting-and-message-box-display.md
@@ -71,7 +71,7 @@ This function will return FALSE if either *lpszFullString* is set to NULL or the
 
 Substitutes the string pointed to by *lpsz1* for any instances of the characters "%1" in the template string resource identified by *nIDS*.
 
-```
+```cpp
 void  AfxFormatString1(
     CString& rString,
     UINT nIDS,
@@ -107,7 +107,7 @@ If the format characters "%1" appear in the string more than once, multiple subs
 
 Substitutes the string pointed to by *lpsz1* for any instances of the characters "%1", and the string pointed to by *lpsz2* for any instances of the characters "%2", in the template string resource identified by *nIDS*.
 
-```
+```cpp
 void AfxFormatString2(
     CString& rString,
     UINT nIDS,

--- a/docs/mfc/reference/ctabctrl-class.md
+++ b/docs/mfc/reference/ctabctrl-class.md
@@ -86,7 +86,7 @@ For more information on using `CTabCtrl`, see [Controls](../../mfc/controls-mfc.
 
 Calculates a tab control's display area given a window rectangle, or calculates the window rectangle that would correspond to a given display area.
 
-```
+```cpp
 void AdjustRect(BOOL bLarger,   LPRECT lpRect);
 ```
 
@@ -239,7 +239,7 @@ Nonzero if successful; otherwise 0.
 
 Resets items in a tab control, clearing any that were pressed.
 
-```
+```cpp
 void DeselectAll(BOOL fExcludeFocus);
 ```
 
@@ -609,7 +609,7 @@ Zero-based index of the new tab if successful; otherwise - 1.
 
 Removes the specified image from a tab control's image list.
 
-```
+```cpp
 void RemoveImage(int nImage);
 ```
 
@@ -626,7 +626,7 @@ The tab control updates each tab's image index so that each tab remains associat
 
 Sets the focus to a specified tab in a tab control.
 
-```
+```cpp
 void SetCurFocus(int nItem);
 ```
 
@@ -819,7 +819,7 @@ This member function implements the behavior of the Win32 message [TCM_SETMINTAB
 
 Sets the amount of space (padding) around each tab's icon and label in a tab control.
 
-```
+```cpp
 void SetPadding(CSize size);
 ```
 
@@ -832,7 +832,7 @@ Sets the amount of space (padding) around each tab's icon and label in a tab con
 
 Assigns a tool tip control to a tab control.
 
-```
+```cpp
 void SetToolTips(CToolTipCtrl* pWndTip);
 ```
 

--- a/docs/mfc/reference/ctaskdialog-class.md
+++ b/docs/mfc/reference/ctaskdialog-class.md
@@ -137,7 +137,7 @@ CTaskDialog Sample
 
 Adds a new command button control to the `CTaskDialog`.
 
-```
+```cpp
 void AddCommandControl(
     int nCommandControlID,
     const CString& strCaption,
@@ -173,7 +173,7 @@ When the user selects a command button control, the `CTaskDialog` closes. If you
 
 Adds a radio button to the `CTaskDialog`.
 
-```
+```cpp
 void CTaskDialog::AddRadioButton(
     int nRadioButtonID,
     const CString& strCaption,
@@ -530,7 +530,7 @@ Use this function to determine at runtime if the computer that is running your a
 
 Adds command button controls by using data from the string table.
 
-```
+```cpp
 void LoadCommandControls(
     int nIDCommandControlsFirst,
     int nIDCommandControlsLast);
@@ -558,7 +558,7 @@ By default, new command button controls are enabled and do not require elevation
 
 Adds radio button controls by using data from the string table.
 
-```
+```cpp
 void LoadRadioButtons(
     int nIDRadioButtonsFirst,
     int nIDRadioButtonsLast);
@@ -812,7 +812,7 @@ Override this method in a derived class to implement custom behavior.
 
 Removes all the command button controls from the `CTaskDialog`.
 
-```
+```cpp
 void RemoveAllCommandControls();
 ```
 
@@ -824,7 +824,7 @@ void RemoveAllCommandControls();
 
 Removes all the radio buttons from the `CTaskDialog`.
 
-```
+```cpp
 void RemoveAllRadioButtons();
 ```
 
@@ -836,7 +836,7 @@ void RemoveAllRadioButtons();
 
 Updates a command button control on the `CTaskDialog`.
 
-```
+```cpp
 void SetCommandControlOptions(
     int nCommandControlID,
     BOOL bEnabled,
@@ -866,7 +866,7 @@ Use this method to change whether a command button control is enabled or require
 
 Updates a subset of common buttons to be enabled and to require UAC elevation.
 
-```
+```cpp
 void SetCommonButtonOptions(
     int nDisabledButtonMask,
     int nElevationButtonMask = 0);
@@ -896,7 +896,7 @@ This method enables any button that is available to the `CTaskDialog` but is not
 
 Adds common buttons to the `CTaskDialog`.
 
-```
+```cpp
 void SetCommonButtons(
     int nButtonMask,
     int nDisabledButtonMask = 0,
@@ -932,7 +932,7 @@ By default, all common buttons are enabled and do not require elevation.
 
 Updates the content of the `CTaskDialog`.
 
-```
+```cpp
 void SetContent(const CString& strContent);
 ```
 
@@ -953,7 +953,7 @@ The content of the `CTaskDialog` class is the text that is displayed to the user
 
 Specifies the default command button control.
 
-```
+```cpp
 void SetDefaultCommandControl(int nCommandControlID);
 ```
 
@@ -976,7 +976,7 @@ This method throws an exception if it cannot find the command button control spe
 
 Specifies the default radio button.
 
-```
+```cpp
 void SetDefaultRadioButton(int nRadioButtonID);
 ```
 
@@ -999,7 +999,7 @@ This method throws an exception if it cannot find the radio button specified by 
 
 Adjusts the width of the `CTaskDialog`.
 
-```
+```cpp
 void SetDialogWidth(int nWidth = 0);
 ```
 
@@ -1022,7 +1022,7 @@ If *nWidth* is set to 0, this method sets the dialog box to the default size.
 
 Updates the expansion area of the `CTaskDialog`.
 
-```
+```cpp
 void SetExpansionArea(
     const CString& strExpandedInformation,
     const CString& strCollapsedLabel = _T(""),
@@ -1054,7 +1054,7 @@ When the `CTaskDialog` is first displayed, it does not show the expanded informa
 
 Updates the footer icon of the `CTaskDialog`.
 
-```
+```cpp
 void SetFooterIcon(HICON hFooterIcon);
 void SetFooterIcon(LPCWSTR lpszFooterIcon);
 ```
@@ -1083,7 +1083,7 @@ A `CTaskDialog` can only accept an `HICON` or `LPCWSTR` as a footer icon. This i
 
 Updates the text on the footer of the `CTaskDialog`.
 
-```
+```cpp
 void SetFooterText(const CString& strFooterText);
 ```
 
@@ -1104,7 +1104,7 @@ The footer icon appears next to the footer text on the bottom of the `CTaskDialo
 
 Updates the main icon of the `CTaskDialog`.
 
-```
+```cpp
 void SetMainIcon(HICON hMainIcon);
 void SetMainIcon(LPCWSTR lpszMainIcon);
 ```
@@ -1131,7 +1131,7 @@ A `CTaskDialog` can only accept an `HICON` or `LPCWSTR` as a main icon. You can 
 
 Updates the main instruction of the `CTaskDialog`.
 
-```
+```cpp
 void SetMainInstruction(const CString& strInstructions);
 ```
 
@@ -1152,7 +1152,7 @@ The main instruction of the `CTaskDialog` class is text displayed to the user in
 
 Configures the options for the `CTaskDialog`.
 
-```
+```cpp
 void SetOptions(int nOptionFlag);
 ```
 
@@ -1194,7 +1194,7 @@ The following table lists all the valid options.
 
 Configures a marquee bar for the `CTaskDialog` and adds it to the dialog box.
 
-```
+```cpp
 void SetProgressBarMarquee(
     BOOL bEnabled = TRUE,
     int nMarqueeSpeed = 0);
@@ -1224,7 +1224,7 @@ This method throws an exception with the [ENSURE](diagnostic-services.md#ensure)
 
 Adjusts the position of the progress bar.
 
-```
+```cpp
 void SetProgressBarPosition(int nProgressPos);
 ```
 
@@ -1245,7 +1245,7 @@ This method throws an exception with the [ENSURE](diagnostic-services.md#ensure)
 
 Adjusts the range of the progress bar.
 
-```
+```cpp
 void SetProgressBarRange(
     int nRangeMin,
     int nRangeMax);
@@ -1275,7 +1275,7 @@ This method throws an exception with the [ENSURE](diagnostic-services.md#ensure)
 
 Sets the state of the progress bar and displays it on the `CTaskDialog`.
 
-```
+```cpp
 void SetProgressBarState(int nState = PBST_NORMAL);
 ```
 
@@ -1306,7 +1306,7 @@ You can set where the progress bar stops with [CTaskDialog::SetProgressBarPositi
 
 Enables or disables a radio button.
 
-```
+```cpp
 void SetRadioButtonOptions(
     int nRadioButtonID,
     BOOL bEnabled);
@@ -1332,7 +1332,7 @@ This method throws an exception with the [ENSURE](diagnostic-services.md#ensure)
 
 Sets the checked state of the verification check box.
 
-```
+```cpp
 void SetVerificationCheckbox(BOOL bChecked);
 ```
 
@@ -1349,7 +1349,7 @@ void SetVerificationCheckbox(BOOL bChecked);
 
 Sets the text that is displayed to the right of the verification check box.
 
-```
+```cpp
 void SetVerificationCheckboxText(CString& strVerificationText);
 ```
 
@@ -1370,7 +1370,7 @@ This method throws an exception with the [ENSURE](diagnostic-services.md#ensure)
 
 Sets the title of the `CTaskDialog`.
 
-```
+```cpp
 void SetWindowTitle(CString& strWindowTitle);
 ```
 

--- a/docs/mfc/reference/ctoolbar-class.md
+++ b/docs/mfc/reference/ctoolbar-class.md
@@ -246,7 +246,7 @@ Call the [Create](#create) member function to create the toolbar window.
 
 This member function retrieves the control ID, style, and image index of the toolbar button or separator at the location specified by *nIndex.*
 
-```
+```cpp
 void GetButtonInfo(
     int nIndex,
     UINT& nID,
@@ -476,7 +476,7 @@ For example, call `SetBitmap` to change the bitmapped image after the user takes
 
 Call this member function to set the button's command ID, style, and image number.
 
-```
+```cpp
 void SetButtonInfo(
     int nIndex,
     UINT nID,
@@ -557,7 +557,7 @@ If *lpIDArray* is NULL, this function allocates space for the number of items sp
 
 Call this member function to set the style of a button or separator, or to group buttons.
 
-```
+```cpp
 void SetButtonStyle(
     int nIndex,
     UINT nStyle);
@@ -626,7 +626,7 @@ Nonzero if successful; otherwise 0.
 
 This member function sets the toolbar's height to the value, in pixels, specified in *cyHeight*.
 
-```
+```cpp
 void SetHeight(int cyHeight);
 ```
 
@@ -645,7 +645,7 @@ If this function is not called, the framework uses the size of the button to det
 
 Call this member function to set the toolbar's buttons to the size, in pixels, specified in *sizeButton*.
 
-```
+```cpp
 void SetSizes(
     SIZE sizeButton,
     SIZE sizeImage);

--- a/docs/mfc/reference/ctoolbarctrl-class.md
+++ b/docs/mfc/reference/ctoolbarctrl-class.md
@@ -339,7 +339,7 @@ You should not pass a `CString` object to this function since it is not possible
 
 Resizes the entire toolbar control.
 
-```
+```cpp
 void AutoSize();
 ```
 
@@ -529,7 +529,7 @@ You must call [Create](#create) to make the toolbar usable.
 
 Displays the Customize Toolbar dialog box.
 
-```
+```cpp
 void Customize();
 ```
 
@@ -856,7 +856,7 @@ This member function implements the behavior of the Win32 message [TB_GETIMAGELI
 
 Retrieves the current insertion mark for the toolbar.
 
-```
+```cpp
 void GetInsertMark(TBINSERTMARK* ptbim) const;
 ```
 
@@ -948,7 +948,7 @@ The maximum number of text rows displayed on a toolbar button.
 
 Retrieves the metrics of the `CToolBarCtrl` object.
 
-```
+```cpp
 void GetMetrics(LPTBMETRICS ptbm) const;
 ```
 
@@ -1383,7 +1383,7 @@ Consider calling [GetState](#getstate) if you want to retrieve more than one but
 
 Loads bitmaps into a toolbar control's image list.
 
-```
+```cpp
 void LoadImages(
     int iBitmapID,
     HINSTANCE hinst);
@@ -1546,7 +1546,7 @@ The following code example replaces the bitmap for the standard toolbar with a d
 
 Restores the state of the toolbar control from the location in the registry specified by the parameters.
 
-```
+```cpp
 void RestoreState(
     HKEY hKeyRoot,
     LPCTSTR lpszSubKey,
@@ -1576,7 +1576,7 @@ Points to a string containing the name of the value to retrieve. If a value with
 
 Saves the state of the toolbar control in the location in the registry specified by the parameters.
 
-```
+```cpp
 void SaveState(
     HKEY hKeyRoot,
     LPCTSTR lpszSubKey,
@@ -1699,7 +1699,7 @@ The button size must always be at least as large as the bitmap size it encloses.
 
 Specifies the size of the `TBBUTTON` structure.
 
-```
+```cpp
 void SetButtonStructSize(int nSize);
 ```
 
@@ -1766,7 +1766,7 @@ Returns nonzero if successful; otherwise zero.
 
 Sets the color scheme of the current toolbar control.
 
-```
+```cpp
 void SetColorScheme(const COLORSCHEME* lpColorScheme);
 ```
 
@@ -1944,7 +1944,7 @@ Nonzero if successful; otherwise zero.
 
 Sets the current insertion mark for the toolbar.
 
-```
+```cpp
 void SetInsertMark(TBINSERTMARK* ptbim);
 ```
 
@@ -1999,7 +1999,7 @@ Nonzero if successful; otherwise zero.
 
 Sets the metrics of the `CToolBarCtrl` object.
 
-```
+```cpp
 void SetMetrics(LPTBMETRICS ptbm);
 ```
 
@@ -2016,7 +2016,7 @@ This member function emulates the functionality of the [TB_SETMETRICS](/windows/
 
 Sets the owner window for the toolbar control.
 
-```
+```cpp
 void SetOwner(CWnd* pWnd);
 ```
 
@@ -2095,7 +2095,7 @@ The following code example sets the pressed image list to be the same as the def
 
 Asks the toolbar control to resize itself to the requested number of rows.
 
-```
+```cpp
 void SetRows(
     int nRows,
     BOOL bLarger,
@@ -2157,7 +2157,7 @@ This function is especially handy if you want to set more than one of the button
 
 Sets the styles for a toolbar control.
 
-```
+```cpp
 void SetStyle(DWORD dwStyle);
 ```
 
@@ -2170,7 +2170,7 @@ A DWORD containing a combination of [toolbar control styles](/windows/win32/Cont
 
 Associates a tool tip control with a toolbar control.
 
-```
+```cpp
 void SetToolTips(CToolTipCtrl* pTip);
 ```
 

--- a/docs/mfc/reference/ctooltipctrl-class.md
+++ b/docs/mfc/reference/ctooltipctrl-class.md
@@ -90,7 +90,7 @@ For more information on using `CToolTipCtrl`, see [Controls](../../mfc/controls-
 
 Call this function to activate or deactivate a tool tip control.
 
-```
+```cpp
 void Activate(BOOL bActivate);
 ```
 
@@ -278,7 +278,7 @@ You must call `Create` after constructing the object.
 
 Removes the tool specified by *pWnd* and *nIDTool* from the collection of tools supported by a tool tip control.
 
-```
+```cpp
 void DelTool(
     CWnd* pWnd,
     UINT_PTR nIDTool = 0);
@@ -372,7 +372,7 @@ This member function implements the behavior of the Win32 message [TTM_GETDELAYT
 
 Retrieves the top, left, bottom, and right margins set for a tool tip window.
 
-```
+```cpp
 void GetMargin(LPRECT lprc) const;
 ```
 
@@ -412,7 +412,7 @@ This member function implements the behavior of the Win32 message [TTM_GETMAXTIP
 
 Retrieves the text that a tool tip control maintains for a tool.
 
-```
+```cpp
 void GetText(
     CString& str,
     CWnd* pWnd,
@@ -470,7 +470,7 @@ This member function implements the behavior of the Win32 message [TTM_GETTIPTEX
 
 Retrieves the title of the current tooltip control.
 
-```
+```cpp
 void GetTitle(PTTGETTITLE pttgt) const;
 ```
 
@@ -582,7 +582,7 @@ typedef struct _TT_HITTESTINFO { // tthti
 
 Removes a displayed tool tip window from the view.
 
-```
+```cpp
 void Pop();
 ```
 
@@ -594,7 +594,7 @@ This member function implements the behavior of the Win32 message [TTM_POP](/win
 
 Causes the current tooltip control to display at the coordinates of the last mouse message.
 
-```
+```cpp
 void Popup();
 ```
 
@@ -612,7 +612,7 @@ The following code example displays a tooltip window.
 
 Passes a mouse message to a tool tip control for processing.
 
-```
+```cpp
 void RelayEvent(LPMSG lpMsg);
 ```
 
@@ -639,7 +639,7 @@ A tool tip control processes only the following messages, which are sent to it b
 
 Sets the delay time for a tool tip control.
 
-```
+```cpp
 void SetDelayTime(UINT nDelay);
 
 void SetDelayTime(
@@ -666,7 +666,7 @@ The delay time is the length of time the cursor must remain on a tool before the
 
 Sets the top, left, bottom, and right margins for a tool tip window.
 
-```
+```cpp
 void SetMargin(LPRECT lprc);
 ```
 
@@ -704,7 +704,7 @@ This member function implements the behavior of the Win32 message [TTM_SETMAXTIP
 
 Sets the background color in a tool tip window.
 
-```
+```cpp
 void SetTipBkColor(COLORREF clr);
 ```
 
@@ -721,7 +721,7 @@ This member function implements the behavior of the Win32 message [TTM_SETTIPBKC
 
 Sets the text color in a tool tip window.
 
-```
+```cpp
 void SetTipTextColor(COLORREF clr);
 ```
 
@@ -764,7 +764,7 @@ This member function implements the behavior of the Win32 message [TTM_SETTITLE]
 
 Sets the information that a tool tip maintains for a tool.
 
-```
+```cpp
 void SetToolInfo(LPTOOLINFO lpToolInfo);
 ```
 
@@ -777,7 +777,7 @@ A pointer to a [TOOLINFO](/windows/win32/api/commctrl/ns-commctrl-tttoolinfoa) s
 
 Sets a new bounding rectangle for a tool.
 
-```
+```cpp
 void SetToolRect(
     CWnd* pWnd,
     UINT_PTR nIDTool,
@@ -820,7 +820,7 @@ This member function emulates the functionality of the [TTM_SETWINDOWTHEME](/win
 
 Forces the current tool to be redrawn.
 
-```
+```cpp
 void Update();
 ```
 
@@ -828,7 +828,7 @@ void Update();
 
 Updates the tool tip text for this control's tools.
 
-```
+```cpp
 void UpdateTipText(
     LPCTSTR lpszText,
     CWnd* pWnd,

--- a/docs/mfc/reference/ctooltipmanager-class.md
+++ b/docs/mfc/reference/ctooltipmanager-class.md
@@ -110,7 +110,7 @@ Call this method for each [CToolTipCtrl Class](../../mfc/reference/ctooltipctrl-
 
 Customizes the appearance of the tooltip control for the specified Windows control types.
 
-```
+```cpp
 void SetTooltipParams(
     UINT nTypes,
     CRuntimeClass* pRTC=RUNTIME_CLASS(CMFCToolTipCtrl),
@@ -180,7 +180,7 @@ The value of *nType* must be the same value as the *nType* parameter of [CToolti
 
 For more detail see the source code located in the **VC\\atlmfc\\src\\mfc** folder of your Visual Studio installation.
 
-```
+```cpp
 void UpdateTooltips();
 ```
 

--- a/docs/mfc/reference/ctreectrl-class.md
+++ b/docs/mfc/reference/ctreectrl-class.md
@@ -1669,7 +1669,7 @@ Pointer to the previous image list, if any; otherwise NULL.
 
 Call this function to set the width of indentation for a tree view control and redraw the control to reflect the new width.
 
-```
+```cpp
 void SetIndent(UINT nIndent);
 ```
 
@@ -2105,7 +2105,7 @@ To use tooltips, indicate the TVS_NOTOOLTIPS style when you create the `CTreeCtr
 
 Displays the infotip for the specified item in the current tree-view control.
 
-```
+```cpp
 void ShowInfoTip(HTREEITEM hItem);
 ```
 

--- a/docs/mfc/reference/ctypedptrarray-class.md
+++ b/docs/mfc/reference/ctypedptrarray-class.md
@@ -120,7 +120,7 @@ For more detailed remarks, see [CObArray::Append](../../mfc/reference/cobarray-c
 
 This member function calls `BASE_CLASS`**::Copy**.
 
-```
+```cpp
 void Copy(const CTypedPtrArray<BASE_CLASS, TYPE>& src);
 ```
 
@@ -191,7 +191,7 @@ For more detailed remarks, see [CObArray::GetAt](../../mfc/reference/cobarray-cl
 
 This member function calls `BASE_CLASS`**::InsertAt**.
 
-```
+```cpp
 void InsertAt(
     INT_PTR nIndex,
     TYPE newElement,
@@ -256,7 +256,7 @@ The Debug version of the library asserts if the subscript (either on the left or
 
 This member function calls `BASE_CLASS`**::SetAt**.
 
-```
+```cpp
 void SetAt(
     INT_PTR nIndex,
     TYPE ptr);
@@ -281,7 +281,7 @@ For more detailed remarks, see [CObArray::SetAt](../../mfc/reference/cobarray-cl
 
 This member function calls `BASE_CLASS`**::SetAtGrow**.
 
-```
+```cpp
 void SetAtGrow(
     INT_PTR nIndex,
     TYPE newElement);

--- a/docs/mfc/reference/ctypedptrlist-class.md
+++ b/docs/mfc/reference/ctypedptrlist-class.md
@@ -326,7 +326,7 @@ You must ensure that the list is not empty before calling `RemoveTail`. If the l
 
 This member function calls `BASE_CLASS`**::SetAt**.
 
-```
+```cpp
 void SetAt(POSITION pos, TYPE newElement);
 ```
 

--- a/docs/mfc/reference/ctypedptrmap-class.md
+++ b/docs/mfc/reference/ctypedptrmap-class.md
@@ -66,7 +66,7 @@ For more information on using `CTypedPtrMap`, see the articles [Collections](../
 
 Retrieves the map element at `rNextPosition`, then updates `rNextPosition` to refer to the next element in the map.
 
-```
+```cpp
 void GetNextAssoc(
     POSITION& rPosition,
     KEY& rKey,
@@ -179,7 +179,7 @@ For more detailed remarks, see [CMapStringToOb::RemoveKey](../../mfc/reference/c
 
 This member function calls `BASE_CLASS`**::SetAt**.
 
-```
+```cpp
 void SetAt(KEY key, VALUE newValue);
 ```
 

--- a/docs/mfc/reference/cusertool-class.md
+++ b/docs/mfc/reference/cusertool-class.md
@@ -80,7 +80,7 @@ BOOL CopyIconToClipboard();
 
 Draws the user tool icon at the center of a specified rectangle.
 
-```
+```cpp
 void DrawToolIcon(
     CDC* pDC,
     const CRect& rectImage);
@@ -202,7 +202,7 @@ virtual void Serialize(CArchive& ar);
 
 Sets the application that the user tool runs.
 
-```
+```cpp
 void SetCommand(LPCTSTR lpszCmd);
 ```
 

--- a/docs/mfc/reference/cusertoolsmanager-class.md
+++ b/docs/mfc/reference/cusertoolsmanager-class.md
@@ -414,7 +414,7 @@ Usually, you do not need to call this method directly, [CWinAppEx::SaveState](..
 
 Specifies the default extension that the **File Open** dialog box ( [CFileDialog Class](../../mfc/reference/cfiledialog-class.md)) uses in the **Command** field on the **Tools** tab of the **Customize** dialog box.
 
-```
+```cpp
 void SetDefExt(const CString& strDefExt);
 ```
 
@@ -431,7 +431,7 @@ Call this method to specify a default file name extension in the **File Open** d
 
 Specifies the file filter that the **File Open** dialog box ( [CFileDialog Class](../../mfc/reference/cfiledialog-class.md)) uses in the **Command** field on the **Tools** tab of the **Customize** dialog box.
 
-```
+```cpp
 void SetFilter(const CString& strFilter);
 ```
 

--- a/docs/mfc/reference/cwaitcursor-class.md
+++ b/docs/mfc/reference/cwaitcursor-class.md
@@ -88,7 +88,7 @@ You can take advantage of the fact that the destructor is called at the end of t
 
 To restore the wait cursor, call this function after performing an operation, such as displaying a message box or dialog box, which might change the wait cursor to another cursor.
 
-```
+```cpp
 void Restore();
 ```
 

--- a/docs/mfc/reference/cwinapp-class.md
+++ b/docs/mfc/reference/cwinapp-class.md
@@ -183,7 +183,7 @@ The `m_hPrevInstance` data member no longer exists. To determine whether another
 
 Call this member function to add a document template to the list of available document templates that the application maintains.
 
-```
+```cpp
 void AddDocTemplate(CDocTemplate* pTemplate);
 ```
 
@@ -252,7 +252,7 @@ To customize the behavior, override this function in a derived [CWinApp Class](.
 
 Call this member function to close all open documents before exiting.
 
-```
+```cpp
 void CloseAllDocuments(BOOL bEndSession);
 ```
 
@@ -424,7 +424,7 @@ Returns TRUE if D2D support was enabled, FALSE - otherwise
 
 Call this member function from within the constructor of your `CWinApp`-derived class to use HTMLHelp for your application's help.
 
-```
+```cpp
 void EnableHtmlHelp();
 ```
 
@@ -434,7 +434,7 @@ void EnableHtmlHelp();
 
 Call this function, typically from your `InitInstance` override, to enable your application's users to open data files when they double-click the files from within the Windows File Manager.
 
-```
+```cpp
 void EnableShellOpen();
 ```
 
@@ -822,7 +822,7 @@ Section key if the function succeeds; otherwise NULL.
 
 Call this member function to hide an application before closing the open documents.
 
-```
+```cpp
 void HideApplication();
 ```
 
@@ -1072,7 +1072,7 @@ Use the `LoadStandardIcon` or [LoadOEMIcon](#loadoemicon) member function to acc
 
 Call this member function from within the [InitInstance](#initinstance) member function to enable and load the list of most recently used (MRU) files and last preview state.
 
-```
+```cpp
 void LoadStdProfileSettings(UINT nMaxMRU = _AFX_MRU_COUNT);
 ```
 
@@ -1563,7 +1563,7 @@ If a document that has that name is already open, the first frame window that co
 
 Call this member function to parse the command line and send the parameters, one at a time, to [CCommandLineInfo::ParseParam](../../mfc/reference/ccommandlineinfo-class.md#parseparam).
 
-```
+```cpp
 void ParseCommandLine(CCommandLineInfo& rCmdInfo);
 ```
 
@@ -1726,7 +1726,7 @@ The default implementation simply returns TRUE. Override this function to provid
 
 Call this member function to register all of your application's document types with the Windows File Manager.
 
-```
+```cpp
 void RegisterShellFileTypes(BOOL bCompat = FALSE);
 ```
 
@@ -1914,7 +1914,7 @@ The default implementation of this member function calls the [CDocument::SaveMod
 
 Call this member function to select a specific printer, and release the printer that was previously selected in the Print Dialog box.
 
-```
+```cpp
 void SelectPrinter(
     HANDLE hDevNames,
     HANDLE hDevMode,
@@ -1940,7 +1940,7 @@ If both *hDevMode* and *hDevNames* are NULL, `SelectPrinter` uses the current de
 
 Sets the application's help type.
 
-```
+```cpp
 void SetHelpMode(AFX_HELP_TYPE eHelpType);
 ```
 
@@ -1959,7 +1959,7 @@ To set your application's Help type to HTMLHelp, you can call [EnableHTMLHelp](#
 
 Causes application settings to be stored in the registry instead of INI files.
 
-```
+```cpp
 void SetRegistryKey(LPCTSTR lpszRegistryKey);
 void SetRegistryKey(UINT nIDRegistryKey);
 ```
@@ -2046,7 +2046,7 @@ Override this function to perform custom unregistration steps.
 
 Call this member function to unregister all of your application's document types with the Windows File Manager.
 
-```
+```cpp
 void UnregisterShellFileTypes();
 ```
 
@@ -2186,7 +2186,7 @@ For another example, see the example for [CWinApp::GetProfileInt](#getprofileint
 
 Explicitly sets Application User Model ID for the application. This method should be called before any user interface is presented to the user (the best place is the application constructor).
 
-```
+```cpp
 void SetAppID(LPCTSTR lpcszAppID);
 ```
 

--- a/docs/mfc/reference/cwinappex-class.md
+++ b/docs/mfc/reference/cwinappex-class.md
@@ -163,7 +163,7 @@ The `CWinAppEx` class has initialization methods, provides functionality for sav
 
 Specifies whether the application will load the initial size and location of the main frame window from the registry.
 
-```
+```cpp
 void EnableLoadWindowPlacement(BOOL bEnable = TRUE);
 ```
 

--- a/docs/mfc/reference/cwnd-class.md
+++ b/docs/mfc/reference/cwnd-class.md
@@ -756,7 +756,7 @@ Do not call the `BeginPaint` member function except in response to a [WM_PAINT](
 
 Binds the calling object's default simple bound property (such as an edit control), as marked in the type library, to the underlying cursor that is defined by the DataSource, UserName, Password, and SQL properties of the data-source control.
 
-```
+```cpp
 void BindDefaultProperty(
     DISPID dwDispID,
     VARTYPE vtProp,
@@ -792,7 +792,7 @@ The `CWnd` object on which you call this function must be a data-bound control.
 
 Binds a cursor-bound property on a data-bound control (such as a grid control) to a data-source control and registers that relationship with the MFC binding manager.
 
-```
+```cpp
 void BindProperty(
     DISPID dwDispId,
     CWnd* pWndDSC);
@@ -820,7 +820,7 @@ The `CWnd` object on which you call this function must be a data-bound control.
 
 Brings `CWnd` to the top of a stack of overlapping windows.
 
-```
+```cpp
 void BringWindowToTop();
 ```
 
@@ -888,7 +888,7 @@ TRUE to cancel tool tips when a key is pressed and set the status bar text to th
 
 Centers a window relative to its parent.
 
-```
+```cpp
 void CenterWindow(CWnd* pAlternateOwner = NULL);
 ```
 
@@ -926,7 +926,7 @@ Nonzero if successful; otherwise 0.
 
 Selects (places a check mark next to) or clears (removes a check mark from) a button, or it changes the state of a three-state button.
 
-```
+```cpp
 void CheckDlgButton(
     int nIDButton,
     UINT nCheck);
@@ -952,7 +952,7 @@ The `CheckDlgButton` function sends a [BM_SETCHECK](/windows/win32/Controls/bm-s
 
 Selects (adds a check mark to) a given radio button in a group and clears (removes a check mark from) all other radio buttons in the group.
 
-```
+```cpp
 void CheckRadioButton(
     int nIDFirstButton,
     int nIDLastButton,
@@ -1023,7 +1023,7 @@ The `CWnd`* that is returned may be temporary and should not be stored for later
 
 Converts the client coordinates of a given point or rectangle on the display to screen coordinates.
 
-```
+```cpp
 void ClientToScreen(LPPOINT lpPoint) const;  void ClientToScreen(LPRECT lpRect) const;
 ```
 
@@ -1049,7 +1049,7 @@ The `ClientToScreen` member function assumes that the given point or rectangle i
 
 Minimizes the window.
 
-```
+```cpp
 void CloseWindow();
 ```
 
@@ -1164,7 +1164,7 @@ Creates an Active Accessibility proxy for the specified object.
 
 Creates a new shape for the system caret and claims ownership of the caret.
 
-```
+```cpp
 void CreateCaret(CBitmap* pBitmap);
 ```
 
@@ -1387,7 +1387,7 @@ The [CWnd::OnCreate](#oncreate) method is called before the `CreateEx` method re
 
 Creates a gray rectangle for the system caret and claims ownership of the caret.
 
-```
+```cpp
 void CreateGrayCaret(
     int nWidth,
     int nHeight);
@@ -1421,7 +1421,7 @@ The system caret is a shared resource. `CWnd` should create a caret only when it
 
 Creates a solid rectangle for the system caret and claims ownership of the caret.
 
-```
+```cpp
 void CreateSolidCaret(
     int nWidth,
     int nHeight);
@@ -1806,7 +1806,7 @@ For more information on dialog data exchange and validation, see [Displaying and
 
 Call this member function from within a window, using a `CWnd` pointer, in your application's [CWinApp::InitInstance](../../mfc/reference/cwinapp-class.md#initinstance) function to indicate that the window accepts dropped files from the Windows File Manager or File Explorer.
 
-```
+```cpp
 void DragAcceptFiles(BOOL bAccept = TRUE);
 ```
 
@@ -1908,7 +1908,7 @@ This member function emulates the functionality of the function [DrawCaption](/w
 
 Redraws the menu bar.
 
-```
+```cpp
 void DrawMenuBar();
 ```
 
@@ -1924,7 +1924,7 @@ If a menu bar is changed after Windows has created the window, call this functio
 
 Enables user-defined Active Accessibility functions.
 
-```
+```cpp
 void EnableActiveAccessibility();
 ```
 
@@ -1936,7 +1936,7 @@ MFC's default Active Accessibility support is sufficient for standard windows an
 
 Enables or disables the dynamic layout manager. When dynamic layout is enabled, the position and size of child windows can adjust dynamically when the user resizes the window.
 
-```
+```cpp
 void EnableDynamicLayout(BOOL bEnable = TRUE);
 ```
 
@@ -1953,7 +1953,7 @@ If you want to enable dynamic layout, you have to do more than just call this me
 
 Enables or disables window D2D support. Call this method before the main window is initialized.
 
-```
+```cpp
 void EnableD2DSupport(
     BOOL bEnable = TRUE,
     BOOL bUseDCRenderTarget = FALSE);
@@ -2007,7 +2007,7 @@ Nonzero if the arrows are enabled or disabled as specified. Otherwise it is 0, w
 
 Enables or disables the scroll bar for this window.
 
-```
+```cpp
 void EnableScrollBarCtrl(
     int nBar,
     BOOL bEnable = TRUE);
@@ -2146,7 +2146,7 @@ virtual void EndModalState();
 
 Marks the end of painting in the given window.
 
-```
+```cpp
 void EndPaint(LPPAINTSTRUCT lpPaint);
 ```
 
@@ -2194,7 +2194,7 @@ TRUE if a dialog resource is executed; otherwise FALSE.
 
 Called by the framework to display tool tip messages.
 
-```
+```cpp
 void FilterToolTipMessage(MSG* pMsg);
 ```
 
@@ -2879,7 +2879,7 @@ ID of the checked radio button, or 0 if none is selected.
 
 Copies the client coordinates of the `CWnd` client area into the structure pointed to by *lpRect*.
 
-```
+```cpp
 void GetClientRect(LPRECT lpRect) const;
 ```
 
@@ -3640,7 +3640,7 @@ In contrast, the [GetParent](#getparent) function returns a pointer to the immed
 
 Call this member function to get the ActiveX control property specified by *dwDispID*.
 
-```
+```cpp
 void GetProperty(
     DISPID dwDispID,
     VARTYPE vtProp,
@@ -3865,7 +3865,7 @@ The current position is a relative value that depends on the current scrolling r
 
 Copies the current minimum and maximum scroll-bar positions for the given scroll bar to the locations specified by *lpMinPos* and *lpMaxPos*.
 
-```
+```cpp
 void GetScrollRange(
     int nBar,
     LPINT lpMinPos,
@@ -4230,7 +4230,7 @@ The `flags` member of the [WINDOWPLACEMENT](/windows/win32/api/winuser/ns-winuse
 
 Copies the dimensions of the bounding rectangle of the `CWnd` object to the structure pointed to by *lpRect*.
 
-```
+```cpp
 void GetWindowRect(LPRECT lpRect) const;
 ```
 
@@ -4340,7 +4340,7 @@ This member function causes the [WM_GETTEXTLENGTH](/windows/win32/winmsg/wm-gett
 
 Hides the caret by removing it from the display screen.
 
-```
+```cpp
 void HideCaret();
 ```
 
@@ -4414,7 +4414,7 @@ See [CWinApp::HtmlHelp](../../mfc/reference/cwinapp-class.md#htmlhelp) for more 
 
 Called by the framework to initialize dynamic layout for a window.
 
-```
+```cpp
 void InitDynamicLayout();
 ```
 
@@ -4426,7 +4426,7 @@ Do not call this method directly.
 
 Invalidates the entire client area of `CWnd`.
 
-```
+```cpp
 void Invalidate(BOOL bErase = TRUE);
 ```
 
@@ -4451,7 +4451,7 @@ Windows sends a [WM_PAINT](#onpaint) message whenever the `CWnd` update region i
 
 Invalidates the client area within the given rectangle by adding that rectangle to the `CWnd` update region.
 
-```
+```cpp
 void InvalidateRect(
     LPCRECT lpRect,
     BOOL bErase = TRUE);
@@ -4477,7 +4477,7 @@ Windows sends a [WM_PAINT](#onpaint) message whenever the `CWnd` update region i
 
 Invalidates the client area within the given region by adding it to the current update region of `CWnd`.
 
-```
+```cpp
 void InvalidateRgn(
     CRgn* pRgn,
     BOOL bErase = TRUE);
@@ -4505,7 +4505,7 @@ The given region must have been previously created by one of the region function
 
 Call this member function to invoke the ActiveX Control method or property specified by *dwDispID*, in the context specified by *wFlags*.
 
-```
+```cpp
 void AFX_CDECL InvokeHelper(
     DISPID dwDispID,
     WORD wFlags,
@@ -4803,7 +4803,7 @@ The `m_hWnd` data member is a public variable of type HWND.
 
 Converts (maps) a set of points from the coordinate space of the `CWnd` to the coordinate space of another window.
 
-```
+```cpp
 void MapWindowPoints(
     CWnd* pwndTo,
     LPRECT lpRect) const;
@@ -4970,7 +4970,7 @@ To modify windows using regular window styles, see [ModifyStyle](#modifystyle).
 
 Changes the position and dimensions.
 
-```
+```cpp
 void MoveWindow(
     int x,
     int y,
@@ -5017,7 +5017,7 @@ The `MoveWindow` function sends the [WM_GETMINMAXINFO](#ongetminmaxinfo) message
 
 Signals the system that a predefined event occurred. If any client applications have registered a hook function for the event, the system calls the client's hook function.
 
-```
+```cpp
 void NotifyWinEvent(
     DWORD event,
     LONG idObjectType,
@@ -7759,7 +7759,7 @@ This method receives the [WM_DWMNCRENDERINGCHANGED](/windows/win32/dwm/wm-dwmncr
 
 The framework calls this member function when the user double-clicks XBUTTON1 or XBUTTON2 while the cursor is in the nonclient area of a window.
 
-```
+```cpp
 void OnNcXButtonDblClk(
     short nHitTest,
     UINT nButton,
@@ -9781,7 +9781,7 @@ Nonzero if the message was translated and should not be dispatched; 0 if the mes
 
 Call this member function to draw the current window in the specified device context, which is most commonly in a printer device context.
 
-```
+```cpp
 void Print(
     CDC* pDC,
     DWORD dwFlags) const;
@@ -9827,7 +9827,7 @@ Specifies the drawing options. This parameter can be one or more of these flags:
 
 Call this member function to draw any window in the specified device context (usually a printer device context).
 
-```
+```cpp
 void PrintClient(
     CDC* pDC,
     DWORD dwFlags) const;
@@ -10032,7 +10032,7 @@ The application must call the `ReleaseDC` member function for each call to the [
 
 Called to reposition and resize control bars in the client area of a window.
 
-```
+```cpp
 void RepositionBars(UINT nIDFirst,
     UINT nIDLast,
     UINT nIDLeftOver,
@@ -10106,7 +10106,7 @@ By default, `ContinueModal` returns FALSE after `EndModalLoop` is called. Return
 
 Converts the screen coordinates of a given point or rectangle on the display to client coordinates.
 
-```
+```cpp
 void ScreenToClient(LPPOINT lpPoint) const;  void ScreenToClient(LPRECT lpRect) const;
 ```
 
@@ -10130,7 +10130,7 @@ The `ScreenToClient` member function replaces the screen coordinates given in *l
 
 Scrolls the contents of the client area of the current `CWnd` object.
 
-```
+```cpp
 void ScrollWindow(
     int xAmount,
     int yAmount,
@@ -10323,7 +10323,7 @@ The `SendMessage` member function calls the window procedure directly and does n
 
 Call this member function to send the specified Windows message to all descendant windows.
 
-```
+```cpp
 void SendMessageToDescendants(
     UINT message,
     WPARAM wParam = 0,
@@ -10493,7 +10493,7 @@ The window can be any child window, not only a control in a dialog box. The wind
 
 Sets the text of a given control in a dialog box to the string representation of a specified integer value.
 
-```
+```cpp
 void SetDlgItemInt(
     int nID,
     UINT nValue,
@@ -10523,7 +10523,7 @@ Specifies whether the integer value is signed or unsigned. If this parameter is 
 
 Sets the caption or text of a control owned by a window or dialog box.
 
-```
+```cpp
 void SetDlgItemText(
     int nID,
     LPCTSTR lpszString);
@@ -10589,7 +10589,7 @@ If the current window is active but does not have the focus (that is, no window 
 
 Sends the WM_SETFONT message to the window to use the specified font.
 
-```
+```cpp
 void SetFont(
     CFont* pFont,
     BOOL bRedraw = TRUE);
@@ -10698,7 +10698,7 @@ Causes the window to be redrawn to reflect the menu change.
 
 Sets the current window's owner to the specified window object.
 
-```
+```cpp
 void SetOwner(CWnd* pOwnerWnd);
 ```
 
@@ -10740,7 +10740,7 @@ If the child window is visible, Windows performs the appropriate redrawing and r
 
 Call this member function to set the OLE control property specified by *dwDispID*.
 
-```
+```cpp
 void AFX_CDECL SetProperty(
     DISPID dwDispID,
     VARTYPE vtProp, ...);
@@ -10768,7 +10768,7 @@ For more information about using this member function with OLE Control Container
 
 An application calls `SetRedraw` to allow changes to be redrawn or to prevent changes from being redrawn.
 
-```
+```cpp
 void SetRedraw(BOOL bRedraw = TRUE);
 ```
 
@@ -10864,7 +10864,7 @@ Setting *bRedraw* to FALSE is useful whenever the scroll bar will be redrawn by 
 
 Sets minimum and maximum position values for the given scroll bar.
 
-```
+```cpp
 void SetScrollRange(
     int nBar,
     int nMinPos,
@@ -10935,7 +10935,7 @@ An interval value is specified, and every time the interval elapses, the system 
 
 The *lpfnTimer* callback function need not be named `TimerProc`, but it must be declared as static and defined as follows.
 
-```
+```cpp
 void CALLBACK TimerProc(
     HWND hWnd,   // handle of CWnd that called SetTimer
     UINT nMsg,   // WM_TIMER
@@ -11129,7 +11129,7 @@ After a successful call to `SetWindowRgn`, the operating system owns the region 
 
 Sets the window's title to the specified text.
 
-```
+```cpp
 void SetWindowText(LPCTSTR lpszString);
 ```
 
@@ -11152,7 +11152,7 @@ This function causes a [WM_SETTEXT](/windows/win32/winmsg/wm-settext) message to
 
 Shows the caret on the screen at the caret's current position.
 
-```
+```cpp
 void ShowCaret();
 ```
 
@@ -11174,7 +11174,7 @@ The caret is a shared resource. The window should show the caret only when it ha
 
 Shows or hides all pop-up windows owned by this window.
 
-```
+```cpp
 void ShowOwnedPopups(BOOL bShow = TRUE);
 ```
 
@@ -11191,7 +11191,7 @@ Specifies whether pop-up windows are to be shown or hidden. If this parameter is
 
 Shows or hides a scroll bar.
 
-```
+```cpp
 void ShowScrollBar(
     UINT nBar,
     BOOL bShow = TRUE);
@@ -11326,7 +11326,7 @@ This member function attaches the Windows control to a `CWnd` object and replace
 
 Call this member function to unlock a window that was locked with `CWnd::LockWindowUpdate`.
 
-```
+```cpp
 void UnlockWindowUpdate();
 ```
 
@@ -11375,7 +11375,7 @@ The framework automatically calls `UpdateData` with *bSaveAndValidate* set to FA
 
 Call this member function to update the state of dialog buttons and other controls in a dialog box or window that uses the [ON_UPDATE_COMMAND_UI](message-map-macros-mfc.md#on_update_command_ui) callback mechanism.
 
-```
+```cpp
 void UpdateDialogControls(
     CCmdTarget* pTarget,
     BOOL bDisableIfNoHndler);
@@ -11455,7 +11455,7 @@ This member function emulates the functionality of the function [UpdateLayeredWi
 
 Updates the client area by sending a [WM_PAINT](/windows/win32/gdi/wm-paint) message if the update region is not empty.
 
-```
+```cpp
 void UpdateWindow();
 ```
 
@@ -11471,7 +11471,7 @@ The `UpdateWindow` member function sends a WM_PAINT message directly, bypassing 
 
 Validates the client area within the given rectangle by removing the rectangle from the update region of the window.
 
-```
+```cpp
 void ValidateRect(LPCRECT lpRect);
 ```
 
@@ -11490,7 +11490,7 @@ Windows continues to generate WM_PAINT messages until the current update region 
 
 Validates the client area within the given region by removing the region from the current update region of the window.
 
-```
+```cpp
 void ValidateRgn(CRgn* pRgn);
 ```
 

--- a/docs/mfc/reference/database-macros-and-globals.md
+++ b/docs/mfc/reference/database-macros-and-globals.md
@@ -32,7 +32,7 @@ For MFC database (or DAO) support from a regular MFC DLL that is dynamically lin
 
 ### Syntax
 
-```
+```cpp
 void AFXAPI AfxDbInitModule( );
 ```
 

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -103,7 +103,7 @@ Call this function to cause a break (at the location of the call to `AfxDebugBre
 
 ### Syntax
 
-```
+```cpp
 void AfxDebugBreak( );
 ```
 
@@ -413,7 +413,7 @@ Internal function that MFC uses to dump the state of an object while debugging.
 
 ### Syntax
 
-```
+```cpp
 void AfxDump(const CObject* pOb);
 ```
 
@@ -462,7 +462,7 @@ int  afxMemDF;
 
 This function tests the passed SCODE to see if it is an error.
 
-```
+```cpp
 void AFXAPI AfxCheckError(SCODE sc);
 throw CMemoryException*
 throw COleException*
@@ -526,7 +526,7 @@ This function works only in the Debug version of MFC.
 
 Call this function while in the debugger to dump the state of an object while debugging.
 
-```
+```cpp
 void AfxDump(const CObject* pOb);
 ```
 
@@ -549,7 +549,7 @@ Your program code should not call `AfxDump`, but should instead call the `Dump` 
 
 This global function can be used to generate an image of the current stack.
 
-```
+```cpp
 void AFXAPI AfxDumpStack(DWORD dwTarget = AFX_STACK_DUMP_TARGET_DEFAULT);
 ```
 
@@ -837,7 +837,7 @@ Note that the AFXAPI calling convention implies that the callee must remove the 
 
 Calls the specified iteration function for all serializable `CObject`-derived classes in the application's memory space.
 
-```
+```cpp
 void
 AFXAPI AfxDoForAllClasses(
     void (* pfn)(const CRuntimeClass* pClass, void* pContext),
@@ -873,7 +873,7 @@ Serializable `CObject`-derived classes are classes derived using the DECLARE_SER
 
 Executes the specified iteration function for all objects derived from `CObject` that have been allocated with **new**.
 
-```
+```cpp
 void AfxDoForAllObjects(
     void (* pfn)(CObject* pObject, void* pContext),
     void* pContext);

--- a/docs/mfc/reference/exception-processing.md
+++ b/docs/mfc/reference/exception-processing.md
@@ -293,7 +293,7 @@ See the example for [CFile::Abort](../../mfc/reference/cfile-class.md#abort).
 
 Throws an archive exception.
 
-```
+```cpp
 void  AfxThrowArchiveException(int cause, LPCTSTR lpszArchiveName);
 ```
 
@@ -313,7 +313,7 @@ Points to a string containing the name of the `CArchive` object that caused the 
 
 Throws a file exception.
 
-```
+```cpp
 void AfxThrowFileException(
     int cause,
     LONG lOsError = -1,
@@ -345,7 +345,7 @@ Throws an invalid argument exception.
 
 ### Syntax
 
-```
+```cpp
 void AfxThrowInvalidArgException( );
 ```
 
@@ -361,7 +361,7 @@ This function is called when invalid arguments are used.
 
 Throws a memory exception.
 
-```
+```cpp
 void AfxThrowMemoryException();
 ```
 
@@ -377,7 +377,7 @@ Call this function if calls to underlying system memory allocators (such as **ma
 
 Throws an exception that is the result of a request for an unsupported feature.
 
-```
+```cpp
 void AfxThrowNotSupportedException();
 ```
 
@@ -389,7 +389,7 @@ void AfxThrowNotSupportedException();
 
 Throws a resource exception.
 
-```
+```cpp
 void  AfxThrowResourceException();
 ```
 
@@ -405,7 +405,7 @@ This function is normally called when a Windows resource cannot be loaded.
 
 Throws an exception to stop an end-user operation.
 
-```
+```cpp
 void AfxThrowUserException();
 ```
 
@@ -421,7 +421,7 @@ This function is normally called immediately after `AfxMessageBox` has reported 
 
 Use this function to throw an exception within an OLE automation function.
 
-```
+```cpp
 void AFXAPI AfxThrowOleDispatchException(
     WORD wCode ,
     LPCSTR lpszDescription,
@@ -463,7 +463,7 @@ The information provided to this function can be displayed by the driving applic
 
 Creates an object of type `COleException` and throws an exception.
 
-```
+```cpp
 void AFXAPI AfxThrowOleException(SCODE sc);
 void AFXAPI AfxThrowOleException(HRESULT hr);
 ```
@@ -488,7 +488,7 @@ The version that takes an HRESULT as an argument converts that result code into 
 
 Call this function to throw an exception of type [CDaoException](../../mfc/reference/cdaoexception-class.md) from your own code.
 
-```
+```cpp
 void AFXAPI AfxThrowDaoException(
     int nAfxDaoError = NO_AFX_DAO_ERROR,
     SCODE scode = S_OK);
@@ -516,7 +516,7 @@ For information about exceptions related to the MFC DAO classes, see class `CDao
 
 Call this function to throw an exception of type `CDBException` from your own code.
 
-```
+```cpp
 void AfxThrowDBException(
     RETCODE nRetCode,
     CDatabase* pdb,
@@ -548,7 +548,7 @@ For information about the RETCODE values defined by ODBC, see Chapter 8, "Retrie
 
 The default termination function supplied by MFC.
 
-```
+```cpp
 void  AfxAbort();
 ```
 

--- a/docs/mfc/reference/extension-dll-macros.md
+++ b/docs/mfc/reference/extension-dll-macros.md
@@ -84,7 +84,7 @@ For OLE support from a regular MFC DLL that is dynamically linked to MFC, call t
 
 ### Syntax
 
-```
+```cpp
 void AFXAPI AfxOleInitModule( );
 ```
 
@@ -104,7 +104,7 @@ For MFC Sockets support from a regular MFC DLL that is dynamically linked to MFC
 
 ### Syntax
 
-```
+```cpp
 void AFXAPI AfxNetInitModule( );
 ```
 
@@ -237,7 +237,7 @@ Use this function to set the per-module state flag, which affects the WinSxS beh
 
 ### Syntax
 
-```
+```cpp
 void AFXAPI AfxSetAmbientActCtx(BOOL bSet);
 ```
 
@@ -272,7 +272,7 @@ Call this function to allow MFC to clean up the MFC extension DLL when each proc
 
 ### Syntax
 
-```
+```cpp
 void AFXAPI AfxTermExtensionModule(  AFX_EXTENSION_MODULE& state,  BOOL bAll  = FALSE );
 ```
 

--- a/docs/mfc/reference/gray-and-dithered-bitmap-functions.md
+++ b/docs/mfc/reference/gray-and-dithered-bitmap-functions.md
@@ -33,7 +33,7 @@ MFC also provides two functions for replacing a bitmap's background with a dithe
 
 Draws a gray version of a bitmap.
 
-```
+```cpp
 void AFXAPI AfxDrawGrayBitmap(
     CDC* pDC,
     int x,
@@ -77,7 +77,7 @@ A bitmap drawn with `AfxDrawGrayBitmap` will have the appearance of a disabled c
 
 Copies a gray version of a bitmap.
 
-```
+```cpp
 void AFXAPI AfxGetGrayBitmap(
     const CBitmap& rSrc,
     CBitmap* pDest,
@@ -113,7 +113,7 @@ A bitmap copied with `AfxGetGrayBitmap` will have the appearance of a disabled c
 
 Draws a bitmap, replacing its background with a dithered (checker) pattern.
 
-```
+```cpp
 void AFXAPI AfxDrawDitheredBitmap(
     CDC* pDC,
     int x,
@@ -161,7 +161,7 @@ The source bitmap is drawn on the destination DC with a two-color (*cr1* and *cr
 
 Copies a bitmap, replacing its background with a dithered (checker) pattern.
 
-```
+```cpp
 void AFXAPI AfxGetDitheredBitmap(
     const CBitmap& rSrc,
     CBitmap* pDest,

--- a/docs/mfc/reference/icommandtarget-interface.md
+++ b/docs/mfc/reference/icommandtarget-interface.md
@@ -39,7 +39,7 @@ For more information on using Windows Forms, see [Using a Windows Form User Cont
 
 Initializes the command target object.
 
-```
+```cpp
 void Initialize(ICommandSource^ cmdSource);
 ```
 

--- a/docs/mfc/reference/icommandui-interface.md
+++ b/docs/mfc/reference/icommandui-interface.md
@@ -61,7 +61,7 @@ This property sets the user interface item for this command to the appropriate c
 
 Tells the command routing mechanism to continue routing the current message down the chain of handlers.
 
-```
+```cpp
 void ContinueRouting();
 ```
 

--- a/docs/mfc/reference/iview-interface.md
+++ b/docs/mfc/reference/iview-interface.md
@@ -41,7 +41,7 @@ Header: afxwinforms.h (defined in assembly atlmfc\lib\mfcmifc80.dll)
 
 Called by MFC when a view is activated or deactivated.
 
-```
+```cpp
 void OnActivateView(bool activate);
 ```
 
@@ -54,7 +54,7 @@ Indicates whether the view is being activated or deactivated.
 
 Called by the framework after the view is first attached to the document, but before the view is initially displayed.
 
-```
+```cpp
 void OnInitialUpdate();
 ```
 
@@ -62,7 +62,7 @@ void OnInitialUpdate();
 
 Called by MFC after the view's document has been modified.
 
-```
+```cpp
 void OnUpdate();
 ```
 

--- a/docs/mfc/reference/ole-initialization.md
+++ b/docs/mfc/reference/ole-initialization.md
@@ -22,7 +22,7 @@ Call this function in your application object's `InitInstance` function to enabl
 
 ### Syntax
 
-```
+```cpp
 void AfxEnableControlContainer( );
 ```
 

--- a/docs/mfc/reference/property-pages-mfc.md
+++ b/docs/mfc/reference/property-pages-mfc.md
@@ -41,7 +41,7 @@ The following is a list of macros used to create and manage property pages for a
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of an integer property with the index of the current selection in a combo box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_CBIndex(
     CDataExchange* pDX,
     int id,
@@ -75,7 +75,7 @@ This function should be called before the corresponding `DDX_CBIndex` function c
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of a string property with the current selection in a combo box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_CBString(
     CDataExchange* pDX,
     int id,
@@ -109,7 +109,7 @@ This function should be called before the corresponding `DDX_CBString` function 
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of a string property that exactly matches the current selection in a combo box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_CBStringExact(
     CDataExchange* pDX,
     int id,
@@ -143,7 +143,7 @@ This function should be called before the corresponding `DDX_CBStringExact` func
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of the property with the associated property page check box control.
 
-```
+```cpp
 void AFXAPI DDP_Check(
     CDataExchange* pDX,
     int id,
@@ -177,7 +177,7 @@ This function should be called before the corresponding `DDX_Check` function cal
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of an integer property with the index of the current selection in a list box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_LBIndex(
     CDataExchange* pDX,
     int id,
@@ -211,7 +211,7 @@ This function should be called before the corresponding `DDX_LBIndex` function c
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of a string property with the current selection in a list box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_LBString(
     CDataExchange* pDX,
     int id,
@@ -245,7 +245,7 @@ This function should be called before the corresponding `DDX_LBString` function 
 
 Call this function in your property page's `DoDataExchange` function to synchronize the value of a string property that exactly matches the current selection in a list box on the property page.
 
-```
+```cpp
 void AFXAPI DDP_LBStringExact(
     CDataExchange* pDX,
     int id,
@@ -279,7 +279,7 @@ This function should be called before the corresponding `DDX_LBStringExact` func
 
 Call this function in your property page's `DoDataExchange` function, to finish the transfer of property values from the property page to your control when property values are being saved.
 
-```
+```cpp
 void AFXAPI DDP_PostProcessing(CDataExchange * pDX);
 ```
 
@@ -302,7 +302,7 @@ This function should be called after all data exchange functions are completed. 
 
 Call this function in your control's `DoPropExchange` function to synchronize the value of the property with the associated property page radio button control.
 
-```
+```cpp
 void AFXAPI DDP_Radio(
     CDataExchange* pDX,
     int id,
@@ -336,7 +336,7 @@ This function should be called before the corresponding `DDX_Radio` function cal
 
 Call this function in your control's `DoDataExchange` function to synchronize the value of the property with the associated property page control.
 
-```
+```cpp
 void AFXAPI DDP_Text(
     CDataExchange* pDX,
     int id,

--- a/docs/mfc/tn045-mfc-database-support-for-long-varchar-varbinary.md
+++ b/docs/mfc/tn045-mfc-database-support-for-long-varchar-varbinary.md
@@ -36,7 +36,7 @@ This approach is simple to understand, and you work with familiar classes. The f
 
 The RFX functions for `CString` and `CByteArray` have an additional argument which lets you override the default size of allocated memory to hold the retrieved value for the data column. Note the nMaxLength argument in the following function declarations:
 
-```
+```cpp
 void AFXAPI RFX_Text(CFieldExchange* pFX,
     const char *szName,
     CString& value,

--- a/docs/mfc/tn059-using-mfc-mbcs-unicode-conversion-macros.md
+++ b/docs/mfc/tn059-using-mfc-mbcs-unicode-conversion-macros.md
@@ -100,7 +100,7 @@ Again, there are similar macros for doing TEXTMETRIC, DEVMODE, BSTR, and OLE all
 
 Do not use the macros in a tight loop. For example, you do not want to write the following kind of code:
 
-```
+```cpp
 void BadIterateCode(LPCTSTR lpsz)
 {
     USES_CONVERSION;
@@ -112,7 +112,7 @@ void BadIterateCode(LPCTSTR lpsz)
 
 The code above could result in allocating megabytes of memory on the stack depending on what the contents of the string `lpsz` is! It also takes time to convert the string for each iteration of the loop. Instead, move such constant conversions out of the loop:
 
-```
+```cpp
 void MuchBetterIterateCode(LPCTSTR lpsz)
 {
     USES_CONVERSION;
@@ -126,7 +126,7 @@ void MuchBetterIterateCode(LPCTSTR lpsz)
 
 If the string is not constant, then encapsulate the method call into a function. This will allow the conversion buffer to be freed each time. For example:
 
-```
+```cpp
 void CallSomeMethod(int ii, LPCTSTR lpsz)
 {
     USES_CONVERSION;


### PR DESCRIPTION

Find/replace for code fences starting with "void"