### PR TITLE
fix __movsq argument types

### DIFF
--- a/docs/intrinsics/movsq.md
+++ b/docs/intrinsics/movsq.md
@@ -16,8 +16,8 @@ Generates a repeated Move String (`rep movsq`) instruction.
 
 ```C
 void __movsq(
-   unsigned char* Destination,
-   unsigned char* Source,
+   unsigned long long* Destination,
+   unsigned long long const* Source,
    size_t Count
 );
 ```


### PR DESCRIPTION
correct the function argument types to match the actual definitions in intrin.h.  The data types have to be __int64 or long long, not char as is currently shown.