### PR TITLE
Update byteswap-uint64-byteswap-ulong-byteswap-ushort.md

### DIFF
--- a/docs/c-runtime-library/reference/byteswap-uint64-byteswap-ulong-byteswap-ushort.md
+++ b/docs/c-runtime-library/reference/byteswap-uint64-byteswap-ulong-byteswap-ushort.md
@@ -54,8 +54,8 @@ int main()
 ```
 
 ```Output
-byteswap of 102030405060708 = 807060504030201
-byteswap of 1020304 = 4030201
+byteswap of 0102030405060708 = 0807060504030201
+byteswap of 01020304 = 04030201
 ```
 
 ## See also


### PR DESCRIPTION
Leading zeros help understanding the example.
See https://man7.org/linux/man-pages/man3/bswap.3.html#EXAMPLES for comparison.