### PR TITLE
Clarify terminology around register volatility.

### DIFF
--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -66,16 +66,16 @@ Default layout alignment for globals and statics:
 
 The AArch64 architecture supports 32 integer registers:
 
-| Register | Save | Role |
+| Register | Volatility | Role |
 | - | - | - |
-| x0 | Caller | Parameter/scratch register 1, result register |
-| x1-x7 | Caller | Parameter/scratch register 2-8 |
-| x8-x15 | Caller | Scratch registers |
-| x16-x17 | Caller | Intra-procedure-call scratch registers |
-| x18 | N/A | Platform register: in kernel mode, points to KPCR for the current processor; in user mode, points to TEB |
-| x19-x28 | Callee | Scratch registers |
-| x29/fp | Callee | Frame pointer |
-| x30/lr | Callee | Link registers |
+| x0 | Volatile | Parameter/scratch register 1, result register |
+| x1-x7 | Volatile | Parameter/scratch register 2-8 |
+| x8-x15 | Volatile | Scratch registers |
+| x16-x17 | Volatile | Intra-procedure-call scratch registers |
+| x18 | N/A | Reserved platform register: in kernel mode, points to KPCR for the current processor; in user mode, points to TEB |
+| x19-x28 | Non-volatile | Scratch registers |
+| x29/fp | Non-volatile | Frame pointer |
+| x30/lr | Both | Link Register: Callee function must preserve it for its own return, but caller's value will be lost. |
 
 Each register may be accessed as a full 64-bit value (via x0-x30) or as a 32-bit value (via w0-w30). 32-bit operations zero-extend their results up to 64 bits.
 
@@ -89,18 +89,18 @@ The frame pointer (x29) is required for compatibility with fast stack walking us
 
 The AArch64 architecture also supports 32 floating-point/SIMD registers, summarized below:
 
-| Register | Save | Role |
+| Register | Volatility | Role |
 | - | - | - |
-| v0 | Caller | Parameter/scratch register 1, result register |
-| v1-v7 | Caller | Parameter/scratch registers 2-8 |
-| v8-v15 | Caller/Callee | Low 64 bits are Callee-Saved. High 64 bits are Caller-Saved. |
-| v16-v31 | Caller | Scratch registers |
+| v0 | Volatile | Parameter/scratch register 1, result register |
+| v1-v7 | Volatile | Parameter/scratch registers 2-8 |
+| v8-v15 | Both | Low 64 bits are Non-Volatile. High 64 bits are Volatile. |
+| v16-v31 | Volatile | Scratch registers |
 
 Each register may be accessed as a full 128-bit value (via v0-v31 or q0-q31). It may be accessed as a 64-bit value (via d0-d31), as a 32-bit value (via s0-s31), as a 16-bit value (via h0-h31), or as an 8-bit value (via b0-b31). Accesses smaller than 128 bits only access the lower bits of the full 128-bit register. They leave the remaining bits untouched unless otherwise specified. (AArch64 is different from AArch32, where the smaller registers were packed on top of the larger registers.)
 
 The floating-point control register (FPCR) has certain requirements on the various bitfields within it:
 
-| Bits | Meaning | Save | Role |
+| Bits | Meaning | Volatility | Role |
 | - | - | - | - |
 | 26 | AHP | Callee | Alternative half-precision control. |
 | 25 | DN | Callee | Default NaN mode control. |

--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -72,7 +72,7 @@ The AArch64 architecture supports 32 integer registers:
 | x1-x7 | Volatile | Parameter/scratch register 2-8 |
 | x8-x15 | Volatile | Scratch registers |
 | x16-x17 | Volatile | Intra-procedure-call scratch registers |
-| x18 | N/A | Reserved platform register: in kernel mode, points to KPCR for the current processor; in user mode, points to TEB |
+| x18 | N/A | Reserved platform register: in kernel mode, points to KPCR for the current processor; In user mode, points to TEB |
 | x19-x28 | Non-volatile | Scratch registers |
 | x29/fp | Non-volatile | Frame pointer |
 | x30/lr | Both | Link Register: Callee function must preserve it for its own return, but caller's value will be lost. |

--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -68,9 +68,8 @@ The AArch64 architecture supports 32 integer registers:
 
 | Register | Volatility | Role |
 | - | - | - |
-| x0 | Volatile | Parameter/scratch register 1, result register |
-| x1-x7 | Volatile | Parameter/scratch register 2-8 |
-| x8-x15 | Volatile | Scratch registers |
+| x0-x8 | Volatile | Parameter/Result scratch registers |
+| x9-x15 | Volatile | Scratch registers |
 | x16-x17 | Volatile | Intra-procedure-call scratch registers |
 | x18 | N/A | Reserved platform register: in kernel mode, points to KPCR for the current processor; In user mode, points to TEB |
 | x19-x28 | Non-volatile | Scratch registers |
@@ -91,8 +90,7 @@ The AArch64 architecture also supports 32 floating-point/SIMD registers, summari
 
 | Register | Volatility | Role |
 | - | - | - |
-| v0 | Volatile | Parameter/scratch register 1, result register |
-| v1-v7 | Volatile | Parameter/scratch registers 2-8 |
+| v0-v7 | Volatile | Parameter/Result scratch registers |
 | v8-v15 | Both | Low 64 bits are Non-Volatile. High 64 bits are Volatile. |
 | v16-v31 | Volatile | Scratch registers |
 

