### PR TITLE
Update extension-dll-macros.md

### DIFF
--- a/docs/mfc/reference/extension-dll-macros.md
+++ b/docs/mfc/reference/extension-dll-macros.md
@@ -201,7 +201,7 @@ TRUE if the MFC extension DLL is successfully initialized; otherwise, FALSE.
 For example:
 
 ```cpp
-static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL = { NULL, NULL };
+static AFX_EXTENSION_MODULE NVC_MFC_DLLDLL;
 extern "C" int APIENTRY
 DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {


### PR DESCRIPTION
The first two parameters of the structure AFX_EXTENSION_MODULE are BOOL and HMODULE. So initialisation with = { NULL, NULL } is inaccurate: first NULL is FALSE (or 0 due to BOOL is defined as int). In fact this expression cannot be transformed to modern C++ equivalent = { nullptr, nullptr }.

struct AFX_EXTENSION_MODULE
{
BOOL bInitialized;
HMODULE hModule;
HMODULE hResource;
CRuntimeClass* pFirstSharedClass;
COleObjectFactory* pFirstSharedFactory;
};