### PR TITLE
Small correction in getch-getwch

### DIFF
--- a/docs/c-runtime-library/reference/getch-getwch.md
+++ b/docs/c-runtime-library/reference/getch-getwch.md
@@ -30,7 +30,7 @@ Returns the character read. There's no error return.
 
 ## Remarks
 
-The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual [key scan code](../../../previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)).
+The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual [key scan code](previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)).
 
 These functions lock the calling thread and are therefore thread-safe. For non-locking versions, see [`_getch_nolock`, `_getwch_nolock`](getch-nolock-getwch-nolock.md).
 

--- a/docs/c-runtime-library/reference/getch-getwch.md
+++ b/docs/c-runtime-library/reference/getch-getwch.md
@@ -30,7 +30,7 @@ Returns the character read. There's no error return.
 
 ## Remarks
 
-The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual [key scan code](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)?redirectedfrom=MSDN).
+The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual [key scan code](../../../previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)).
 
 These functions lock the calling thread and are therefore thread-safe. For non-locking versions, see [`_getch_nolock`, `_getwch_nolock`](getch-nolock-getwch-nolock.md).
 

--- a/docs/c-runtime-library/reference/getch-getwch.md
+++ b/docs/c-runtime-library/reference/getch-getwch.md
@@ -30,7 +30,7 @@ Returns the character read. There's no error return.
 
 ## Remarks
 
-The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual key code.
+The **`_getch`** and **`_getwch`** functions read a single character from the console without echoing the character. None of these functions can be used to read CTRL+C. When reading a function key or an arrow key, each function must be called twice; the first call returns 0 or 0xE0, and the second call returns the actual [key scan code](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-6.0/aa299374(v=vs.60)?redirectedfrom=MSDN).
 
 These functions lock the calling thread and are therefore thread-safe. For non-locking versions, see [`_getch_nolock`, `_getwch_nolock`](getch-nolock-getwch-nolock.md).
 


### PR DESCRIPTION
'key code' implies virtual key code whereas the function actually returns a scan code on the second call, added link for further clarity