### PR TITLE
Three syntaxes for initialising auto-typed variables

### DIFF
--- a/docs/cpp/auto-cpp.md
+++ b/docs/cpp/auto-cpp.md
@@ -40,7 +40,7 @@ Conversion cases in which you might not want to use **`auto`**:
 
 To use the **`auto`** keyword, use it instead of a type to declare a variable, and specify an initialization expression. In addition, you can modify the **`auto`** keyword by using specifiers and declarators such as **`const`**, **`volatile`**, pointer (**`*`**), reference (**`&`**), and rvalue reference (**`&&`**). The compiler evaluates the initialization expression and then uses that information to deduce the type of the variable.
 
-The initialization expression can be an assignment (equal-sign syntax), a direct initialization (function-style syntax), an [`operator new`](new-operator-cpp.md) expression, or the initialization expression can be the *for-range-declaration* parameter in a [Range-based `for` Statement (C++)](../cpp/range-based-for-statement-cpp.md) statement. For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
+The initialization expression can be passed using an assignment syntax (`auto int = 0;`) or a constructor syntax (`auto int (0);`). For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
 
 The **`auto`** keyword is a placeholder for a type, but it is not itself a type. Therefore, the **`auto`** keyword cannot be used in casts or operators such as [`sizeof`](../cpp/sizeof-operator.md) and (for C++/CLI) [`typeid`](../extensions/typeid-cpp-component-extensions.md).
 

--- a/docs/cpp/auto-cpp.md
+++ b/docs/cpp/auto-cpp.md
@@ -40,7 +40,7 @@ Conversion cases in which you might not want to use **`auto`**:
 
 To use the **`auto`** keyword, use it instead of a type to declare a variable, and specify an initialization expression. In addition, you can modify the **`auto`** keyword by using specifiers and declarators such as **`const`**, **`volatile`**, pointer (**`*`**), reference (**`&`**), and rvalue reference (**`&&`**). The compiler evaluates the initialization expression and then uses that information to deduce the type of the variable.
 
-The initialization expression can be passed using an assignment syntax (`auto int = 0;`) or a constructor syntax (`auto int (0);`). For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
+The initialization expression can be passed using an assignment syntax (`auto x = 0;`), a block syntax (`auto x { 0 };`} or a constructor syntax (`auto x (0);`). It is also used to declare the loop variable in a container-based iterator loop (`for (auto x : vector)`).  For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
 
 The **`auto`** keyword is a placeholder for a type, but it is not itself a type. Therefore, the **`auto`** keyword cannot be used in casts or operators such as [`sizeof`](../cpp/sizeof-operator.md) and (for C++/CLI) [`typeid`](../extensions/typeid-cpp-component-extensions.md).
 

--- a/docs/cpp/auto-cpp.md
+++ b/docs/cpp/auto-cpp.md
@@ -40,7 +40,16 @@ Conversion cases in which you might not want to use **`auto`**:
 
 To use the **`auto`** keyword, use it instead of a type to declare a variable, and specify an initialization expression. In addition, you can modify the **`auto`** keyword by using specifiers and declarators such as **`const`**, **`volatile`**, pointer (**`*`**), reference (**`&`**), and rvalue reference (**`&&`**). The compiler evaluates the initialization expression and then uses that information to deduce the type of the variable.
 
-The initialization expression can be passed using an assignment syntax (`auto x = 0;`), a block syntax (`auto x { 0 };`} or a constructor syntax (`auto x (0);`). It is also used to declare the loop variable in a container-based iterator loop (`for (auto x : vector)`).  For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
+The **`auto`** initialization expression can take several forms:
+
+- Universal initialization syntax, such as `auto a { 42 };`.
+- Assignment syntax, such as `auto b = 0;`.
+- Universal assignment syntax, which combines the two previous forms, such as `auto c = { 3.14156 };`.
+- Direct initialization, or constructor-style syntax, such as `auto d( 1.41421f );`.
+
+For more information, see [Initializers](../cpp/initializers.md) and the code examples later in this document.
+
+When **`auto`** is used to declare the loop parameter in a range-based **`for`** statement, it uses a different initialization syntax, for example `for (auto& i : iterable) do_action(i);`. For more information, see [Range-based `for` Statement (C++)](../cpp/range-based-for-statement-cpp.md).
 
 The **`auto`** keyword is a placeholder for a type, but it is not itself a type. Therefore, the **`auto`** keyword cannot be used in casts or operators such as [`sizeof`](../cpp/sizeof-operator.md) and (for C++/CLI) [`typeid`](../extensions/typeid-cpp-component-extensions.md).
 


### PR DESCRIPTION
The initialisation expression can be an assignment but that means `a = b = 0`.
The initialisation expression can involve `operator new` but it is not a separate case. Compare `auto a = new int;` and `auto a (new int);`.  There is no initialisation statement inherently involving `operator new` (unlike in Visual Basic).
The fact that a `for` loop involves an initialisation statement is a side note at best.  This trivia fact is not specific to `auto`.
The parenthesised "explanations" explained one unknown with another unknown.  I replaced them with short examples.