### PR TITLE
update clarity

### DIFF
--- a/docs/cpp/const-cpp.md
+++ b/docs/cpp/const-cpp.md
@@ -165,7 +165,7 @@ But to get the same behavior in C++, you must declare your **`const`** variable 
 extern const int i = 2;
 ```
 
-If you wish to declare an **`extern`** variable in a C++ source code file for use in a C source code file, use:
+If you wish to declare an **`extern`** variable in a C++ source code file (e.g header file) for use in a C source code file, use:
 
 ```cpp
 extern "C" const int x=10;


### PR DESCRIPTION
we can make this one clearer, usually we seen <code> extern 'C' ...</code> in header files, & avoid paraphrasing redundancy in "source code file"