### PR TITLE
Update afx-extension-module-structure_1.cpp - inaccurate initialisation of AFX_EXTENSION_MODULE structure

### DIFF
--- a/docs/atl-mfc-shared/codesnippet/CPP/afx-extension-module-structure_1.cpp
+++ b/docs/atl-mfc-shared/codesnippet/CPP/afx-extension-module-structure_1.cpp
@@ -1,4 +1,4 @@
-static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL = { 0 };
+static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL;
 extern "C" int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {

--- a/docs/atl-mfc-shared/codesnippet/CPP/afx-extension-module-structure_1.cpp
+++ b/docs/atl-mfc-shared/codesnippet/CPP/afx-extension-module-structure_1.cpp
@@ -1,4 +1,4 @@
-static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL = { NULL, NULL };
+static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL = { 0 };
 extern "C" int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {


### PR DESCRIPTION
The first two parameters of the structure AFX_EXTENSION_MODULE are BOOL and HMODULE. So initialisation with = { NULL, NULL } is inaccurate: first NULL is FALSE (or 0 due to BOOL is defined as int). In fact this expression cannot be transformed to modern C++ equivalent = { nullptr, nullptr }.

struct AFX_EXTENSION_MODULE
{
BOOL bInitialized;
HMODULE hModule;
HMODULE hResource;
CRuntimeClass* pFirstSharedClass;
COleObjectFactory* pFirstSharedFactory;
};