### PR TITLE
example needed to mitigate dev floundering

### DIFF
--- a/docs/mfc/reference/cmfcpropertygridproperty-class.md
+++ b/docs/mfc/reference/cmfcpropertygridproperty-class.md
@@ -1513,7 +1513,17 @@ Sets the value of a property grid property.
 ```
 virtual void SetValue(const _variant_t& varValue);
 ```
-
+Example:
+```
+void SetPropBarValue( UINT propId, const DWORD& barPropDwordValue )
+{
+  auto property = propertiesGridCtrlList.FindItemByData( propId );
+  if( property )
+  {
+    property->SetValue( static_cast< _variant_t >( barPropDwordValue == 1 ) ); // sets property bar value to true or false depending on dword value
+  }
+}
+```
 ### Parameters
 
 *`varValue`*\


### PR DESCRIPTION
It is not easy to match up variant vt types with POD types. Especially since there is a gradual transition to modern C++. I used a number of dev hours on attempts to match the variant type, vt, to make the true/false work. The m_bValue type for the simple property was a BOOL  type, but trying to create a variant of type BOOL directly didn't work. Only by looking at VC Sample code for VisualStudioDemo did I see the (_variant_t)true construct, which becomes the standard_cast contruct in modern C++. I figured my Example code could make other programmer's efforts easier.