### PR TITLE
Meaning of the postfix-expression

### DIFF
--- a/docs/cpp/function-call-operator-parens.md
+++ b/docs/cpp/function-call-operator-parens.md
@@ -7,7 +7,7 @@ no-loc: [ opt ]
 ---
 # Function Call Operator: ()
 
-A function call is a kind of *`postfix-expression`*, formed by an expression that evaluates to a function or some other callable object followed by the function-call operator, **`()`**. An object can declare an `operator ()` function, which provides function call semantics for the object.
+A function call is a kind of *`postfix-expression`*, formed by an expression that evaluates to a function or callable object followed by the function-call operator, **`()`**. An object can declare an `operator ()` function, which provides function call semantics for the object.
 
 ## Syntax
 
@@ -18,14 +18,14 @@ A function call is a kind of *`postfix-expression`*, formed by an expression tha
 
 The arguments to the function-call operator come from an *`argument-expression-list`*, a comma-separated list of expressions. The values of these expressions are passed to the function as arguments. The *argument-expression-list* can be empty. Before C++ 17, the order of evaluation of the function expression and the argument expressions is unspecified and may occur in any order. In C++17 and later, the function expression is evaluated before any argument expressions or default arguments. The argument expressions are evaluated in an indeterminate sequence.
 
-The *`postfix-expression`* will evaluate to the function to be called. It can take any of several forms:
+The *`postfix-expression`* evaluates to the function to call. It can take any of several forms:
 
 - a function identifier, visible in the current scope or in the scope of any of the function arguments provided, 
-- an expression that evaluates to a function, a function pointer or a some other callable object, or to a reference to one,
+- an expression that evaluates to a function, a function pointer, a callable object, or to a reference to one,
 - a member function accessor, either explicit or implied,
 - a dereferenced pointer to a member function.
 
-The *`postfix-expression`* may consist of an overloaded function identifier or overloaded member function accessor. The rules for overload resolution determine the actual function to be called.  If the member function is virtual, the function to be called will be determined at run time.
+The *`postfix-expression`* may be an overloaded function identifier or overloaded member function accessor. The rules for overload resolution determine the actual function to call. If the member function is virtual, the function to call is determined at run time.
 
 Some example declarations:
 

--- a/docs/cpp/function-call-operator-parens.md
+++ b/docs/cpp/function-call-operator-parens.md
@@ -7,24 +7,25 @@ no-loc: [ opt ]
 ---
 # Function Call Operator: ()
 
-A function call is a kind of *`postfix-expression`*, formed by an expression that identifies a function followed by the function-call operator, **`()`**. An object can declare an `operator ()` function, which provides function call semantics for the object.
+A function call is a kind of *`postfix-expression`*, formed by an expression that evaluates to a function or some other callable object followed by the function-call operator, **`()`**. An object can declare an `operator ()` function, which provides function call semantics for the object.
 
 ## Syntax
 
 > *`postfix-expression`*:\
-> &nbsp;&nbsp;&nbsp;&nbsp;*`postfix-expression`* **`(`** *`argument-expression-list`* <sub>opt</sub> **`)`**
+> &emsp;*`postfix-expression`* **`(`** *`argument-expression-list`* <sub>opt</sub> **`)`**
 
 ## Remarks
 
 The arguments to the function-call operator come from an *`argument-expression-list`*, a comma-separated list of expressions. The values of these expressions are passed to the function as arguments. The *argument-expression-list* can be empty. Before C++ 17, the order of evaluation of the function expression and the argument expressions is unspecified and may occur in any order. In C++17 and later, the function expression is evaluated before any argument expressions or default arguments. The argument expressions are evaluated in an indeterminate sequence.
 
-The *`postfix-expression`* identifies the function to call. It must evaluate to a function address. It can take any of several forms:
+The *`postfix-expression`* will evaluate to the function to be called. It can take any of several forms:
 
-- a function or function object name or pointer,
-- an lvalue expression that refers to a function or function object,
-- a member function accessor, either explicit or implied.
+- a function identifier, visible in the current scope or in the scope of any of the function arguments provided, 
+- an expression that evaluates to a function, a function pointer or a some other callable object, or to a reference to one,
+- a member function accessor, either explicit or implied,
+- a dereferenced pointer to a member function.
 
-The function specified by the *`postfix-expression`* may be an overloaded function. The usual rules for overload resolution determine the actual function to call.
+The *`postfix-expression`* may consist of an overloaded function identifier or overloaded member function accessor. The rules for overload resolution determine the actual function to be called.  If the member function is virtual, the function to be called will be determined at run time.
 
 Some example declarations:
 


### PR DESCRIPTION
Fix the following problems with the current text:
1. An expression does not identify anything, it is an identifier’s job.
2. There is no such thing as a function object.
3. A reference to a callable object need not be an lvalue expression.
4. Joining some elements of an unordered list with **or** is confusing, especially when all alternatives are of equal status and importance.

I also have also included several remarks that I consider would improve the reliability of the text.

## TO DO

1. The examples are inconsistent.
1. Links to detailed explanations of key concepts.