### PR TITLE
Fix CRect::CRect description

### DIFF
--- a/docs/atl-mfc-shared/reference/crect-class.md
+++ b/docs/atl-mfc-shared/reference/crect-class.md
@@ -284,15 +284,15 @@ Specifies the bottom-right position of `CRect`.
 
 ### Remarks
 
-If no arguments are given, `left`, `top`, `right`, and `bottom` members are not initialized.
+If no arguments are given, `left`, `top`, `right`, and `bottom` members are set to 0.
 
 The `CRect`(`const RECT&`) and `CRect`(`LPCRECT`) constructors perform a [CopyRect](#copyrect). The other constructors initialize the member variables of the object directly.
 
 ### Example
 
 ```cpp
-// default constructor doesn't initialize!
-CRect rectUnknown;
+// default constructor is equivalent to CRect(0, 0, 0, 0)
+CRect emptyRect;
 
 // four-integers are left, top, right, and bottom
 CRect rect(0, 0, 100, 50);


### PR DESCRIPTION
According to the source code (see atltypes.h file) it actually initializes all members with `= 0`.

I checked that CPoint and CSize documentation is correct.
Please correct me if I'm wrong, here is the source code of CRect::CRect on my machine:
```
// CRect
inline CRect::CRect() throw()
{
	left = 0;
	top = 0;
	right = 0;
	bottom = 0;
}
```