### PR TITLE
Fix std::fputws return value documentation

### DIFF
--- a/docs/c-runtime-library/reference/fputs-fputws.md
+++ b/docs/c-runtime-library/reference/fputs-fputws.md
@@ -37,7 +37,7 @@ Pointer to **FILE** structure.
 
 ## Return Value
 
-Each of these functions returns a nonnegative value if it is successful. On an error, **fputs** and **fputws** return **EOF**. If *str* or *stream* is a null pointer, these functions invoke the invalid parameter handler, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions set **errno** to **EINVAL** and then **fputs** returns **EOF**, and **fputws** returns **WEOF**.
+Each of these functions returns a nonnegative value if it is successful. On an error, **fputs** and **fputws** return **EOF**. If *str* or *stream* is a null pointer, these functions invoke the invalid parameter handler, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions set **errno** to **EINVAL** and then return **EOF**.
 
 See [_doserrno, errno, _sys_errlist, and _sys_nerr](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md) for more information on these, and other, error codes.
 


### PR DESCRIPTION
The current Microsoft documentation for std::fputws incorrectly states that it "returns **WEOF**", when, in reality, it returns **EOF** as-per the C/C++ standard.

I've verified this by checking ucrt's "stdio\fputws.cpp", which returns **EOF** and also makes a note of this in a comment:
```
(Note well that we return EOF and not WEOF on failure.  This is intentional, and is the correct behavior per the C Language Standard).
```