### PR TITLE
Fix dumpbin command switch

### DIFF
--- a/docs/build/reference/decorated-names.md
+++ b/docs/build/reference/decorated-names.md
@@ -70,7 +70,7 @@ You can get the decorated form of a symbol name after you compile the source fil
 
 #### To use DUMPBIN to view decorated names
 
-1. To see the exported symbols in an .obj or .lib file, enter `dumpbin /symbols` `objfile` at a developer command prompt.
+1. To see the exported symbols in an .obj or .lib file, enter `dumpbin /exports` `objfile` at a developer command prompt.
 
 2. To find the decorated form of a symbol, look for the undecorated name in parentheses. The decorated name is on the same line, after a pipe (&#124;) character and before the undecorated name.
 

--- a/docs/build/reference/decorated-names.md
+++ b/docs/build/reference/decorated-names.md
@@ -70,9 +70,9 @@ You can get the decorated form of a symbol name after you compile the source fil
 
 #### To use DUMPBIN to view decorated names
 
-1. To see the exported symbols in an .obj or .lib file, enter `dumpbin /exports` `objfile` at a developer command prompt.
+1. To see the exported symbols in an .obj or .lib file, enter `dumpbin /exports <obj-or-lib-file>` at a developer command prompt.
 
-2. To find the decorated form of a symbol, look for the undecorated name in parentheses. The decorated name is on the same line, after a pipe (&#124;) character and before the undecorated name.
+2. To find the decorated form of a symbol, look for the undecorated name in parentheses. The decorated name is on the same line, before the undecorated name.
 
 ## <a name="Undecorated"></a> Viewing undecorated names
 


### PR DESCRIPTION
The `/symbols` switch only outputs a summary; you need the `/exports` switch to list the decorated names.