### PR TITLE
Remove superfluous empty lines

### DIFF
--- a/docs/build/reference/microsoft-extensions-to-c-and-cpp.md
+++ b/docs/build/reference/microsoft-extensions-to-c-and-cpp.md
@@ -205,7 +205,6 @@ The C compiler supports the following data declaration and definition features.
    //     error C2059: syntax error: 'empty declaration'
    ```
 
-
 ## Intrinsic floating-point functions
 
 Both the x86 C++ compiler and C compiler support inline generation of the `atan`, `atan2`, `cos`, `exp`, `log`, `log10`, `sin`, `sqrt`, and `tan` functions when **`/Oi`** is specified. These intrinsics don't conform to the standard, because they don't set the `errno` variable.

--- a/docs/c-runtime-library/reference/fsopen-wfsopen.md
+++ b/docs/c-runtime-library/reference/fsopen-wfsopen.md
@@ -91,7 +91,6 @@ The argument *`shflag`* is a constant expression consisting of one of the follow
 | `_SH_DENYRW` | Denies read and write access to the file. |
 | `_SH_DENYWR` | Denies write access to the file. |
 
-
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).
 
 ### Generic-text routine mappings

--- a/docs/code-quality/c26460.md
+++ b/docs/code-quality/c26460.md
@@ -24,7 +24,6 @@ struct MyStruct
     void MemberFn2();
 };
 
-
 void Function1_Helper(const MyStruct&);
 void Function1(MyStruct& myStruct) // C26460, see comments below.
 {

--- a/docs/cpp/codesnippet/CPP/smart-pointers-modern-cpp_1.cpp
+++ b/docs/cpp/codesnippet/CPP/smart-pointers-modern-cpp_1.cpp
@@ -9,7 +9,6 @@ void UseRawPointer()
     delete pSong;   
 }
 
-
 void UseSmartPointer()
 {
     // Declare a smart pointer on stack and pass it the raw pointer.

--- a/docs/cpp/raw-pointers.md
+++ b/docs/cpp/raw-pointers.md
@@ -81,7 +81,6 @@ void func_B(MyClass mc)
     mc.print(); // "Erika, 21"
 }
 
-
 int main()
 {
     // Use the * operator to declare a pointer type

--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -40,7 +40,6 @@ This sample generates C4834, and shows four ways to fix it:
 [[nodiscard]]
 int square_of(int i) { return i * i; }
 
-
 int main()
 {
     square_of(42); // warning C4834: discarding return value of function with 'nodiscard' attribute

--- a/docs/parallel/concrt/codesnippet/CPP/walkthrough-creating-a-dataflow-agent_2.cpp
+++ b/docs/parallel/concrt/codesnippet/CPP/walkthrough-creating-a-dataflow-agent_2.cpp
@@ -5,7 +5,6 @@ void run()
    size_t negative_count = 0;
    size_t positive_count = 0;
 
-
    // Write the counts to the message buffers.
    send(_negatives, negative_count);
    send(_positives, positive_count);

--- a/docs/standard-library/range-adaptors.md
+++ b/docs/standard-library/range-adaptors.md
@@ -724,7 +724,6 @@ The type of the elements to extract from the stream.
 
 A [`basic_istream_view`](basic-istream-view-class.md).
 
-
 This range adaptor is equivalent to `ranges::basic_istream_view<Val, typename U::char_type, typename U::traits_type>(str)`, where `U` is the type of `str`.
 
 ### Example: `istream`


### PR DESCRIPTION
Remove extra new lines in the markdown that does not seem to have a purpose and made some code snippets slightly terser.