### PR TITLE
docs: corrected ARGS.C command-line list output

### DIFF
--- a/docs/c-language/parsing-c-command-line-arguments.md
+++ b/docs/c-language/parsing-c-command-line-arguments.md
@@ -34,7 +34,7 @@ This list illustrates the rules above by showing the interpreted result passed t
 | `a\\\b d"e f"g h` | `a\\\b` | `de fg` | `h` |
 | `a\\\"b c d` | `a\"b` | `c` | `d` |
 | `a\\\\"b c" d e` | `a\\b c` | `d` | `e` |
-| `a"b"" c d` | `ab" c d` |  |  |
+| `a"b"" c d` | `ab"` | `c` | `d` |
 
 ## Example
 


### PR DESCRIPTION
This commit includes a correction to the ARGS.C command-line list output in the documentation, ensuring it accurately reflects the actual output.
Best regards,