### PR TITLE
Add docs on using existing cache without cmake-server

### DIFF
--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -64,12 +64,12 @@ When you open an existing CMake cache file (*`CMakeCache.txt`*), Visual Studio d
 You can add an existing CMake cache to an open project. It's done the same way you'd add a new configuration. For more information, see our blog post on [opening an existing cache in Visual Studio](https://devblogs.microsoft.com/cppblog/open-existing-cmake-caches-in-visual-studio/).
 
 > [!NOTE]
-> The default existing cache experience relies on cmake-server, which has been removed from CMake in version 3.20. In Visual Studio 2019 16.10 and later, you will need to do one of the following in order to continue using existing cache functionality:
-> 1. Manually install CMake with version 3.19 or lower. Then set the `cmakeExecutable` property in your existing cache configuration to that CMake.
-> 2. In your existing cache configuration, set the `cacheGenerationCommand` property (see the [CMakeSettings.json reference page](cmakesettings-reference.md) for more details). This allows Visual Studio to request the necessary CMake file-based API files.
-> 3. Ensure the CMake file-based API files are requested when generating your cache prior to opening it in Visual Studio. The instructions for how to do this are described below in "Advanced CMake cache troubleshooting".
+> The default existing cache experience relies on `cmake-server`, which was removed from CMake in version 3.20. To continue using existing cache functionality in Visual Studio 2019 version 16.10 and later, take one of these steps:
+> - Manually install CMake version 3.19 or lower. Then, set the `cmakeExecutable` property in your existing cache configuration to use that version of CMake.
+> - In your existing cache configuration, set the `cacheGenerationCommand` property to let Visual Studio request the necessary CMake file-based API files. For more information on that property, see [CMakeSettings.json reference](cmakesettings-reference.md#configurations).
+> - Use a query file to request the CMake file-based API files when generating your cache before it's opened in Visual Studio. For query file instructions, see the next section, [Advanced CMake cache troubleshooting](#advanced).
 
-### Advanced CMake cache troubleshooting
+### <a name="advanced"></a> Advanced CMake cache troubleshooting
 
 Visual Studio uses the CMake [file-based API](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html) (in versions 3.14 and later) to populate the editor with information specific to your project structure. For more information, see the C++ team blog post on [multi-root workspaces and file-based API](https://devblogs.microsoft.com/cppblog/visual-studio-code-cmake-tools-extension-multi-root-workspaces-and-file-based-api/).
 

--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -63,6 +63,12 @@ When you open an existing CMake cache file (*`CMakeCache.txt`*), Visual Studio d
 
 You can add an existing CMake cache to an open project. It's done the same way you'd add a new configuration. For more information, see our blog post on [opening an existing cache in Visual Studio](https://devblogs.microsoft.com/cppblog/open-existing-cmake-caches-in-visual-studio/).
 
+> [!NOTE]
+> The default existing cache experience relies on cmake-server, which has been removed from CMake in version 3.20. In Visual Studio 2019 16.10 and later, you will need to do one of the following in order to continue using existing cache functionality:
+> 1. Manually install CMake with version 3.19 or lower. Then set the `cmakeExecutable` property in your existing cache configuration to that CMake.
+> 2. In your existing cache configuration, set the `cacheGenerationCommand` property (see the [CMakeSettings.json reference page](cmakesettings-reference.md) for more details). This allows Visual Studio to request the necessary CMake file-based API files.
+> 3. Ensure the CMake file-based API files are requested when generating your cache prior to opening it in Visual Studio. The instructions for how to do this are described below in "Advanced CMake cache troubleshooting".
+
 ### Advanced CMake cache troubleshooting
 
 Visual Studio uses the CMake [file-based API](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html) (in versions 3.14 and later) to populate the editor with information specific to your project structure. For more information, see the C++ team blog post on [multi-root workspaces and file-based API](https://devblogs.microsoft.com/cppblog/visual-studio-code-cmake-tools-extension-multi-root-workspaces-and-file-based-api/).


### PR DESCRIPTION
Add instructions on how to continue using existing cache after the deprecation of cmake-server in CMake 3.20