### PR TITLE
Fix ComputeXdataSize samples for ARM/ARM64

### DIFF
--- a/docs/build/arm-exception-handling.md
+++ b/docs/build/arm-exception-handling.md
@@ -188,29 +188,32 @@ When the packed unwind format is insufficient to describe the unwinding of a fun
 The `.xdata` record is designed so that it is possible to fetch the first 8 bytes and compute the full size of the record, not including the length of the variable-sized exception data that follows. This code snippet computes the record size:
 
 ```cpp
-ULONG Comput`.xdata`Size(PULONG `.xdata`)
+ULONG ComputeXdataSize(PULONG Xdata)
 {
-    ULONG EpilogueScopes;
     ULONG Size;
+    ULONG EpilogueScopes;
     ULONG UnwindWords;
 
-    if (`.xdata`[0] >> 23) != 0) {
+    if ((Xdata[0] >> 23) != 0) {
         Size = 4;
-        EpilogueScopes = `.xdata`[0] >> 23) & 0x1f;
-        UnwindWords = `.xdata`[0] >> 28) & 0x0f;
+        EpilogueScopes = (Xdata[0] >> 23) & 0x1f;
+        UnwindWords = (Xdata[0] >> 28) & 0x0f;
     } else {
         Size = 8;
-        EpilogueScopes =`.xdata`[1] & 0xffff;
-        UnwindWords = `.xdata`[1] >> 16) & 0xff;
+        EpilogueScopes = Xdata[1] & 0xffff;
+        UnwindWords = (Xdata[1] >> 16) & 0xff;
     }
 
-    if (!`.xdata`[0] & (1 << 21))) {
+    if (!(Xdata[0] & (1 << 21))) {
         Size += 4 * EpilogueScopes;
     }
+
     Size += 4 * UnwindWords;
-    if `.xdata`[0] & (1 << 20)) {
-        Size += 4;
+
+    if (Xdata[0] & (1 << 20)) {
+        Size += 4;  // Exception handler RVA
     }
+
     return Size;
 }
 ```


### PR DESCRIPTION
The ARM version was logically correct; however, its text was badly broken.  The ARM64 version had a number of logical issues:
- The `Xdata` parameter was typed incorrectly (the code would not compile).
- An incorrect shift amount (`27` instead of `22`) was used to check whether the extension word is present.  That contradicted the textual description.
- An incorrect mask (`0x0f` instead of `0x1f`) was used to extract the 5-bit `UnwindWords` field.  That caused losing the most significant bit of `UnwindWords` and returning an incorrect size for .xdata records containing from 61 to 124 unwind byte codes.
- Checking the `E` bit was missing.

See the implementation of the `RtlpUnwindFunctionFull` OS function for the source of truth.