### PR TITLE
fix typo - change "map" to "set" on <set> functions page

### DIFF
--- a/docs/standard-library/set-functions.md
+++ b/docs/standard-library/set-functions.md
@@ -7,7 +7,7 @@ ms.assetid: d1277d14-8502-46c0-b820-bcda820f9406
 ---
 # `<set>` functions
 
-## <a name="swap"></a> swap (map)
+## <a name="swap"></a> swap (set)
 
 Exchanges the elements of two sets.
 


### PR DESCRIPTION
The <set> functions page lists "swap (map)", which should actually be "swap (set)"