### PR TITLE
Fix invalid nodiscard attribute

### DIFF
--- a/docs/standard-library/ambiguous-local-time.md
+++ b/docs/standard-library/ambiguous-local-time.md
@@ -98,7 +98,7 @@ You typically won't create this exception. It's thrown by functions that convert
 Gets a string describing the details of the ambiguity.
 
 ```cpp
-[nodiscard] virtual const char* what() const noexcept;
+[[nodiscard]] virtual const char* what() const noexcept;
 ```
 
 ### Return value

--- a/docs/standard-library/nonexistent-local-time.md
+++ b/docs/standard-library/nonexistent-local-time.md
@@ -94,7 +94,7 @@ You typically won't create this exception. It's thrown by functions that convert
 Gets a string describing why the time is non-existent.
 
 ```cpp
-[nodiscard] virtual const char* what() const noexcept;
+[[nodiscard]] virtual const char* what() const noexcept;
 ```
 
 ### Return value

--- a/docs/standard-library/subrange-class.md
+++ b/docs/standard-library/subrange-class.md
@@ -332,7 +332,7 @@ Returns `true` if the `subrange` has no elements. Otherwise, returns `false`.
 Get the sentinel at the end of the `subrange`
 
 ```cpp
-[[NODISCARD]] constexpr S end() const;
+[[nodiscard]] constexpr S end() const;
 ```
 
 ### Parameters


### PR DESCRIPTION
`nodiscard` attribute with only 1 set of square brackets is not valid, neither is the all caps version.