### PR TITLE
Update C2534

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
@@ -12,7 +12,6 @@ ms.assetid: 481f9f54-5b51-4aa0-8eea-218f10807705
 
 A constructor cannot contain a **`return`** statement with an expression (even if the expression has type **`void`**). This differs from regular void-returning function where a return expression of type **`void`** is allowed. However, using the **`return`** statement without an expression is allowed for early returns in the constructor.
 
-## Example
 
 The following sample generates C2534:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
@@ -10,17 +10,29 @@ ms.assetid: 481f9f54-5b51-4aa0-8eea-218f10807705
 
 'identifier' : constructor cannot return a value
 
-A constructor cannot return a value or have a return type (not even a **`void`** return type).
+A constructor cannot contain a **`return`** statement with an expression (even if the expression has type **`void`**). This differs from regular void-returning function where a return expression of type **`void`** is allowed. However, using the **`return`** statement without an expression is allowed for early returns in the constructor.
 
-This error may be fixed by removing the **`return`** statement from the constructor definition.
+## Example
 
 The following sample generates C2534:
 
 ```cpp
 // C2534.cpp
+// compile with: /c
+void void_func() {}
+
 class A {
 public:
    int i;
-   A() { return i; }   // C2534
+   A() {
+      return i;   // C2534
+      return 123;   // C2534
+      return (void)0;   // C2534
+      return void_func();   // C2534
+
+      return;   // OK
+   }
 };
 ```
+
+The preceding errors may be fixed by removing the entire **`return`** statement or omitting the return expression if an early return is desired.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2534.md
@@ -12,7 +12,6 @@ ms.assetid: 481f9f54-5b51-4aa0-8eea-218f10807705
 
 A constructor cannot contain a **`return`** statement with an expression (even if the expression has type **`void`**). This differs from regular void-returning function where a return expression of type **`void`** is allowed. However, using the **`return`** statement without an expression is allowed for early returns in the constructor.
 
-
 The following sample generates C2534:
 
 ```cpp


### PR DESCRIPTION
Be slightly more explicit that `return;` is allowed and add a little more info should the user attempt to return an expression of type `void`.