### PR TITLE
docs: few minor fixes.

### DIFF
--- a/docs/c-language/c-enumeration-declarations.md
+++ b/docs/c-language/c-enumeration-declarations.md
@@ -103,7 +103,7 @@ enum BOOLEAN end_flag, match_flag; /* Two variables of type BOOLEAN */
 This declaration can also be specified as
 
 ```C
-enum BOOLEAN { false, true } end_flag, match_flag;\
+enum BOOLEAN { false, true } end_flag, match_flag;
 ```
 
 or as

--- a/docs/c-language/c-type-specifiers.md
+++ b/docs/c-language/c-type-specifiers.md
@@ -55,7 +55,7 @@ The Microsoft C compiler also generates warnings for differences in sign. For ex
 
 ```C
 signed int *pi;
-unsigned int *pu
+unsigned int *pu;
 
 pi = pu;  /* Now generates warning */
 ```

--- a/docs/c-language/declarators-and-variable-declarations.md
+++ b/docs/c-language/declarators-and-variable-declarations.md
@@ -67,7 +67,7 @@ int list[20]; // Declares an array of 20 int values named list
 char *cp;     // Declares a pointer to a char value
 double func( void ); // Declares a function named func, with no
                      // arguments, that returns a double value
-int *aptr[10] // Declares an array of 10 pointers
+int *aptr[10]; // Declares an array of 10 pointers
 ```
 
 **Microsoft Specific**

--- a/docs/c-language/extern-storage-class-specifier.md
+++ b/docs/c-language/extern-storage-class-specifier.md
@@ -49,7 +49,7 @@ void func(void)
 }
 ```
 
-In this example, the variable `i` is defined in Source1.c with an initial value of 1. An **`extern`** declaration in Source2.c is makes 'i' visible in that file.
+In this example, the variable `i` is defined in Source1.c with an initial value of 1. An **`extern`** declaration in Source2.c makes 'i' visible in that file.
 
 In the `func` function, the address of the global variable `i` is used to initialize the **`static`** pointer variable `external_i`. This works because the global variable has **`static`** lifetime, meaning its address does not change during program execution. Next, a variable `i` is defined within the scope of `func` as a local variable with initial value 16. This definition does not affect the value of the external-level `i`, which is hidden by the use of its name for the local variable. The value of the global `i` is now accessible only through the pointer `external_i`.
 


### PR DESCRIPTION
Apologies for submitting PRs over the weekend. Here are the changes I've made:

1. **Rectified a minor grammar mistake in the documentation concerning the extern specifier.**  [commit](https://github.com/MicrosoftDocs/cpp-docs/pull/4647/commits/8e6baf0c43873e0cebe4325e633e69efd33815f2)
2. **Incorporated a missing comma in the example code of the C Type Specifiers documentation.**  [commit](https://github.com/MicrosoftDocs/cpp-docs/pull/4647/commits/808c6caf9fb703268fd9b9301e7f3852c8b741ba)
3. **Incorporated a missing comma in the example code of the Declarators and variable declarations documentation.** [commit](https://github.com/MicrosoftDocs/cpp-docs/pull/4647/commits/d99c8ae99d3760914d7e7d87b3f19abf2a6a698e)
4. **Removed an unnecessary forward slash in the example code of the C enumeration declarations documentation.** [commit](https://github.com/MicrosoftDocs/cpp-docs/pull/4647/commits/59088d4ce7b3c0bf80a0482f8278f91864fdf2b7)

Best regards,