### PR TITLE
UD2 is allowed in Ring 3 code

### DIFF
--- a/docs/intrinsics/ud2.md
+++ b/docs/intrinsics/ud2.md
@@ -22,7 +22,7 @@ void __ud2();
 
 The processor raises an invalid opcode exception if you execute an undefined instruction.
 
-The `__ud2` function is equivalent to the `UD2` machine instruction, and is available only in kernel mode. For more information, search for the document, "Intel Architecture Software Developer's Manual, Volume 2: Instruction Set Reference," at the [Intel Corporation](https://software.intel.com/articles/intel-sdm) site.
+The `__ud2` function is equivalent to the `UD2` machine instruction. For more information, search for the document, "Intel Architecture Software Developer's Manual, Volume 2: Instruction Set Reference," at the [Intel Corporation](https://software.intel.com/articles/intel-sdm) site.
 
 ## Requirements
 


### PR DESCRIPTION
Sometimes I'll use __ud2() as a way of intentionally triggering an exception in order to execute a SEH exception handler, rather than triggering one with something like `*(int*)0;`.