### PR TITLE
Correct documentation for C99 comments

### DIFF
--- a/docs/c-language/c-comments.md
+++ b/docs/c-language/c-comments.md
@@ -51,7 +51,7 @@ While you can use comments to render certain lines of code inactive for test pur
 
 **Microsoft Specific**
 
-The Microsoft compiler also supports single-line comments preceded by two forward slashes (__//__). If you compile with /Za (ANSI standard), these comments generate errors. These comments cannot extend to a second line.
+The Microsoft compiler also supports single-line comments preceded by two forward slashes (__//__). These comments cannot extend to a second line.
 
 ```C
 // This is a valid comment


### PR DESCRIPTION
From the 'Microsoft extensions to C and C++' article:

> C99 comments are unaffected by `/Za` and cause no diagnostic at any level.

https://learn.microsoft.com/en-us/cpp/build/reference/microsoft-extensions-to-c-and-cpp?view=msvc-170#single-line-comments