### PR TITLE
Add C++ Core Guidelines link to C26406

### DIFF
--- a/docs/code-quality/c26406.md
+++ b/docs/code-quality/c26406.md
@@ -7,6 +7,7 @@ helpviewer_keywords: ["C26406"]
 ms.assetid: 02fb8e23-1989-4e24-a5a5-e30f71d00325
 ---
 # C26406  DONT_ASSIGN_RAW_TO_OWNER
+This warning enforces R.3 from the C++ Core Guidelines, see [C++ Core Guidelines R.3](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning) for additional information.
 
 Owners are initialized from allocations or from other owners. Assigning a value from a raw pointer to an owner pointer is not allowed. Raw pointers don’t guarantee ownership transfer; there is still may be an original owner which holds the resource and will attempt to release it. Note that assigning a value from owner to a raw pointer is fine; raw pointers are valid clients to access resources, but not to manage them.
 

--- a/docs/code-quality/c26406.md
+++ b/docs/code-quality/c26406.md
@@ -1,17 +1,22 @@
 ---
 title: C26406
-ms.date: 07/21/2017
+ms.date: 08/18/2020
 ms.topic: "conceptual"
 f1_keywords: ["C26406"]
 helpviewer_keywords: ["C26406"]
 ms.assetid: 02fb8e23-1989-4e24-a5a5-e30f71d00325
 ---
 # C26406  DONT_ASSIGN_RAW_TO_OWNER
-This warning enforces R.3 from the C++ Core Guidelines, see [C++ Core Guidelines R.3](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning) for additional information.
 
-Owners are initialized from allocations or from other owners. Assigning a value from a raw pointer to an owner pointer is not allowed. Raw pointers don’t guarantee ownership transfer; there is still may be an original owner which holds the resource and will attempt to release it. Note that assigning a value from owner to a raw pointer is fine; raw pointers are valid clients to access resources, but not to manage them.
+This warning enforces R.3 from the C++ Core Guidelines. For more information, see [C++ Core Guidelines R.3](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r3-a-raw-pointer-a-t-is-non-owning).
+
+## Remarks
+
+Owners are initialized from allocations or from other owners. This warning occurs when you assign a value from a raw pointer to an owner pointer. Raw pointers don’t guarantee ownership transfer; the original owner may still hold the resource and attempt to release it. It's okay to assign a value from an owner to a raw pointer. Raw pointers are valid clients to access resources, but not to manage them.
 
 ## Example 1:  Using address of object
+
+This sample attempts to assign ownership of the address of `defaultSocket` to owner pointer `socket`:
 
 ```cpp
 gsl::owner<Socket*> socket = defaultSocket ? &defaultSocket : new Socket(); // C26406


### PR DESCRIPTION
This rule enforces R.3, so I've added a link to R.3 in the Core Guidelines.