### PR TITLE
Format /Fopathname so it doesn't get separated

### DIFF
--- a/docs/build/reference/fo-object-file-name.md
+++ b/docs/build/reference/fo-object-file-name.md
@@ -6,13 +6,13 @@ f1_keywords: ["/Fo", "VC.Project.VCCLCompilerTool.ObjectFile", "VC.Project.VCCLW
 helpviewer_keywords: ["Fo compiler option [C++]", "object files, naming", "/Fo compiler option [C++]", "-Fo compiler option [C++]"]
 ms.assetid: 0e6d593e-4e7f-4990-9e6e-92e1dcbcf6e6
 ---
-# `/Fo` (Object File Name)
+# `/Fo`(Object File Name)
 
 Specifies an object (*`.obj`*) file name or directory to be used instead of the default.
 
 ## Syntax
 
-> **`/Fo`***`pathname`*
+> **/Fo***pathname*
 
 ## Remarks
 


### PR DESCRIPTION
Browsers render **`/Fo`***`pathname`* as two separate strings which confuses those who want to quickly glance at the syntax and move on. "Remarks" section clearly says "Don't put a space between the /Fo option and the pathname argument".