### PR TITLE
Repo sync for protected CLA branch

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -27,7 +27,7 @@
   "notification_subscribers": [],
   "sync_notification_subscribers": null,
   "branches_to_filter": [],
-  "git_repository_url_open_to_public_contributors": "https://github.com/Microsoft/cpp-docs",
+  "git_repository_url_open_to_public_contributors": "https://github.com/MicrosoftDocs/cpp-docs",
   "git_repository_branch_open_to_public_contributors": "main",
   "skip_source_output_uploading": false,
   "need_preview_pull_request": true,


### PR DESCRIPTION
The pull request is created from main637949727964297604sync_temp to main to fix git push error for protected CLA branch