### PR TITLE
Revamp C2385

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2385.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2385.md
@@ -1,22 +1,20 @@
 ---
 description: "Learn more about: Compiler Error C2385"
 title: "Compiler Error C2385"
-ms.date: "12/20/2023"
+ms.date: "1/19/2024"
 f1_keywords: ["C2385"]
 helpviewer_keywords: ["C2385"]
-ms.assetid: 6d3dd1f2-e56d-49d7-865c-6a9acdb17417
 ---
 # Compiler Error C2385
 
-ambiguous access of 'member'
+> ambiguous access of 'member'
 
-The member can be inherited from more than one base type causing an unqualified access to be ambiguous. To resolve this error:
+A member is inherited from more than one base type, making unqualified access to that member ambiguous. To resolve this error:
 
-- Make the member unambiguous by explicitly qualifying it, or providing a cast.
-
-- Rename the ambiguous members in the base classes.
-
-- Bring the desired member into scope.
+- Explicitly qualify access to the member.
+- Cast the object to the base class containing the member before accessing the member.
+- Rename the ambiguous member in the base class.
+- Bring the member into scope.
 
 ## Example
 
@@ -39,6 +37,7 @@ struct B
 struct C : A, B
 {
     // Uncomment the following lines to resolve the first 2 errors
+    // The error below for the call to c.func2() will remain
     // using A::func1;
     // using B::func1;
 };
@@ -49,13 +48,16 @@ int main()
 
     c.func1(123); // C2385
     c.func1('a'); // C2385
-
     c.func2(); // C2385
-    c.A::func2(); // OK
-    c.B::func2(); // OK
-    static_cast<A>(c).func2(); // OK
-    static_cast<B>(c).func2(); // OK
+
+    c.A::func2(); // OK because explicitly qualified
+    c.B::func2(); // OK because explicitly qualified
+    static_cast<A>(c).func2(); // OK because of the cast
+    static_cast<B>(c).func2(); // OK because of the cast
 }
 ```
 
-Ambiguous calls to `func1` can be resolved by bringing both overloads into scope. However, doing the same for `func2` does not fix the error, since both `A::func2` and `B::func2` take no arguments and are still ambiguous. If only one is desired, introducing just one into scope does fix the issue. Alternatively, the call can be explicitly qualified with the base type, or the object can be casted before the function is called.
+You can resolve the ambiguous calls to `func1` by bringing both overloads into scope. However, this doesn't work for `func2` because `A::func2` and `B::func2` don't take arguments, so calling them can't be differentiated by their parameters. You can resolve the issue by:
+- Introduce the one you want to use into scope
+- Explicitly qualify the call with the base type
+- Cast the object before calling the function.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2385.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2385.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: Compiler Error C2385"
 title: "Compiler Error C2385"
-ms.date: "11/04/2016"
+ms.date: "12/20/2023"
 f1_keywords: ["C2385"]
 helpviewer_keywords: ["C2385"]
 ms.assetid: 6d3dd1f2-e56d-49d7-865c-6a9acdb17417
@@ -10,57 +10,52 @@ ms.assetid: 6d3dd1f2-e56d-49d7-865c-6a9acdb17417
 
 ambiguous access of 'member'
 
-The member can derive from more than one object (it is inherited from more than one object).  To resolve this error,
+The member can be inherited from more than one base type causing an unqualified access to be ambiguous. To resolve this error:
 
-- Make the member unambiguous by providing a cast.
+- Make the member unambiguous by explicitly qualifying it, or providing a cast.
 
 - Rename the ambiguous members in the base classes.
 
+- Bring the desired member into scope.
+
 ## Example
 
-The following sample generates C2385.
+The following sample generates C2385:
 
 ```cpp
 // C2385.cpp
-// C2385 expected
-#include <stdio.h>
-
 struct A
 {
-    void x(int i)
-    {
-        printf_s("\nIn A::x");
-    }
+    void func1(int i) {}
+    void func2() {}
 };
 
 struct B
 {
-    void x(char c)
-    {
-        printf_s("\nIn B::x");
-    }
+    void func1(char c) {}
+    void func2() {}
 };
-
-// Delete the following line to resolve.
-struct C : A, B {}
-
-// Uncomment the following 4 lines to resolve.
-// struct C : A, B
-// {
-//     using B::x;
-//     using A::x;
-// };
-
-int main()
-{
-    C aC;
-    aC.x(100);
-    aC.x('c');
-}
 
 struct C : A, B
 {
-    using B::x;
-    using A::x;
+    // Uncomment the following lines to resolve the first 2 errors
+    // using A::func1;
+    // using B::func1;
 };
+
+int main()
+{
+    C c;
+
+    c.func1(123); // C2385
+    c.func1('a'); // C2385
+
+    c.func2(); // C2385
+    c.A::func2(); // OK
+    c.B::func2(); // OK
+    static_cast<A>(c).func2(); // OK
+    static_cast<B>(c).func2(); // OK
+}
 ```
+
+Ambiguous calls to `func1` can be resolved by bringing both overloads into scope. However, doing the same for `func2` does not fix the error, since both `A::func2` and `B::func2` take no arguments and are still ambiguous. If only one is desired, introducing just one into scope does fix the issue. Alternatively, the call can be explicitly qualified with the base type, or the object can be casted before the function is called.


### PR DESCRIPTION
The previous example is slightly haphazard, remove the need to include any additional headers, fix up the example and augment the suggested fix with explicit qualification.