### PR TITLE
fix formatting error in build configuration

### DIFF
--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -59,7 +59,7 @@ When you choose a configuration, it is added to the *CMakeSettings.json* file in
       "inheritEnvironments": [
         "linux_x64"
       ]
-    }
+}
 
 {
       "name": "Linux-Release",

--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -88,8 +88,8 @@ When you choose a configuration, it is added to the *CMakeSettings.json* file in
       "inheritEnvironments": [
         "linux_x64"
       ]
-    },
-    ```
+},
+```
 
 
 You can use these optional settings for more control:


### PR DESCRIPTION
A '```' was indented so it did not end the code section properly