### PR TITLE
Update install-visual-cpp-for-cross-platform-mobile-development

### DIFF
--- a/docs/cross-platform/install-visual-cpp-for-cross-platform-mobile-development.md
+++ b/docs/cross-platform/install-visual-cpp-for-cross-platform-mobile-development.md
@@ -46,12 +46,12 @@ The Visual Studio Installer includes a **Mobile development with C++** workload.
 
 - Android Native Development Kit (NDK), Apache Ant, and the C++ Android development tools are required to build C++ code that targets the Android platform.
 
+  > [!NOTE]
+  > Some tools in the Android NDK don't support Unicode characters in file paths and file names. If a project or source file has Unicode characters in its path or file name, the project will fail to build.
+
 - The Google Android Emulator and Intel Hardware Accelerated Execution Manager (HAXM) are optional, but recommended, components. (The Intel HAXM drivers only work on Intel processors, and are incompatible with some VMs, including Hyper-V.) You can develop and debug directly on an Android device, but it's often easier to use an emulator on your desktop for debugging.
 
 - C++ iOS development tools are required to build C++ code that targets the iOS platform.
-
-> [!NOTE]
-> Some tools in the Android NDK does not support Unicode characters in file paths and file names. So if a project or source file has Unicode characters in its path or file name, the project will fail to build.
 
 > [!NOTE]
 > If you're using Visual Studio 2015, see [Install Visual C++ for Cross-Platform Mobile Development (Visual Studio 2015)](install-visual-cpp-for-cross-platform-mobile-development.md?view=vs-2015)

--- a/docs/cross-platform/install-visual-cpp-for-cross-platform-mobile-development.md
+++ b/docs/cross-platform/install-visual-cpp-for-cross-platform-mobile-development.md
@@ -51,6 +51,9 @@ The Visual Studio Installer includes a **Mobile development with C++** workload.
 - C++ iOS development tools are required to build C++ code that targets the iOS platform.
 
 > [!NOTE]
+> Some tools in the Android NDK does not support Unicode characters in file paths and file names. So if a project or source file has Unicode characters in its path or file name, the project will fail to build.
+
+> [!NOTE]
 > If you're using Visual Studio 2015, see [Install Visual C++ for Cross-Platform Mobile Development (Visual Studio 2015)](install-visual-cpp-for-cross-platform-mobile-development.md?view=vs-2015)
 
 ### Install the Mobile development with C++ workload


### PR DESCRIPTION
Add a note about a limitation on the third-party tool Android NDK.