### PR TITLE
Update C2345

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2345.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2345.md
@@ -12,11 +12,12 @@ align(value) : illegal alignment value
 
 You passed a value to the [align](../../cpp/align-cpp.md) keyword that is outside the allowable range.
 
-The following code generates C2345
+The following sample generates C2345:
 
 ```cpp
 // C2345.cpp
 // compile with: /c
-__declspec(align(0)) int a;   // C2345
-__declspec(align(1)) int a;   // OK
+__declspec(align(0)) int a;   // OK
+__declspec(align(8)) int b;   // OK
+__declspec(align(16384)) int c;   // C2345
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2345.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2345.md
@@ -17,7 +17,6 @@ The following sample generates C2345:
 ```cpp
 // C2345.cpp
 // compile with: /c
-__declspec(align(0)) int a;   // OK
-__declspec(align(8)) int b;   // OK
-__declspec(align(16384)) int c;   // C2345
+__declspec(align(8)) int a;   // OK
+__declspec(align(16384)) int b;   // C2345
 ```


### PR DESCRIPTION
`__declspec(align(0))` no longer generates `C2345`, added a high power of 2 to trigger the error.