### PR TITLE
Locale

### DIFF
--- a/docs/c-runtime-library/reference/atodbl-atodbl-l-atoldbl-atoldbl-l-atoflt-atoflt-l.md
+++ b/docs/c-runtime-library/reference/atodbl-atodbl-l-atoldbl-atoldbl-l-atoflt-atoflt-l.md
@@ -18,11 +18,11 @@ Converts a string to a double (**_atodbl**), long double (**_atoldbl**), or floa
 
 ```C
 int _atodbl( _CRT_DOUBLE * value, char * str );
-int _atodbl_l ( _CRT_DOUBLE * value, char * str, locale_t locale );
+int _atodbl_l ( _CRT_DOUBLE * value, char * str, _locale_t locale );
 int _atoldbl( _LDOUBLE * value, char * str );
-int _atoldbl_l ( _LDOUBLE * value, char * str, locale_t locale );
+int _atoldbl_l ( _LDOUBLE * value, char * str, _locale_t locale );
 int _atoflt( _CRT_FLOAT * value, const char * str );
-int _atoflt_l( _CRT_FLOAT * value, const char * str, locale_t locale );
+int _atoflt_l( _CRT_FLOAT * value, const char * str, _locale_t locale );
 ```
 
 ### Parameters

--- a/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
+++ b/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
@@ -24,14 +24,14 @@ int _cprintf(
 );
 int _cprintf_l(
    const char * format,
-   locale_t locale [, argument_list]
+   _locale_t locale [, argument_list]
 );
 int _cwprintf(
    const wchar * format [, argument_list]
 );
 int _cwprintf_l(
    const wchar * format,
-   locale_t locale [, argument_list]
+   _locale_t locale [, argument_list]
 );
 ```
 

--- a/docs/c-runtime-library/reference/cprintf-p-cprintf-p-l-cwprintf-p-cwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/cprintf-p-cprintf-p-l-cwprintf-p-cwprintf-p-l.md
@@ -25,7 +25,7 @@ int _cprintf_p(
 );
 int _cprintf_p_l(
    const char * format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _cwprintf_p(
@@ -34,7 +34,7 @@ int _cwprintf_p(
 );
 int _cwprintf_p_l(
    const wchar * format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/cprintf-s-cprintf-s-l-cwprintf-s-cwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/cprintf-s-cprintf-s-l-cwprintf-s-cwprintf-s-l.md
@@ -25,7 +25,7 @@ int _cprintf_s(
 );
 int _cprintf_s_l(
    const char * format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _cwprintf_s(
@@ -34,7 +34,7 @@ int _cwprintf_s(
 );
 int _cwprintf_s_l(
    const wchar * format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/cscanf-cscanf-l-cwscanf-cwscanf-l.md
+++ b/docs/c-runtime-library/reference/cscanf-cscanf-l-cwscanf-cwscanf-l.md
@@ -29,7 +29,7 @@ int _cscanf(
 );
 int _cscanf_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _cwscanf(
@@ -38,7 +38,7 @@ int _cwscanf(
 );
 int _cwscanf_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
+++ b/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
@@ -26,7 +26,7 @@ int _cscanf_s(
 );
 int _cscanf_s_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _cwscanf_s(
@@ -35,7 +35,7 @@ int _cwscanf_s(
 );
 int _cwscanf_s_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/fprintf-fprintf-l-fwprintf-fwprintf-l.md
+++ b/docs/c-runtime-library/reference/fprintf-fprintf-l-fwprintf-fwprintf-l.md
@@ -24,7 +24,7 @@ int fprintf(
 int _fprintf_l(
    FILE *stream,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 int fwprintf(
@@ -35,7 +35,7 @@ int fwprintf(
 int _fwprintf_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 ```

