### PR TITLE
Updates to documentation for string printf functions

### DIFF
--- a/docs/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l.md
@@ -84,13 +84,34 @@ The locale to use.
 
 ## Return Value
 
-**`_snprintf_s`** returns the number of characters stored in *`buffer`*, not counting the terminating null character. **`_snwprintf_s`** returns the number of wide characters stored in *`buffer`*, not counting the terminating null wide character.
+**`_snprintf_s`** and **`_snwprintf_s`** return the number of characters written, not including the terminating null, or a negative value if truncation of the data occurs (for **`_snwprintf_s`**, this is a count of wide characters).
 
-If the storage required to store the data and a terminating null exceeds *`sizeOfBuffer`*, the invalid parameter handler is invoked, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution continues after the invalid parameter handler, these functions set *`buffer`* to an empty string, set **`errno`** to **`ERANGE`**, and return -1.
+If an encoding error occurs during formatting, **`errno`** is set to **`EILSEQ`**. If the encoding error occurs during formatting for a string conversion specifier (type character **`s`** , **`S`**  or **`Z`**), processing of the format specification is aborted and a negative value is returned by the function. Otherwise, if an encoding error occurs during processing a character conversion specifier (type character **`c`** or **`C`**), the processing of the specifier will be aborted and the invalid character will be skipped. In particular, the number of characters written will not be incremented for this specifier, nor will any data be written for it. Processing of the format specification will continue after skipping the specifier which caused the encoding error, and the function return value will be as described further below.
 
-If *`buffer`* or *`format`* is a **`NULL`** pointer, or if *`count`* is less than or equal to zero, the invalid parameter handler is invoked. If execution is allowed to continue, these functions set **`errno`** to **`EINVAL`** and return -1.
+* If *`count`* is less than *`sizeOfBuffer`* and the number of characters of data is less than or equal to *`count`*, or *`count`* is [`_TRUNCATE`](../../c-runtime-library/truncate.md) and the number of characters of data is less than *`sizeOfBuffer`*, then all of the data is written, a terminating null is appended and the number of characters is returned.
+
+* If *`count`* is less than *`sizeOfBuffer`* but the data exceeds *`count`* characters, then the first *`count`* characters are written. Truncation of the remaining data occurs and -1 is returned without invoking the invalid parameter handler.
+
+* If *`count`* is [`_TRUNCATE`](../../c-runtime-library/truncate.md) and the number of characters of data equals or exceeds *`sizeOfBuffer`*, then as much of the string as will fit in *`buffer`* (with terminating null) is written. Truncation of the remaining data occurs and -1 is returned without invoking the invalid parameter handler.
+
+* If *`count`* is greater than or equal to *`sizeOfBuffer`* but the number of characters of data is less than *`sizeOfBuffer`*, then all of the data is written (with terminating null) and the number of characters is returned.
+
+* If *`count`* and the number of characters of data both equal or exceed *`sizeOfBuffer`* (and *`count`* is not [`_TRUNCATE`](../../c-runtime-library/truncate.md)), the invalid parameter handler is invoked &mdash; as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution continues after the invalid parameter handler, these functions set *buffer* to an empty string, set **`errno`** to **`ERANGE`**, and return -1.
+
+* If *`buffer`* is a null pointer and both *`sizeOfBuffer`* and *`count`* are equal to zero, these functions return 0.
+
+* If *`format`* is a null pointer, or *`buffer`* is a null pointer and either *`sizeOfBuffer`* or *`count`* are nonzero, or if *`buffer`* is not a null pointer and *`sizeOfBuffer`* is zero, the invalid parameter handler is invoked. If execution is allowed to continue, these functions set **`errno`** to **`EINVAL`** and return -1.
 
 For information about these and other error codes, see [`_doserrno`, `errno`, `_sys_errlist`, and `_sys_nerr`](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md).
