### PR TITLE
Update c-tokens.md

### DIFF
--- a/docs/c-language/c-tokens.md
+++ b/docs/c-language/c-tokens.md
@@ -12,6 +12,7 @@ In a C source program, the basic element recognized by the compiler is the "toke
 ## Syntax
 
 *token*:
+
 *keyword*
 
 *identifier*


### PR DESCRIPTION
Fixed spacing between token and keyword. My understanding is it should be under the statement "token:" not besides it.