### PR TITLE
wstrlen -> wcslen on strlen... page

### DIFF
--- a/docs/c-runtime-library/reference/strlen-wcslen-mbslen-mbslen-l-mbstrlen-mbstrlen-l.md
+++ b/docs/c-runtime-library/reference/strlen-wcslen-mbslen-mbslen-l-mbstrlen-mbstrlen-l.md
@@ -106,7 +106,7 @@ int main()
    // strlen gives the length of single-byte character string
    printf("Length of '%s' : %d\n", str1, strlen(str1) );
 
-   // wstrlen gives the length of a wide character string
+   // wcslen gives the length of a wide character string
    wprintf(L"Length of '%s' : %d\n", wstr1, wcslen(wstr1) );
 
    // A multibyte string: [A] [B] [C] [katakana A] [D] [\0]


### PR DESCRIPTION
The comment states that "wstrlen gives the length of a wide string", but then uses the "wcslen" function. The rest of the page indicates that "wcslen" is the correct function, so I modified the comment to match.