### PR TITLE
Setting PATH allows DUMPBIN to be executed from the command prompt

### DIFF
--- a/docs/build/reference/dumpbin-reference.md
+++ b/docs/build/reference/dumpbin-reference.md
@@ -11,7 +11,7 @@ ms.assetid: 4bc06822-5330-44b4-8a3f-6180dfd41dfb
 The Microsoft COFF Binary File Dumper (DUMPBIN.EXE) displays information about Common Object File Format (COFF) binary files. You can use DUMPBIN to examine COFF object files, standard libraries of COFF objects, executable files, and dynamic-link libraries (DLLs).
 
 > [!NOTE]
-> You can start this tool only from the Visual Studio command prompt. You cannot start it from a system command prompt or from File Explorer.
+> You can start this tool only from the Visual Studio command prompt. You cannot start it from a system command prompt or from File Explorer unless you set up your system search PATH correctly.
 
 Only the [/HEADERS](headers.md) DUMPBIN option is available for use on files produced with the [/GL](gl-whole-program-optimization.md) compiler option.
 

--- a/docs/build/reference/dumpbin-reference.md
+++ b/docs/build/reference/dumpbin-reference.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: DUMPBIN Reference"
 title: "DUMPBIN Reference"
-ms.date: "11/04/2016"
+ms.date: 08/09/2021
 f1_keywords: ["dumpbin"]
 helpviewer_keywords: ["binary data, binary file dumper", "DUMPBIN program", "Microsoft COFF binary file dumper", "COFF files, displaying information about", "binary file dumper"]
 ms.assetid: 4bc06822-5330-44b4-8a3f-6180dfd41dfb
@@ -11,7 +11,7 @@ ms.assetid: 4bc06822-5330-44b4-8a3f-6180dfd41dfb
 The Microsoft COFF Binary File Dumper (DUMPBIN.EXE) displays information about Common Object File Format (COFF) binary files. You can use DUMPBIN to examine COFF object files, standard libraries of COFF objects, executable files, and dynamic-link libraries (DLLs).
 
 > [!NOTE]
-> You can start this tool only from the Visual Studio command prompt. You cannot start it from a system command prompt or from File Explorer unless you set up your system search PATH correctly.
+> We recommend you run DUMPBIN from the Visual Studio command prompt. You can't start it from a system command prompt unless you set the environment correctly. For more information, see [Use the Microsoft C++ toolset from the command line](../building-on-the-command-line.md).
 
 Only the [/HEADERS](headers.md) DUMPBIN option is available for use on files produced with the [/GL](gl-whole-program-optimization.md) compiler option.
 


### PR DESCRIPTION
There are multiple DUMPBIN.EXE's in the MSVC folder, but they can be executed if the PATH is set correctly.
If this is not true, or undesireable per system design constraints, please clarify otherwise.