### PR TITLE
Link C4834 to C26457

### DIFF
--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -13,7 +13,7 @@ helpviewer_keywords: ["C4834"]
 
 Starting in the C++17 Standard, the `[[nodiscard]]` attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834.
 
-To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by using a cast to **`void`**.
+To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by assigning the value to **`std::ignore`** or by using a cast to **`void`** (see [Warning C26457](code-quality/c26457.md)).
 
 This warning was introduced in Visual Studio 2017 version 15.3 as a level 3 warning. It was changed to a level 1 warning in Visual Studio 2017 version 15.7. Code that compiled without warnings in versions of the compiler before Visual Studio 2017 version 15.3 can now generate C4834. For information on how to disable warnings introduced in a particular compiler version or later, see [Compiler warnings by compiler version](compiler-warnings-by-compiler-version.md).
 
@@ -29,7 +29,7 @@ To turn off the warning for an entire project in the Visual Studio IDE:
 
 ## Example
 
-This sample generates C4834, and shows a way to fix it:
+This sample generates C4834, and shows three ways to fix it:
 
 ```cpp
 // C4834.cpp
@@ -42,8 +42,12 @@ int square_of(int i) { return i * i; }
 int main()
 {
     square_of(42); // warning C4834: discarding return value of function with 'nodiscard' attribute
-    // to fix, make use of the return value, as shown here:
+    // If ignoring the [[nodiscard] attribute is unintentional, to fix the warning, make use of the return value, as shown here:
     // std::cout << "square_of(42) = " << square_of(42) << "\n";
+    // If discarding the nodiscard value is intentional, but you cannot fix it another way (for example, if the function marked [[nodiscard]] is from a third-party dependency), you can also suppress the warning by assigning to std::ignore, as shown here:
+    //  std::ignore = square_of(42); // Ok, C++ 11 and higher
+    // You can also suppress the warning by casting the return result to (void), but the intent of the cast may not be clear. This may produce warning C26457 depending on your code analysis settings.
+    // (void) square_of(42); // warning C26457 if enabled
     return 0;
 }
 ```

--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -13,7 +13,7 @@ helpviewer_keywords: ["C4834"]
 
 Starting in the C++17 Standard, the `[[nodiscard]]` attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834.
 
-To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by assigning the value to **`std::ignore`** or by using a cast to **`void`** (see [Warning C26457](code-quality/c26457.md)).
+To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by assigning the value to **`std::ignore`** or by using a cast to **`void`** (see [Warning C26457](../../code-quality/c26457.md)).
 
 This warning was introduced in Visual Studio 2017 version 15.3 as a level 3 warning. It was changed to a level 1 warning in Visual Studio 2017 version 15.7. Code that compiled without warnings in versions of the compiler before Visual Studio 2017 version 15.3 can now generate C4834. For information on how to disable warnings introduced in a particular compiler version or later, see [Compiler warnings by compiler version](compiler-warnings-by-compiler-version.md).
 


### PR DESCRIPTION
C4834 recommends either using referenced value or casting to (void). However, we also have a code quality rule for [[nodiscard]] that says "assign to std::ignore" is preferred over "(void)". The documentation should link to this page, rather than recommending an approach we will also warn over.