### PR TITLE
Update run-time-library-behavior.md - inaccurate initialisation of AFX_EXTENSION_MODULE structure

### DIFF
--- a/docs/build/run-time-library-behavior.md
+++ b/docs/build/run-time-library-behavior.md
@@ -116,7 +116,7 @@ The wizard provides the following code for MFC extension DLLs. In the code, `PRO
 #undef THIS_FILE
 static char THIS_FILE[] = __FILE__;
 #endif
-static AFX_EXTENSION_MODULE PROJNAMEDLL = { 0 };
+static AFX_EXTENSION_MODULE PROJNAMEDLL;
 
 extern "C" int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)

--- a/docs/build/run-time-library-behavior.md
+++ b/docs/build/run-time-library-behavior.md
@@ -116,7 +116,7 @@ The wizard provides the following code for MFC extension DLLs. In the code, `PRO
 #undef THIS_FILE
 static char THIS_FILE[] = __FILE__;
 #endif
-static AFX_EXTENSION_MODULE PROJNAMEDLL = { NULL, NULL };
+static AFX_EXTENSION_MODULE PROJNAMEDLL = { 0 };
 
 extern "C" int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)


### PR DESCRIPTION
The first two parameters of the structure AFX_EXTENSION_MODULE are BOOL and HMODULE. So initialisation with = { NULL, NULL } is inaccurate: first NULL is FALSE (or 0 due to BOOL is defined as int). In fact this expression cannot be transformed to modern C++ equivalent = { nullptr, nullptr }.

struct AFX_EXTENSION_MODULE
{
    BOOL bInitialized;
    HMODULE hModule;
    HMODULE hResource;
    CRuntimeClass* pFirstSharedClass;
    COleObjectFactory* pFirstSharedFactory;
};