### PR TITLE
Update C26432 doc - use default keyword everywhere

### DIFF
--- a/docs/code-quality/c26432.md
+++ b/docs/code-quality/c26432.md
@@ -30,7 +30,7 @@ Special operations such as constructors are assumed to alter the behavior of typ
 
 ## Example
 
-In this example, `warning::S` defines only a default constructor and a destructor. The `no_warning::S` declaration defines all five special member functions.
+In this example, `warning::S` defines only a default constructor and a destructor. The `no_warning::S` declaration defines or deletes all five special member functions.
 
 ```cpp
 // C26432.cpp
@@ -38,21 +38,25 @@ namespace warning
 {
     struct S
     {
-        S() noexcept {}
-        ~S() {} // C26432 because only the constructor and destructor are explicitly defined.
+        S() noexcept { ++_count; }
+        ~S() { --_count; } // C26432 because only the constructor and destructor are explicitly defined.
+        static unsigned _count;
     };
+    unsigned S::_count = 0;
 }
 
 namespace no_warning
 {
     struct S
     {
-        S() noexcept = default;
-        S(const S& s) = default;
-        S(S&& s) = default;
-        S& operator=(const S& s) = default;
-        S& operator=(S&& s) = default;
-        ~S() = default;
+        S() noexcept { _count++;  }
+        S(const S& s) = delete;
+        S(S&& s) = delete;
+        S& operator=(const S& s) = delete;
+        S& operator=(S&& s) = delete;
+        ~S() { --_count; }
+        static unsigned _count;
     };
+    unsigned S::_count = 0;
 }
 ```

--- a/docs/code-quality/c26432.md
+++ b/docs/code-quality/c26432.md
@@ -47,12 +47,12 @@ namespace no_warning
 {
     struct S
     {
-        S() noexcept {}
+        S() noexcept = default;
         S(const S& s) = default;
         S(S&& s) = default;
         S& operator=(const S& s) = default;
         S& operator=(S&& s) = default;
-        ~S() {}
+        ~S() = default;
     };
 }
 ```


### PR DESCRIPTION
The "no warning" example doesn't use the default keyword everywhere it could be.

Other analyzers could complain: https://rules.sonarsource.com/cpp/RSPEC-3490