### PR TITLE
add note regarding pch.h files

### DIFF
--- a/docs/mfc/tn011-using-mfc-as-part-of-a-dll.md
+++ b/docs/mfc/tn011-using-mfc-as-part-of-a-dll.md
@@ -51,6 +51,8 @@ You must add the AFX_MANAGE_STATE macro at the beginning of all the exported fun
 
 `AFX_MANAGE_STATE(AfxGetStaticModuleState( ))`
 
+Note: New generated MFC projects and DLLs with pch.h headers must explicitly include *afxmfc* header files which are used in your code. For example, using CString requires you to `include <atlstr.h>` in your pch.h.
+
 ## WinMain -> DllMain
 
 The MFC library defines the standard Win32 `DllMain` entry point that initializes your [CWinApp](../mfc/reference/cwinapp-class.md) derived object as in a typical MFC application. Place all DLL-specific initialization in the [InitInstance](../mfc/reference/cwinapp-class.md#initinstance) method as in a typical MFC application.


### PR DESCRIPTION
For a lot of us devs who generated MFC projects years ago, (re)generating new MFC projects create a pch.h header instead of a stdafx.h file. pch.h files include windows header files, but operate differently. This topic should be introduced and I can think of no better way than to address head on how to make CString compile.
The Note I wrote needs to be formatted, for example, with green background.
By the way, I did submit feedback to the Developer Community about this, so maybe they will weigh in on the correct approach to all this. See [Unable to compile with MFC CString using new pch.h](https://developercommunity.visualstudio.com/t/Unable-to-compile-with-MFC-CString-using/10062888?entry=problem).