### PR TITLE
Add note about supported windows versions to <chrono>

### DIFF
--- a/docs/standard-library/chrono.md
+++ b/docs/standard-library/chrono.md
@@ -14,6 +14,8 @@ Beginning in Visual Studio 2015, the implementation of `steady_clock` has change
 - `high_resolution_clock` is now a typedef for `steady_clock`
 In the Microsoft C++ implementation, `steady_clock::time_point` is now a `typedef` for `chrono::time_point<steady_clock>`.  However, this isn't necessarily the case for other implementations.
 
+While the STL generally provides all features on all supported versions of Windows, leap seconds and time zones (which change over time) require OS support that was added to Windows 10. Specifically, updating the leap second database requires Windows 10 version 1809 or later, and time zones require icu.dll which is provided by Windows 10 version 1903/19H1 or later. This applies to both client and server OSes; note that Windows Server 2019 is based on Windows 10 version 1809. Attempting to use the time-zone facilities when running on older versions of windows will result in a runtime error.
+
 ## Requirements
 
 **Header:** `<chrono>`


### PR DESCRIPTION
Some features of chrono are not supported when running on older versions of windows, but that's only documented in our github changelogs and is very, very easy to miss.

This clarifies the situation directly in the toplevel chrono documentation.

It may also be good to add a note or link back from the individual time-zone functions.