### PR TITLE
C26472/C26475 docs: gsl:narrow throws rather than crashes

### DIFF
--- a/docs/code-quality/c26472.md
+++ b/docs/code-quality/c26472.md
@@ -9,19 +9,19 @@ ms.assetid: 51e215a7-0e0a-4e6c-bff1-805bf5b1af29
 ---
 # C26472 NO_CASTS_FOR_ARITHMETIC_CONVERSION
 
-"Don't use a static_cast for arithmetic conversions. Use brace initialization, gsl::narrow_cast, or gsl::narrow."
+"Don't use a static_cast for arithmetic conversions. Use brace initialization, `gsl::narrow_cast`, or `gsl::narrow`."
 
 **C++ Core Guidelines**:
 [Type.1](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#prosafety-type-safety-profile): Avoid casts
 
 This rule helps to find places where static casts are used to convert between integral types. These casts are unsafe because the compiler would not warn if any data loss occurs. Brace initializers are better for the cases where constants are used, and a compiler error is desired. There are also utilities from the Guidelines Support Library that help to describe intentions clearly:
 
-- gsl::narrow ensures lossless conversion and throws gsl::narrowing_error if it is not possible.
-- gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
+- `gsl::narrow` ensures lossless conversion and throws `gsl::narrowing_error` if it's not possible.
+- `gsl::narrow_cast` clearly states that conversion can lose data and it's acceptable.
 
 ## Remarks
 
-- This rule is implemented only for static_casts. Using of C-style casts is generally discouraged.
+- This rule is implemented only for static casts. Using of C-style casts is generally discouraged.
 
 ## Example
 

--- a/docs/code-quality/c26472.md
+++ b/docs/code-quality/c26472.md
@@ -16,7 +16,7 @@ ms.assetid: 51e215a7-0e0a-4e6c-bff1-805bf5b1af29
 
 This rule helps to find places where static casts are used to convert between integral types. These casts are unsafe because the compiler would not warn if any data loss occurs. Brace initializers are better for the cases where constants are used, and a compiler error is desired. There are also utilities from the Guidelines Support Library that help to describe intentions clearly:
 
-- gsl::narrow ensures lossless conversion and causes run-time crash if it is not possible.
+- gsl::narrow ensures lossless conversion and throws gsl::narrowing_error if it is not possible.
 - gsl::narrow_cast clearly states that conversion can lose data and it is acceptable.
 
 ## Remarks

--- a/docs/code-quality/c26475.md
+++ b/docs/code-quality/c26475.md
@@ -16,7 +16,7 @@ ms.assetid: 4ed71cf8-f155-4961-b4fe-77feb3b880c3
 
 Function-style casts (for example, `int(1.1)`) are another form of C-style casts (like `(int)1.1`), which have questionable safety. Specifically, the compiler doesn't try to check if any data loss can occur either in C-casts or in function casts. In both cases, it's better either to avoid casting or to use a braced initializer if possible. If neither works, static casts may be suitable, but it's still better to use utilities from the Guidelines Support Library:
 
-- `gsl::narrow` ensures lossless conversion and causes run-time crash if it's not possible.
+- `gsl::narrow` ensures lossless conversion and throws `gsl::narrowing_error` if it's not possible.
 - `gsl::narrow_cast` clearly states that conversion can lose data and it's acceptable.
 
 ## Remarks


### PR DESCRIPTION
While at it, I updated `c26472.md` to match the style of the more recently edited `c26475.md`.