### PR TITLE
Removing reference to /Oa

### DIFF
--- a/docs/build/optimization-best-practices.md
+++ b/docs/build/optimization-best-practices.md
@@ -94,8 +94,6 @@ A pointer that is modified with **`__restrict`** is referred to as a *__restrict
 
 **`__restrict`** can be a powerful tool for the Microsoft C++ optimizer, but use it with great care. If used improperly, the optimizer might perform an optimization that would break your application.
 
-The **`__restrict`** keyword replaces the **/Oa** switch from previous versions.
-
 With **`__assume`**, a developer can tell the compiler to make assumptions about the value of some variable.
 
 For example `__assume(a < 5);` tells the optimizer that at that line of code the variable `a` is less than 5. Again this is a promise to the compiler. If `a` is actually 6 at this point in the program then the behavior of the program after the compiler has optimized may not be what you would expect. **`__assume`** is most useful prior to switch statements and/or conditional expressions.


### PR DESCRIPTION
The `/Oa` switch hasn't been in the compiler for more than a decade (nearly two decades). This reference to /Oa is, i believe, the only reference to this long gone switch; i believe referencing /Oa in this context is actually more harmful then helpful.