### PR TITLE
Correct the documentation for fmaf

### DIFF
--- a/docs/c-runtime-library/reference/fma-fmaf-fmal.md
+++ b/docs/c-runtime-library/reference/fma-fmaf-fmal.md
@@ -1,6 +1,6 @@
 ---
 title: "fma, fmaf, fmal"
-description: "API reference for fma, fmaf, and fmal; which multiplies two values together, adds a third value, and then rounds the result, without losing any precision due to intermediary rounding."
+description: "API reference for fma, fmaf, and fmal; which multiplies two values together, adds a third value, and then rounds the result, while only losing a small amount of precision due to intermediary rounding."
 ms.date: "9/1/2020"
 api_name: ["fma", "fmaf", "fmal", "_o_fma", "_o_fmaf", "_o_fmal"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-math-l1-1-0.dll", "api-ms-win-crt-private-l1-1-0.dll"]
@@ -12,7 +12,7 @@ ms.assetid: 584a6037-da1e-4e86-9f0c-97aae86de0c0
 ---
 # fma, fmaf, fmal
 
-Multiplies two values together, adds a third value, and then rounds the result, without losing any precision due to intermediary rounding.
+Multiplies two values together, adds a third value, and then rounds the result, while only losing a small amount of precision due to intermediary rounding.
 
 ## Syntax
 
@@ -63,7 +63,7 @@ The value to add.
 
 ## Return Value
 
-Returns `(x * y) + z`. The return value is then rounded using the current rounding format.
+Returns approximately `(x * y) + z`. The return value is then rounded using the current rounding format, although in many cases, it returns incorrectly rounded results and thus the value may be inexact by up to half an ulp from the correct value.
 
 Otherwise, may return one of the following values:
 


### PR DESCRIPTION
The documentation states that this function is correctly rounded, but empirically, that is not true, so here we remove that incorrect information from the documentation. For example, this would be the correct answer, but it is not the answer that is given by this function (unless the computer has FMA3 hardware).

fmaf(-1.9369631e13f, 2.1513551e-7f, -1.7354427e-24f) == -4.16709575e6

Some sample test code to demonstrate why this documentation is wrong:
```c
#include <cmath>
#include <iostream>
int main() {
    float a = -1.9369631e13f, b = 2.1513551e-7f, c = -1.7354427e-24f;
    volatile float va = a, vb = b, vc = c;
    float f1 = fmaf(a, b, c);
    float f2 = fmaf(va, vb, vc);
    std::cout.setf(std::ios::scientific, ::std::ios::floatfield);
    std::cout.precision(19);
    std::cout << f1 << " = -4.1670957500000000000e+06\n";
    std::cout << f2 << " = -4.1670957500000000000e+06\n";
    return 0;
}
```

This outputs:
```
-4.1670955000000000000e+06 = -4.1670957500000000000e+06
-4.1670955000000000000e+06 = -4.1670957500000000000e+06
```

Which we can see means the documentation is wrong, since that `5` needs to be a `7` for this function to be corrected rounded.