### PR TITLE
Clarify int main(void) example

### DIFF
--- a/docs/c-language/c-bit-fields.md
+++ b/docs/c-language/c-bit-fields.md
@@ -48,7 +48,7 @@ Bit fields defined as **`int`** are treated as **`signed`**. A Microsoft extensi
 
 Bit fields are allocated within an integer from least-significant to most-significant bit. In the following code
 
-```
+```C
 struct mybitfields
 {
     unsigned short a : 4;

--- a/docs/c-language/c-bit-fields.md
+++ b/docs/c-language/c-bit-fields.md
@@ -56,15 +56,16 @@ struct mybitfields
     unsigned short c : 7;
 } test;
 
-int main( void );
+int main( void )
 {
     test.a = 2;
     test.b = 31;
     test.c = 0;
+    return 0;
 }
 ```
 
-the bits would be arranged as follows:
+the bits of `test` would be arranged as follows:
 
 ```
 00000001 11110010


### PR DESCRIPTION
The semicolon can elicit a syntax error from C compilers such as MSVC.
Specifying a return is useful: in ISO C ("C99") and later, the `return 0;` is implied.
However, in ANSI C (AKA "C89") the compiler is not required to add `return 0;`.
This document references ANSI C, so clarity on the matter and consistent style is best.
Also, it is best to identify the struct with the bit layout in question.