### PR TITLE
Update C26474 to clarify base/derived use cases.

### DIFF
--- a/docs/code-quality/c26474.md
+++ b/docs/code-quality/c26474.md
@@ -21,11 +21,11 @@ In some cases, implicit casts between pointer types can safely be done and donâ€
 - The rule ID is a bit misleading: it should be interpreted as "implicit cast is not used where it is acceptable".
   - The rule is applicable to pointers only and checks static casts and reinterpret casts.
   - The following cases are acceptable pointer conversions that should not use explicit cast expressions:
-  - conversion to nullptr_t;
-  - conversion to void*;
-  - conversion from derived type to its base.
+    - conversion to nullptr_t;
+    - conversion to void*;
+    - conversion from a derived type to its base when invoking a base member function that is not hidden by the derived type. 
 
-## Example
+## Example 1
 
 unnecessary conversion hides logic error
 
@@ -57,4 +57,25 @@ bool register_buffer(T *buffer) {
     return buffers_.insert(p).second;
 }
 // ...
+```
+
+## Example 2
+Using casts to access base-class member functions
+```cpp
+struct struct_1
+{
+  void foo();
+  void bar();
+}
+struct struct_2 : struct_1
+{
+  void foo(); // this definition hides struct_1::foo
+}
+
+void fn(struct_2* ps2)
+{
+  static_cast<struct_1*>(ps2)->foo(); // this cast is necessary to access `struct_1::foo`
+                                      // alternatively ps2->struct_1::foo();
+  static_cast<struct_1*>(ps2)->bar(); // this cast is unnecessary and can be done implicitly
+}
 ```

--- a/docs/code-quality/c26474.md
+++ b/docs/code-quality/c26474.md
@@ -66,11 +66,11 @@ struct struct_1
 {
   void foo();
   void bar();
-}
+};
 struct struct_2 : struct_1
 {
   void foo(); // this definition hides struct_1::foo
-}
+};
 
 void fn(struct_2* ps2)
 {


### PR DESCRIPTION
Updating documentation regarding base/derived casts.
Additionally, updated the indentation in the provided examples.