### PR TITLE
Fixes #3847 by using puts() and by NUL-terminating szMsg[]

### DIFF
--- a/docs/c-runtime-library/reference/getdiskfree.md
+++ b/docs/c-runtime-library/reference/getdiskfree.md
@@ -73,10 +73,10 @@ For more compatibility information, see [Compatibility](../../c-runtime-library/
 #include <stdio.h>
 #include <tchar.h>
 
-TCHAR   g_szBorder[] = _T("======================================================================\n");
-TCHAR   g_szTitle1[] = _T("|DRIVE|TOTAL CLUSTERS|AVAIL CLUSTERS|SECTORS / CLUSTER|BYTES / SECTOR|\n");
-TCHAR   g_szTitle2[] = _T("|=====|==============|==============|=================|==============|\n");
-TCHAR   g_szLine[]   = _T("|  A: |              |              |                 |              |\n");
+TCHAR   g_szBorder[] = _T("======================================================================");
+TCHAR   g_szTitle1[] = _T("|DRIVE|TOTAL CLUSTERS|AVAIL CLUSTERS|SECTORS / CLUSTER|BYTES / SECTOR|");
+TCHAR   g_szTitle2[] = _T("|=====|==============|==============|=================|==============|");
+TCHAR   g_szLine[]   = _T("|  A: |              |              |                 |              |");
 
 void utoiRightJustified(TCHAR* szLeft, TCHAR* szRight, unsigned uVal);
 
@@ -86,9 +86,9 @@ int main(int argc, char* argv[]) {
    ULONG uDriveMask = _getdrives();
    unsigned uErr, uLen, uDrive;
 
-   printf(g_szBorder);
-   printf(g_szTitle1);
-   printf(g_szTitle2);
+   puts(g_szBorder);
+   puts(g_szTitle1);
+   puts(g_szTitle2);
 
    for (uDrive=1; uDrive<=26; ++uDrive) {
       if (uDriveMask & 1) {
@@ -108,15 +108,20 @@ int main(int argc, char* argv[]) {
             szMsg[uLen+6] = ' ';
             szMsg[uLen+7] = ' ';
             szMsg[uLen+8] = ' ';
+            if (uLen + 9 >= sizeof(g_szLine)) {
+                /* Make sure szMsg is NUL-terminated if we
+                 * wrote past the end of g_szLine */
+                szMsg[uLen+6] = 0;
+            }
          }
 
-         printf(szMsg);
+         puts(szMsg);
       }
 
       uDriveMask >>= 1;
    }
 
-   printf(g_szBorder);
+   puts(g_szBorder);
 }
 
 void utoiRightJustified(TCHAR* szLeft, TCHAR* szRight, unsigned uVal) {


### PR DESCRIPTION
This is one potential way to solve the issues with the `_getdiskfree()` example I brought up in #3847.  There's more than one way to solve those problems, so if there's a different way you prefer better, that's fine.  I just wanted to suggest one potential way.

I changed `printf()` to `puts()`, since `printf()` was not being used to do any formatting.  Since `puts()` prints a newline after printing the string, I removed the newlines from the `g_szXXX[]` constants.

I added a check to see if the error message was longer than `g_szLine[]`, and if so, terminate the message with a NUL character, to avoid potentially reading past the end of the buffer.

**Note:** I don't currently have a Windows VM set up (it's on my to-do list) so I wasn't able to test my fixed version of the program.  So if you decide to go with my solution, please be sure to test it first, and make sure it compiles and runs.  Thanks!