### PR TITLE
Add mention of C++ AMP deprecation

### DIFF
--- a/docs/overview/whats-new-cpp-docs.md
+++ b/docs/overview/whats-new-cpp-docs.md
@@ -48,6 +48,7 @@ For the latest C++ conformance status, see [C++ conformance improvements in Visu
 - [`assert Macro, _assert, _wassert`](../c-runtime-library/reference/assert-macro-assert-wassert.md) - Clarified assert behavior
 - [`vsnprintf_s, _vsnprintf_s, _vsnprintf_s_l, _vsnwprintf_s, _vsnwprintf_s_l`](../c-runtime-library/reference/vsnprintf-s-vsnprintf-s-vsnprintf-s-l-vsnwprintf-s-vsnwprintf-s-l.md) - Clarified return values
 - [`setlocale, _wsetlocale`](../c-runtime-library/reference/setlocale-wsetlocale.md) - Added C Runtime UTF-8 support info
+- [`C++ AMP Overview`](../parallel/amp/cpp-amp-overview.md) - Added note about C++ AMP deprecation.
 
 ## C/C++ preprocessor reference
 

--- a/docs/overview/whats-new-cpp-docs.md
+++ b/docs/overview/whats-new-cpp-docs.md
@@ -48,7 +48,6 @@ For the latest C++ conformance status, see [C++ conformance improvements in Visu
 - [`assert Macro, _assert, _wassert`](../c-runtime-library/reference/assert-macro-assert-wassert.md) - Clarified assert behavior
 - [`vsnprintf_s, _vsnprintf_s, _vsnprintf_s_l, _vsnwprintf_s, _vsnwprintf_s_l`](../c-runtime-library/reference/vsnprintf-s-vsnprintf-s-vsnprintf-s-l-vsnwprintf-s-vsnwprintf-s-l.md) - Clarified return values
 - [`setlocale, _wsetlocale`](../c-runtime-library/reference/setlocale-wsetlocale.md) - Added C Runtime UTF-8 support info
-- [`C++ AMP Overview`](../parallel/amp/cpp-amp-overview.md) - Added note about C++ AMP deprecation.
 
 ## C/C++ preprocessor reference
 

--- a/docs/parallel/amp/cpp-amp-overview.md
+++ b/docs/parallel/amp/cpp-amp-overview.md
@@ -8,7 +8,7 @@ ms.assetid: 9e593b06-6e3c-43e9-8bae-6d89efdd39fc
 # C++ AMP Overview
 
 > [!NOTE]
-> C++ AMP is deprecated, starting with Visual Studio 2022 version 17.0.
+> C++ AMP headers are deprecated. Including any AMP headers will generate build errors. To Silence the errors, define "_SILENCE_AMP_DEPRECATION_WARNINGS" before including the headers.
 
 C++ Accelerated Massive Parallelism (C++ AMP) accelerates execution of C++ code by taking advantage of data-parallel hardware such as a graphics processing unit (GPU) on a discrete graphics card. By using C++ AMP, you can code multi-dimensional data algorithms so that execution can be accelerated by using parallelism on heterogeneous hardware. The C++ AMP programming model includes multidimensional arrays, indexing, memory transfer, tiling, and a mathematical function library. You can use C++ AMP language extensions to control how data is moved from the CPU to the GPU and back, so that you can improve performance.
 

--- a/docs/parallel/amp/cpp-amp-overview.md
+++ b/docs/parallel/amp/cpp-amp-overview.md
@@ -7,6 +7,9 @@ ms.assetid: 9e593b06-6e3c-43e9-8bae-6d89efdd39fc
 ---
 # C++ AMP Overview
 
+> [!NOTE]
+> C++ AMP is deprecated, starting with Visual Studio 2022 version 17.0.
+
 C++ Accelerated Massive Parallelism (C++ AMP) accelerates execution of C++ code by taking advantage of data-parallel hardware such as a graphics processing unit (GPU) on a discrete graphics card. By using C++ AMP, you can code multi-dimensional data algorithms so that execution can be accelerated by using parallelism on heterogeneous hardware. The C++ AMP programming model includes multidimensional arrays, indexing, memory transfer, tiling, and a mathematical function library. You can use C++ AMP language extensions to control how data is moved from the CPU to the GPU and back, so that you can improve performance.
 
 ## System Requirements

--- a/docs/parallel/amp/cpp-amp-overview.md
+++ b/docs/parallel/amp/cpp-amp-overview.md
@@ -8,7 +8,8 @@ ms.assetid: 9e593b06-6e3c-43e9-8bae-6d89efdd39fc
 # C++ AMP Overview
 
 > [!NOTE]
-> C++ AMP headers are deprecated. Including any AMP headers will generate build errors. To Silence the errors, define "_SILENCE_AMP_DEPRECATION_WARNINGS" before including the headers.
+> C++ AMP headers are deprecated, starting with Visual Studio 2022 version 17.0.
+> Including any AMP headers will generate build errors. To Silence the errors, define "_SILENCE_AMP_DEPRECATION_WARNINGS" before including the headers.
 
 C++ Accelerated Massive Parallelism (C++ AMP) accelerates execution of C++ code by taking advantage of data-parallel hardware such as a graphics processing unit (GPU) on a discrete graphics card. By using C++ AMP, you can code multi-dimensional data algorithms so that execution can be accelerated by using parallelism on heterogeneous hardware. The C++ AMP programming model includes multidimensional arrays, indexing, memory transfer, tiling, and a mathematical function library. You can use C++ AMP language extensions to control how data is moved from the CPU to the GPU and back, so that you can improve performance.
 

--- a/docs/parallel/amp/cpp-amp-overview.md
+++ b/docs/parallel/amp/cpp-amp-overview.md
@@ -9,7 +9,7 @@ ms.assetid: 9e593b06-6e3c-43e9-8bae-6d89efdd39fc
 
 > [!NOTE]
 > C++ AMP headers are deprecated, starting with Visual Studio 2022 version 17.0.
-> Including any AMP headers will generate build errors. To Silence the errors, define "_SILENCE_AMP_DEPRECATION_WARNINGS" before including the headers.
+> Including any AMP headers will generate build errors. Define `_SILENCE_AMP_DEPRECATION_WARNINGS` before including any AMP headers to silence the warnings.
 
 C++ Accelerated Massive Parallelism (C++ AMP) accelerates execution of C++ code by taking advantage of data-parallel hardware such as a graphics processing unit (GPU) on a discrete graphics card. By using C++ AMP, you can code multi-dimensional data algorithms so that execution can be accelerated by using parallelism on heterogeneous hardware. The C++ AMP programming model includes multidimensional arrays, indexing, memory transfer, tiling, and a mathematical function library. You can use C++ AMP language extensions to control how data is moved from the CPU to the GPU and back, so that you can improve performance.
 


### PR DESCRIPTION
C++ AMP headers are deprecated in dev17, add note mentioning that and how to suppress the deprecation error.

I believe the "whats-new-cpp-docs" page I updated is the correct one, but it mentions VS 16.8, so I'm not totally sure.