### PR TITLE
says "you must also specify \Og" but that is not true

### DIFF
--- a/docs/build/reference/os-ot-favor-small-code-favor-fast-code.md
+++ b/docs/build/reference/os-ot-favor-small-code-favor-fast-code.md
@@ -23,9 +23,6 @@ Minimizes or maximizes the size of EXEs and DLLs.
 **/Ot** (Favor Fast Code) maximizes the speed of EXEs and DLLs by instructing the compiler to favor speed over size. (This is the default.) The compiler can reduce many C and C++ constructs to functionally similar sequences of machine code. Occasionally, these differences offer tradeoffs of size versus speed. The **/Ot** option is implied by the Maximize Speed ([/O2](o1-o2-minimize-size-maximize-speed.md)) option. The **/O2** option combines several options to produce very fast code.
 
 > [!NOTE]
-> **/Os** or **/Ot** only takes effect if code optimization is enabled. For more information on optimizations, see [/O1, /O2 (Minimize Size, Maximize Speed)](o1-o2-minimize-size-maximize-speed.md) or [/Ox (Enable Most Speed Optimizations)](ox-full-optimization.md).
-
-> [!NOTE]
 > Information that is gathered from profiling test runs will override optimizations that would otherwise be in effect if you specify **/Ob**, **/Os**, or **/Ot**. For more information, [Profile-Guided Optimizations](../profile-guided-optimizations.md).
 
 **x86 Specific**

--- a/docs/build/reference/os-ot-favor-small-code-favor-fast-code.md
+++ b/docs/build/reference/os-ot-favor-small-code-favor-fast-code.md
@@ -22,7 +22,8 @@ Minimizes or maximizes the size of EXEs and DLLs.
 
 **/Ot** (Favor Fast Code) maximizes the speed of EXEs and DLLs by instructing the compiler to favor speed over size. (This is the default.) The compiler can reduce many C and C++ constructs to functionally similar sequences of machine code. Occasionally, these differences offer tradeoffs of size versus speed. The **/Ot** option is implied by the Maximize Speed ([/O2](o1-o2-minimize-size-maximize-speed.md)) option. The **/O2** option combines several options to produce very fast code.
 
-If you use **/Os** or **/Ot**, then you must also specify [/Og](og-global-optimizations.md) to optimize the code.
+> [!NOTE]
+> **/Os** or **/Ot** only takes effect if code optimization is enabled. For more information on optimizations, see [/O1, /O2 (Minimize Size, Maximize Speed)](o1-o2-minimize-size-maximize-speed.md) or [/Ox (Enable Most Speed Optimizations)](ox-full-optimization.md).
 
 > [!NOTE]
 > Information that is gathered from profiling test runs will override optimizations that would otherwise be in effect if you specify **/Ob**, **/Os**, or **/Ot**. For more information, [Profile-Guided Optimizations](../profile-guided-optimizations.md).


### PR DESCRIPTION
Doc for /Ot /Os says

`If you use **/Os** or **/Ot**, then you must also specify [/Og](og-global-optimizations.md) to optimize the code.`

...but if you look at the doc for /Og it says

"Deprecated. Provides local and global optimizations, automatic-register allocation, and loop optimization. We recommend you use either /O1 (Minimize Size) or /O2 (Maximize Speed) instead."

...and in the remarks section

"/Og is deprecated. These optimizations are now generally enabled by default. For more information on optimizations, see /O1, /O2 (Minimize Size, Maximize Speed) or /Ox (Enable Most Speed Optimizations)."

...so I've removed the misleading instruction to turn on /Og (which is actually not even possible through the Visual Studio options optimization pane - which makes sense since it's deprecated) and instead added a more generic message about turning on optimizations (copied the "For more information" part from https://github.com/MicrosoftDocs/cpp-docs/edit/master/docs/build/reference/og-global-optimizations.md)

Since it's no longer a direct instruction but just further info I've changed it to a [!NOTE]