### PR TITLE
Remove DST notes from gmtime docs

### DIFF
--- a/docs/c-runtime-library/reference/gmtime-gmtime32-gmtime64.md
+++ b/docs/c-runtime-library/reference/gmtime-gmtime32-gmtime64.md
@@ -54,9 +54,6 @@ These functions validate their parameters. If *`sourceTime`* is a `NULL` pointer
 
 The **`_gmtime32`** function breaks down the *`sourceTime`* value and stores it in a statically allocated structure of type `tm`, defined in `TIME.H`. The value of *`sourceTime`* is typically obtained from a call to the [`time`](time-time32-time64.md) function.
 
-> [!NOTE]
-> In most cases, the target environment tries to determine whether daylight savings time is in effect. The C run-time library assumes that the United States rules for implementing the calculation of Daylight Saving Time (DST) are used.
-
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).
 
 ## Requirements

--- a/docs/c-runtime-library/reference/gmtime-gmtime32-gmtime64.md
+++ b/docs/c-runtime-library/reference/gmtime-gmtime32-gmtime64.md
@@ -1,7 +1,7 @@
 ---
 title: "gmtime, _gmtime32, _gmtime64"
 description: "API reference for gmtime, _gmtime32, and _gmtime64, which convert a time_t value."
-ms.date: "10/27/2020"
+ms.date: 02/23/2024
 api_name: ["_gmtime32", "gmtime", "_gmtime64", "_o__gmtime32", "_o__gmtime64"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-time-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
+++ b/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
@@ -56,9 +56,6 @@ The first two error conditions invoke the invalid parameter handler, as describe
 
 The **`_gmtime32_s`** function breaks down the *`sourceTime`* value and stores it in a structure of type `tm`, defined in `Time.h`. The address of the structure is passed in *`tmDest`*. The value of *`sourceTime`* is often obtained from a call to the [`time`](time-time32-time64.md) function.
 
-> [!NOTE]
-> The target environment should try to determine whether daylight savings time is in effect. The C run-time library assumes the United States rules for implementing the calculation of daylight saving time .
-
 Each of the structure fields is of type **`int`**, as shown in the following table.
 
 | Field | Description |

--- a/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
+++ b/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: gmtime_s, _gmtime32_s, _gmtime64_s"
 title: "gmtime_s, _gmtime32_s, _gmtime64_s"
-ms.date: "4/2/2020"
+ms.date: 02/23/2024
 api_name: ["_gmtime32_s", "gmtime_s", "_gmtime64_s", "_o__gmtime32_s", "_o__gmtime64_s"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-time-l1-1-0.dll"]
 api_type: ["DLLExport"]


### PR DESCRIPTION
Remove note about daylight savings time, as these functions convert from time-since-epoch to UTC, neither of which are affected by daylight savings
Fixes #3443