### PR TITLE
Add io.h header into example code

### DIFF
--- a/docs/c-runtime-library/reference/get-errno.md
+++ b/docs/c-runtime-library/reference/get-errno.md
@@ -41,11 +41,12 @@ By default, this function's global state is scoped to the application. To change
 
 ```C
 // crt_get_errno.c
-#include <stdio.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <share.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <io.h>
+#include <share.h>
+#include <stdio.h>
+#include <sys/stat.h>
 
 int main()
 {


### PR DESCRIPTION
Repro:

1. Paste sample code for _get_errno is placed into new Visual Studio 2019 project
1. Try to compile

Result:
Compilation fails
The error is:
Error	C3861	'_sopen_s': identifier not found	

Expected Result:
Sample code should just compile

Fix:
Add io.h header file to avoid the above error in sample code.