--- a/docs/c-runtime-library/reference/fprintf-p-fprintf-p-l-fwprintf-p-fwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/fprintf-p-fprintf-p-l-fwprintf-p-fwprintf-p-l.md
@@ -24,7 +24,7 @@ int _fprintf_p(
 int _fprintf_p_l(
    FILE *stream,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 int _fwprintf_p(
@@ -35,7 +35,7 @@ int _fwprintf_p(
 int _fwprintf_p_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 ```

--- a/docs/c-runtime-library/reference/fprintf-s-fprintf-s-l-fwprintf-s-fwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/fprintf-s-fprintf-s-l-fwprintf-s-fwprintf-s-l.md
@@ -24,7 +24,7 @@ int fprintf_s(
 int _fprintf_s_l(
    FILE *stream,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument_list ]
 );
 int fwprintf_s(
@@ -35,7 +35,7 @@ int fwprintf_s(
 int _fwprintf_s_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument_list ]
 );
 ```

--- a/docs/c-runtime-library/reference/fscanf-fscanf-l-fwscanf-fwscanf-l.md
+++ b/docs/c-runtime-library/reference/fscanf-fscanf-l-fwscanf-fwscanf-l.md
@@ -25,7 +25,7 @@ int fscanf(
 int _fscanf_l(
    FILE *stream,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 int fwscanf(
@@ -36,7 +36,7 @@ int fwscanf(
 int _fwscanf_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 ```

--- a/docs/c-runtime-library/reference/fscanf-s-fscanf-s-l-fwscanf-s-fwscanf-s-l.md
+++ b/docs/c-runtime-library/reference/fscanf-s-fscanf-s-l-fwscanf-s-fwscanf-s-l.md
@@ -25,7 +25,7 @@ int fscanf_s(
 int _fscanf_s_l(
    FILE *stream,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 int fwscanf_s(
@@ -36,7 +36,7 @@ int fwscanf_s(
 int _fwscanf_s_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ]...
 );
 ```

--- a/docs/c-runtime-library/reference/mbccpy-s-mbccpy-s-l.md
+++ b/docs/c-runtime-library/reference/mbccpy-s-mbccpy-s-l.md
@@ -31,7 +31,7 @@ errno_t _mbccpy_s_l(
    size_t buffSizeInBytes,
    int * pCopied,
    const unsigned char *src,
-   locale_t locale
+   _locale_t locale
 );
 template <size_t size>
 errno_t _mbccpy_s(
@@ -44,7 +44,7 @@ errno_t _mbccpy_s_l(
    unsigned char (&dest)[size],
    int * pCopied,
    const unsigned char *src,
-   locale_t locale
+   _locale_t locale
 ); // C++ only
 ```
 

--- a/docs/c-runtime-library/reference/printf-p-printf-p-l-wprintf-p-wprintf-p-l.md
+++ b/docs/c-runtime-library/reference/printf-p-printf-p-l-wprintf-p-wprintf-p-l.md
@@ -22,7 +22,7 @@ int _printf_p(
 );
 int _printf_p_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 int _wprintf_p(
@@ -31,7 +31,7 @@ int _wprintf_p(
 );
 int _wprintf_p_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 ```

--- a/docs/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l.md
+++ b/docs/c-runtime-library/reference/printf-printf-l-wprintf-wprintf-l.md
@@ -22,7 +22,7 @@ int printf(
 );
 int _printf_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 int wprintf(
@@ -31,7 +31,7 @@ int wprintf(
 );
 int _wprintf_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 ```

--- a/docs/c-runtime-library/reference/printf-s-printf-s-l-wprintf-s-wprintf-s-l.md
+++ b/docs/c-runtime-library/reference/printf-s-printf-s-l-wprintf-s-wprintf-s-l.md
@@ -22,7 +22,7 @@ int printf_s(
 );
 int _printf_s_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 int wprintf_s(
@@ -31,7 +31,7 @@ int wprintf_s(
 );
 int _wprintf_s_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 ```

--- a/docs/c-runtime-library/reference/scanf-s-scanf-s-l-wscanf-s-wscanf-s-l.md
+++ b/docs/c-runtime-library/reference/scanf-s-scanf-s-l-wscanf-s-wscanf-s-l.md
@@ -23,7 +23,7 @@ int scanf_s(
 );
 int _scanf_s_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 int wscanf_s(
@@ -32,7 +32,7 @@ int wscanf_s(
 );
 int _wscanf_s_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 ```

--- a/docs/c-runtime-library/reference/scanf-scanf-l-wscanf-wscanf-l.md
+++ b/docs/c-runtime-library/reference/scanf-scanf-l-wscanf-wscanf-l.md
@@ -26,7 +26,7 @@ int scanf(
 );
 int _scanf_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 int wscanf(
@@ -35,7 +35,7 @@ int wscanf(
 );
 int _wscanf_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument]...
 );
 ```

--- a/docs/c-runtime-library/reference/scprintf-p-scprintf-p-l-scwprintf-p-scwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/scprintf-p-scprintf-p-l-scwprintf-p-scwprintf-p-l.md
@@ -22,7 +22,7 @@ int _scprintf_p(
 );
 int _scprintf_p_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _scwprintf_p (
@@ -31,7 +31,7 @@ int _scwprintf_p (
 );
 int _scwprintf_p _l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/scprintf-scprintf-l-scwprintf-scwprintf-l.md
+++ b/docs/c-runtime-library/reference/scprintf-scprintf-l-scwprintf-scwprintf-l.md
@@ -22,7 +22,7 @@ int _scprintf(
 );
 int _scprintf_l(
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _scwprintf(
@@ -31,7 +31,7 @@ int _scwprintf(
 );
 int _scwprintf_l(
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 ```

--- a/docs/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l.md
@@ -28,7 +28,7 @@ int _snprintf_s_l(
    size_t sizeOfBuffer,
    size_t count,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _snwprintf_s(
@@ -43,7 +43,7 @@ int _snwprintf_s_l(
    size_t sizeOfBuffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 template <size_t size>

--- a/docs/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l.md
+++ b/docs/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l.md
@@ -32,7 +32,7 @@ int _snprintf_l(
    char *buffer,
    size_t count,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int _snwprintf(
@@ -45,7 +45,7 @@ int _snwprintf_l(
    wchar_t *buffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 template <size_t size>
@@ -60,7 +60,7 @@ int _snprintf_l(
    char (&buffer)[size],
    size_t count,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 ); // C++ only
 template <size_t size>
@@ -75,7 +75,7 @@ int _snwprintf_l(
    wchar_t (&buffer)[size],
    size_t count,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 ); // C++ only
 ```

--- a/docs/c-runtime-library/reference/snscanf-s-snscanf-s-l-snwscanf-s-snwscanf-s-l.md
+++ b/docs/c-runtime-library/reference/snscanf-s-snscanf-s-l-snwscanf-s-snwscanf-s-l.md
@@ -26,7 +26,7 @@ int __cdecl _snscanf_s_l(
    const char * input,
    size_t length,
    const char * format,
-   locale_t locale [, argument_list]
+   _locale_t locale [, argument_list]
 );
 int __cdecl _snwscanf_s(
    const wchar_t * input,
@@ -37,7 +37,7 @@ int __cdecl _snwscanf_s_l(
    const wchar_t * input,
    size_t length,
    const wchar_t * format,
-   locale_t locale [, argument_list]
+   _locale_t locale [, argument_list]
 );
 ```
 

--- a/docs/c-runtime-library/reference/snscanf-snscanf-l-snwscanf-snwscanf-l.md
+++ b/docs/c-runtime-library/reference/snscanf-snscanf-l-snwscanf-snwscanf-l.md
@@ -27,7 +27,7 @@ int __cdecl _snscanf_l(
    const char * input,
    size_t length,
    const char * format,
-   locale_t locale,
+   _locale_t locale,
    ...
 );
 int __cdecl _snwscanf(
@@ -40,7 +40,7 @@ int __cdecl _snwscanf_l(
    const wchar_t * input,
    size_t length,
    const wchar_t * format,
-   locale_t locale,
+   _locale_t locale,
    ...
 );
 ```

--- a/docs/c-runtime-library/reference/sprintf-p-sprintf-p-l-swprintf-p-swprintf-p-l.md
+++ b/docs/c-runtime-library/reference/sprintf-p-sprintf-p-l-swprintf-p-swprintf-p-l.md
@@ -26,7 +26,7 @@ int _sprintf_p_l(
    char *buffer,
    size_t sizeOfBuffer,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument_list]
 );
 int _swprintf_p(
@@ -39,7 +39,7 @@ int _swprintf_p_l(
    wchar_t *buffer,
    size_t sizeOfBuffer,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument_list]
 );
 ```

--- a/docs/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l.md
+++ b/docs/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l.md
@@ -26,7 +26,7 @@ int _sprintf_s_l(
    char *buffer,
    size_t sizeOfBuffer,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    ...
 );
 int swprintf_s(
@@ -39,7 +39,7 @@ int _swprintf_s_l(
    wchar_t *buffer,
    size_t sizeOfBuffer,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    ...
 );
 template <size_t size>

--- a/docs/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l.md
+++ b/docs/c-runtime-library/reference/sprintf-sprintf-l-swprintf-swprintf-l-swprintf-l.md
@@ -24,7 +24,7 @@ int sprintf(
 int _sprintf_l(
    char *buffer,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int swprintf(
@@ -37,13 +37,13 @@ int _swprintf_l(
    wchar_t *buffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 int __swprintf_l(
    wchar_t *buffer,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 );
 template <size_t size>
@@ -56,7 +56,7 @@ template <size_t size>
 int _sprintf_l(
    char (&buffer)[size],
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument] ...
 ); // C++ only
 ```

--- a/docs/c-runtime-library/reference/sscanf-s-sscanf-s-l-swscanf-s-swscanf-s-l.md
+++ b/docs/c-runtime-library/reference/sscanf-s-sscanf-s-l-swscanf-s-swscanf-s-l.md
@@ -25,7 +25,7 @@ int sscanf_s(
 int _sscanf_s_l(
    const char *buffer,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ] ...
 );
 int swscanf_s(
@@ -36,7 +36,7 @@ int swscanf_s(
 int _swscanf_s_l(
    const wchar_t *buffer,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ] ...
 );
 ```

--- a/docs/c-runtime-library/reference/sscanf-sscanf-l-swscanf-swscanf-l.md
+++ b/docs/c-runtime-library/reference/sscanf-sscanf-l-swscanf-swscanf-l.md
@@ -25,7 +25,7 @@ int sscanf(
 int _sscanf_l(
    const char *buffer,
    const char *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ] ...
 );
 int swscanf(
@@ -36,7 +36,7 @@ int swscanf(
 int _swscanf_l(
    const wchar_t *buffer,
    const wchar_t *format,
-   locale_t locale [,
+   _locale_t locale [,
    argument ] ...
 );
 ```

--- a/docs/c-runtime-library/reference/strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l.md
+++ b/docs/c-runtime-library/reference/strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l.md
@@ -57,7 +57,7 @@ errno_t _mbsncpy_s_l(
    size_t numberOfElements,
    const unsigned char *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 );
 template <size_t size>
 errno_t strncpy_s(
@@ -96,7 +96,7 @@ errno_t _mbsncpy_s_l(
    unsigned char (&strDest)[size],
    const unsigned char *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 ); // C++ only
 ```
 

--- a/docs/c-runtime-library/reference/strncpy-strncpy-l-wcsncpy-wcsncpy-l-mbsncpy-mbsncpy-l.md
+++ b/docs/c-runtime-library/reference/strncpy-strncpy-l-wcsncpy-wcsncpy-l-mbsncpy-mbsncpy-l.md
@@ -29,7 +29,7 @@ char *_strncpy_l(
    char *strDest,
    const char *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 );
 wchar_t *wcsncpy(
    wchar_t *strDest,
@@ -40,7 +40,7 @@ wchar_t *_wcsncpy_l(
    wchar_t *strDest,
    const wchar_t *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 );
 unsigned char *_mbsncpy(
    unsigned char *strDest,
@@ -64,7 +64,7 @@ char *_strncpy_l(
    char (&strDest)[size],
    const char *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 ); // C++ only
 template <size_t size>
 wchar_t *wcsncpy(
@@ -77,7 +77,7 @@ wchar_t *_wcsncpy_l(
    wchar_t (&strDest)[size],
    const wchar_t *strSource,
    size_t count,
-   locale_t locale
+   _locale_t locale
 ); // C++ only
 template <size_t size>
 unsigned char *_mbsncpy(

--- a/docs/c-runtime-library/reference/strnset-s-strnset-s-l-wcsnset-s-wcsnset-s-l-mbsnset-s-mbsnset-s-l.md
+++ b/docs/c-runtime-library/reference/strnset-s-strnset-s-l-wcsnset-s-wcsnset-s-l-mbsnset-s-mbsnset-s-l.md
@@ -31,7 +31,7 @@ errno_t _strnset_s_l(
    size_t numberOfElements,
    int c,
    size_t count,
-   locale_t locale
+   _locale_t locale
 );
 errno_t _wcsnset_s(
    wchar_t *str,

--- a/docs/c-runtime-library/reference/strnset-strnset-l-wcsnset-wcsnset-l-mbsnset-mbsnset-l.md
+++ b/docs/c-runtime-library/reference/strnset-strnset-l-wcsnset-wcsnset-l-mbsnset-mbsnset-l.md
@@ -29,7 +29,7 @@ char *_strnset_l(
    char *str,
    int c,
    size_t count,
-   locale_t locale
+   _locale_t locale
 );
 wchar_t *_wcsnset(
    wchar_t *str,

--- a/docs/c-runtime-library/reference/strset-s-strset-s-l-wcsset-s-wcsset-s-l-mbsset-s-mbsset-s-l.md
+++ b/docs/c-runtime-library/reference/strset-s-strset-s-l-wcsset-s-wcsset-s-l-mbsset-s-mbsset-s-l.md
@@ -29,7 +29,7 @@ errno_t _strset_s_l(
    char *str,
    size_t numberOfElements,
    int c,
-   locale_t locale
+   _locale_t locale
 );
 errno_t _wcsset_s(
    wchar_t *str,
@@ -40,7 +40,7 @@ errno_t *_wcsset_s_l(
    wchar_t *str,
    size_t numberOfElements,
    wchar_t c,
-   locale_t locale
+   _locale_t locale
 );
 errno_t _mbsset_s(
    unsigned char *str,

--- a/docs/c-runtime-library/reference/strset-strset-l-wcsset-wcsset-l-mbsset-mbsset-l.md
+++ b/docs/c-runtime-library/reference/strset-strset-l-wcsset-wcsset-l-mbsset-mbsset-l.md
@@ -27,7 +27,7 @@ char *_strset(
 char *_strset_l(
    char *str,
    int c,
-   locale_t locale
+   _locale_t locale
 );
 wchar_t *_wcsset(
    wchar_t *str,
@@ -36,7 +36,7 @@ wchar_t *_wcsset(
 wchar_t *_wcsset_l(
    wchar_t *str,
    wchar_t c,
-   locale_t locale
+   _locale_t locale
 );
 unsigned char *_mbsset(
    unsigned char *str,

--- a/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
@@ -25,7 +25,7 @@ int _vcprintf_p(
 );
 int _vcprintf_p_l(
    const char* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vcwprintf_p(
@@ -34,7 +34,7 @@ int _vcwprintf_p(
 );
 int _vcwprintf_p_l(
    const wchar_t* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vcprintf-s-vcprintf-s-l-vcwprintf-s-vcwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-s-vcprintf-s-l-vcwprintf-s-vcwprintf-s-l.md
@@ -25,7 +25,7 @@ int _vcprintf(
 );
 int _vcprintf(
    const char* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vcwprintf_s(
@@ -34,7 +34,7 @@ int _vcwprintf_s(
 );
 int _vcwprintf_s_l(
    const wchar_t* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vcprintf-vcprintf-l-vcwprintf-vcwprintf-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-vcprintf-l-vcwprintf-vcwprintf-l.md
@@ -25,7 +25,7 @@ int _vcprintf(
 );
 int _vcprintf_l(
    const char* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vcwprintf(
@@ -34,7 +34,7 @@ int _vcwprintf(
 );
 int _vcwprintf_l(
    const wchar_t* format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vfprintf-p-vfprintf-p-l-vfwprintf-p-vfwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vfprintf-p-vfprintf-p-l-vfwprintf-p-vfwprintf-p-l.md
@@ -24,7 +24,7 @@ int _vfprintf_p(
 int _vfprintf_p_l(
    FILE *stream,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vfwprintf_p(
@@ -35,7 +35,7 @@ int _vfwprintf_p(
 int _vfwprintf_p_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vfprintf-s-vfprintf-s-l-vfwprintf-s-vfwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/vfprintf-s-vfprintf-s-l-vfwprintf-s-vfwprintf-s-l.md
@@ -24,7 +24,7 @@ int vfprintf_s(
 int _vfprintf_s_l(
    FILE *stream,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vfwprintf_s(
@@ -35,7 +35,7 @@ int vfwprintf_s(
 int _vfwprintf_s_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vfprintf-vfprintf-l-vfwprintf-vfwprintf-l.md
+++ b/docs/c-runtime-library/reference/vfprintf-vfprintf-l-vfwprintf-vfwprintf-l.md
@@ -24,7 +24,7 @@ int vfprintf(
 int _vfprintf_l(
    FILE *stream,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vfwprintf(
@@ -35,7 +35,7 @@ int vfwprintf(
 int _vfwprintf_l(
    FILE *stream,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vprintf-p-vprintf-p-l-vwprintf-p-vwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vprintf-p-vprintf-p-l-vwprintf-p-vwprintf-p-l.md
@@ -22,7 +22,7 @@ int _vprintf_p(
 );
 int _vprintf_p_l(
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vwprintf_p(
@@ -31,7 +31,7 @@ int _vwprintf_p(
 );
 int _vwprintf_p_l(
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vprintf-s-vprintf-s-l-vwprintf-s-vwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/vprintf-s-vprintf-s-l-vwprintf-s-vwprintf-s-l.md
@@ -22,7 +22,7 @@ int vprintf_s(
 );
 int _vprintf_s_l(
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vwprintf_s(
@@ -31,7 +31,7 @@ int vwprintf_s(
 );
 int _vwprintf_s_l(
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vprintf-vprintf-l-vwprintf-vwprintf-l.md
+++ b/docs/c-runtime-library/reference/vprintf-vprintf-l-vwprintf-vwprintf-l.md
@@ -22,7 +22,7 @@ int vprintf(
 );
 int _vprintf_l(
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vwprintf(
@@ -31,7 +31,7 @@ int vwprintf(
 );
 int _vwprintf_l(
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vscprintf-p-vscprintf-p-l-vscwprintf-p-vscwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vscprintf-p-vscprintf-p-l-vscwprintf-p-vscwprintf-p-l.md
@@ -22,7 +22,7 @@ int _vscprintf_p(
 );
 int _vscprintf_p _l(
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vscwprintf_p (
@@ -31,7 +31,7 @@ int _vscwprintf_p (
 );
 int _vscwprintf_p _l(
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vscprintf-vscprintf-l-vscwprintf-vscwprintf-l.md
+++ b/docs/c-runtime-library/reference/vscprintf-vscprintf-l-vscwprintf-vscwprintf-l.md
@@ -22,7 +22,7 @@ int _vscprintf(
 );
 int _vscprintf_l(
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vscwprintf(
@@ -31,7 +31,7 @@ int _vscwprintf(
 );
 int _vscwprintf_l(
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vsnprintf-s-vsnprintf-s-vsnprintf-s-l-vsnwprintf-s-vsnwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/vsnprintf-s-vsnprintf-s-vsnprintf-s-l-vsnwprintf-s-vsnwprintf-s-l.md
@@ -35,7 +35,7 @@ int _vsnprintf_s_l(
    size_t sizeOfBuffer,
    size_t count,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vsnwprintf_s(
@@ -50,7 +50,7 @@ int _vsnwprintf_s_l(
    size_t sizeOfBuffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 template <size_t size>

--- a/docs/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l.md
+++ b/docs/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l.md
@@ -32,7 +32,7 @@ int _vsnprintf_l(
    char *buffer,
    size_t count,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vsnwprintf(
@@ -45,7 +45,7 @@ int _vsnwprintf_l(
    wchar_t *buffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 template <size_t size>
@@ -67,7 +67,7 @@ int _vsnprintf_l(
    char (&buffer)[size],
    size_t count,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 ); // C++ only
 template <size_t size>
@@ -82,7 +82,7 @@ int _vsnwprintf_l(
    wchar_t (&buffer)[size],
    size_t count,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 ); // C++ only
 ```

--- a/docs/c-runtime-library/reference/vsprintf-p-vsprintf-p-l-vswprintf-p-vswprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vsprintf-p-vsprintf-p-l-vswprintf-p-vswprintf-p-l.md
@@ -26,7 +26,7 @@ int _vsprintf_p_l(
    char *buffer,
    size_t sizeInBytes,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int _vswprintf_p(
@@ -39,7 +39,7 @@ int _vswprintf_p_l(
    wchar_t *buffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 ```

--- a/docs/c-runtime-library/reference/vsprintf-s-vsprintf-s-l-vswprintf-s-vswprintf-s-l.md
+++ b/docs/c-runtime-library/reference/vsprintf-s-vsprintf-s-l-vswprintf-s-vswprintf-s-l.md
@@ -26,7 +26,7 @@ int _vsprintf_s_l(
    char *buffer,
    size_t numberOfElements,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vswprintf_s(
@@ -39,7 +39,7 @@ int _vswprintf_s_l(
    wchar_t *buffer,
    size_t numberOfElements,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 template <size_t size>

--- a/docs/c-runtime-library/reference/vsprintf-vsprintf-l-vswprintf-vswprintf-l-vswprintf-l.md
+++ b/docs/c-runtime-library/reference/vsprintf-vsprintf-l-vswprintf-vswprintf-l-vswprintf-l.md
@@ -24,7 +24,7 @@ int vsprintf(
 int _vsprintf_l(
    char *buffer,
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int vswprintf(
@@ -37,13 +37,13 @@ int _vswprintf_l(
    wchar_t *buffer,
    size_t count,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 int __vswprintf_l(
    wchar_t *buffer,
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 );
 template <size_t size>
@@ -56,7 +56,7 @@ template <size_t size>
 int _vsprintf_l(
    char (&buffer)[size],
    const char *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 ); // C++ only
 template <size_t size>
@@ -69,7 +69,7 @@ template <size_t size>
 int _vswprintf_l(
    wchar_t (&buffer)[size],
    const wchar_t *format,
-   locale_t locale,
+   _locale_t locale,
    va_list argptr
 ); // C++ only
 ```


### PR DESCRIPTION
Fix references to `locale_t` to use `_locale_t` instead.