### PR TITLE
Fix the link of ARM64 intrinsics

### DIFF
--- a/docs/build/configuring-programs-for-arm-processors-visual-cpp.md
+++ b/docs/build/configuring-programs-for-arm-processors-visual-cpp.md
@@ -30,5 +30,5 @@ Describes the encoding scheme for stack unwinding during structured exception ha
 [ARM intrinsics](../intrinsics/arm-intrinsics.md)\
 Describes compiler intrinsics for processors that use the ARM architecture.
 
-[ARM64 intrinsics](../intrinsics/arm-intrinsics.md)\
+[ARM64 intrinsics](../intrinsics/arm64-intrinsics.md)\
 Describes compiler intrinsics for processors that use the ARM64 architecture.


### PR DESCRIPTION
The current link target of ARM64 intrinsics is arm32 intrinsics page incorrectly.