### PR TITLE
Fixes #3484

### DIFF
--- a/docs/c-runtime-library/reference/strerror-s-strerror-s-wcserror-s-wcserror-s.md
+++ b/docs/c-runtime-library/reference/strerror-s-strerror-s-wcserror-s-wcserror-s.md
@@ -99,7 +99,7 @@ The **strerror_s** function maps *errnum* to an error-message string, returning 
 ```C
 if (( _access( "datafile",2 )) == -1 )
 {
-   _strerror_s(buffer, 80);
+   _strerror_s(buffer, 80, NULL);
    fprintf( stderr, buffer );
 }
 ```


### PR DESCRIPTION
Fixes the incorrect code sample on the [strerror_s, _strerror_s, _wcserror_s, __wcserror_s](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/strerror-s-strerror-s-wcserror-s-wcserror-s?view=msvc-160) reference page.

Fixes #3484