### PR TITLE
Correct the documentation for raw pointers. 

### DIFF
--- a/docs/cpp/raw-pointers.md
+++ b/docs/cpp/raw-pointers.md
@@ -34,7 +34,7 @@ A pointer (if it isn't declared as **`const`**) can be incremented or decremente
     const char* str = "Hello world";
 
     const int c = 1;
-    const int* pconst = &c; // declare a non-const pointer to const int
+    int* pconst = &c; // declare a non-const pointer to const int
     const int c2 = 2;
     pconst = &c2;  // OK pconst itself isn't const
     const int* const pconst2 = &c;


### PR DESCRIPTION
Fixed the third code example. line 37 demonstrates declaring a non-const pointer but actually declared a const pointer. Deleted 'const' keyword from line 37.