--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -66,16 +66,16 @@ Default layout alignment for globals and statics:
 
 The AArch64 architecture supports 32 integer registers:
 
-| Register | Volatile? | Role |
+| Register | Save | Role |
 | - | - | - |
-| x0 | Volatile | Parameter/scratch register 1, result register |
-| x1-x7 | Volatile | Parameter/scratch register 2-8 |
-| x8-x15 | Volatile | Scratch registers |
-| x16-x17 | Volatile | Intra-procedure-call scratch registers |
-| x18 | Non-volatile | Platform register: in kernel mode, points to KPCR for the current processor; in user mode, points to TEB |
-| x19-x28 | Non-volatile | Scratch registers |
-| x29/fp | Non-volatile | Frame pointer |
-| x30/lr | Non-volatile | Link registers |
+| x0 | Caller | Parameter/scratch register 1, result register |
+| x1-x7 | Caller | Parameter/scratch register 2-8 |
+| x8-x15 | Caller | Scratch registers |
+| x16-x17 | Caller | Intra-procedure-call scratch registers |
+| x18 | N/A | Platform register: in kernel mode, points to KPCR for the current processor; in user mode, points to TEB |
+| x19-x28 | Callee | Scratch registers |
+| x29/fp | Callee | Frame pointer |
+| x30/lr | Callee | Link registers |
 
 Each register may be accessed as a full 64-bit value (via x0-x30) or as a 32-bit value (via w0-w30). 32-bit operations zero-extend their results up to 64 bits.
 
@@ -89,24 +89,24 @@ The frame pointer (x29) is required for compatibility with fast stack walking us
 
 The AArch64 architecture also supports 32 floating-point/SIMD registers, summarized below:
 
-| Register | Volatile? | Role |
+| Register | Save | Role |
 | - | - | - |
-| v0 | Volatile | Parameter/scratch register 1, result register |
-| v1-v7 | Volatile | Parameter/scratch registers 2-8 |
-| v8-v15 | Non-volatile | Scratch registers (only the low 64 bits are non-volatile) |
-| v16-v31 | Volatile | Scratch registers |
+| v0 | Caller | Parameter/scratch register 1, result register |
+| v1-v7 | Caller | Parameter/scratch registers 2-8 |
+| v8-v15 | Caller/Callee | Low 64 bits are Callee-Saved. High 64 bits are Caller-Saved. |
+| v16-v31 | Caller | Scratch registers |
 
 Each register may be accessed as a full 128-bit value (via v0-v31 or q0-q31). It may be accessed as a 64-bit value (via d0-d31), as a 32-bit value (via s0-s31), as a 16-bit value (via h0-h31), or as an 8-bit value (via b0-b31). Accesses smaller than 128 bits only access the lower bits of the full 128-bit register. They leave the remaining bits untouched unless otherwise specified. (AArch64 is different from AArch32, where the smaller registers were packed on top of the larger registers.)
 
 The floating-point control register (FPCR) has certain requirements on the various bitfields within it:
 
-| Bits | Meaning | Volatile? | Role |
+| Bits | Meaning | Save | Role |
 | - | - | - | - |
-| 26 | AHP | Non-Volatile | Alternative half-precision control. |
-| 25 | DN | Non-Volatile | Default NaN mode control. |
-| 24 | FZ | Non-volatile | Flush-to-zero mode control. |
-| 23-22 | RMode | Non-volatile | Rounding mode control. |
-| 15,12-8 | IDE/IXE/etc | Non-Volatile | Exception trap enable bits, must always be 0. |
+| 26 | AHP | Callee | Alternative half-precision control. |
+| 25 | DN | Callee | Default NaN mode control. |
+| 24 | FZ | Callee | Flush-to-zero mode control. |
+| 23-22 | RMode | Callee | Rounding mode control. |
+| 15,12-8 | IDE/IXE/etc | Callee | Exception trap enable bits, must always be 0. |
 
 ## System registers
 

--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -102,11 +102,11 @@ The floating-point control register (FPCR) has certain requirements on the vario
 
 | Bits | Meaning | Volatility | Role |
 | - | - | - | - |
-| 26 | AHP | Callee | Alternative half-precision control. |
-| 25 | DN | Callee | Default NaN mode control. |
-| 24 | FZ | Callee | Flush-to-zero mode control. |
-| 23-22 | RMode | Callee | Rounding mode control. |
-| 15,12-8 | IDE/IXE/etc | Callee | Exception trap enable bits, must always be 0. |
+| 26 | AHP | Non-Volatile | Alternative half-precision control. |
+| 25 | DN | Non-Volatile | Default NaN mode control. |
+| 24 | FZ | Non-volatile | Flush-to-zero mode control. |
+| 23-22 | RMode | Non-volatile | Rounding mode control. |
+| 15,12-8 | IDE/IXE/etc | Non-Volatile | Exception trap enable bits, must always be 0. |
 
 ## System registers
 


### PR DESCRIPTION
Volatile vs Non-volatile is a very Microsoft specific terminology. Out in the industry, register calling convention assignment are more frequently referred to as Caller vs Callee saved.

Also, x18 is a reserved register, so it is neither Caller nor Callee Saved.
