### PR TITLE
Change incorrect link for logical AND

### DIFF
--- a/docs/cpp/keywords-cpp.md
+++ b/docs/cpp/keywords-cpp.md
@@ -16,7 +16,7 @@ Keywords are predefined reserved identifiers that have special meanings. They ca
     :::column:::
         [`alignas`](align-cpp.md)\
         [`alignof`](alignof-operator.md)\
-        [`and`](bitwise-and-operator-amp.md) <sup>b</sup>\
+        [`and`](logical-and-operator-amp-amp.md) <sup>b</sup>\
         [`and_eq`](assignment-operators.md) <sup>b</sup>\
         [`asm`](../assembler/inline/asm.md) <sup>a</sup>\
         [`auto`](./auto-cpp.md)\


### PR DESCRIPTION
Currently the link for the `and` keyword links to the bitwise version of itself, when it should link to the logical version of itself.

This PR fixes this by changing the link to the logical AND instead.