### PR TITLE
Fix missing semicolon

### DIFF
--- a/docs/cpp/tutorial-named-modules-cpp.md
+++ b/docs/cpp/tutorial-named-modules-cpp.md
@@ -304,7 +304,7 @@ Module implementation unit files have a *`.cpp`* extension. The basic outline of
 // optional #include or import statements. These only apply to this file
 // imports in the associated module's interface are automatically available to this file
 
-module [module-name] // required. Identifies which named module this implementation unit belongs to
+module [module-name]; // required. Identifies which named module this implementation unit belongs to
 
 // implementation
 ```


### PR DESCRIPTION
This fixes a missing semicolon in one of the code samples for C++20 Modules.