### PR TITLE
Fixing a minor typo in `strtod` documentation.

### DIFF
--- a/docs/c-runtime-library/reference/strtod-strtod-l-wcstod-wcstod-l.md
+++ b/docs/c-runtime-library/reference/strtod-strtod-l-wcstod-wcstod-l.md
@@ -72,7 +72,7 @@ By default, this function's global state is scoped to the application. To change
 |**_tcstod**|**strtod**|**strtod**|**wcstod**|
 |**_tcstod_l**|**_strtod_l**|**_strtod_l**|**_wcstod_l**|
 
-The **LC_NUMERIC** category setting of the current locale determines recognition of the radix point character in *strSource*. For more information, see [setlocale](setlocale-wsetlocale.md). The functions without the **_l** suffix use the current locale; **_strtod_l** is identical to **_strtod_l** except they use the *locale* passed in instead. For more information, see [Locale](../../c-runtime-library/locale.md).
+The **LC_NUMERIC** category setting of the current locale determines recognition of the radix point character in *strSource*. For more information, see [setlocale](setlocale-wsetlocale.md). The functions without the **_l** suffix use the current locale; **_strtod_l** is identical to **_strtod** except the former uses the *locale* passed in instead. For more information, see [Locale](../../c-runtime-library/locale.md).
 
 If *endptr* isn't **NULL**, a pointer to the character that stopped the scan is stored at the location pointed to by *endptr*. If no conversion can be performed (no valid digits were found or an invalid base was specified), the value of *strSource* is stored at the location pointed to by *endptr*.
 


### PR DESCRIPTION
The error was pointed in a
[tweet](https://twitter.com/lemire/status/1303423235585908738?s=20).