### PR TITLE
Fix printing streampos to ostream

### DIFF
--- a/docs/standard-library/ios-typedefs.md
+++ b/docs/standard-library/ios-typedefs.md
@@ -61,7 +61,7 @@ int main( )
    ofstream x( "iostream.txt" );
    x << "testing";
    streampos y = x.tellp( );
-   cout << y << endl;
+   cout << + y << endl;
 }
 ```
 


### PR DESCRIPTION
The expression `cout << y` works as described only if no shift operator of `streampos` into `ostream` is defined.  That operator may be defined by user code and the result may be different.