### PR TITLE
Document exceptions to the rules for parsing C arguments

### DIFF
--- a/docs/c-language/parsing-c-command-line-arguments.md
+++ b/docs/c-language/parsing-c-command-line-arguments.md
@@ -22,6 +22,8 @@ Microsoft C startup code uses the following rules when interpreting arguments gi
 
 - If an odd number of backslashes is followed by a double quotation mark, then one backslash (**\\**) is placed in the `argv` array for every pair of backslashes (**\\\\**) and the double quotation mark is interpreted as an escape sequence by the remaining backslash, causing a literal double quotation mark (**"**) to be placed in `argv`.
 
+- A double quotation mark appearing after a closing double quotation mark, **"*""**, will be interpreted as a literal double quotation mark (**\*"**). It might also (depending on the target program) delimit the start of a new string region.
+
 This list illustrates the rules above by showing the interpreted result passed to `argv` for several examples of command-line arguments. The output listed in the second, third, and fourth columns is from the ARGS.C program that follows the list.
 
 |Command-Line Input|argv[1]|argv[2]|argv[3]|
@@ -31,6 +33,9 @@ This list illustrates the rules above by showing the interpreted result passed t
 |`a\\\b d"e f"g h`|`a\\\b`|`de fg`|`h`|
 |`a\\\"b c d`|`a\"b`|`c`|`d`|
 |`a\\\\"b c" d e`|`a\\b c`|`d`|`e`|
+|`a"b"" c d`|`ab"`|`c`|`d`|
+
+Note that the command itself (**argv[0]**) may use different parsing rules, and often does not treat a backslash as an escape character.
 
 ## Example
 

--- a/docs/c-language/parsing-c-command-line-arguments.md
+++ b/docs/c-language/parsing-c-command-line-arguments.md
@@ -1,7 +1,8 @@
 ---
 title: "Parsing C Command-Line Arguments"
-ms.date: "11/04/2016"
-helpviewer_keywords: ["quotation marks, command-line arguments", "double quotation marks", "command line, parsing", "parsing, command-line arguments", "startup code, parsing command-line arguments"]
+description: "Learn how the Microsoft C runtime startup code interprets command-line arguments to create the argv and argc parameters."
+ms.date: 11/09/2020
+helpviewer_keywords: ["quotation marks, command-line arguments", "double quotation marks", "double quote marks", "command line, parsing", "parsing, command-line arguments", "startup code, parsing command-line arguments"]
 ms.assetid: ffce8037-2811-45c4-8db4-1ed787859c80
 ---
 # Parsing C Command-Line Arguments
@@ -12,17 +13,17 @@ Microsoft C startup code uses the following rules when interpreting arguments gi
 
 - Arguments are delimited by white space, which is either a space or a tab.
 
-- A string surrounded by double quotation marks is interpreted as a single argument, regardless of white space contained within. A quoted string can be embedded in an argument. Note that the caret (**^**) is not recognized as an escape character or delimiter.
+- The first argument (`argv[0]`) is treated specially. It represents the program name. Because it must be a valid pathname, parts surrounded by double quote marks (**`"`**) are allowed. The double quote marks aren't included in the `argv[0]` output. The parts surrounded by double quote marks prevent interpretation of a space or tab character as the end of the argument. The later rules in this list don't apply.
 
-- A double quotation mark preceded by a backslash, **\\"**, is interpreted as a literal double quotation mark (**"**).
+- A string surrounded by double quote marks is interpreted as a single argument, whether or not it contains white space. A quoted string can be embedded in an argument. The caret (**`^`**) isn't recognized as an escape character or delimiter. Within a quoted string, a pair of double quote marks is interpreted as a single escaped double quote mark. If the command line ends before a closing double quote mark is found, then all the characters read so far are output as the last argument.
 
-- Backslashes are interpreted literally, unless they immediately precede a double quotation mark.
+- A double quote mark preceded by a backslash (**`\"`**) is interpreted as a literal double quote mark (**`"`**).
 
-- If an even number of backslashes is followed by a double quotation mark, then one backslash (**\\**) is placed in the `argv` array for every pair of backslashes (**\\\\**), and the double quotation mark (**"**) is interpreted as a string delimiter.
+- Backslashes are interpreted literally, unless they immediately precede a double quote mark.
 
-- If an odd number of backslashes is followed by a double quotation mark, then one backslash (**\\**) is placed in the `argv` array for every pair of backslashes (**\\\\**) and the double quotation mark is interpreted as an escape sequence by the remaining backslash, causing a literal double quotation mark (**"**) to be placed in `argv`.
+- If an even number of backslashes is followed by a double quote mark, then one backslash (**`\`**) is placed in the `argv` array for every pair of backslashes (**`\\`**), and the double quote mark (**`"`**) is interpreted as a string delimiter.
 
-- A double quotation mark appearing after a closing double quotation mark, **"*""**, will be interpreted as a literal double quotation mark (**\*"**). It might also (depending on the target program) delimit the start of a new string region.
+- If an odd number of backslashes is followed by a double quote mark, then one backslash (**`\`**) is placed in the `argv` array for every pair of backslashes (**`\\`**). The double quote mark is interpreted as an escape sequence by the remaining backslash, causing a literal double quote mark (**`"`**) to be placed in `argv`.
 
 This list illustrates the rules above by showing the interpreted result passed to `argv` for several examples of command-line arguments. The output listed in the second, third, and fourth columns is from the ARGS.C program that follows the list.
 
@@ -33,16 +34,13 @@ This list illustrates the rules above by showing the interpreted result passed t
 |`a\\\b d"e f"g h`|`a\\\b`|`de fg`|`h`|
 |`a\\\"b c d`|`a\"b`|`c`|`d`|
 |`a\\\\"b c" d e`|`a\\b c`|`d`|`e`|
-|`a"b"" c d`|`ab"`|`c`|`d`|
-
-Note that the command itself (**argv[0]**) may use different parsing rules, and often does not treat a backslash as an escape character.
+|`a"b"" c d`|`ab" c d`|||
 
 ## Example
 
 ### Code
 
 ```c
-// Parsing_C_Commandline_args.c
 // ARGS.C illustrates the following variables used for accessing
 // command-line arguments and environment variables:
 // argc  argv  envp


### PR DESCRIPTION
This description was empirically wrong, which made it rather confusing to read and rely upon. This is my best guess at the actual behavior, based upon some experiments, though I'm hoping the actual behavior will be documented based upon reading of the relevant codes themselves.

Note that this incomplete description was copied to other places, including:
- https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw
- https://docs.microsoft.com/en-us/dotnet/api/system.environment.getcommandlineargs?view=net-5.0#remarks
- https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs#L860

The `CommandLineToArgvW` function documentation also contains the misleading claim that "The GetCommandLineW function can be used to get a command line string that is suitable for use as the lpCmdLine parameter". This is not quite true, as the quoting/escape rules applied to argv[0] are usually different than those for the remaining arguments, so the user may want to first scan forward to the first space character not enclosed in double quotes.

Amusingly, dotnet also contains some contradictory advice to this existing documentation, but helpfully also gives a sample program that can be used to directly test in what ways it is non-conforming: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.arguments, and this seems to have lead to this other very long conversation about the many ways that this can and has caused problems: https://github.com/PowerShell/PowerShell/issues/1995