### PR TITLE
`<filesystem>` no longer includes `<experimental/filesystem>`

### DIFF
--- a/docs/standard-library/filesystem.md
+++ b/docs/standard-library/filesystem.md
@@ -19,7 +19,7 @@ using namespace std::experimental::filesystem::v1;
 
 > [!IMPORTANT]
 > At the release of Visual Studio 2017, the `<filesystem>` header was not yet a C++ standard. C++ in Visual Studio 2017 RTW implements the final draft standard, found in [ISO/IEC JTC 1/SC 22/WG 21 N4100](https://wg21.link/n4100). Visual Studio 2017 version 15.7 and later supports the new C++17 `<filesystem>` standard.
-> This is a completely new implementation, incompatible with the previous `std::experimental` version. It was made necessary by symlink support, bug fixes, and changes in standard-required behavior. Currently, including `<filesystem>` provides the new `std::filesystem` and the previous `std::experimental::filesystem`. Including `<experimental/filesystem>` provides only the old experimental implementation. The experimental implementation will be removed in the next ABI-breaking release of the libraries.
+> This is a completely new implementation, incompatible with the previous `std::experimental` version. It was made necessary by symlink support, bug fixes, and changes in standard-required behavior. In Visual Studio 2019 version 16.3 and later, including `<filesystem>` provides only the new `std::filesystem`. Including `<experimental/filesystem>` provides only the old experimental implementation. The experimental implementation will be removed in the next ABI-breaking release of the libraries.
 
 This header supports file systems for one of two broad classes of host operating systems: Microsoft Windows and POSIX.
 

--- a/docs/standard-library/filesystem.md
+++ b/docs/standard-library/filesystem.md
@@ -1,7 +1,7 @@
 ---
 title: "&lt;filesystem&gt;"
 description: "Describes the classes, functions, and types in the filesystem header of the Standard C++ library."
-ms.date: "01/15/2021"
+ms.date: "09/02/2021"
 f1_keywords: ["<filesystem>", "filesystem/std::filesystem", "std::filesystem", "std::experimental::filesystem"]
 no-loc: [filesystem, experimental, char, wchar_t, char16_t, char32_t]
 ---


### PR DESCRIPTION
Our [C++20 Features and Fixes in VS 2019 16.1 through 16.6](https://devblogs.microsoft.com/cppblog/c20-features-and-fixes-in-vs-2019-16-1-through-16-6/#vs-2019-16-3) changelog said:

> ### VS 2019 16.3
> [...]
> * `<filesystem>` no longer includes `<experimental/filesystem>`.

This was internal [MSVC-PR-186809](https://devdiv.visualstudio.com/DevDiv/_git/msvc/pullrequest/186809) on 2019-06-17.