### PR TITLE
Update cmfctoolbar-class.md for m_bDontScaleImages

### DIFF
--- a/docs/mfc/reference/cmfctoolbar-class.md
+++ b/docs/mfc/reference/cmfctoolbar-class.md
@@ -3579,6 +3579,8 @@ This method repositions buttons within the toolbar, wrapping buttons to addition
 ## <a name="m_bdontscaleimages"></a> `CMFCToolBar::m_bDontScaleImages`
 
 Specifies whether or not to scale toolbar images in high DPI mode.
+Prevents image scaling when image sizes don't match button sizes.
+Set this member to TRUE, when you wish to prevent automatic image scaling if image sizes don't match button sizes.
 
 ```
 AFX_IMPORT_DATA static BOOL m_bDontScaleImages;

--- a/docs/mfc/reference/cmfctoolbar-class.md
+++ b/docs/mfc/reference/cmfctoolbar-class.md
@@ -3579,8 +3579,7 @@ This method repositions buttons within the toolbar, wrapping buttons to addition
 ## <a name="m_bdontscaleimages"></a> `CMFCToolBar::m_bDontScaleImages`
 
 Specifies whether or not to scale toolbar images in high DPI mode.
-Prevents image scaling when image sizes don't match button sizes.
-Set this member to TRUE, when you wish to prevent automatic image scaling if image sizes don't match button sizes.
+Set to `TRUE` to prevent image scaling when an image size doesn't match a button size.
 
 ```
 AFX_IMPORT_DATA static BOOL m_bDontScaleImages;


### PR DESCRIPTION
Description of m_bDontScaleImages was unhelpful (like far to much of Microsoft docs that simply document "DoFoo" as "Does Foo" instead of explaining what "Foo" is and why somebody would want to do it or not.)
I copied the documentation from the BCGSoft docs for this.  Since much of the MFC was obtained from them, we should use their documentation more.