### PR TITLE
Improve C4834 spacing, line wrapping, and wording

### DIFF
--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -44,10 +44,10 @@ int main()
     square_of(42); // warning C4834: discarding return value of function with 'nodiscard' attribute
     // If ignoring the [[nodiscard] attribute is unintentional, to fix the warning, make use of the return value, as shown here:
     // std::cout << "square_of(42) = " << square_of(42) << "\n";
-    // If discarding the nodiscard value is intentional, but you cannot fix it another way (for example, if the function marked [[nodiscard]] is from a third-party dependency), you can also suppress the warning by assigning to std::ignore, as shown here:
-    //  std::ignore = square_of(42); // Ok, C++ 11 and higher
-    // You can also suppress the warning by casting the return result to (void), but the intent of the cast may not be clear. This may produce warning C26457 depending on your code analysis settings.
-    // (void) square_of(42); // warning C26457 if enabled
+    // If discarding the nodiscard value is intentional, but you cannot fix it another way (for example, if the function marked [[nodiscard]] is from a third-party dependency), you can also suppress the warning by assigning the return value to std::ignore, as shown here:
+    // std::ignore = square_of(42); // Ok, C++ 11 and higher
+    // You can also suppress the warning by casting the return value to void, but it may be less clear that the intent is to discard the result. Depending on your code analysis settings, casting to void may produce warning C26457.
+    // (void) square_of(42); // Will not produce warning C4834, may produce warning C26457
     return 0;
 }
 ```

--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -13,7 +13,8 @@ helpviewer_keywords: ["C4834"]
 
 Starting in the C++17 Standard, the `[[nodiscard]]` attribute specifies that a function's return value isn't intended to be discarded. If a caller discards the return value, the compiler generates warning C4834.
 
-To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by assigning the value to **`std::ignore`** or by using a cast to **`void`** (see [Warning C26457](../../code-quality/c26457.md)).
+To resolve this warning, consider why your code doesn't use the return value. Your use of the function may not match its intent. You can circumvent the warning by assigning the value to **`std::ignore`** or by casting it to **`void`** if discarding the value is intentional.  
+Assignment to **`std::ignore`** is preferred over casting to **`void`** in C++ 11 and higher, as it makes your intent clearer and will not trigger [Warning C26457](../../code-quality/c26457.md) if enabled in your code analysis settings.
 
 This warning was introduced in Visual Studio 2017 version 15.3 as a level 3 warning. It was changed to a level 1 warning in Visual Studio 2017 version 15.7. Code that compiled without warnings in versions of the compiler before Visual Studio 2017 version 15.3 can now generate C4834. For information on how to disable warnings introduced in a particular compiler version or later, see [Compiler warnings by compiler version](compiler-warnings-by-compiler-version.md).
 
@@ -29,7 +30,7 @@ To turn off the warning for an entire project in the Visual Studio IDE:
 
 ## Example
 
-This sample generates C4834, and shows three ways to fix it:
+This sample generates C4834, and shows four ways to fix it:
 
 ```cpp
 // C4834.cpp
@@ -39,15 +40,23 @@ This sample generates C4834, and shows three ways to fix it:
 [[nodiscard]]
 int square_of(int i) { return i * i; }
 
+
 int main()
 {
     square_of(42); // warning C4834: discarding return value of function with 'nodiscard' attribute
-    // If ignoring the [[nodiscard] attribute is unintentional, to fix the warning, make use of the return value, as shown here:
-    // std::cout << "square_of(42) = " << square_of(42) << "\n";
-    // If discarding the nodiscard value is intentional, but you cannot fix it another way (for example, if the function marked [[nodiscard]] is from a third-party dependency), you can also suppress the warning by assigning the return value to std::ignore, as shown here:
-    // std::ignore = square_of(42); // Ok, C++ 11 and higher
-    // You can also suppress the warning by casting the return value to void, but it may be less clear that the intent is to discard the result. Depending on your code analysis settings, casting to void may produce warning C26457.
-    // (void) square_of(42); // Will not produce warning C4834, may produce warning C26457
+    // If ignoring the [[nodiscard] attribute is unintentional, make use of the return value as intended:
+    // For example:
+    std::cout << "square_of(42) = " << square_of(42) << "\n"; // Ok
+    // Or:
+    int result = square_of(43); // Ok
+    std::cout << "square_of(43) = " << result << "\n"; 
+
+    // If ignoring the [[nodiscard]] attribute value is intentional, you have two options:
+    // Preferrably, assign the return value to std::ignore:
+    std::ignore = square_of(42); // Ok, C++ 11 and higher
+    // Alternatively, you can cast the return value to void. 
+    // The intent may be less clear to other developers.
+    (void) square_of(42); // May produce warning C26457
     return 0;
 }
 ```


### PR DESCRIPTION
My previous PR  #4638 added an unintended space in line 48. 
While I'm at it:
* Improve consistency of wording added in my previous PR and the rest of the article.
* Improve line breaks in example and restructure it for legibility