### PR TITLE
Split code blocks for C2992

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2992.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2992.md
@@ -20,30 +20,34 @@ The following sample generates C2992:
 // C2992.cpp
 // compile with: /c
 template <class T>
-struct TC1 {
+struct Outer {
    template <class U>
-   struct TC2;
+   struct Inner;
 };
 
-template <class T>   struct TC1<T>::TC2 {};   // C2992
+template <class T>   // C2992
+struct Outer<T>::Inner {};
 
-// OK
 template <class T>
-template <class U>
-struct TC1<T>::TC2 {};
-// C2992 can also occur when using generics:
-// C2992c.cpp
-// compile with: /clr /c
+template <class U>   // OK
+struct Outer<T>::Inner {};
+```
+
+C2992 can also occur when using generics:
+
+```cpp
+// C2992b.cpp
+// compile with: /c /clr
 generic <class T>
-ref struct GC1 {
+ref struct Outer {
    generic <class U>
-   ref struct GC2;
+   ref struct Inner;
 };
 
-generic <class T> ref struct GC1<T>::GC2 {};   // C2992
+generic <class T>   // C2992
+ref struct Outer<T>::Inner {};
 
-// OK
 generic <class T>
-generic <class U>
-ref struct GC1<T>::GC2 {};
+generic <class U>   // OK
+ref struct Outer<T>::Inner {};
 ```


### PR DESCRIPTION
Since there are 2 distinct parts in the example, splitting them up makes more sense. Made a few identifiers clearer and some formatting works.