### PR TITLE
Add C++ Core Guidelines link on C26405

### DIFF
--- a/docs/code-quality/c26405.md
+++ b/docs/code-quality/c26405.md
@@ -8,7 +8,7 @@ ms.assetid: 2034d961-3ec5-4184-bbef-aa792e4c03c0
 ---
 # C26405  DONT_ASSIGN_TO_VALID
 
-If an owner pointer already points to a valid memory buffer, it must not be assigned to another value without releasing its current resource first. Such assignment may lead to a resource leak even if the resource address is copied into some raw pointer (because raw pointers shouldn’t release resources).
+If an owner pointer already points to a valid memory buffer, it must not be assigned to another value without releasing its current resource first. Such assignment may lead to a resource leak even if the resource address is copied into some raw pointer (because raw pointers shouldn’t release resources). For more information, see the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning).
 
 ## Example 1: Overwriting an owner in a loop
 


### PR DESCRIPTION
The rule C26405 references R.3 from the C++ Core Guidelines. This change adds a link to the R.3 section of the C++ Core Guidelines.