### PR TITLE
Make the CCoInitializer constructor exception safe

### DIFF
--- a/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_3.cpp
+++ b/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_3.cpp
@@ -8,7 +8,7 @@ public:
    {
       // Initialize the COM library on the current thread.
       HRESULT hr = CoInitializeEx(NULL, dwCoInit);
-      if (hr == S_OK)
+      if (SUCCEEDED(hr))
          _coinitialized = true;
    }
    ~CCoInitializer()

--- a/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_3.cpp
+++ b/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_3.cpp
@@ -8,9 +8,8 @@ public:
    {
       // Initialize the COM library on the current thread.
       HRESULT hr = CoInitializeEx(NULL, dwCoInit);
-      if (FAILED(hr))
-         throw hr;
-      _coinitialized = true;
+      if (hr == S_OK)
+         _coinitialized = true;
    }
    ~CCoInitializer()
    {


### PR DESCRIPTION
The source [code example](https://github.com/MicrosoftDocs/cpp-docs/blob/master/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_3.cpp) is accompanied by the following comment:

> // An **exception-safe** wrapper class that manages the lifetime 
> // of the COM library in a given scope.

, but the `CCoInitializer` constructor throws an exception when the `CoInitializeEx` call completes with an error:

```
// Initialize the COM library on the current thread.
HRESULT hr = CoInitializeEx(NULL, dwCoInit);
if (FAILED(hr))
   throw hr;
```

I thought it may be a mistake in the comment, but the [example below](https://github.com/MicrosoftDocs/cpp-docs/blob/master/docs/parallel/concrt/codesnippet/CPP/walkthrough-using-the-concurrency-runtime-in-a-com-enabled-application_8.cpp) says otherwise:

```
int wmain()
{
   HRESULT hr;

   // Enable COM on this thread for the lifetime of the program.   
   CCoInitializer coinit(COINIT_MULTITHREADED);
   // Code
}
```

There is no try/catch block that encloses the creation of the `CCoInitializer` class instance.

The `CCoInitializer` implementation also indicates that the constructor shouldn't throw an exception:

```
explicit CCoInitializer(DWORD dwCoInit = COINIT_APARTMENTTHREADED)
   : _coinitialized(false)
{
   // Initialize the COM library on the current thread.
   HRESULT hr = CoInitializeEx(NULL, dwCoInit);
   if (FAILED(hr))
      throw hr;
   _coinitialized = true;
}
```
, otherwise, the usage of the `_coinitialized` flag is redundant - if an exception will be thrown at the constructor call, the destructor will never be called, so the `_coinitialized` flag will never be used.