### PR TITLE
Update volatile-volatile-keyword-interpretation.md

### DIFF
--- a/docs/build/reference/volatile-volatile-keyword-interpretation.md
+++ b/docs/build/reference/volatile-volatile-keyword-interpretation.md
@@ -17,10 +17,10 @@ Specifies how the [volatile](../../cpp/volatile-cpp.md) keyword is to be interpr
 ## Arguments
 
 **/volatile:iso**<br/>
-Selects strict **`volatile`** semantics as defined by the ISO-standard C++ language. Acquire/release semantics are not guaranteed on volatile accesses. If the compiler targets ARM, this is the default interpretation of **`volatile`**.
+Selects strict **`volatile`** semantics as defined by the ISO-standard C++ language. Acquire/release semantics are not guaranteed on volatile accesses. If the compiler targets ARM/ARM64/ARM64EC, this is the default interpretation of **`volatile`**.
 
 **/volatile:ms**<br/>
-Selects Microsoft extended **`volatile`** semantics, which add memory ordering guarantees beyond the ISO-standard C++ language. Acquire/release semantics are guaranteed on volatile accesses. However, this option also forces the compiler to generate hardware memory barriers, which might add significant overhead on ARM and other weak memory-ordering architectures. If the compiler targets any platform except ARM, this is default interpretation of **`volatile`**.
+Selects Microsoft extended **`volatile`** semantics, which add memory ordering guarantees beyond the ISO-standard C++ language. Acquire/release semantics are guaranteed on volatile accesses. However, this option also forces the compiler to generate hardware memory barriers, which might add significant overhead on ARM and other weak memory-ordering architectures. If the compiler targets any platform except ARM/ARM64/ARM64EC, this is default interpretation of **`volatile`**.
 
 ## Remarks
 


### PR DESCRIPTION
Further clarify the target archs (ARM-related) that use /volatile:iso by default, and those that use /volatile:ms by default.