### PR TITLE
Add examples for void type in cpp (#4331)

### DIFF
--- a/docs/cpp/void-cpp.md
+++ b/docs/cpp/void-cpp.md
@@ -19,11 +19,17 @@ You can't declare a variable of type **`void`**.
 ## Example
 
 ```cpp
+void  print_num(int num)
+{
+   std::cout << num << std::endl;
+}
+
 // void.cpp
 void vobject;   // C2182
 void *pv;   // okay
 int *pint; int i;
-int main() {
+int main(void)
+{
    pv = &i;
    // Cast optional in C required in C++
    pint = (int *)pv;

--- a/docs/cpp/void-cpp.md
+++ b/docs/cpp/void-cpp.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: void (C++)"
 title: "void (C++)"
-ms.date: 10/15/2021
+ms.date: 12/13/2022
 f1_keywords: ["void_cpp"]
 helpviewer_keywords: ["void keyword [C++]", "functions [C++], void", "pointers, void"]
 ms.assetid: d203edba-38e6-4056-8b89-011437351057
@@ -16,22 +16,26 @@ In C++, a **`void`** pointer can point to a free function (a function that's not
 
 You can't declare a variable of type **`void`**.
 
+As a matter of style, the C++ Core Guidelines recommend you don't use **`void`** to specify an empty formal parameter list. For more information, see [C++ Core Guidelines NL.25: Don't use `void` as an argument type](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl25-dont-use-void-as-an-argument-type).
+
 ## Example
 
 ```cpp
-void print_num(int num)
+// void.cpp
+
+void return_nothing()
 {
-   std::cout << num << std::endl;
+   // A void function can have a return with no argument,
+   // or no return statement.
 }
 
-// void.cpp
 void vobject;   // C2182
 void *pv;   // okay
 int *pint; int i;
-int main(void)
+int main()
 {
    pv = &i;
-   // Cast optional in C required in C++
+   // Cast is optional in C, required in C++
    pint = (int *)pv;
 }
 ```

--- a/docs/cpp/void-cpp.md
+++ b/docs/cpp/void-cpp.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: void (C++)"
 title: "void (C++)"
-ms.date: 10/15/2021
+ms.date: 12/12/2022
 f1_keywords: ["void_cpp"]
 helpviewer_keywords: ["void keyword [C++]", "functions [C++], void", "pointers, void"]
 ms.assetid: d203edba-38e6-4056-8b89-011437351057
@@ -16,22 +16,26 @@ In C++, a **`void`** pointer can point to a free function (a function that's not
 
 You can't declare a variable of type **`void`**.
 
+As a matter of style, the C++ Core Guidelines recommend you don't use **`void`** to specify an empty formal parameter list. For more information, see [C++ Core Guidelines NL.25: Don't use `void` as an argument type](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl25-dont-use-void-as-an-argument-type).
+
 ## Example
 
 ```cpp
-void  print_num(int num)
+// void.cpp
+
+void return_nothing()
 {
-   std::cout << num << std::endl;
+   // A void function can have a return with no argument,
+   // or no return statement.
 }
 
-// void.cpp
 void vobject;   // C2182
 void *pv;   // okay
 int *pint; int i;
-int main(void)
+int main()
 {
    pv = &i;
-   // Cast optional in C required in C++
+   // Cast is optional in C, required in C++
    pint = (int *)pv;
 }
 ```

--- a/docs/cpp/void-cpp.md
+++ b/docs/cpp/void-cpp.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: void (C++)"
 title: "void (C++)"
-ms.date: 12/12/2022
+ms.date: 10/15/2021
 f1_keywords: ["void_cpp"]
 helpviewer_keywords: ["void keyword [C++]", "functions [C++], void", "pointers, void"]
 ms.assetid: d203edba-38e6-4056-8b89-011437351057
@@ -16,26 +16,22 @@ In C++, a **`void`** pointer can point to a free function (a function that's not
 
 You can't declare a variable of type **`void`**.
 
-As a matter of style, the C++ Core Guidelines recommend you don't use **`void`** to specify an empty formal parameter list. For more information, see [C++ Core Guidelines NL.25: Don't use `void` as an argument type](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl25-dont-use-void-as-an-argument-type).
-
 ## Example
 
 ```cpp
-// void.cpp
-
-void return_nothing()
+void print_num(int num)
 {
-   // A void function can have a return with no argument,
-   // or no return statement.
+   std::cout << num << std::endl;
 }
 
+// void.cpp
 void vobject;   // C2182
 void *pv;   // okay
 int *pint; int i;
-int main()
+int main(void)
 {
    pv = &i;
-   // Cast is optional in C, required in C++
+   // Cast optional in C required in C++
    pint = (int *)pv;
 }
 ```


### PR DESCRIPTION
Adding examples to cpp void page to comply with the description made in the above text.
Also fixing bracket to comply with code norm given as example in guidelines.
Fixes #4331