### PR TITLE
Use ConcRT instead of ConCRT

### DIFF
--- a/docs/build/configuring-programs-for-windows-xp.md
+++ b/docs/build/configuring-programs-for-windows-xp.md
@@ -47,7 +47,7 @@ Along with the Windows XP platform toolset, several libraries include runtime su
 - Universal C Runtime Library (UCRT)
 - C++ Standard Library
 - Active Template Library (ATL)
-- Concurrency Runtime Library (ConCRT)
+- Concurrency Runtime Library (ConcRT)
 - Parallel Patterns Library (PPL)
 - Microsoft Foundation Class Library (MFC)
 - C++ AMP (C++ Accelerated Massive Programming) library.
@@ -61,7 +61,7 @@ These libraries are supported by the platform toolsets installed by Visual Studi
 |CRT|X|X|X|
 |C++ Standard Library|X|X|X|
 |ATL|X|X|X|
-|ConCRT/PPL|X|X|X|
+|ConcRT/PPL|X|X|X|
 |MFC|X||X|
 |C++ AMP|X|X||
 

--- a/docs/parallel/toc.yml
+++ b/docs/parallel/toc.yml
@@ -167,7 +167,7 @@ items:
               href: ../parallel/amp/reference/concurrency-precise-math-namespace.md
             - name: "Concurrency::precise_math namespace functions"
               href: ../parallel/amp/reference/concurrency-precise-math-namespace-functions.md
-- name: Concurrency Runtime (ConCRT)
+- name: Concurrency Runtime (ConcRT)
   expanded: false
   items:
     - name: Concurrency Runtime


### PR DESCRIPTION
The abbreviation `ConCRT` in this [page](https://docs.microsoft.com/en-us/cpp/parallel/concrt/concurrency-runtime?view=msvc-170) is confusing.
![Screenshot](https://user-images.githubusercontent.com/5435649/154199524-1c786709-333c-49fa-9c60-405a2a1ef114.png)
I think ConcRT is a more correct abbreviation for `Concurrency Runtime Library`:
- `ConcRT` appears in the comment in the beginning of [concrt.h](https://github.com/icestudent/vc-19-changes/blob/e9f49e36a28463963e8199ff7bc14222910598df/concrt.h#L11)
- MS C++ Team blog has a tag `ConcRT`: [ConcRT - C++ Team Blog](https://devblogs.microsoft.com/cppblog/tag/concrt/)
- SO guys use `ConcRT`:
  - [ConcRT synchronization structures vs Standard Library](https://stackoverflow.com/questions/18263937/concrt-synchronization-structures-vs-standard-library)
  - [Periodic task with ConcRT](https://stackoverflow.com/questions/16131897/periodic-task-with-concrt)