### PR TITLE
Visual C++ 17.0 has unlimited string literals

### DIFF
--- a/docs/cpp/string-and-character-literals-cpp.md
+++ b/docs/cpp/string-and-character-literals-cpp.md
@@ -331,7 +331,8 @@ const size_t byteSize = (wcslen(str) + 1) * sizeof(wchar_t);
 
 Notice that `strlen()` and `wcslen()` don't include the size of the terminating null character, whose size is equal to the element size of the string type: one byte on a `char*` or `char8_t*` string, two bytes on `wchar_t*` or `char16_t*` strings, and four bytes on `char32_t*` strings.
 
-The maximum length of a string literal is 65,535 bytes. This limit applies to both narrow string literals and wide string literals.
+The maximum length of a string literal was 65,535 bytes. This limit applied to both narrow string literals and wide string literals.
+This limit was removed in VS 2022 17.0 GA.
 
 ### Modifying string literals
 

--- a/docs/cpp/string-and-character-literals-cpp.md
+++ b/docs/cpp/string-and-character-literals-cpp.md
@@ -331,8 +331,7 @@ const size_t byteSize = (wcslen(str) + 1) * sizeof(wchar_t);
 
 Notice that `strlen()` and `wcslen()` don't include the size of the terminating null character, whose size is equal to the element size of the string type: one byte on a `char*` or `char8_t*` string, two bytes on `wchar_t*` or `char16_t*` strings, and four bytes on `char32_t*` strings.
 
-The maximum length of a string literal was 65,535 bytes. This limit applied to both narrow string literals and wide string literals.
-This limit was removed in VS 2022 17.0 GA.
+In versions of Visual Studio before Visual Studio 2022 version 17.0, the maximum length of a string literal is 65,535 bytes. This limit applies to both narrow string literals and wide string literals. In Visual Studio 2022 version 17.0 and later, this restriction is lifted and string length is limited by available resources.
 
 ### Modifying string literals
 


### PR DESCRIPTION
I believe this was changed while fixing https://developercommunity.visualstudio.com/t/1437715
@cdacamar knows for sure.