### PR TITLE
Fixed location in IDE

### DIFF
--- a/docs/build/reference/md-mt-ld-use-run-time-library.md
+++ b/docs/build/reference/md-mt-ld-use-run-time-library.md
@@ -40,9 +40,7 @@ For more about DLLs, see [Create C/C++ DLLs in Visual Studio](../dlls-in-visual-
 
 1. Open the project's **Property Pages** dialog box. For details, see [Set C++ compiler and build properties in Visual Studio](../working-with-project-properties.md).
 
-1. Select the **Configuration Properties** > **C/C++** > **Command Line** property page.
-
-1. Select the **Code Generation** property page.
+1. Select the **Configuration Properties** > **C/C++** > **Code Generation** property page.
 
 1. Modify the **Runtime Library** property.
 


### PR DESCRIPTION
Runtime Library is located in Code Generation, not Command Line, in Visual Studio 2019