### PR TITLE
docs: few minor fixes.

### DIFF
--- a/docs/c-language/c-bit-fields.md
+++ b/docs/c-language/c-bit-fields.md
@@ -19,7 +19,7 @@ The *`constant-expression`* specifies the width of the field in bits. The *`type
 
 Unnamed bit fields can't be referenced, and their contents at run time are unpredictable. They can be used as "dummy" fields, for alignment purposes. An unnamed bit field whose width is specified as 0 guarantees that storage for the member following it in the *struct-declaration-list* begins on an **`int`** boundary.
 
-Bit fields must also be long enough to contain the bit pattern. For example, these two statements aren't legal:
+Bit fields should not exceed the total number of bits of their underlying type. For example, these two statements aren't legal:
 
 ```C
 short a:17;        /* Illegal! */
@@ -72,7 +72,7 @@ the bits of `test` would be arranged as follows:
 cccccccb bbbbaaaa
 ```
 
-Since the 8086 family of processors stores the low byte of integer values before the high byte, the integer `0x01F2` would be stored in physical memory as `0xF2` followed by `0x01`.
+Since the 8086 family of processors store the low byte of integer values before the high byte, the integer `0x01F2` would be stored in physical memory as `0xF2` followed by `0x01`.
 
 The ISO C99 standard lets an implementation choose whether a bit field may straddle two storage instances. Consider this structure, which stores bit fields that total 64 bits:
 

--- a/docs/c-language/c-bit-fields.md
+++ b/docs/c-language/c-bit-fields.md
@@ -19,7 +19,7 @@ The *`constant-expression`* specifies the width of the field in bits. The *`type
 
 Unnamed bit fields can't be referenced, and their contents at run time are unpredictable. They can be used as "dummy" fields, for alignment purposes. An unnamed bit field whose width is specified as 0 guarantees that storage for the member following it in the *struct-declaration-list* begins on an **`int`** boundary.
 
-Bit fields should not exceed the total number of bits of their underlying type. For example, these two statements aren't legal:
+The number of bits in a bit field must be less than or equal to the size of the underlying type. For example, these two statements aren't legal:
 
 ```C
 short a:17;        /* Illegal! */

--- a/docs/c-language/storage-and-alignment-of-structures.md
+++ b/docs/c-language/storage-and-alignment-of-structures.md
@@ -27,7 +27,7 @@ where *n* is the packing size expressed with the /Zp[*n*] option and *item* is t
 
 To use the `pack` pragma to specify packing other than the packing specified on the command line for a particular structure, give the `pack` pragma, where the packing size is 1, 2, 4, 8, or 16, before the structure. To reinstate the packing given on the command line, specify the `pack` pragma with no arguments.
 
-Bit fields default to size **`long`** for the Microsoft C compiler. Structure members are aligned on the size of the type or the /Zp[*n*] size, whichever is smaller. The default size is 4.
+For the Microsoft C compiler, bit fields default to a size of 4 bytes, which is a **`long`** data type. Structure members are aligned on the size of the type or the /Zp[*n*] size, whichever is smaller.
 
 **END Microsoft Specific**
 

--- a/docs/c-language/union-declarations.md
+++ b/docs/c-language/union-declarations.md
@@ -81,7 +81,7 @@ Nested unions can be declared anonymously when they're members of another struct
 struct str
 {
     int a, b;
-    union            / * Unnamed union */
+    union            /* Unnamed union */
     {
       char c[4];
       long l;


### PR DESCRIPTION
Hi! I hope you are having a great day.
I am submitting a pull request with the following changes:

1. __Updated explanation to align with code and fix a minor grammar mistake in the documentation related to C Bit Fields.__ [1cfca66](https://github.com/MicrosoftDocs/cpp-docs/pull/4653/commits/1cfca6679900fe0c3a07fd390dfd0a3ba7544386)
2. __Clarify the description regarding the default size in the documentation related to Storage and Alignment of Structures.__ [532242a](https://github.com/MicrosoftDocs/cpp-docs/pull/4653/commits/532242a39f2c9cf70a2ff4cf755c821ce9947f6f)
3. __Fix a comment formatting error in the documentation related to Union Declarations.__ [f92be36](https://github.com/MicrosoftDocs/cpp-docs/pull/4653/commits/f92be3668f8cf0d9648c250f5b7f0ea560338b34)

Thank you for your time and consideration in reviewing these changes.
Best regards,
melody