### PR TITLE
Mark first code block as C++

### DIFF
--- a/docs/cpp/aliases-and-typedefs-cpp.md
+++ b/docs/cpp/aliases-and-typedefs-cpp.md
@@ -11,7 +11,7 @@ You can use an *alias declaration* to declare a name to use as a synonym for a p
 
 ## Syntax
 
-```
+```cpp
 using identifier = type;
 ```
 


### PR DESCRIPTION
Syntax highlighting did not work for the `using identifier = type;` block due to missing language information.