### PR TITLE
Improve `<stdexcept>` documentation and examples

### DIFF
--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -8,7 +8,7 @@ ms.assetid: a1d8245d-61c2-4d1e-973f-073bd5dd5fa3
 ---
 # domain_error Class
 
-The class serves as the base class for all exceptions thrown to report a domain error.
+The class serves as the base class for all exceptions thrown to report a domain error (as in mathematics, not networking).
 
 ## Syntax
 

--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: domain_error Class"
 title: "domain_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::domain_error"]
 helpviewer_keywords: ["domain_error class"]
 ms.assetid: a1d8245d-61c2-4d1e-973f-073bd5dd5fa3

--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -26,6 +26,8 @@ public:
 
 The value returned by `what()` is a copy of `message.data()`. For more information, see [`what`](../standard-library/exception-class.md) and [`data`](../standard-library/basic-string-class.md#data).
 
+`domain_error` isn't thrown by any functions in Microsoft's implementation of the C++ Standard Library, but may be thrown by third-party libraries or user code.
+
 ## Example
 
 ```cpp

--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -32,22 +32,24 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // domain_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
+#include <exception>
 #include <iostream>
-
+#include <stdexcept>
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
    try
    {
-      throw domain_error( "Your domain is in error!" );
+      throw domain_error("Your domain is in error!");
    }
-   catch (exception &e)
+   catch (const exception& e)
    {
-      cerr << "Caught: " << e.what( ) << endl;
-      cerr << "Type: " << typeid(e).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
 Caught: Your domain is in error!

--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -26,7 +26,7 @@ public:
 
 The value returned by `what()` is a copy of `message.data()`. For more information, see [`what`](../standard-library/exception-class.md) and [`data`](../standard-library/basic-string-class.md#data).
 
-`domain_error` isn't thrown by any functions in Microsoft's implementation of the C++ Standard Library, but may be thrown by third-party libraries or user code.
+`domain_error` isn't thrown by any functions in the Microsoft implementation of the C++ Standard Library, but it might be thrown by third-party libraries or user code.
 
 ## Example
 

--- a/docs/standard-library/invalid-argument-class.md
+++ b/docs/standard-library/invalid-argument-class.md
@@ -29,28 +29,29 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 ## Example
 
 ```cpp
-// invalid_arg.cpp
-// compile with: /EHsc /GR
+// invalid_argument.cpp
+// compile with: /EHsc
 #include <bitset>
+#include <exception>
 #include <iostream>
-
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
    try
    {
-      bitset< 32 > bitset( string( "11001010101100001b100101010110000") );
+      bitset<32> b("11001010101100001b100101010110000");
    }
-   catch ( exception &e )
+   catch (const exception& e)
    {
-      cerr << "Caught " << e.what( ) << endl;
-      cerr << "Type " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
-Caught invalid bitset<N> char
-Type class std::invalid_argument
+Caught: invalid bitset char
+Type: class std::invalid_argument
 */
 ```
 

--- a/docs/standard-library/invalid-argument-class.md
+++ b/docs/standard-library/invalid-argument-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: invalid_argument Class"
 title: "invalid_argument Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::invalid_argument"]
 helpviewer_keywords: ["invalid_argument class"]
 ms.assetid: af6c227d-ad7c-4e63-9dee-67af81d83506

--- a/docs/standard-library/length-error-class.md
+++ b/docs/standard-library/length-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: length_error Class"
 title: "length_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::length_error"]
 helpviewer_keywords: ["length_error class"]
 ms.assetid: d53c46c5-4626-400d-bd76-bf3e1e0f64ae

--- a/docs/standard-library/length-error-class.md
+++ b/docs/standard-library/length-error-class.md
@@ -30,41 +30,29 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // length_error.cpp
-// compile with: /EHsc /GR /MDd
-#include <vector>
+// compile with: /EHsc
+#include <cstddef>
+#include <exception>
 #include <iostream>
-
+#include <typeinfo>
+#include <vector>
 using namespace std;
 
-template<class  T>
-class stingyallocator : public allocator< T>
-{
-public:
-   template <class U>
-      struct rebind { typedef stingyallocator<U> other; };
-   _SIZT max_size( ) const
-   {
-         return 10;
-   };
-
-};
-
-int main( )
+int main()
 {
    try
    {
-      vector<int, stingyallocator< int > > myv;
-      for ( int i = 0; i < 11; i++ ) myv.push_back( i );
+      vector<int> v(100 + static_cast<size_t>(-1) / sizeof(int));
    }
-   catch ( exception &e )
+   catch (const exception& e)
    {
-      cerr << "Caught " << e.what( ) << endl;
-      cerr << "Type " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
-Caught vector<T> too long
-Type class std::length_error
+Caught: vector too long
+Type: class std::length_error
 */
 ```
 

--- a/docs/standard-library/logic-error-class.md
+++ b/docs/standard-library/logic-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: logic_error Class"
 title: "logic_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::logic_error"]
 helpviewer_keywords: ["logic_error class"]
 ms.assetid: b290d73d-94e1-4288-af86-2bb5d71f677a

--- a/docs/standard-library/logic-error-class.md
+++ b/docs/standard-library/logic-error-class.md
@@ -30,27 +30,29 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // logic_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
+#include <exception>
 #include <iostream>
+#include <stdexcept>
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
    try
    {
-      throw logic_error( "logic error" );
+      throw logic_error("Does not compute!");
    }
-   catch ( exception &e )
+   catch (const exception& e)
    {
-      cerr << "Caught: " << e.what( ) << endl;
-      cerr << "Type: " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
-```
-
-```Output
-Caught: logic error
+/* Output:
+Caught: Does not compute!
 Type: class std::logic_error
+*/
 ```
 
 ## Requirements

--- a/docs/standard-library/out-of-range-class.md
+++ b/docs/standard-library/out-of-range-class.md
@@ -31,29 +31,31 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 ```cpp
 // out_of_range.cpp
 // compile with: /EHsc
-#include <string>
+#include <exception>
 #include <iostream>
-
+#include <string>
+#include <typeinfo>
 using namespace std;
 
-int main() {
-// out_of_range
-   try {
-      string str( "Micro" );
-      string rstr( "soft" );
-      str.append( rstr, 5, 3 );
+int main()
+{
+   try
+   {
+      string str("Micro");
+      string rstr("soft");
+      str.append(rstr, 5, 3);
       cout << str << endl;
    }
-   catch ( exception &e ) {
-      cerr << "Caught: " << e.what( ) << endl;
-   };
+   catch (const exception& e)
+   {
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
-```
-
-## Output
-
-```cpp
+/* Output:
 Caught: invalid string position
+Type: class std::out_of_range
+*/
 ```
 
 ## Requirements

--- a/docs/standard-library/out-of-range-class.md
+++ b/docs/standard-library/out-of-range-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: out_of_range Class"
 title: "out_of_range Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::out_of_range"]
 helpviewer_keywords: ["out_of_range class"]
 ms.assetid: d0e14dc0-065e-4666-9ac9-51e52223c503

--- a/docs/standard-library/overflow-error-class.md
+++ b/docs/standard-library/overflow-error-class.md
@@ -30,30 +30,31 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // overflow_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
 #include <bitset>
+#include <exception>
 #include <iostream>
-
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
    try
    {
-      bitset< 33 > bitset;
-      bitset[32] = 1;
-      bitset[0] = 1;
-      unsigned long x = bitset.to_ulong( );
+      bitset<33> b;
+      b[32] = 1;
+      b[0] = 1;
+      unsigned long x = b.to_ulong();
    }
-   catch ( exception &e )
+   catch (const exception& e)
    {
-      cerr << "Caught " << e.what( ) << endl;
-      cerr << "Type " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
-Caught bitset<N> overflow
-Type class std::overflow_error
+Caught: bitset overflow
+Type: class std::overflow_error
 */
 ```
 

--- a/docs/standard-library/overflow-error-class.md
+++ b/docs/standard-library/overflow-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: overflow_error Class"
 title: "overflow_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::overflow_error"]
 helpviewer_keywords: ["overflow_error class"]
 ms.assetid: bae7128d-e36b-4a45-84f1-2f89da441d20

--- a/docs/standard-library/range-error-class.md
+++ b/docs/standard-library/range-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: range_error Class"
 title: "range_error Class"
-ms.date: "08/14/2018"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::range_error"]
 helpviewer_keywords: ["range_error class"]
 ms.assetid: 8afb3e88-fc49-4213-b096-ed63d7aea37c

--- a/docs/standard-library/range-error-class.md
+++ b/docs/standard-library/range-error-class.md
@@ -22,7 +22,7 @@ public:
 
 ## Remarks
 
-The value returned by [what](../standard-library/exception-class.md) is a copy of `message.data`. For more information, see [basic_string::data](../standard-library/basic-string-class.md#data).
+The value returned by [what](../standard-library/exception-class.md) is a copy of `message.data()`. For more information, see [basic_string::data](../standard-library/basic-string-class.md#data).
 
 ## Example
 

--- a/docs/standard-library/range-error-class.md
+++ b/docs/standard-library/range-error-class.md
@@ -28,20 +28,24 @@ The value returned by [what](../standard-library/exception-class.md) is a copy o
 
 ```cpp
 // range_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
+#include <exception>
 #include <iostream>
+#include <stdexcept>
+#include <typeinfo>
 using namespace std;
+
 int main()
 {
    try
    {
-      throw range_error( "The range is in error!" );
+      throw range_error("The range is in error!");
    }
-   catch (range_error &e)
+   catch (const exception& e)
    {
-      cerr << "Caught: " << e.what( ) << endl;
-      cerr << "Type: " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
 Caught: The range is in error!

--- a/docs/standard-library/range-error-class.md
+++ b/docs/standard-library/range-error-class.md
@@ -8,7 +8,7 @@ ms.assetid: 8afb3e88-fc49-4213-b096-ed63d7aea37c
 ---
 # range_error Class
 
-The class serves as the base class for all exceptions thrown to report a range error.
+The class serves as the base class for all exceptions thrown to report a range error (as in mathematics, not iterators).
 
 ## Syntax
 

--- a/docs/standard-library/runtime-error-class.md
+++ b/docs/standard-library/runtime-error-class.md
@@ -30,27 +30,28 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // runtime_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
+#include <exception>
 #include <iostream>
-
+#include <locale>
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
-// runtime_error
    try
    {
-      locale loc( "test" );
+      locale loc("test");
    }
-   catch ( exception &e )
+   catch (const exception& e)
    {
-      cerr << "Caught " << e.what( ) << endl;
-      cerr << "Type " << typeid( e ).name( ) << endl;
-   };
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
-Caught bad locale name
-Type class std::runtime_error
+Caught: bad locale name
+Type: class std::runtime_error
 */
 ```
 

--- a/docs/standard-library/runtime-error-class.md
+++ b/docs/standard-library/runtime-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: runtime_error Class"
 title: "runtime_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::runtime_error"]
 helpviewer_keywords: ["runtime_error class"]
 ms.assetid: 4d0227bf-847b-45a2-a320-2351ebf98368

--- a/docs/standard-library/underflow-error-class.md
+++ b/docs/standard-library/underflow-error-class.md
@@ -26,7 +26,7 @@ public:
 
 The value returned by `what()` is a copy of `message.data()`. For more information, see [`what`](../standard-library/exception-class.md) and [`data`](../standard-library/basic-string-class.md#data).
 
-`underflow_error` isn't thrown by any functions in Microsoft's implementation of the C++ Standard Library, but may be thrown by third-party libraries or user code.
+`underflow_error` isn't thrown by any functions in the Microsoft implementation of the C++ Standard Library, but it might be thrown by third-party libraries or user code.
 
 ## Example
 

--- a/docs/standard-library/underflow-error-class.md
+++ b/docs/standard-library/underflow-error-class.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: underflow_error Class"
 title: "underflow_error Class"
-ms.date: "11/04/2016"
+ms.date: "09/09/2021"
 f1_keywords: ["stdexcept/std::underflow_error"]
 helpviewer_keywords: ["underflow_error class"]
 ms.assetid: d632f1f9-9c6c-4954-b96b-03041bfab22d

--- a/docs/standard-library/underflow-error-class.md
+++ b/docs/standard-library/underflow-error-class.md
@@ -26,6 +26,8 @@ public:
 
 The value returned by `what()` is a copy of `message.data()`. For more information, see [`what`](../standard-library/exception-class.md) and [`data`](../standard-library/basic-string-class.md#data).
 
+`underflow_error` isn't thrown by any functions in Microsoft's implementation of the C++ Standard Library, but may be thrown by third-party libraries or user code.
+
 ## Example
 
 ```cpp

--- a/docs/standard-library/underflow-error-class.md
+++ b/docs/standard-library/underflow-error-class.md
@@ -32,21 +32,24 @@ The value returned by `what()` is a copy of `message.data()`. For more informati
 
 ```cpp
 // underflow_error.cpp
-// compile with: /EHsc /GR
+// compile with: /EHsc
+#include <exception>
 #include <iostream>
-
+#include <stdexcept>
+#include <typeinfo>
 using namespace std;
 
-int main( )
+int main()
 {
    try
    {
-      throw underflow_error( "The number's a bit small, captain!" );
+      throw underflow_error("The number's a bit small, captain!");
    }
-   catch ( exception &e ) {
-      cerr << "Caught: " << e.what( ) << endl;
-      cerr << "Type: " << typeid( e ).name( ) << endl;
-   };
+   catch (const exception& e)
+   {
+      cerr << "Caught: " << e.what() << endl;
+      cerr << "Type: " << typeid(e).name() << endl;
+   }
 }
 /* Output:
 Caught: The number's a bit small, captain!


### PR DESCRIPTION
+ `<stdexcept>` docs: Update `ms.date`.
+ Fix #2410.
  * Explain how `domain_error` and `range_error` refer to math.
  * Mention that the STL doesn't throw `domain_error` or `underflow_error`.
+ Add parens to `message.data()` for consistency with other docs.
+ Overhaul all `<stdexcept>` examples.
  * `/GR` is enabled by default.
  * We don't need `/MDd`.
  * Include all necessary headers.
  * Improve paren/brace/bracket consistency.
  * Remove unnecessary semicolons.
  * Add constness when catching `const exception&`.
  * Rename to `invalid_argument.cpp`, matching the type exactly.
  * `bitset` can be directly constructed from `const char *`, we don't need `string`.
  * Shadowing the `bitset` type with a `bitset` variable is confusing; rename to `b`.
  * Always print colons in `"Caught: "` and `"Type: "` for consistency.
  * Regenerate all outputs with VS 2022 17.0 Preview 3, some exception messages changed slightly.
  * Massively simplify the `length_error` example and remove non-Standard code.
  * Change the `logic_error` string to `"Does not compute!"` to avoid potential confusion.
  * Drop unnecessary comments like `// out_of_range`.
  * Always print the type - it was missing from the `out_of_range` example.
  * Consistently display the output as a comment at the end of the file.
  * In the `range_error` example, catch `const exception&` to demonstrate inheritance like all other examples.
