### PR TITLE
Add C++ Core Guidelines links to C26410

### DIFF
--- a/docs/code-quality/c26410.md
+++ b/docs/code-quality/c26410.md
@@ -8,11 +8,11 @@ ms.assetid: d1547faf-96c6-48da-90f5-841154d0e878
 ---
 # C26410  NO_REF_TO_CONST_UNIQUE_PTR
 
-Generally, references to const unique pointer are meaningless. They can safely be replaced by a raw reference or a pointer.
+Generally, references to const unique pointer are meaningless. They can safely be replaced by a raw reference or a pointer. This warning enforces [C++ Core Guidelines rule R.32](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r32-take-a-unique_ptrwidget-parameter-to-express-that-a-function-assumes-ownership-of-a-widget).
 
 ## Remarks
 
-- Unique pointer checks have rather broad criteria to identify smart pointers. The rule R.31: *If you have non-std smart pointers, follow the basic pattern from std describes the unique pointer and shared pointer concepts*. The heuristic is simple, but may lead to surprises: a smart pointer type is any type which defines either operator-> or operator\*; a copy-able type (shared pointer) must have either public copy constructor or overloaded assignment operator which deals with a non-R-value reference parameter.
+- Unique pointer checks have rather broad criteria to identify smart pointers. The [C++ Core Guidelines rule R.31](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r31-if-you-have-non-std-smart-pointers-follow-the-basic-pattern-from-std): *If you have non-std smart pointers, follow the basic pattern from std describes the unique pointer and shared pointer concepts*. The heuristic is simple, but may lead to surprises: a smart pointer type is any type which defines either operator-> or operator\*; a copy-able type (shared pointer) must have either public copy constructor or overloaded assignment operator which deals with a non-R-value reference parameter.
 
 - Template code may produce a lot of noise. Keep in mind that templates can be instantiated with various type parameters with different levels of indirection, including references. Some warnings may not be obvious and fixes may require some rework of templates (for example, explicit removal of reference indirection). If template code is intentionally generic, the warning can be suppressed.
 


### PR DESCRIPTION
The rule enforces R.32 and mentions R.31 in the remarks. This change adds links to the respective rules.