### PR TITLE
Update assert-asserte-assert-expr-macros.md

### DIFF
--- a/docs/c-runtime-library/reference/assert-asserte-assert-expr-macros.md
+++ b/docs/c-runtime-library/reference/assert-asserte-assert-expr-macros.md
@@ -79,7 +79,8 @@ In this program, calls are made to the `_ASSERT` and `_ASSERTE` macros to test t
 
 int main()
 {
-   char *p1, *p2;
+    char* p1 = NULL;
+    char* p2 = NULL;
 
    // The Reporting Mode and File must be specified
    // before generating a debug report via an assert
@@ -93,10 +94,12 @@ int main()
    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDOUT);
 
    // Allocate and assign the pointer variables.
-   p1 = (char *)malloc(10);
-   strcpy_s(p1, 10, "I am p1");
-   p2 = (char *)malloc(10);
-   strcpy_s(p2, 10, "I am p2");
+   p1 = (char*)malloc(10);
+   if(p1 != NULL)       // _ASSERT(p1 != NULL);
+       strcpy_s(p1, 10, "I am p1");
+   p2 = (char*)malloc(10);
+   if(p2 != NULL)       // _ASSERT(p2 != NULL);
+       strcpy_s(p2, 10, "I am p2");
 
    // Use the report macros as a debugging
    // warning mechanism, similar to printf.


### PR DESCRIPTION
1) In dynamic memory allocation parts arise the "null pointer dereferencing" which can cause to undefined behaviour later. The first appeal to the memory by null pointer or in a differ terms dereferencing the null pointer usually causes the "structured exception" in Windows systems. In "Microsoft Visual Studio Community 2019 Version 16.11.29" environment compiler generates "Warning C6387" coherented with "NULL values of p1, p2", since p1, p2 are separately the arguments of strcpy_s and due to SAL for strcpy_s function the p1, p2 can not be NULL which maybe related indirectly with "Warning C6011" where it took its initial point which corresponds to "null pointer dereferencing":

```
// string.h
_Check_return_wat_
_ACRTIMP errno_t __cdecl strcpy_s(
        _Out_writes_z_(_SizeInBytes) char*       _Destination,
        _In_                         rsize_t     _SizeInBytes,
        _In_z_                       char const* _Source
        );
```

**P.S.:** if statements could be replaced respectively with:
```
 _ASSERT(p1 != NULL);
 _ASSERT(p2 != NULL); 

```
2) Initialized the pointers to NULL.
**P.S.:** In C23 it could be initialized as nullptr:
```
char *p1{nullptr};
char* p2{nullptr};
```
https://en.cppreference.com/w/c/compiler_support/23#:~:text=13-,nullptr,-N3042