### PR TITLE
Update cmake-presets-vs.md

### DIFF
--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -223,7 +223,7 @@ Build with `clang`:
 }
 ```
 
-*OR* use the `toolset` configure preset to specify the `ClangCL` toolset like so:
+*OR* if you are using a generator that supports specifying a native build system toolset, such as Visual Studio Generators for VS 2010 and above, then you can use the `toolset` configure preset to specify the `ClangCL` toolset like so:
   
 ```json
 "cacheVariables": {
@@ -238,7 +238,9 @@ Build with `clang`:
   }
 }
 ```
-  
+
+See the documentation on [CMAKE_GENERATOR_TOOLSET](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html) for more information on generators that support the `toolset` specification.
+
 > [!IMPORTANT]
 > In Visual Studio 2019, you must explicitly specify a Clang IntelliSense mode when you're building with `clang` or `clang-cl`.
 

--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -223,8 +223,8 @@ Build with `clang`:
 }
 ```
 
-*OR* if you are using a generator that supports specifying a native build system toolset, such as Visual Studio Generators for VS 2010 and above, then you can use the `toolset` configure preset to specify the `ClangCL` toolset like so:
-  
+*OR* if you are using either `Visual Studio 16 2019` or `Visual Studio 17 2022` as your generator, then you can use the `toolset` configure preset to specify the `ClangCL` toolset:
+
 ```json
 "cacheVariables": {
   "CMAKE_BUILD_TYPE": "Debug",

--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -223,6 +223,22 @@ Build with `clang`:
 }
 ```
 
+*OR* use the `toolset` configure preset to specify the `ClangCL` toolset like so:
+  
+```json
+"cacheVariables": {
+  "CMAKE_BUILD_TYPE": "Debug",
+  "CMAKE_INSTALL_PREFIX": "${sourceDir}/out/install/${presetName}",
+},
+"toolset": "ClangCL",
+
+"vendor": {
+  "microsoft.com/VisualStudioSettings/CMake/1.0": {
+    "intelliSenseMode": "windows-clang-x64"
+  }
+}
+```
+  
 > [!IMPORTANT]
 > In Visual Studio 2019, you must explicitly specify a Clang IntelliSense mode when you're building with `clang` or `clang-cl`.
 

--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -223,7 +223,7 @@ Build with `clang`:
 }
 ```
 
-*OR* if you are using either `Visual Studio 16 2019` or `Visual Studio 17 2022` as your generator, then you can use the `toolset` configure preset to specify the `ClangCL` toolset:
+If you use either `Visual Studio 16 2019` or `Visual Studio 17 2022` as your generator, you can use the `toolset` Configure Preset to specify the `ClangCL` toolset:
 
 ```json
 "cacheVariables": {
@@ -239,7 +239,7 @@ Build with `clang`:
 }
 ```
 
-See the documentation on [CMAKE_GENERATOR_TOOLSET](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html) for more information on generators that support the `toolset` specification.
+For more information on generators that support the `toolset` specification, see [`CMAKE_GENERATOR_TOOLSET`](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html) in the CMake documentation.
 
 > [!IMPORTANT]
 > In Visual Studio 2019, you must explicitly specify a Clang IntelliSense mode when you're building with `clang` or `clang-cl`.


### PR DESCRIPTION
Add instructions for configuring clang-cl with the ClangCL toolset configure preset instead of by setting CMAKE_C_COMPILER and CMAKE_CXX_COMPILER in cacheVariables.

Fixes #3446.