### PR TITLE
remove unneeded `To`

### DIFF
--- a/docs/data/installing-database-support-mfc-atl.md
+++ b/docs/data/installing-database-support-mfc-atl.md
@@ -8,7 +8,7 @@ ms.custom: intro-installation
 ---
 # Installing Database Support (MFC/ATL)
 
-Visual C++ does not include any database products. To
+Visual C++ does not include any database products.
 
 ## See also
 


### PR DESCRIPTION
You probably wanted to add some sentence but forgot, and since it was 7 years ago, we can probably just delete `To`. If you remember what you wanted to write, then we can restore that sentence.

A commit which introduced this: https://github.com/MicrosoftDocs/cpp-docs/commit/4ef5dd8d5748adb62f90d60ac6c030b1bcfa4f9e#diff-5a6d84f5bdac77cadd72740a09586da004c5e58f8631de9c94e20474415ed894R39