### PR TITLE
Fix signature of _wcsnextc

### DIFF
--- a/docs/c-runtime-library/reference/strnextc-wcsnextc-mbsnextc-mbsnextc-l.md
+++ b/docs/c-runtime-library/reference/strnextc-wcsnextc-mbsnextc-mbsnextc-l.md
@@ -23,7 +23,7 @@ Finds the next character in a string.
 unsigned int _strnextc(
    const char *str
 );
-unsigned int _wscnextc(
+unsigned int _wcsnextc(
    const wchar_t *str
 );
 unsigned int _mbsnextc(


### PR DESCRIPTION
Hi Team! 👋

I'm pretty sure `_wscnextc` in the signature is incorrect. It's the only occurrence of that function name in the document (the other ones being `_wcsnextc`), and [_wscnextc has 4 Google hits](https://www.google.com/search?q=_wscnextc), while [_wcsnextc has ~2000](https://www.google.com/search?q=_wcsnextc).