### PR TITLE
There are no short integer literals

### DIFF
--- a/docs/cpp/numeric-boolean-and-pointer-literals-cpp.md
+++ b/docs/cpp/numeric-boolean-and-pointer-literals-cpp.md
@@ -22,7 +22,7 @@ Sometimes it's important to tell the compiler how to interpret a literal, or wha
 
 ## Integer literals
 
-Integer literals begin with a digit and have no fractional parts or exponents. You can specify integer literals in decimal, octal, or hexadecimal form. You can specify signed or unsigned types, and long or medium types.
+Integer literals begin with a digit and have no fractional parts or exponents. You can specify integer literals in decimal, binary, octal, or hexadecimal form. You can optionally specify an integer literal as unsigned, and as a long or long long type, by using a suffix.
 
 When no prefix or suffix is present, the compiler will give an integral literal value type **`int`** (32 bits), if the value will fit, otherwise it will give it type **`long long`** (64 bits).
 

--- a/docs/cpp/numeric-boolean-and-pointer-literals-cpp.md
+++ b/docs/cpp/numeric-boolean-and-pointer-literals-cpp.md
@@ -22,7 +22,7 @@ Sometimes it's important to tell the compiler how to interpret a literal, or wha
 
 ## Integer literals
 
-Integer literals begin with a digit and have no fractional parts or exponents. You can specify integer literals in decimal, octal, or hexadecimal form. You can specify signed or unsigned types, and long or short types.
+Integer literals begin with a digit and have no fractional parts or exponents. You can specify integer literals in decimal, octal, or hexadecimal form. You can specify signed or unsigned types, and long or medium types.
 
 When no prefix or suffix is present, the compiler will give an integral literal value type **`int`** (32 bits), if the value will fit, otherwise it will give it type **`long long`** (64 bits).
 


### PR DESCRIPTION
I replaced literals for _short_ integer types with literals for _medium_ integer types because there are no such literals (`0S` is not a valid short integer).