### PR TITLE
Update multithreading-and-locales.md

### DIFF
--- a/docs/parallel/multithreading-and-locales.md
+++ b/docs/parallel/multithreading-and-locales.md
@@ -13,20 +13,20 @@ Both the C Runtime Library and the C++ Standard Library provide support for chan
 
 With the C Runtime Library, you can create multithreaded applications using the `_beginthread` and `_beginthreadex` functions. This topic only covers multithreaded applications created using these functions. For more information, see [_beginthread, _beginthreadex](../c-runtime-library/reference/beginthread-beginthreadex.md).
 
-To change the locale using the C Runtime Library, use the [setlocale](../preprocessor/setlocale.md) function. In previous versions of Visual C++, this function would always modify the locale throughout the entire application. There is now support for setting the locale on a per-thread basis. This is done using the [_configthreadlocale](../c-runtime-library/reference/configthreadlocale.md) function. To specify that [setlocale](../preprocessor/setlocale.md) should only change the locale in the current thread, call `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)` in that thread. Conversely, calling `_configthreadlocale(_DISABLE_PER_THREAD_LOCALE)` will cause that thread to use the global locale, and any call to [setlocale](../preprocessor/setlocale.md) in that thread will change the locale in all threads that have not explicitly enabled per-thread locale.
+To change the locale using the C Runtime Library, use the [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) function. In previous versions of Visual C++, this function would always modify the locale throughout the entire application. There is now support for setting the locale on a per-thread basis. This is done using the [_configthreadlocale](../c-runtime-library/reference/configthreadlocale.md) function. To specify that [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) should only change the locale in the current thread, call `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)` in that thread. Conversely, calling `_configthreadlocale(_DISABLE_PER_THREAD_LOCALE)` will cause that thread to use the global locale, and any call to [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) in that thread will change the locale in all threads that have not explicitly enabled per-thread locale.
 
 To change the locale using the C++ Runtime Library, use the [locale Class](../standard-library/locale-class.md). By calling the [locale::global](../standard-library/locale-class.md#global) method, you change the locale in every thread that has not explicitly enabled per-thread locale. To change the locale in a single thread or portion of an application, simply create an instance of a `locale` object in that thread or portion of code.
 
 > [!NOTE]
-> Calling [locale::global](../standard-library/locale-class.md#global) changes the locale for both the C++ Standard Library and the C Runtime Library. However, calling [setlocale](../preprocessor/setlocale.md) only changes the locale for the C Runtime Library; the C++ Standard Library is not affected.
+> Calling [locale::global](../standard-library/locale-class.md#global) changes the locale for both the C++ Standard Library and the C Runtime Library. However, calling [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) only changes the locale for the C Runtime Library; the C++ Standard Library is not affected.
 
-The following examples show how to use the [setlocale](../preprocessor/setlocale.md) function, the [locale Class](../standard-library/locale-class.md), and the [_configthreadlocale](../c-runtime-library/reference/configthreadlocale.md) function to change the locale of an application in several different scenarios.
+The following examples show how to use the [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) function, the [locale Class](../standard-library/locale-class.md), and the [_configthreadlocale](../c-runtime-library/reference/configthreadlocale.md) function to change the locale of an application in several different scenarios.
 
 ## Example: Change locale with per-thread locale enabled
 
-In this example, the main thread spawns two child threads. The first thread, Thread A, enables per-thread locale by calling `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)`. The second thread, Thread B, as well as the main thread, do not enable per-thread locale. Thread A then proceeds to change the locale using the [setlocale](../preprocessor/setlocale.md) function of the C Runtime Library.
+In this example, the main thread spawns two child threads. The first thread, Thread A, enables per-thread locale by calling `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)`. The second thread, Thread B, as well as the main thread, do not enable per-thread locale. Thread A then proceeds to change the locale using the [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) function of the C Runtime Library.
 
-Since Thread A has per-thread locale enabled, only the C Runtime Library functions in Thread A start using the "french" locale. The C Runtime Library functions in Thread B and in the main thread continue to use the "C" locale. Also, since [setlocale](../preprocessor/setlocale.md) does not affect the C++ Standard Library locale, all C++ Standard Library objects continue to use the "C" locale.
+Since Thread A has per-thread locale enabled, only the C Runtime Library functions in Thread A start using the "french" locale. The C Runtime Library functions in Thread B and in the main thread continue to use the "C" locale. Also, since [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) does not affect the C++ Standard Library locale, all C++ Standard Library objects continue to use the "C" locale.
 
 ```cpp
 // multithread_locale_1.cpp
@@ -222,9 +222,9 @@ unsigned __stdcall RunThreadB(void *params)
 
 ## Example: Change locale without per-thread locale enabled
 
-In this example, the main thread spawns two child threads. The first thread, Thread A, enables per-thread locale by calling `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)`. The second thread, Thread B, as well as the main thread, do not enable per-thread locale. Thread B then proceeds to change the locale using the [setlocale](../preprocessor/setlocale.md) function of the C Runtime Library.
+In this example, the main thread spawns two child threads. The first thread, Thread A, enables per-thread locale by calling `_configthreadlocale(_ENABLE_PER_THREAD_LOCALE)`. The second thread, Thread B, as well as the main thread, do not enable per-thread locale. Thread B then proceeds to change the locale using the [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) function of the C Runtime Library.
 
-Since Thread B does not have per-thread locale enabled, the C Runtime Library functions in Thread B and in the main thread start using the "french" locale. The C Runtime Library functions in Thread A continue to use the "C" locale because Thread A has per-thread locale enabled. Also, since [setlocale](../preprocessor/setlocale.md) does not affect the C++ Standard Library locale, all C++ Standard Library objects continue to use the "C" locale.
+Since Thread B does not have per-thread locale enabled, the C Runtime Library functions in Thread B and in the main thread start using the "french" locale. The C Runtime Library functions in Thread A continue to use the "C" locale because Thread A has per-thread locale enabled. Also, since [setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md) does not affect the C++ Standard Library locale, all C++ Standard Library objects continue to use the "C" locale.
 
 ```cpp
 // multithread_locale_3.cpp
@@ -431,7 +431,7 @@ unsigned __stdcall RunThreadB(void *params)
 [Multithreading Support for Older Code (Visual C++)](multithreading-support-for-older-code-visual-cpp.md)<br/>
 [_beginthread, _beginthreadex](../c-runtime-library/reference/beginthread-beginthreadex.md)<br/>
 [_configthreadlocale](../c-runtime-library/reference/configthreadlocale.md)<br/>
-[setlocale](../preprocessor/setlocale.md)<br/>
+[setlocale](../c-runtime-library/reference/setlocale-wsetlocale.md)<br/>
 [Internationalization](../c-runtime-library/internationalization.md)<br/>
 [Locale](../c-runtime-library/locale.md)<br/>
 [\<clocale>](../standard-library/clocale.md)<br/>


### PR DESCRIPTION
Wrong `setlocale()` reference, it should be a C runtime function, not a preprocessor macro.