### PR TITLE
Correct a word in the remarks of /DIRECTIVES.

### DIFF
--- a/docs/build/reference/directives.md
+++ b/docs/build/reference/directives.md
@@ -14,7 +14,7 @@ ms.assetid: cb85d679-6d20-4244-ba0b-6f495228e970
 
 ## Remarks
 
-This option dumps the compiler-generated .drective section of an image.
+This option dumps the compiler-generated .drectve section of an image.
 
 Only the [/HEADERS](headers.md) DUMPBIN option is available for use on files produced with the [/GL](gl-whole-program-optimization.md) compiler option.
 


### PR DESCRIPTION
The section is .drectve instead of .drective.