### PR TITLE
Update 'Connect to your target Linux system in Visual Studio'.

### DIFF
--- a/docs/linux/connect-to-your-remote-linux-computer.md
+++ b/docs/linux/connect-to-your-remote-linux-computer.md
@@ -83,6 +83,9 @@ If `ssh` isn't already set up and running on your Linux system, follow these ste
    | **Passphrase** | Passphrase used with private key selected above |
 
    You can use either a password or a key file and passphrase for authentication. For many development scenarios, password authentication is sufficient, but key files are more secure. If you already have a key pair, it's possible to reuse it. Currently Visual Studio only supports RSA and DSA keys for remote connections.
+   
+   > [!NOTE]
+   > If using `ssh-keygen` to create the private key, you must specify the switch `-m pem`, or the key will not be accepted by Visual Studio. If your private key begins with `-----BEGIN OPENSSH PRIVATE KEY-----`, you must convert it with `ssh-keygen -p -f <FILE> -m pem`. 
 
 1. Choose the **Connect** button to attempt a connection to the remote computer.
 


### PR DESCRIPTION
Clearly state that Windows' default `ssh-keygen` does not produce valid private keys for use with ConnectionManager/VS, including steps to adjust private keys to conform with it.

Specifically, the reasoning behind this change _and_ the underlying issue are explained clearly in the following Developer Community tickets and SO threads:
https://developercommunity.visualstudio.com/t/Connect-to-Remote-System-fails-to-esta/10311053
https://developercommunity.visualstudio.com/t/cannot-connect-to-remote-using-private-key/1555749
https://stackoverflow.com/questions/53134212/invalid-privatekey-when-using-jsch

Until such a time as ConnectionManager is fixed to be compliant with default `ssh-keygen` options in modern Windows editions, it should be stated clearly that this is not the case and how this can be resolved.