### PR TITLE
VMCS -> VMXON

### DIFF
--- a/docs/intrinsics/vmx-on.md
+++ b/docs/intrinsics/vmx-on.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: __vmx_on"
 title: "__vmx_on"
-ms.date: "09/02/2019"
+ms.date: 04/14/2022"
 f1_keywords: ["__vmx_on"]
 helpviewer_keywords: ["VMXON instruction", "__vmx_on intrinsic"]
 ms.assetid: 16804991-6a75-4adf-8ec2-bc95acfa4801
@@ -35,7 +35,7 @@ unsigned char __vmx_on(
 
 ## Remarks
 
-The `__vmx_on` function corresponds to the `VMXON` machine instruction. This function supports the interaction of a host's virtual machine monitor with a guest operating system and its applications. For more information, search for the document, "Intel Virtualization Technical Specification for the IA-32 Intel Architecture," document number C97063-002, at the [Intel Corporation](https://software.intel.com/articles/intel-sdm) site.
+The `__vmx_on` function corresponds to the `VMXON` machine instruction. This function supports the interaction of a host's virtual machine monitor with a guest operating system and its applications. For more information, see "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 3C: System Programming Guide, Part 3" in the [Intel 64 and IA-32 Architecture Developer Manuals](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html).
 
 ## Requirements
 

--- a/docs/intrinsics/vmx-on.md
+++ b/docs/intrinsics/vmx-on.md
@@ -23,7 +23,7 @@ unsigned char __vmx_on(
 ### Parameters
 
 *VmsSupportPhysicalAddress*\
-[in] A pointer to a 64-bit physical address that points to a virtual-machine control structure (VMCS).
+[in] A pointer to a 64-bit physical address that points to a VMXON region.
 
 ## Return value
 


### PR DESCRIPTION
According to the intel IA32 development manual (Volume 3 C3 23.7):

"Before executing VMXON, software should allocate a naturally aligned 4-KByte region of memory that a logical
processor may use to support VMX operation. This region is called the **VMXON region**."