### PR TITLE
[link.exe /INTEGRITYCHECK] fix -- ":NO" suffix doesn't work, so update the docs

### DIFF
--- a/docs/build/reference/integritycheck-require-signature-check.md
+++ b/docs/build/reference/integritycheck-require-signature-check.md
@@ -7,7 +7,7 @@ ms.date: 04/21/2021
 
 Specifies that the digital signature of the binary image must be checked at load time.
 
-> **`/INTEGRITYCHECK`**[**`:NO`**]
+> **`/INTEGRITYCHECK`**
 
 ## Remarks
 
@@ -25,7 +25,11 @@ Microsoft has new signing guidance for DLL and executable files linked by using 
 
 1. Select the **Configuration Properties** > **Linker** > **Command Line** property page.
 
-1. In **Additional Options**, enter *`/INTEGRITYCHECK`* or *`/INTEGRITYCHECK:NO`*. Choose **OK** to save your changes.
+1. To build an image which requires digital signature verification to be loaded, add *`/INTEGRITYCHECK`* to the **Additional Options** command line.
+
+1. To disable the feature, remove the *`/INTEGRITYCHECK`* option.
+
+1. Choose **OK** to save your changes.
 
 ## See also
 

--- a/docs/build/reference/integritycheck-require-signature-check.md
+++ b/docs/build/reference/integritycheck-require-signature-check.md
@@ -25,9 +25,7 @@ Microsoft has new signing guidance for DLL and executable files linked by using 
 
 1. Select the **Configuration Properties** > **Linker** > **Command Line** property page.
 
-1. To build an image which requires digital signature verification to be loaded, add *`/INTEGRITYCHECK`* to the **Additional Options** command line.
-
-1. To disable the feature, remove the *`/INTEGRITYCHECK`* option.
+1. To build an image which requires digital signature verification to be loaded, add *`/INTEGRITYCHECK`* to the **Additional Options** command line. By default, **`/INTEGRITYCHECK`** is off.
 
 1. Choose **OK** to save your changes.
 


### PR DESCRIPTION
The doc mentions `/INTEGRITYCHECK:NO`, but this does not appear to be a valid command line option with the current `link.exe` releases. My version of `link` rejects that syntax entirely.

I don't know where the official `link.exe` source code is kept, but it likely has the exact same bug in the code that I found in the link below. Due to this obvious bug that I point out in the source code, there seems to be no way to explicilty assert `/INTEGRITYCHECK` in the negative, except by simply removing the option. 

https://github.com/microsoft/BuildXL/blob/main/Public/Sdk/Experimental/Msvc/Native/Tools/Link/Link.dsc#L303-L307

I would welcome a `link` developer to fix the program itself, so it works as described, but in the meantime, at least the docs can be changed to reflect the current situation.