### PR TITLE
Fix Supported SSH algorithms

### DIFF
--- a/docs/linux/connect-to-your-remote-linux-computer.md
+++ b/docs/linux/connect-to-your-remote-linux-computer.md
@@ -116,8 +116,8 @@ Starting in Visual Studio version 16.9, support for older, insecure SSH algorith
 
 | Algorithm type | Supported algorithms |
 |--|--|
-| Encryption | `aes128-cbc`</br>`aes128-cbc`</br>`aes192-cbc`</br>`aes192-ctr`</br>`aes256-cbc`</br>`aes256-ctr` |
-| HMAC | `hmac-sha2-256`</br>`hmac-sha2-256` |
+| Encryption | `aes128-cbc`</br>`aes128-ctr`</br>`aes192-cbc`</br>`aes192-ctr`</br>`aes256-cbc`</br>`aes256-ctr` |
+| HMAC | `hmac-sha2-256`</br>`hmac-sha2-512` |
 | Key exchange | `diffie-hellman-group14-sha256`</br>`diffie-hellman-group16-sha512`</br>`diffie-hellman-group-exchange-sha256`</br>`ecdh-sha2-nistp256`</br>`ecdh-sha2-nistp384`</br>`ecdh-sha2-nistp521` |
 | Host key | `ecdsa-sha2-nistp256`</br>`ecdsa-sha2-nistp384`</br>`ecdsa-sha2-nistp521`</br>`ssh-dss`</br>`ssh-rsa` |
 


### PR DESCRIPTION
- `Supported SSH algorithms` > `Encryption`
  - Two `aes128-cbc` and no `aes128-ctr`.
- `Supported SSH algorithms` > `HMAC`
  - Two `hmac-sha2-256` and no `hmac-sha2-512`.

We have not been able to verify the operation, so we apologize if this is an incorrect correction.

ℹ️ As for `hmac-sha2-512`, it is described in [HMAC example](https://learn.microsoft.com/en-us/cpp/linux/connect-to-your-remote-linux-computer?view=msvc-170#hmac-example). I think there is no problem.