### PR TITLE
Add example to C3550

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -22,9 +22,11 @@ The following sample generates C3550:
 decltype(auto)* func1();   // C3550
 decltype(auto)& func2();   // C3550
 decltype(auto)&& func3();   // C3550
+
+auto* func4();   // OK
 ```
 
-To resolve the error remove all illegal qualification on `decltype(auto)`.
+To resolve the error remove all illegal qualification on `decltype(auto)`. For instance, `decltype(auto)* func1()` can be turned into `auto* func1()`.
 
 ## See also
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -10,7 +10,31 @@ ms.assetid: 9f2d5ffc-e429-41a1-89e3-7acc4fd47e14
 
 only plain 'decltype(auto)' is allowed in this context
 
-If `decltype(auto)` is used as a placeholder for the return type of a function, it must be used by itself. It cannot be used as part of a pointer declaration (`decltype(auto*)`), a reference declaration (`decltype(auto&)`), or any other such qualification.
+If [`decltype(auto)`](../../cpp/decltype-cpp.md#decltype-and-auto) is used as a placeholder for the return type of a function, it must be used by itself. It cannot be used as part of a pointer declaration (`decltype(auto)*`), a reference declaration (`decltype(auto)&`), or any other such qualification.
+
+## Example
+
+The following sample generates C3550:
+
+```cpp
+// C3550.cpp
+// compile with: /c
+int dummy;
+
+decltype(auto)* func1() {   // C3550
+   return &dummy;
+}
+
+decltype(auto)& func2() {   // C3550
+   return dummy;
+}
+
+decltype(auto)&& func3() {   // C3550
+   return 123;
+}
+```
+
+To resolve the error remove all illegal qualification on `decltype(auto)`.
 
 ## See also
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -19,19 +19,9 @@ The following sample generates C3550:
 ```cpp
 // C3550.cpp
 // compile with: /c
-int dummy;
-
-decltype(auto)* func1() {   // C3550
-   return &dummy;
-}
-
-decltype(auto)& func2() {   // C3550
-   return dummy;
-}
-
-decltype(auto)&& func3() {   // C3550
-   return 123;
-}
+decltype(auto)* func1();   // C3550
+decltype(auto)& func2();   // C3550
+decltype(auto)&& func3();   // C3550
 ```
 
 To resolve the error remove all illegal qualification on `decltype(auto)`.


### PR DESCRIPTION
~~The "dummy" int was added to reduce the number of compiler errors generated (to make the example more targeted), as omitting the return statement in those functions yielded a lot of compiler errors.~~

Edit: forgotten that just the function prototype is needed.