### PR TITLE
Document warning C5267

### DIFF
--- a/docs/cpp/explicitly-defaulted-and-deleted-functions.md
+++ b/docs/cpp/explicitly-defaulted-and-deleted-functions.md
@@ -36,7 +36,7 @@ This is convenient for simple types, but complex types often define one or more 
 > - If a copy constructor or destructor is explicitly declared, then automatic generation of the copy-assignment operator is deprecated.
 > - If a copy-assignment operator or destructor is explicitly declared, then automatic generation of the copy constructor is deprecated.
 >
-> In both cases, Visual Studio continues to automatically generate the necessary functions implicitly, and does not emit a warning.
+> In both cases, Visual Studio continues to automatically generate the necessary functions implicitly, and does not emit a warning by default. Since Visual Studio 2022 version 17.7, [C5267](../error-messages/compiler-warnings/c5267.md) can be enabled to emit a warning.
 
 The consequences of these rules can also leak into object hierarchies. For example, if for any reason a base class fails to have a default constructor that's callable from a deriving class—that is, a **`public`** or **`protected`** constructor that takes no parameters—then a class that derives from it cannot automatically generate its own default constructor.
 

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -1,0 +1,52 @@
+---
+title: "Compiler warning C5267"
+description: Compiler warning C5267 description and solution.
+ms.date: 11/08/2023
+f1_keywords: ["C5267"]
+helpviewer_keywords: ["C5267"]
+---
+# Compiler warning C5267
+
+> definition of implicit copy constructor/assignment operator for '*type*' is deprecated because it has a user-provided assignment operator/copy constructor
+
+## Remarks
+
+Since C++11, when only the copy constructor or copy assignment operator is explicitly defined, the implicit generation of the other is deprecated. However, to preserve backwards compatibility, the special functions are still implicitly generated.
+
+## Example
+
+The following sample code shows the warning being emitted when a deprecated implicitly generated special function is called, without it being explicitly defined:
+
+```cpp
+// C5267.cpp
+// compile using: /W4 /w45267
+struct CopyCtorOnly
+{
+    CopyCtorOnly() = default;
+    CopyCtorOnly(const CopyCtorOnly&) {}   // C5267
+};
+
+struct CopyAssignOpOnly
+{
+    CopyAssignOpOnly() = default;
+    CopyAssignOpOnly& operator=(const CopyAssignOpOnly&)   // C5267
+    {
+        return *this;
+    }
+};
+
+int main()
+{
+    CopyCtorOnly a1, a2;
+    a1 = a2;   // Calls deprecated copy assignment operator
+
+    CopyAssignOpOnly b1;
+    CopyAssignOpOnly b2 = b1;   // Calls deprecated copy constructor
+}
+```
+
+To resolve this issue explicitly define the missing copy constructor or copy assignment operator.
+
+## See also
+
+[Explicitly Defaulted and Deleted Functions](../../cpp/explicitly-defaulted-and-deleted-functions.md)

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -15,7 +15,7 @@ The C++ Standard deprecated (but did not remove) the implicit generation of copy
 
 The relevant sections in the C++ standard are:
 - [class.copy.ctor paragraph 6](https://eel.is/c++draft/class.copy.ctor#6) which says: "If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted. The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor."
-- [Annex D D.8]([https://eel.is/c++draft/depr.impldec](https://eel.is/c++draft/depr.impldec#1)) which says: "The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor. It is possible that future versions of C++ will specify that these implicit definitions are deleted."
+- [Annex D D.8](https://eel.is/c++draft/depr.impldec#1) which says: "The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor. It is possible that future versions of C++ will specify that these implicit definitions are deleted."
 
 ## Example
 

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -11,7 +11,11 @@ helpviewer_keywords: ["C5267"]
 
 ## Remarks
 
-Since C++11, when only the copy constructor or copy assignment operator is explicitly defined, implicitly generating the other is deprecated. However, to preserve backwards compatibility, the special functions are still implicitly generated.
+Since C++11, the C++ Standard deprecated (but did not removed) implicitly generating the copy constructor or copy assignment operator when only or the other is explicitly defined. The MSVC compiler continues to implicitly generate the copy constructor and copy assignment assignement operator when not explicitly defined. The purpose of this warning is to help users future proof their code if the committee decides to remove this functionality, instead of just deprecate it.
+
+The relevant sections in the C++ standard are:
+- [class.copy.ctor paragraph 6](https://eel.is/c++draft/class.copy.ctor#6) which says: "If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted. The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor."
+- [Annex D D.8]([https://eel.is/c++draft/depr.impldec](https://eel.is/c++draft/depr.impldec#1)) which says: "The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor. It is possible that future versions of C++ will specify that these implicit definitions are deleted"
 
 ## Example
 

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C5267"]
 
 ## Remarks
 
-Since C++11, the C++ Standard deprecated (but did not remove) implicitly generating the copy constructor or copy assignment operator when only or the other is explicitly defined. The MSVC compiler continues to implicitly generate the copy constructor and copy assignment assignement operator when not explicitly defined. The purpose of this warning is to help users future proof their code if the committee decides to remove this functionality, instead of just deprecate it.
+The C++ Standard deprecated (but did not remove) the implicit generation of copy and assignment operators under some conditions. The MSVC compiler still generates the copy and assignment operators under those conditions, but may change its behavior in the future if the standard removes the deprecated behavior. The purpose of this warning is to help future proof your code if the committee decides to remove this functionality.
 
 The relevant sections in the C++ standard are:
 - [class.copy.ctor paragraph 6](https://eel.is/c++draft/class.copy.ctor#6) which says: "If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted. The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor."

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C5267"]
 
 ## Remarks
 
-Since C++11, the C++ Standard deprecated (but did not removed) implicitly generating the copy constructor or copy assignment operator when only or the other is explicitly defined. The MSVC compiler continues to implicitly generate the copy constructor and copy assignment assignement operator when not explicitly defined. The purpose of this warning is to help users future proof their code if the committee decides to remove this functionality, instead of just deprecate it.
+Since C++11, the C++ Standard deprecated (but did not remove) implicitly generating the copy constructor or copy assignment operator when only or the other is explicitly defined. The MSVC compiler continues to implicitly generate the copy constructor and copy assignment assignement operator when not explicitly defined. The purpose of this warning is to help users future proof their code if the committee decides to remove this functionality, instead of just deprecate it.
 
 The relevant sections in the C++ standard are:
 - [class.copy.ctor paragraph 6](https://eel.is/c++draft/class.copy.ctor#6) which says: "If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted. The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor."

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -11,11 +11,11 @@ helpviewer_keywords: ["C5267"]
 
 ## Remarks
 
-Since C++11, when only the copy constructor or copy assignment operator is explicitly defined, the implicit generation of the other is deprecated. However, to preserve backwards compatibility, the special functions are still implicitly generated.
+Since C++11, when only the copy constructor or copy assignment operator is explicitly defined, implicitly generating the other is deprecated. However, to preserve backwards compatibility, the special functions are still implicitly generated.
 
 ## Example
 
-The following sample code shows the warning being emitted when a deprecated implicitly generated special function is called, without it being explicitly defined:
+The following code shows warning C5267 when an implicitly generated special function is called but isn't explicitly defined:
 
 ```cpp
 // C5267.cpp
@@ -38,14 +38,14 @@ struct CopyAssignOpOnly
 int main()
 {
     CopyCtorOnly a1, a2;
-    a1 = a2;   // Calls deprecated copy assignment operator
+    a1 = a2; // Calls deprecated copy assignment operator
 
     CopyAssignOpOnly b1;
-    CopyAssignOpOnly b2 = b1;   // Calls deprecated copy constructor
+    CopyAssignOpOnly b2 = b1; // Calls deprecated copy constructor
 }
 ```
 
-To resolve this issue explicitly define the missing copy constructor or copy assignment operator.
+To resolve this issue, explicitly define the missing copy constructor or copy assignment operator.
 
 ## See also
 

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -15,7 +15,7 @@ Since C++11, the C++ Standard deprecated (but did not removed) implicitly genera
 
 The relevant sections in the C++ standard are:
 - [class.copy.ctor paragraph 6](https://eel.is/c++draft/class.copy.ctor#6) which says: "If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared implicitly. If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted. The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor."
-- [Annex D D.8]([https://eel.is/c++draft/depr.impldec](https://eel.is/c++draft/depr.impldec#1)) which says: "The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor. It is possible that future versions of C++ will specify that these implicit definitions are deleted"
+- [Annex D D.8]([https://eel.is/c++draft/depr.impldec](https://eel.is/c++draft/depr.impldec#1)) which says: "The implicit definition of a copy constructor as defaulted is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor. The implicit definition of a copy assignment operator as defaulted is deprecated if the class has a user-declared copy constructor or a user-declared destructor. It is possible that future versions of C++ will specify that these implicit definitions are deleted."
 
 ## Example
 

--- a/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
@@ -48,12 +48,21 @@ These versions of the compiler introduced new warnings:
 | Visual Studio 2022 version 17.3 | 19.33 |
 | Visual Studio 2022 version 17.4 | 19.34 |
 | Visual Studio 2022 version 17.5 | 19.35 |
+| Visual Studio 2022 version 17.7 | 19.37 |
 
 You can specify only the major number, the major and minor numbers, or the major, minor, and build numbers to the **`/Wv`** option. The compiler reports all warnings that match versions that begin with the specified number. It suppresses all warnings for versions greater than the specified number. For example, **`/Wv:17`** reports warnings introduced in or before any version of Visual Studio 2012, and suppresses warnings introduced by any compiler from Visual Studio 2013 (version 18) or later. To suppress warnings introduced in Visual Studio 2015 update 2 and later, you can use **`/Wv:19.00.23506`**. Use **`/Wv:19.11`** to report the warnings introduced in any version of Visual Studio before Visual Studio 2017 version 15.5, but suppress warnings introduced in Visual Studio 2017 version 15.5 and later.
 
 The following sections list the warnings introduced by each version of Visual C++ that you can suppress by using the **`/Wv`** compiler option. The **`/Wv`** option can't suppress warnings that aren't listed, which predate the specified versions of the compiler.
 
 ::: moniker range=">= msvc-170"
+
+## Warnings introduced in Visual Studio 2022 version 17.7 (compiler version 19.37)
+
+These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.36`**.
+
+| Warning | Message |
+|--|--|
+| C5267 | definition of implicit copy constructor/assignment operator for '*type*' is deprecated because it has a user-provided assignment operator/copy constructor |
 
 ## Warnings introduced in Visual Studio 2022 version 17.5 (compiler version 19.35)
 

--- a/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
@@ -58,7 +58,7 @@ The following sections list the warnings introduced by each version of Visual C+
 
 ## Warnings introduced in Visual Studio 2022 version 17.7 (compiler version 19.37)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.36`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.36`**.
 
 | Warning | Message |
 |--|--|
@@ -66,7 +66,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.5 (compiler version 19.35)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.34`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.34`**.
 
 | Warning | Message |
 |--|--|
@@ -75,7 +75,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.4 (compiler version 19.34)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.33`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.33`**.
 
 | Warning | Message |
 |--|--|
@@ -87,7 +87,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.3 (compiler version 19.33)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.32`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.32`**.
 
 | Warning | Message |
 |--|--|
@@ -95,7 +95,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.2 (compiler version 19.32)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.31`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.31`**.
 
 | Warning | Message |
 |--|--|
@@ -111,7 +111,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.1 (compiler version 19.31)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.30`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.30`**.
 
 | Warning | Message |
 |--|--|
@@ -121,7 +121,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2022 version 17.0 (compiler version 19.30)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.29`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.29`**.
 
 | Warning | Message |
 |--|--|
@@ -138,7 +138,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.11 (compiler version 19.29.30100.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.29.30099`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.29.30099`**.
 
 | Warning | Message |
 |--|--|
@@ -147,7 +147,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.10 (compiler version 19.29.30000.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.28`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.28`**.
 
 | Warning | Message |
 |--|--|
@@ -165,7 +165,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.9 (compiler version 19.28.29700.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.28.29699`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.28.29699`**.
 
 | Warning | Message |
 |--|--|
@@ -173,7 +173,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.8 (compiler version 19.28.29333.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.27`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.27`**.
 
 | Warning | Message |
 |--|--|
@@ -192,7 +192,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.7 (compiler version 19.27.29112.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.26`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.26`**.
 
 | Warning | Message |
 |--|--|
@@ -212,7 +212,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.6 (compiler version 19.26.28805.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.25`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.25`**.
 
 | Warning | Message |
 |--|--|
@@ -221,7 +221,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.5 (compiler version 19.25.28610.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.24`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.24`**.
 
 |Warning|Message|
 |-|-|
@@ -235,7 +235,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.4 (compiler version 19.24.28314.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.23`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.23`**.
 
 | Warning | Message |
 |--|--|
@@ -246,7 +246,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.3 (compiler version 19.23.28105.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.22`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.22`**.
 
 | Warning | Message |
 |--|--|
@@ -255,7 +255,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.2 (compiler version 19.22.27905.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.21`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.21`**.
 
 | Warning | Message |
 |--|--|
@@ -270,7 +270,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 version 16.1 (compiler version 19.21.27702.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.20`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.20`**.
 
 | Warning | Message |
 |--|--|
@@ -279,7 +279,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2019 RTW (compiler version 19.20.27004.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.15`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.15`**.
 
 | Warning | Message |
 |--|--|
@@ -292,7 +292,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 version 15.8 (compiler version 19.15.26726.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.14`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.14`**.
 
 | Warning | Message |
 |--|--|
@@ -318,7 +318,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 version 15.7 (compiler version 19.14.26428.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.13`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.13`**.
 
 | Warning | Message |
 |--|--|
@@ -327,7 +327,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 version 15.6 (compiler version 19.13.26128.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.12`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.12`**.
 
 | Warning | Message |
 |--|--|
@@ -335,7 +335,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 version 15.5 (compiler version 19.12.25830.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.11`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.11`**.
 
 | Warning | Message |
 |--|--|
@@ -349,7 +349,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 version 15.3 (compiler version 19.11.25506.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.10`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.10`**.
 
 | Warning | Message |
 |--|--|
@@ -371,7 +371,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2017 RTM (compiler version 19.10.25017.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.00`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.00`**.
 
 | Warning | Message |
 |--|--|
@@ -384,7 +384,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2015 Update 3 (compiler version 19.00.24215.1)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.00.23918`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.00.23918`**.
 
 | Warning | Message |
 |--|--|
@@ -395,7 +395,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2015 Update 2 (compiler version 19.00.23918.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.00.23506`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.00.23506`**.
 
 | Warning | Message |
 |--|--|
@@ -406,7 +406,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2015 Update 1 (compiler version 19.00.23506.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:19.00.23026`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:19.00.23026`**.
 
 | Warning | Message |
 |--|--|
@@ -417,7 +417,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2015 RTM (compiler version 19.00.23026.0)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:18`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:18`**.
 
 | Warning | Message |
 |--|--|
@@ -476,7 +476,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2013 (compiler version 18.00.21005.1)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:17`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:17`**.
 
 | Warning | Message |
 |--|--|
@@ -505,7 +505,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2012 (compiler version 17.00.51106.1)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:16`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:16`**.
 
 | Warning | Message |
 |--|--|
@@ -548,7 +548,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2010 (compiler version 16.00.40219.01)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:15`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:15`**.
 
 | Warning | Message |
 |--|--|
@@ -564,7 +564,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2008 (compiler version 15.00.21022.08)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:14`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:14`**.
 
 | Warning | Message |
 |--|--|
@@ -579,7 +579,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2005 (compiler version 14.00.50727.762)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:13`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:13`**.
 
 | Warning | Message |
 |--|--|
@@ -722,7 +722,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2003 (compiler version 13.10.3077)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:13.00.9466`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:13.00.9466`**.
 
 | Warning | Message |
 |--|--|
@@ -758,7 +758,7 @@ These warnings and all warnings in later versions are suppressed by using the co
 
 ## Warnings introduced in Visual Studio 2002 (compiler version 13.00.9466)
 
-These warnings and all warnings in later versions are suppressed by using the compiler option **`/Wv:12`**.
+These warnings, and all warnings in later versions, are suppressed by using the compiler option **`/Wv:12`**.
 
 | Warning | Message |
 |--|--|

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4800-through-c4999.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4800-through-c4999.md
@@ -247,6 +247,7 @@ The articles in this section of the documentation explain a subset of the warnin
 | [Compiler warning (level 1, error, off) C5262](c5262.md) | implicit fall-through occurs here; are you missing a break statement? Use `[[fallthrough]]` when a `break` statement is intentionally omitted between cases |
 | Compiler warning (level 4, off) C5263 | calling '`std::move`' on a temporary object prevents copy elision |
 | Compiler warning (level 4, off) C5264 | '*variable-name*': 'const' variable is not used |
+| [Compiler warning C5267](c5267.md) | definition of implicit copy constructor/assignment operator for '*type*' is deprecated because it has a user-provided assignment operator/copy constructor |
 | Compiler warning (level 1, error) C5300 | '#pragma omp atomic': left operand of '*operator*' must match left hand side of assignment-expression |
 | [Compiler warning (level 1) C5301](c5301-c5302.md) | '#pragma omp for': '*loop-index*' increases while loop condition uses '*comparison*'; non-terminating loop? |
 | [Compiler warning (level 1) C5302](c5301-c5302.md) | '#pragma omp for': '*loop-index*' decreases while loop condition uses '*comparison*'; non-terminating loop? |

--- a/docs/error-messages/toc.yml
+++ b/docs/error-messages/toc.yml
@@ -4363,6 +4363,8 @@ items:
           href: compiler-warnings/c5248.md
         - name: Compiler warning (level 1, error, off) C5262
           href: compiler-warnings/c5262.md
+        - name: Compiler warning C5267
+          href: compiler-warnings/c5267.md
         - name: Compiler warning (level 1) C5301 and C5302
           href: compiler-warnings/c5301-c5302.md
 - name: Compiler warnings by compiler version

--- a/docs/preprocessor/compiler-warnings-that-are-off-by-default.md
+++ b/docs/preprocessor/compiler-warnings-that-are-off-by-default.md
@@ -191,6 +191,7 @@ The following warnings are turned off by default in Visual Studio 2022 and later
 | [C5262](../error-messages/compiler-warnings/c5262.md) (level 1, error) | implicit fall-through occurs here; are you missing a `break` statement? Use `[[fallthrough]]` when a `break` statement is intentionally omitted between cases <sup>17.4</sup> |
 | C5263 (level 4) | calling '`std::move`' on a temporary object prevents copy elision <sup>17.4</sup> |
 | C5264 (level 4) | '*variable-name*': 'const' variable is not used <sup>17.4</sup> |
+| [C5267](../error-messages/compiler-warnings/c5267.md) | definition of implicit copy constructor/assignment operator for '*type*' is deprecated because it has a user-provided assignment operator/copy constructor <sup>17.7</sup> |
 
 <sup>14.1</sup> This warning is available starting in Visual Studio 2015 Update 1.\
 <sup>14.3</sup> This warning is available starting in Visual Studio 2015 Update 3.\
@@ -209,6 +210,9 @@ The following warnings are turned off by default in Visual Studio 2022 and later
 <sup>17.2</sup> This warning is available starting in Visual Studio 2022 version 17.2.\
 <sup>17.3</sup> This warning is available starting in Visual Studio 2022 version 17.3.\
 <sup>17.4</sup> This warning is available starting in Visual Studio 2022 version 17.4.\
+<sup>17.5</sup> This warning is available starting in Visual Studio 2022 version 17.5.\
+<sup>17.6</sup> This warning is available starting in Visual Studio 2022 version 17.6.\
+<sup>17.7</sup> This warning is available starting in Visual Studio 2022 version 17.7.\
 <sup>Perm</sup> This warning is off unless the [`/permissive-`](../build/reference/permissive-standards-conformance.md) compiler option is set.
 
 ## Warnings off by default in earlier versions


### PR DESCRIPTION
I accidentally stumbled upon this new warning code by misreading the following sentence as it "emitting a warning" (instead of it not emitting, as shown below)

https://github.com/MicrosoftDocs/cpp-docs/blob/02e1daf14e94eba83636de726812417ba78cc0ef/docs/cpp/explicitly-defaulted-and-deleted-functions.md?plain=1#L39

So this PR just documented this relatively new warning code.