### PR TITLE
Update aligned-msize.md

### DIFF
--- a/docs/c-runtime-library/reference/aligned-msize.md
+++ b/docs/c-runtime-library/reference/aligned-msize.md
@@ -16,7 +16,7 @@ Returns the size of a memory block allocated in the heap.
 ## Syntax
 
 ```C
-size_t _msize(
+size_t _aligned_msize(
    void *memblock,
    size_t alignment,
    size_t offset
@@ -44,7 +44,7 @@ The **_aligned_msize** function returns the size, in bytes, of the memory block 
 
 When the application is linked with a debug version of the C run-time libraries, **_aligned_msize** resolves to [_aligned_msize_dbg](aligned-msize-dbg.md). For more information about how the heap is managed during the debugging process, see [The CRT Debug Heap](/visualstudio/debugger/crt-debug-heap-details).
 
-This function validates its parameter. If *memblock* is a null pointer or *alignment* is not a power of 2, **_msize** invokes an invalid parameter handler, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If the error is handled, the function sets **errno** to **EINVAL** and returns -1.
+This function validates its parameter. If *memblock* is a null pointer or *alignment* is not a power of 2, **_aligned_msize** invokes an invalid parameter handler, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If the error is handled, the function sets **errno** to **EINVAL** and returns -1.
 
 By default, this function's global state is scoped to the application. To change this, see [Global state in the CRT](../global-state.md).
 
@@ -52,7 +52,7 @@ By default, this function's global state is scoped to the application. To change
 
 |Routine|Required header|
 |-------------|---------------------|
-|**_msize**|\<malloc.h>|
+|**_aligned_msize**|\<malloc.h>|
 
 For more compatibility information, see [Compatibility](../../c-runtime-library/compatibility.md).
 


### PR DESCRIPTION
Uses `_msize` when is should be `_aligned_msize`.