### PR TITLE
Clean up C2397

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
@@ -15,26 +15,22 @@ The C language allows implicit narrowing conversions in assignments and initiali
 
 A narrowing conversion can be okay when you know the possible range of converted values can fit in the target. In this case, you know more than the compiler does. If you make a narrowing conversion intentionally, make your intentions explicit by using a static cast. Otherwise, this error message almost always indicates you have a bug in your code. You can fix it by making sure the objects you initialize have types that are large enough to handle the inputs.
 
-The following sample generates C2397 and shows one way to fix it:
+The following sample generates C2397:
 
-```
-// C2397.cpp -- C++ narrowing conversion diagnostics
-// Compile by using: cl /EHsc C2397.cpp
-#include <vector>
-
-struct S1 {
-    int m1;
-    double m2, m3;
+```cpp
+// C2397.cpp
+// compile with: /c
+struct S {
+   int m1;
+   double m2, m3;
 };
 
-void function_C2397(double d1) {
-    char c1 { 127 };          // OK
-    char c2 { 513 };          // error C2397
-
-    std::vector<S1> vS1;
-    vS1.push_back({ d1, 2, 3 }); // error C2397
-
-    // Possible fix if you know d1 always fits in an int
-    vS1.push_back({ static_cast<int>(d1), 2, 3 });
+void func(double d1) {
+   char c1 { 127 };   // OK
+   char c2 { 513 };   // C2397
+   
+   S arr[2]{};
+   arr[0] = { d1, 2.0, 3.0 };   // C2397
+   arr[1] = { static_cast<int>(d1), 2.0, 3.0 };   // OK
 }
 ```


### PR DESCRIPTION
Make the example more uniform with the others, remove the need to use `std::vector` and made the `double`s in the initializers more explicit (`2` -> `2.0`).