### PR TITLE
Add a missing space in a syntax example

### DIFF
--- a/docs/extensions/classes-and-structs-cpp-component-extensions.md
+++ b/docs/extensions/classes-and-structs-cpp-component-extensions.md
@@ -15,7 +15,7 @@ The **ref class** or **ref struct** extensions declare a class or struct whose *
 ### Syntax
 
 ```cpp
-class_access ref class name modifier : inherit_accessbase_type {};
+class_access ref class name modifier : inherit_access base_type {};
 class_access ref struct name modifier : inherit_access base_type {};
 class_access value class name modifier : inherit_access base_type {};
 class_access value struct name modifier : inherit_access base_type {};


### PR DESCRIPTION
This pull requests inserts a missing space between "inherit_access" and "base_type" in a syntax example of `ref class`.