### PR TITLE
extraneous named parameters on deleted functions

### DIFF
--- a/docs/code-quality/c26432.md
+++ b/docs/code-quality/c26432.md
@@ -50,10 +50,10 @@ namespace no_warning
     struct S
     {
         S() noexcept { _count++;  }
-        S(const S& s) = delete;
-        S(S&& s) = delete;
-        S& operator=(const S& s) = delete;
-        S& operator=(S&& s) = delete;
+        S(const S&) = delete;
+        S(S&&) = delete;
+        S& operator=(const S&) = delete;
+        S& operator=(S&&) = delete;
         ~S() { --_count; }
         static unsigned _count;
     };


### PR DESCRIPTION
Unless it's part of a coding standard, I think named parameters can be skipped for deleted functions.