### PR TITLE
Fix incorrect quotation marks in `Inline functions (C++)`

### DIFF
--- a/docs/cpp/inline-functions-cpp.md
+++ b/docs/cpp/inline-functions-cpp.md
@@ -233,7 +233,7 @@ int main() {
 
 The intent of the expression `toupper(getc(stdin))` is that a character should be read from the console device (`stdin`) and, if necessary, converted to uppercase.
 
-Because of the implementation of the macro, `getc` is executed once to determine whether the character is greater than or equal to "a," and once to determine whether it's less than or equal to "z." If it is in that range, `getc` is executed again to convert the character to uppercase. It means the program waits for two or three characters when, ideally, it should wait for only one.
+Because of the implementation of the macro, `getc` is executed once to determine whether the character is greater than or equal to "a", and once to determine whether it's less than or equal to "z". If it is in that range, `getc` is executed again to convert the character to uppercase. It means the program waits for two or three characters when, ideally, it should wait for only one.
 
 Inline functions remedy the problem previously described:
 

--- a/docs/cpp/inline-functions-cpp.md
+++ b/docs/cpp/inline-functions-cpp.md
@@ -233,7 +233,7 @@ int main() {
 
 The intent of the expression `toupper(getc(stdin))` is that a character should be read from the console device (`stdin`) and, if necessary, converted to uppercase.
 
-Because of the implementation of the macro, `getc` is executed once to determine whether the character is greater than or equal to "a", and once to determine whether it's less than or equal to "z". If it is in that range, `getc` is executed again to convert the character to uppercase. It means the program waits for two or three characters when, ideally, it should wait for only one.
+Because of the implementation of the macro, `getc` is executed once to determine whether the character is greater than or equal to `'a'`, and once to determine whether it's less than or equal to `'z'`. If it is in that range, `getc` is executed again to convert the character to uppercase. It means the program waits for two or three characters when, ideally, it should wait for only one
 
 Inline functions remedy the problem previously described:
 


### PR DESCRIPTION
This PR fixes incorrect quotation marks in `Inline functions (C++)`:

- "a," -> "a",
- "z." -> "z".