### PR TITLE
Fix error in /W3 /W4 C4244

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -36,7 +36,7 @@ int main() {
 ```
 
 For more information, see [Usual Arithmetic Conversions](../../c-language/usual-arithmetic-conversions.md).\
-For more information about setting the warning level in Visual Studio, see[To set the compiler options in the Visual Studio development environment](../build/reference/compiler-option-warnings-level#to-set-the-compiler-options-in-the-visual-studio-development-environment.md)
+For more information about setting the warning level in Visual Studio, see [To set the compiler options in the Visual Studio development environment](../../build/reference/compiler-option-warning-level.md#to-set-the-compiler-options-in-the-visual-studio-development-environment)
 
 ```cpp
 // C4244_level3.cpp
@@ -50,7 +50,7 @@ int main() {
 }
 ```
 
-Warning C4244 can occur when building code for 64-bit targets that does not generate the warning when building for 32-bit targets. For example, a pointer is a 32-bit quantity on 32-bit platforms, but a 64-bit quantity on 64-bit platforms.
+Warning C4244 can occur when building code for 64-bit targets that does not generate the warning when building for 32-bit targets. For example, pointer arithmetic results in a 32-bit quantity on 32-bit platforms, but a 64-bit quantity on 64-bit platforms.
 
 The following sample generates C4244 when compiled for 64-bit targets:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -8,29 +8,28 @@ ms.assetid: f116bb09-c479-4b4e-a647-fe629a1383f6
 
 'conversion' conversion from 'type1' to 'type2', possible loss of data
 
-An integer type is converted to a smaller integer type. This is a level-4 warning if *type1* is **`int`** and *type2* is smaller than **`int`**. Otherwise, it is a level 3 (assigned a value of type [__int64](../../cpp/int8-int16-int32-int64.md) to a variable of type **`unsigned int`**). A possible loss of data may have occurred.
+An integer type is converted to a smaller integer type. This is a level-4 warning if *type1* is **`int`**/**`unsigned int`** and *type2* is smaller than **`int`**/**`unsigned int`**, such as **`short`** and **`unsigned short`**. Otherwise, it is a level 3 if a value of type [__int64](../../cpp/int8-int16-int32-int64.md)/**`unsigned __int64`** is assigned to a variable of type **`int`**/**`unsigned int`**. A possible loss of data may have occurred due to a narrowing conversion, which may lead to unexpected effects.
 
-If you get C4244, you should either change your program to use compatible types, or add some logic to your code, to ensure that the range of possible values will always be compatible with the types you are using.
+If you get C4244, you should either change your program to use compatible types, or add some logic to your code, to ensure that the range of possible values will always be compatible with the types you are using. If the conversion is intended, an explicit cast can be added to silence the warning.
 
 C4244 can also fire at level 2; see [Compiler Warning (level 2) C4244](../../error-messages/compiler-warnings/compiler-warning-level-2-c4244.md) for more information.
-
-The conversion may have a problem due to implicit conversions.
 
 The following sample generates C4244:
 
 ```cpp
 // C4244_level4.cpp
 // compile with: /W4
-int aa;
-unsigned short bb;
-int main() {
-   int b = 0, c = 0;
-   short a = b + c;   // C4244
+void foo(unsigned short num) {}
 
-   bb += c;   // C4244
-   bb = bb + c;   // C4244
-   bb += (unsigned short)aa;   // C4244
-   bb = bb + (unsigned short)aa;   // OK
+int main() {
+   int int1 = 1;
+   unsigned int uint1 = 2;
+
+   short short1 = int1;   // C4244
+   short short2 = (short)int1;   // OK
+
+   short short3 = uint1;   // C4244
+   foo(uint1);   // C4244
 }
 ```
 
@@ -40,12 +39,15 @@ For more information, see [Usual Arithmetic Conversions](../../c-language/usual-
 // C4244_level3.cpp
 // compile with: /W3
 int main() {
-   __int64 i = 8;
-   unsigned int ii = i;   // C4244
+   __int64 i64 = 1;
+   unsigned __int64 u64 = 2;
+
+   int int1 = i64;   // C4244
+   int int3 = u64;   // C4244
 }
 ```
 
-Warning C4244 can occur when building code for 64-bit targets that does not generate the warning when building for 32-bit targets. For example, a difference between pointers is a 32-bit quantity on 32-bit platforms, but a 64-bit quantity on 64-bit platforms.
+Warning C4244 can occur when building code for 64-bit targets that does not generate the warning when building for 32-bit targets. For example, a pointer is a 32-bit quantity on 32-bit platforms, but a 64-bit quantity on 64-bit platforms.
 
 The following sample generates C4244 when compiled for 64-bit targets:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -2,24 +2,25 @@
 description: "Learn more about: Compiler Warning (levels 3 and 4) C4244"
 title: "Compiler Warning (levels 3 and 4) C4244"
 ms.date: "11/04/2016"
-ms.assetid: f116bb09-c479-4b4e-a647-fe629a1383f6
 ---
 # Compiler Warning (levels 3 and 4) C4244
 
 'conversion' conversion from 'type1' to 'type2', possible loss of data
 
-An integer type is converted to a smaller integer type. This is a level-4 warning if *type1* is **`int`**/**`unsigned int`** and *type2* is smaller than **`int`**/**`unsigned int`**, such as **`short`** and **`unsigned short`**. Otherwise, it is a level 3 if a value of type [__int64](../../cpp/int8-int16-int32-int64.md)/**`unsigned __int64`** is assigned to a variable of type **`int`**/**`unsigned int`**. A possible loss of data may have occurred due to a narrowing conversion, which may lead to unexpected effects.
+An integer type is converted to a smaller integer type.
+- This is a level-4 warning if *type1* is a signed or unsigned **`int`** and *type2* is a smaller--such as a signed or unsigned **`short`**.
+- It is a level 3 warning if a value of type [__int64](../../cpp/int8-int16-int32-int64.md) or **`unsigned __int64`** is assigned to a signed or unsigned **`int`**. A possible loss of data may have occurred due to a narrowing conversion, which might lead to unexpected results.
 
-If you get C4244, you should either change your program to use compatible types, or add some logic to your code, to ensure that the range of possible values will always be compatible with the types you are using. If the conversion is intended, an explicit cast can be added to silence the warning.
+To fix this warning, either change your program to use compatible types, or add logic that ensures that the range of possible values is compatible with the types you are using. If the conversion is intended, use an explicit cast to silence the warning.
 
-C4244 can also fire at level 2; see [Compiler Warning (level 2) C4244](../../error-messages/compiler-warnings/compiler-warning-level-2-c4244.md) for more information.
+C4244 can also appear when the warning level is 2; see [Compiler Warning (level 2) C4244](../../error-messages/compiler-warnings/compiler-warning-level-2-c4244.md) for more information.
 
 The following sample generates C4244:
 
 ```cpp
 // C4244_level4.cpp
 // compile with: /W4
-void foo(unsigned short num) {}
+void test(unsigned short num) {}
 
 int main() {
    int int1 = 1;
@@ -29,11 +30,13 @@ int main() {
    short short2 = (short)int1;   // OK
 
    short short3 = uint1;   // C4244
-   foo(uint1);   // C4244
+   unsigned short ushort = uint1; // C4244
+   test(uint1);   // C4244
 }
 ```
 
-For more information, see [Usual Arithmetic Conversions](../../c-language/usual-arithmetic-conversions.md).
+For more information, see [Usual Arithmetic Conversions](../../c-language/usual-arithmetic-conversions.md).\
+For more information about setting the warning level in Visual Studio, see[](../build/reference/compiler-option-warnings-level#to-set-the-compiler-options-in-the-visual-studio-development-environment.md)
 
 ```cpp
 // C4244_level3.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -1,15 +1,15 @@
 ---
 description: "Learn more about: Compiler Warning (levels 3 and 4) C4244"
 title: "Compiler Warning (levels 3 and 4) C4244"
-ms.date: "11/04/2016"
+ms.date: "11/6/2023"
 ---
 # Compiler Warning (levels 3 and 4) C4244
 
 'conversion' conversion from 'type1' to 'type2', possible loss of data
 
 An integer type is converted to a smaller integer type.
-- This is a level-4 warning if *type1* is a signed or unsigned **`int`** and *type2* is a smaller--such as a signed or unsigned **`short`**.
-- It is a level 3 warning if a value of type [__int64](../../cpp/int8-int16-int32-int64.md) or **`unsigned __int64`** is assigned to a signed or unsigned **`int`**. A possible loss of data may have occurred due to a narrowing conversion, which might lead to unexpected results.
+- This is a level-4 warning if *type1* is a signed or unsigned **`int`** and *type2* is a smaller, such as a signed or unsigned **`short`**.
+- It is a level 3 warning if a value of type [`__int64`](../../cpp/int8-int16-int32-int64.md) or **`unsigned __int64`** is assigned to a signed or unsigned **`int`**. A possible loss of data may have occurred due to a narrowing conversion, which might lead to unexpected results.
 
 To fix this warning, either change your program to use compatible types, or add logic that ensures that the range of possible values is compatible with the types you are using. If the conversion is intended, use an explicit cast to silence the warning.
 
@@ -27,7 +27,7 @@ int main() {
    unsigned int uint1 = 2;
 
    short short1 = int1;   // C4244
-   short short2 = (short)int1;   // OK
+   short short2 = (short)int1;   // warning silenced - explicit cast
 
    short short3 = uint1;   // C4244
    unsigned short ushort = uint1; // C4244
@@ -36,7 +36,7 @@ int main() {
 ```
 
 For more information, see [Usual Arithmetic Conversions](../../c-language/usual-arithmetic-conversions.md).\
-For more information about setting the warning level in Visual Studio, see[](../build/reference/compiler-option-warnings-level#to-set-the-compiler-options-in-the-visual-studio-development-environment.md)
+For more information about setting the warning level in Visual Studio, see[To set the compiler options in the Visual Studio development environment](../build/reference/compiler-option-warnings-level#to-set-the-compiler-options-in-the-visual-studio-development-environment.md)
 
 ```cpp
 // C4244_level3.cpp


### PR DESCRIPTION
Fixes #4611

The previous description is slightly misleading as for `/W4` they use types `int`, but for `/W3` they use `__int64` and `unsigned int`. Since the sign of the types used are a little specific, one may be a little confused whether it affects both signed and unsigned counter-parts. Made that part clearer and demonstrated that in the examples. Fixed the error highlighted in issue 4611 and reflowed some content.

Hi @TylerMSFT, I hope it is alright to take up issues already assigned to you. Do let me know if that is undesirable. Thanks.