### PR TITLE
Update compiler-error-c3028.md to ensure correct syntax highlighting in browser for MyClass::x_private inside OpenMP pragma

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3028.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3028.md
@@ -71,8 +71,7 @@ MyClass::MyClass(int x) {
    // OK
       ;
 
-   #pragma omp parallel reduction(+: x, g_i, MyClass::x_public,
-   MyClass::x_private)
+   #pragma omp parallel reduction(+: MyClass::x_public, MyClass::x_private)
    // OK
       ;
 


### PR DESCRIPTION
Ensure MyClass::x_private is in the same line as #pragma, to get correct syntax highlighting. Also removed x/g_i since previous OpenMP pragma line already covered them. This is to ensure the line width does not increase too much since previous issue may be caused by auto format post processing to ensure better experience in all devices.