### PR TITLE
Document ARM64 unwind handling for return address signing

### DIFF
--- a/docs/build/arm64-exception-handling.md
+++ b/docs/build/arm64-exception-handling.md
@@ -1,7 +1,7 @@
 ---
 title: "ARM64 exception handling"
 description: Describes the exception handling conventions and data used by windows on ARM64.
-ms.date: 04/07/2022
+ms.date: 10/10/2022
 ---
 # ARM64 exception handling
 
@@ -344,7 +344,7 @@ The fields are as follows:
 - **Function Length** is an 11-bit field providing the length of the entire function in bytes, divided by 4. If the function is larger than 8k, a full `.xdata` record must be used instead.
 - **Frame Size** is a 9-bit field indicating the number of bytes of stack that is allocated for this function, divided by 16. Functions that allocate greater than (8k-16) bytes of stack must use a full `.xdata` record. It includes the local variable area, outgoing parameter area, callee-saved Int and FP area, and home parameter area. It excludes the dynamic allocation area.
 - **CR** is a 2-bit flag indicating whether the function includes extra instructions to set up a frame chain and return link:
-  - 00 = unchained function, \<x29,lr> pair isn't saved in stack.
+  - 00 = unchained function, \<x29,lr> pair isn't saved in stack
   - 01 = unchained function, \<lr> is saved in stack
   - 10 = chained function with signed return address
   - 11 = chained function, a store/load pair instruction is used in prolog/epilog \<x29,lr>
@@ -366,7 +366,7 @@ Step 4: Save FP callee-saved registers.
 
 Step 5: Save input arguments in the home parameter area.
 
-Step 6: Allocate remaining stack, including local area, \<x29,lr> pair, and outgoing parameter area. 5a  corresponds to canonical type 1. 5b and 5c are for canonical type 2. 5d and 5e are for both type 3 and type 4.
+Step 6: Allocate remaining stack, including local area, \<x29,lr> pair, and outgoing parameter area. 6a corresponds to canonical type 1. 6b and 6c are for canonical type 2. 6d and 6e are for both type 3 and type 4.
 
 | Step # | Flag values | # of instructions | Opcode | Unwind code |
 |--|--|--|--|--|


### PR DESCRIPTION
This is deduced/guessed from studying the output of MSVC with the `/d2guardsignret` flag. Hopefully someone with insight into the unwinder internals can confirm whether this indeed is the case.

I made up an unwind opcode name for this opcode (0xfc, `sign_ra`) - other suggestions are welcome.

I'm not entirely sure about whether this is how it is handled for the packed functions, but this would intuitively be how it works.

Since there are two parallel instructions for signing return addresses, `paciasp` and `pacibsp`, the unwinder would need to know which one to use for signing - MSVC seems to generate `pacibsp` (togeter with `autibsp`) - is there any other similar opcode for `paciasp`, or is that one unsupported for Windows unwinding purposes?