+
+### Error Conditions
+
+|**Condition**|Return|**`errno`**|
+|-----------------|------------|-------------|
+|*`buffer`* is **`NULL`** (and either *`sizeOfBuffer`* or *`count`* != 0)|-1|**`EINVAL`**|
+|*`format`* is **`NULL`**|-1|**`EINVAL`**|
+|*`buffer`* != **`NULL`** and *`sizeOfBuffer`* == 0|-1|**`EINVAL`**|
+|*`sizeOfBuffer`* too small (and *`count`* != **`_TRUNCATE`**)|-1 (and *`buffer`* set to an empty string)|**`ERANGE`**|
 
 ## Remarks
 

--- a/docs/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l.md
+++ b/docs/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l.md
@@ -101,19 +101,23 @@ For more information, see [Format Specification Syntax: `printf` and `wprintf` F
 
 ## Return Value
 
-Let **`len`** be the length of the formatted data string, not including the terminating null. Both **`len`** and **`count`** are the number of characters for **`snprintf`** and **`_snprintf`**, and the number of wide characters for **`_snwprintf`**.
+Let **`len`** be the length of the formatted data string, not including the terminating null. Both **`len`** and *`count`* are the number of characters for **`snprintf`** and **`_snprintf`**, and the number of wide characters for **`_snwprintf`**.
+
+For all functions, if an encoding error occurs during formatting, **`errno`** is set to **`EILSEQ`**. If the encoding error occurs during formatting for a string conversion specifier (type character **`s`** , **`S`**  or **`Z`**), processing of the format specification is aborted and a negative value is returned by the function.
+
+**Microsoft-specific**: if an encoding error occurs during processing a character conversion specifier (type character **`c`** or **`C`**), the processing of the specifier will be aborted and the invalid character will be skipped. In particular, the character count (**`len`**) will not be incremented for this specifier, nor will output be generated for it. Processing of the format specification will continue after skipping the specifier which caused the encoding error, and the function return value will be as described further below.
+
+For all functions, if *`buffer`* is a null pointer and *`count`* is zero, **`len`** is returned as the count of characters required to format the output &mdash; not including the terminating null. To make a successful call with the same *`argument`* and *`locale`* parameters, allocate a buffer holding at least **`len`** + 1 characters.
 
 For all functions, if **`len`** < *`count`*, **`len`** characters are stored in *`buffer`*, a null-terminator is appended, and **`len`** is returned.
 
-The **`snprintf`** function truncates the output when **`len`** is greater than or equal to *`count`*, by placing a null-terminator at `buffer[count-1]`. The value returned is **`len`**, the number of characters that would have been output if *`count`* was large enough. The **`snprintf`** function returns a negative value if an encoding error occurs.
+The **`snprintf`** function truncates the output when *`count`* is nonzero and **`len`** >= *`count`*, by placing a null-terminator at `buffer[count-1]` (when *`count`* is zero, no characters are stored in *`buffer`* &mdash; whether it is a null pointer or not). In all cases where **`len`** >= *`count`*, the value returned by the **`snprintf`** function is **`len`** (the number of characters that would have been output if *`count`* was large enough). As a corollary, if **`snprintf`** returns a value > *`count`* - 1, the output has been truncated.
 
-For all functions other than **`snprintf`**, if **`len`** = *`count`*, **`len`** characters are stored in *`buffer`*, no null-terminator is appended, and **`len`** is returned. If **`len`** > *`count`*, *`count`* characters are stored in *`buffer`*, no null-terminator is appended, and a negative value is returned.
+For all functions other than **`snprintf`**, if **`len`** = *`count`*, **`len`** characters are stored in *`buffer`*, no null-terminator is appended, and **`len`** is returned. If **`len`** > *`count`* and *`buffer`* is not a null pointer, *`count`* characters are stored in *`buffer`*, no null-terminator is appended, and a negative value is returned.
 
-If *`buffer`* is a null pointer and *`count`* is zero, **`len`** is returned as the count of characters required to format the output, not including the terminating null. To make a successful call with the same *`argument`* and *`locale`* parameters, allocate a buffer holding at least **`len`** + 1 characters.
+If *`buffer`* is a null pointer and *`count`* is nonzero, or if *`format`* is a null pointer, the invalid parameter handler is invoked &mdash; as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions return -1 and set **`errno`** to **`EINVAL`**.
 
-If *`buffer`* is a null pointer and *`count`* is nonzero, or if *`format`* is a null pointer, the invalid parameter handler is invoked, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions return -1 and set **`errno`** to **`EINVAL`**.
-
-For information about these and other error codes, see [`errno`, `_doserrno`, `_sys_errlist, and `_sys_nerr`](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md).
+For information about these and other error codes, see [`errno`, `_doserrno`, `_sys_errlist`, and `_sys_nerr`](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md).
 
 ## Remarks
 

--- a/docs/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l.md
+++ b/docs/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l.md
@@ -104,19 +104,27 @@ Pointer to list of arguments.
 *`locale`*<br/>
 The locale to use.
 
-For more information, see [Format Specifications](../../c-runtime-library/format-specification-syntax-printf-and-wprintf-functions.md).
+For more information, see [Format Specification Syntax: `printf` and `wprintf` Functions](../../c-runtime-library/format-specification-syntax-printf-and-wprintf-functions.md).
 
 ## Return Value
 
-The **`vsnprintf`** function returns the number of characters that are written, not counting the terminating null character. If the buffer size specified by *`count`* isn't sufficiently large to contain the output specified by *`format`* and *`argptr`*, the return value of **`vsnprintf`** is the number of characters that would be written, not counting the null character, if *`count`* were sufficiently large. If the return value is greater than *`count`* - 1, the output has been truncated. A return value of -1 indicates that an encoding error has occurred.
+Let **`len`** be the length of the formatted data string specified by *`format`* and *`argptr`*, not including the terminating null. Both **`len`** and *`count`* are the number of characters for **`vsnprintf`** and **`_vsnprintf`**, and the number of wide characters for **`_vsnwprintf`**.
 
-Both **`_vsnprintf`** and **`_vsnwprintf`** functions return the number of characters written if the number of characters to write is less than or equal to *`count`*. If the number of characters to write is greater than *`count`*, these functions return -1 indicating that output has been truncated.
+For all functions, if an encoding error occurs during formatting, **`errno`** is set to **`EILSEQ`**. If the encoding error occurs during formatting for a string conversion specifier (type character **`s`** , **`S`**  or **`Z`**), processing of the format specification is aborted and a negative value is returned by the function.
 
-The value returned by all these functions doesn't include the terminating null, whether one is written or not.
+**Microsoft-specific**: if an encoding error occurs during processing a character conversion specifier (type character **`c`** or **`C`**), the processing of the specifier will be aborted and the invalid character will be skipped. In particular, the character count (**`len`**) will not be incremented for this specifier, nor will output be generated for it. Processing of the format specification will continue after skipping the specifier which caused the encoding error, and the function return value will be as described further below.
 
-- If *`count`* is zero and *`buffer`* is **`NULL`**, the value returned is the number of characters the functions would write. The value does not take into account a terminating **`NULL`**. You can use this result to allocate sufficient buffer space for the string and its terminating null, and then call the function again to fill the buffer.
-- If *`count`* is zero but *`buffer`* isn't **`NULL`**, nothing is written and the function returns `-1`.
-- If *`format`* is **`NULL`**, or if *`buffer`* is **`NULL`** and *count* isn't equal to zero, these functions invoke the invalid parameter handler, as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions return -1 and set **`errno`** to **`EINVAL`**.
+For all functions, if *`buffer`* is a null pointer and *`count`* is zero, **`len`** is returned as the count of characters required to format the output &mdash; not including the terminating null. To make a successful call with the same *`argument`* and *`locale`* parameters, allocate a buffer holding at least **`len`** + 1 characters.
+
+For all functions, if **`len`** < *`count`*, **`len`** characters are stored in *`buffer`*, a null-terminator is appended, and **`len`** is returned.
+
+The **`vsnprintf`** function truncates the output when *`count`* is nonzero and **`len`** >= *`count`*, by placing a null-terminator at `buffer[count-1]` (when *`count`* is zero, no characters are stored in *`buffer`* &mdash; whether it is a null pointer or not). In all cases where **`len`** >= *`count`*, the value returned by the **`vsnprintf`** function is **`len`** (the number of characters that would have been output if *`count`* was large enough). As a corollary, if **`vsnprintf`** returns a value > *`count`* - 1, the output has been truncated.
+
+For all functions other than **`vsnprintf`**, if **`len`** = *`count`*, **`len`** characters are stored in *`buffer`*, no null-terminator is appended, and **`len`** is returned. If **`len`** > *`count`* and *`buffer`* is not a null pointer, *`count`* characters are stored in *`buffer`*, no null-terminator is appended, and a negative value is returned.
+
+If *`buffer`* is a null pointer and *`count`* is nonzero, or if *`format`* is a null pointer, the invalid parameter handler is invoked &mdash; as described in [Parameter Validation](../../c-runtime-library/parameter-validation.md). If execution is allowed to continue, these functions return -1 and set **`errno`** to **`EINVAL`**.
+
+For information about these and other error codes, see [`errno`, `_doserrno`, `_sys_errlist`, and `_sys_nerr`](../../c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr.md).
 
 ## Remarks
 


### PR DESCRIPTION
The behaviour of `vsnprintf()` with `count == 0` and `buffer != NULL` is to return the length of the formatted data, rather than returning `-1` &mdash; as the documentation currently states. I have cross-referenced the behaviour of `vsnprintf()` with the C specification, and confirmed that the implementation behaviour (returning the length of the formatted data) conforms to the C specification and is correct. Therefore, the current `vsnprintf()` documentation is incorrect and needs to be updated.

After making this observation, I conducted a broader review of the documentation for the `*sn[w]printf*` family of functions, making these updates as a result.

In general, I've corrected a number of errors in the description of the behaviour of the `*sn[w]printf*` family of functions, and have aligned the information for:

* `_snprintf_s()`/`_snwprintf_s()` and `_vsnprintf_s()`/`_vsnwprintf_s()`
* `snprintf()`/`_snprintf()`/`_snwprintf()` and `vsnprintf()`/`_vsnprintf()`/`_vsnwprintf()`

A detailed description of the problems addressed on each page is given below:

[`_snprintf_s()`/`_snwprintf_s()`](https://github.com/MicrosoftDocs/cpp-docs/pull/3411/files#diff-2c1761e96a107f6a14271996f9150488d3c113254edf0f557e339ca981a53819):

* Add description of behaviour which occurs when an encoding error occurs during formatting &mdash; setting `errno` to `EILSEQ` in all cases and either returning a negative value for a string conversion specifier, or skipping the character for a character conversion specifier.

* Clarify that in cases where truncation does not occur, null-termination is performed

* Clarify truncation behaviour:

  - If `count < sizeOfBuffer`, but formatted data `> count`, then formatted data is truncated to `count` characters, null-terminated and -1 is returned with no error handler / update to `errno`
  - With `count == _TRUNCATE`, and formatted data `>= sizeOfBuffer`, then formatted data is truncated to `(sizeOfBuffer - 1)` characters, null-terminated and -1 is returned with no error handler / update to `errno`
  - If `count >= sizeOfBuffer`, formatted data `>= sizeOfBuffer`, and `count != _TRUNCATE`, the invalid parameter handler is invoked. If continued, the functions truncate the buffer to an empty string, return -1 and set `errno` to `ERANGE`

* Clarify error handling behaviour:

  - If `buffer` is `NULL`, an `EINVAL` error occurs if (and only if) either `count` or `sizeOfBuffer` are `!= 0` (if both are 0, no error occurs and 0 is returned)
  - An `EINVAL` error does not occur in all cases where `count == 0`, only when one of the other conditions are met (`count` cannot be negative, as `size_t` is unsigned)
  - If `sizeOfBuffer` (not `count`!) `== 0`, and additionally if buffer is not `NULL`, then an `EINVAL` error occurs

* Add copy of error conditions table from `_vsnprintf_s()`/`_vsnwprintf_s()`.


[`snprintf()`/`_snprintf()`/`_snwprintf()`](https://github.com/MicrosoftDocs/cpp-docs/pull/3411/files#diff-54edb01b728e04768edd942b1fca211a31a18783978e460f0caa29577cd28def):

* Add description of behaviour which occurs when an encoding error occurs during formatting &mdash; setting `errno` to `EILSEQ` in all cases and either returning a negative value for a string conversion specifier, or skipping the character for a character conversion specifier.

* Clarify truncation behaviour:

  - For `snprintf()`, clarify that null-termination by writing to `buffer[count-1]` is only performed if `count != 0`.
  - For `_snprintf()`/`_snwprintf()`, clarify that non-terminated truncation is performed only when `buffer != NULL` (if `buffer == NULL` and `count != 0`, it is an error and if if `buffer == NULL` and `count == 0`, the length of the formatted data is returned).


[`_vsnprintf_s()`/`_vsnwprintf_s()`](https://github.com/MicrosoftDocs/cpp-docs/pull/3411/files#diff-9d9d8428ca05e85c55b27511c2774457b44e6588800fff19ee40869c79eabcf4):

* Add description of behaviour which occurs when an encoding error occurs during formatting &mdash; setting `errno` to `EILSEQ` in all cases and either returning a negative value for a string conversion specifier, or skipping the character for a character conversion specifier.

* Clarify that in cases where truncation does not occur, null-termination is performed

* Clarify truncation behaviour:

  - Note that if `count >= sizeOfBuffer` and formatted data `>= sizeOfBuffer`, then only if also `count != _TRUNCATE` the invalid parameter handler is invoked, etc.

* Clarify error handling behaviour:

  - If `buffer` is `NULL`, an `EINVAL` error occurs if (and only if) either `count` or `sizeOfBuffer` are `!= 0` (if both are 0, no error occurs and 0 is returned)
  - An `EINVAL` error does not occur in all cases where `count == 0`, only when one of the other conditions are met (`count` cannot be negative, as `size_t` is unsigned)
  - If `sizeOfBuffer` (not `count`!) `== 0`, and additionally if buffer is not `NULL`, then an `EINVAL` error occurs

* Update error conditions table to correct from `count == 0` to `sizeOfBuffer == 0` as the condition required for an `EINVAL` error (when `buffer != NULL`). 


[`vsnprintf()`/`_vsnprintf()`/`_vsnwprintf()`](https://github.com/MicrosoftDocs/cpp-docs/pull/3411/files#diff-f4bb82a31fd50d09ff036ee86744072fe6441960ffc3a0040e51eb1e563602af):

* Add description of behaviour which occurs when an encoding error occurs during formatting &mdash; setting `errno` to `EILSEQ` in all cases and either returning a negative value for a string conversion specifier, or skipping the character for a character conversion specifier.

* Clarify that in cases where truncation does not occur, null-termination is performed

* Clarify truncation behaviour:

  - For `vsnprintf()`, clarify that null-termination by writing to `buffer[count-1]` is only performed if `count != 0`.
  - For `_vsnprintf()`/`_vsnwprintf()`, clarify that non-terminated truncation is performed only when `buffer != NULL` (if `buffer == NULL` and `count != 0`, it is an error and if if `buffer == NULL` and `count == 0`, the length of the formatted data is returned).
  - For `vsnprintf()`, clarify that if `count == 0` and `buffer != NULL`, the length of the formatted data is returned, rather than `-1` (as is the case for `_vsnprintf()`/`_vsnwprintf()`).

To verify the behaviour of these functions, I constructed the attached test code \([printf.zip](https://github.com/MicrosoftDocs/cpp-docs/files/7239309/printf.zip)\). The updated descriptions of these functions' behaviour can be verified using the output from this:
```
C:\Temp>cl /Zi /Od /MTd printf.c && printf >printf.txt
Microsoft (R) C/C++ Optimizing Compiler Version 19.30.30528 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

printf.c
Microsoft (R) Incremental Linker Version 14.30.30528.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:printf.exe
/debug
printf.obj
```