### PR TITLE
Clarify master and single directives.

### DIFF
--- a/docs/parallel/openmp/reference/openmp-clauses.md
+++ b/docs/parallel/openmp/reference/openmp-clauses.md
@@ -32,12 +32,12 @@ For data-sharing attributes:
 |[shared](#shared-openmp)|Specifies that one or more variables should be shared among all threads.|
 |[default](#default-openmp)|Specifies the behavior of unscoped variables in a parallel region.|
 |[reduction](#reduction)|Specifies that one or more variables that are private to each thread are the subject of a reduction operation at the end of the parallel region.|
-|[copyin](#copyin)|Allows threads to access the master thread's value, for a [threadprivate](openmp-directives.md#threadprivate) variable.|
+|[copyin](#copyin)|Allows threads to access the main thread's value, for a [threadprivate](openmp-directives.md#threadprivate) variable.|
 |[copyprivate](#copyprivate)|Specifies that one or more variables should be shared among all threads.|
 
 ## <a name="copyin"></a> copyin
 
-Allows threads to access the master thread's value, for a [threadprivate](openmp-directives.md#threadprivate) variable.
+Allows threads to access the main thread's value, for a [threadprivate](openmp-directives.md#threadprivate) variable.
 
 ```cpp
 copyin(var)
@@ -46,7 +46,7 @@ copyin(var)
 ### Parameters
 
 *var*<br/>
-The `threadprivate` variable that will be initialized with the variable's value in the master thread, as it exists before the parallel construct.
+The `threadprivate` variable that will be initialized with the variable's value in the main thread, as it exists before the parallel construct.
 
 ### Remarks
 
@@ -513,7 +513,7 @@ int main() {
    printf_s("These are the variables after exit from "
             "the parallel region.\n");
    printf_s("nThreadPrivate = %d (The last value in the "
-            "master thread)\n", nThreadPrivate);
+            "main thread)\n", nThreadPrivate);
    printf_s("      nPrivate = %d (The value prior to "
             "entering parallel region)\n", nPrivate);
    printf_s(" nFirstPrivate = %d (The value prior to "
@@ -591,7 +591,7 @@ nFirstPrivate = 3
        nShared = 3
 
 These are the variables after exit from the parallel region.
-nThreadPrivate = 0 (The last value in the master thread)
+nThreadPrivate = 0 (The last value in the main thread)
       nPrivate = 4 (The value prior to entering parallel region)
 nFirstPrivate = 4 (The value prior to entering parallel region)
   nLastPrivate = 3 (The value from the last iteration of the loop)

--- a/docs/parallel/openmp/reference/openmp-directives.md
+++ b/docs/parallel/openmp/reference/openmp-directives.md
@@ -369,9 +369,9 @@ Specifies that only the master thread should execute a section of the program.
 
 The `master` directive supports no clauses.
 
-The [single](#single) directive lets you specify that a section of code should be executed on a single thread, not necessarily the master thread.
-
 For more information, see [2.6.1 master construct](../2-directives.md#261-master-construct).
+
+To specify that a section of code should be executed on a single thread, not necessarily the master thread, use the [single](#single) directive instead.
 
 ### Example
 
@@ -629,9 +629,9 @@ The `single` directive supports the following clauses:
 - [copyprivate](openmp-clauses.md#copyprivate)
 - [nowait](openmp-clauses.md#nowait)
 
-The [master](#master) directive lets you specify that a section of code should be executed only on the master thread.
-
 For more information, see [2.4.3 single construct](../2-directives.md#243-single-construct).
+
+To specify that a section of code should only be executed on the master thread, use the [master](#master) directive instead.
 
 ### Example
 

--- a/docs/parallel/openmp/reference/openmp-directives.md
+++ b/docs/parallel/openmp/reference/openmp-directives.md
@@ -19,13 +19,13 @@ For parallel work-sharing:
 |[parallel](#parallel)|Defines a parallel region, which is code that will be executed by multiple threads in parallel.|
 |[for](#for-openmp)|Causes the work done in a `for` loop inside a parallel region to be divided among threads.|
 |[sections](#sections-openmp)|Identifies code sections to be divided among all threads.|
-|[single](#single)|Lets you specify that a section of code should be executed on a single thread, not necessarily the master thread.|
+|[single](#single)|Lets you specify that a section of code should be executed on a single thread, not necessarily the main thread.|
 
-For master and synchronization:
+For main thread and synchronization:
 
 |Directive|Description|
 |---------|-----------|
-|[master](#master)|Specifies that only the master thread should execute a section of the program.|
+|[master](#master)|Specifies that only the main thread should execute a section of the program.|
 |[critical](#critical)|Specifies that code is only executed on one thread at a time.|
 |[barrier](#barrier)|Synchronizes all threads in a team; all threads pause at the barrier, until all threads execute the barrier.|
 |[atomic](#atomic)|Specifies that a memory location that will be updated atomically.|
@@ -356,7 +356,7 @@ The sum of 1 through 10 is 55
 
 ## <a name="master"></a> master
 
-Specifies that only the master thread should execute a section of the program.
+Specifies that only the main thread should execute a section of the program.
 
 ```cpp
 #pragma omp master
@@ -371,12 +371,11 @@ The `master` directive supports no clauses.
 
 For more information, see [2.6.1 master construct](../2-directives.md#261-master-construct).
 
-To specify that a section of code should be executed on a single thread, not necessarily the master thread, use the [single](#single) directive instead.
+To specify that a section of code should be executed on a single thread, not necessarily the main thread, use the [single](#single) directive instead.
 
 ### Example
 
 ```cpp
-// omp_master.cpp
 // compile with: /openmp
 #include <omp.h>
 #include <stdio.h>
@@ -606,7 +605,7 @@ Hello from thread 0
 
 ## <a name="single"></a> single
 
-Lets you specify that a section of code should be executed on a single thread, not necessarily the master thread.
+Lets you specify that a section of code should be executed on a single thread, not necessarily the main thread.
 
 ```cpp
 #pragma omp single [clauses]
@@ -631,7 +630,7 @@ The `single` directive supports the following clauses:
 
 For more information, see [2.4.3 single construct](../2-directives.md#243-single-construct).
 
-To specify that a section of code should only be executed on the master thread, use the [master](#master) directive instead.
+To specify that a section of code should only be executed on the main thread, use the [master](#master) directive instead.
 
 ### Example
 


### PR DESCRIPTION
A customer reported that the Remarks section for the master and single directives was confusing. Updated to make it clear that the reference to single in the remarks for master and the reference to master in the remarks for single are suggesting alternatives.

Have to use 'master' instead of 'main' here because that it is an OpenMP keyword.