### PR TITLE
Typo "** _O_APPEND**"→"**_O_APPEND**"

### DIFF
--- a/docs/c-runtime-library/reference/fopen-s-wfopen-s.md
+++ b/docs/c-runtime-library/reference/fopen-s-wfopen-s.md
@@ -145,11 +145,11 @@ Valid characters for the *mode* string used in **fopen_s** and [_fdopen](fdopen-
 
 |Characters in *mode* string|Equivalent *oflag* value for _open/_sopen|
 |-------------------------------|----------------------------------------------------|
-|**a**|**_O_WRONLY** &#124; **_O_APPEND** (usually **_O_WRONLY** &#124; **_O_CREAT** &#124;** _O_APPEND**)|
-|**a+**|**_O_RDWR** &#124; **_O_APPEND** (usually **_O_RDWR** &#124; **_O_APPEND** &#124; **_O_CREAT** )|
+|**a**|**_O_WRONLY** &#124; **_O_APPEND** (usually **_O_WRONLY** &#124; **_O_CREAT** &#124; **_O_APPEND**)|
+|**a+**|**_O_RDWR** &#124; **_O_APPEND** (usually **_O_RDWR** &#124; **_O_APPEND** &#124; **_O_CREAT**)|
 |**r**|**_O_RDONLY**|
 |**r+**|**_O_RDWR**|
-|**w**|**_O_WRONLY** (usually **_O_WRONLY** &#124; **_O_CREAT** &#124;** _O_TRUNC**)|
+|**w**|**_O_WRONLY** (usually **_O_WRONLY** &#124; **_O_CREAT** &#124; **_O_TRUNC**)|
 |**w+**|**_O_RDWR** (usually **_O_RDWR** &#124; **_O_CREAT** &#124; **_O_TRUNC**)|
 |**b**|**_O_BINARY**|
 |**t**|**_O_TEXT**|


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-s-wfopen-s?view=vs-2019