### PR TITLE
Fix syntax examples for interfaces, ref classes, and ref structs (C++/CLI and C++/CX)

### DIFF
--- a/docs/extensions/classes-and-structs-cpp-component-extensions.md
+++ b/docs/extensions/classes-and-structs-cpp-component-extensions.md
@@ -15,13 +15,10 @@ The **ref class** or **ref struct** extensions declare a class or struct whose *
 ### Syntax
 
 ```cpp
-      class_access
-      ref class
-      name
-      modifier :  inherit_accessbase_type {};
-class_accessref structnamemodifier :  inherit_accessbase_type {};
-class_accessvalue classnamemodifier :  inherit_accessbase_type {};
-class_accessvalue structnamemodifier :  inherit_accessbase_type {};
+class_access ref class name modifier :  inherit_accessbase_type {};
+class_access ref struct name modifier :  inherit_access base_type {};
+class_access value class name modifier :  inherit_access base_type {};
+class_access value struct name modifier :  inherit_access base_type {};
 ```
 
 ### Parameters

--- a/docs/extensions/classes-and-structs-cpp-component-extensions.md
+++ b/docs/extensions/classes-and-structs-cpp-component-extensions.md
@@ -15,10 +15,10 @@ The **ref class** or **ref struct** extensions declare a class or struct whose *
 ### Syntax
 
 ```cpp
-class_access ref class name modifier :  inherit_accessbase_type {};
-class_access ref struct name modifier :  inherit_access base_type {};
-class_access value class name modifier :  inherit_access base_type {};
-class_access value struct name modifier :  inherit_access base_type {};
+class_access ref class name modifier : inherit_accessbase_type {};
+class_access ref struct name modifier : inherit_access base_type {};
+class_access value class name modifier : inherit_access base_type {};
+class_access value struct name modifier : inherit_access base_type {};
 ```
 
 ### Parameters

--- a/docs/extensions/interface-class-cpp-component-extensions.md
+++ b/docs/extensions/interface-class-cpp-component-extensions.md
@@ -15,9 +15,8 @@ Declares an interface.  For information on native interfaces, see [__interface](
 ### Syntax
 
 ```cpp
-interface_access
-interface class
-name :  inherit_accessbase_interface{};interface_accessinterface structname :  inherit_accessbase_interface{};
+interface_access interface class name : inherit_access base_interface {};
+interface_access interface struct name : inherit_access base_interface {};
 ```
 
 ### Parameters


### PR DESCRIPTION
This pull request corrects wrongly formatted syntax examples for interfaces, ref classes, and ref structs (C++/CLI and C++/CX).