### PR TITLE
Add information about _stat to VS Change History

### DIFF
--- a/docs/porting/visual-cpp-change-history-2003-2015.md
+++ b/docs/porting/visual-cpp-change-history-2003-2015.md
@@ -253,6 +253,10 @@ Additionally, ongoing improvements to compiler conformance can sometimes change 
 
    The `smallheap` link option has been removed. See [Link Options](../c-runtime-library/link-options.md).
 
+- **_stat**
+
+   The [`_stat`](../c-runtime-library/reference/stat-functions.md) family of functions use `CreateFile` in Visual Studio 2015, instead of `FindFirstFile` as in Visual Studio 2013 and earlier. This means that `_stat` on a path ending with a slash succeeds if the path refers to a directory, as opposed to before when the function would error with `errno` set to `ENOENT`.
+
 #### \<string.h>
 
 - **wcstok**


### PR DESCRIPTION
In VS 2013 and previous, `_stat(R"(C:\path\to\directory\)")` would fail due to the trailing backslash, because we used to use `FindFirstFile`. Now, we use `CreateFile`, and so trailing backslashes work when the path is the name of a directory.