### PR TITLE
system-function.md: remove outdated language

### DIFF
--- a/docs/c-language/system-function.md
+++ b/docs/c-language/system-function.md
@@ -9,7 +9,7 @@ ms.assetid: 0786ccdc-20cd-4d96-b3d8-3230507c3066
 
 **ANSI 4.10.4.5** The contents and mode of execution of the string by the **system** function
 
-The **system** function executes an internal operating system command, or an .EXE, .COM, .CMD or .BAT file from within a C program rather than from the command line.
+The **system** function executes an internal operating system command, or an .EXE, .COM, .CMD, or .BAT file from within a C program rather than from the command line.
 
 The system function finds the command interpreter, which is typically CMD.EXE in the Windows operating system. The system function then passes the argument string to the command interpreter.
 

--- a/docs/c-language/system-function.md
+++ b/docs/c-language/system-function.md
@@ -9,9 +9,9 @@ ms.assetid: 0786ccdc-20cd-4d96-b3d8-3230507c3066
 
 **ANSI 4.10.4.5** The contents and mode of execution of the string by the **system** function
 
-The **system** function executes an internal operating system command, or an .EXE, .COM (.CMD in Windows NT) or .BAT file from within a C program rather than from the command line.
+The **system** function executes an internal operating system command, or an .EXE, .COM, .CMD or .BAT file from within a C program rather than from the command line.
 
-The system function finds the command interpreter, which is typically CMD.EXE in the Windows NT operating system or COMMAND.COM in Windows. The system function then passes the argument string to the command interpreter.
+The system function finds the command interpreter, which is typically CMD.EXE in the Windows operating system. The system function then passes the argument string to the command interpreter.
 
 For more information, see [system, _wsystem](../c-runtime-library/reference/system-wsystem.md).
 


### PR DESCRIPTION
This text talks about "Windows" and "Windows NT" as if they were two different things. It looks like the text dates back to the Windows 9x/Me era, when that was true. But, that hasn't been true for over 20 years now. Trying to update it.