### PR TITLE
Fix built-in operators toc yml

### DIFF
--- a/docs/cpp/left-shift-and-right-shift-operators-input-and-output.md
+++ b/docs/cpp/left-shift-and-right-shift-operators-input-and-output.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Left shift and right shift operators: `<<` and `>>`"
-title: "Left shift and right shift operators: `<<` and `>>`"
+description: "Learn more about: Left shift and right shift operators: << and >>"
+title: "Left shift and right shift operators: << and >>"
 ms.date: 12/09/2021
 f1_keywords: ["<<", ">>"]
 helpviewer_keywords: ["<< operator [C++], with specific objects", "left shift operators [C++]", "right shift operators [C++]", "bitwise-shift operators [C++]", ">> operator", "shift operators [C++]", "operators [C++], shift"]
-ms.assetid: 25fa0cbb-5fdd-4657-8745-b35f7d8f1606
 ---
 # Left shift and right shift operators: `<<` and `>>`
 

--- a/docs/cpp/left-shift-and-right-shift-operators-input-and-output.md
+++ b/docs/cpp/left-shift-and-right-shift-operators-input-and-output.md
@@ -1,12 +1,12 @@
 ---
-description: "Learn more about: Left shift and right shift operators ('<<' and '>>')"
-title: "Left shift and right shift operators ('<<' and '>>')"
+description: "Learn more about: Left shift and right shift operators: `<<` and `>>`"
+title: "Left shift and right shift operators: `<<` and `>>`"
 ms.date: 12/09/2021
 f1_keywords: ["<<", ">>"]
 helpviewer_keywords: ["<< operator [C++], with specific objects", "left shift operators [C++]", "right shift operators [C++]", "bitwise-shift operators [C++]", ">> operator", "shift operators [C++]", "operators [C++], shift"]
 ms.assetid: 25fa0cbb-5fdd-4657-8745-b35f7d8f1606
 ---
-# Left shift and right shift operators (`<<` and `>>`)
+# Left shift and right shift operators: `<<` and `>>`
 
 The bitwise shift operators are the right-shift operator (**`>>`**), which moves the bits of an integer or enumeration type expression to the right, and the left-shift operator (**`<<`**), which moves the bits to the left. <sup>1</sup>
 
@@ -218,5 +218,5 @@ The value of `E1 >> E2` is `E1` right-shifted `E2` bit positions. If `E1` has an
 
 ## See also
 
-[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)<br/>
+[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)\
 [C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)

--- a/docs/cpp/subscript-operator.md
+++ b/docs/cpp/subscript-operator.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn more about: Subscript Operator: `[]`"
+description: "Learn more about: Subscript Operator: []"
 title: "Subscript Operator: []"
 ms.date: "11/04/2016"
 f1_keywords: ["[]"]

--- a/docs/cpp/subscript-operator.md
+++ b/docs/cpp/subscript-operator.md
@@ -1,10 +1,9 @@
 ---
 description: "Learn more about: Subscript Operator: `[]`"
-title: "Subscript Operator: `[]`"
+title: "Subscript Operator: []"
 ms.date: "11/04/2016"
 f1_keywords: ["[]"]
 helpviewer_keywords: ["operators [C++], subscript", "postfix operators [C++]", "[] operator", "subscript operator [C++], syntax"]
-ms.assetid: 69c31494-52da-4dd0-8bbe-6ccbfd50f197
 ---
 # Subscript Operator: `[]`
 

--- a/docs/cpp/subscript-operator.md
+++ b/docs/cpp/subscript-operator.md
@@ -1,12 +1,12 @@
 ---
-description: "Learn more about: Subscript Operator []"
-title: "Subscript Operator []"
+description: "Learn more about: Subscript Operator: `[]`"
+title: "Subscript Operator: `[]`"
 ms.date: "11/04/2016"
 f1_keywords: ["[]"]
 helpviewer_keywords: ["operators [C++], subscript", "postfix operators [C++]", "[] operator", "subscript operator [C++], syntax"]
 ms.assetid: 69c31494-52da-4dd0-8bbe-6ccbfd50f197
 ---
-# Subscript Operator []
+# Subscript Operator: `[]`
 
 ## Syntax
 
@@ -98,8 +98,8 @@ The subscript operator is commutative. Therefore, the expressions *array*[*index
 
 ## See also
 
-[Postfix Expressions](../cpp/postfix-expressions.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
-[Arrays](../cpp/arrays-cpp.md)<br/>
-[One-Dimensional Arrays](../c-language/one-dimensional-arrays.md)<br/>
-[Multidimensional Arrays](../c-language/multidimensional-arrays-c.md)<br/>
+[Postfix Expressions](../cpp/postfix-expressions.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
+[Arrays](../cpp/arrays-cpp.md)\
+[One-Dimensional Arrays](../c-language/one-dimensional-arrays.md)\
+[Multidimensional Arrays](../c-language/multidimensional-arrays-c.md)

--- a/docs/cpp/toc.yml
+++ b/docs/cpp/toc.yml
@@ -160,7 +160,7 @@ items:
           href: ../cpp/function-call-operator-parens.md
         - name: "Indirection operator: *"
           href: ../cpp/indirection-operator-star.md
-        - name: Left shift and right shift operators (>> and <<)
+        - name: "Left shift and right shift operators: << and >>"
           href: ../cpp/left-shift-and-right-shift-operators-input-and-output.md
         - name: "Logical AND operator: &&"
           href: ../cpp/logical-and-operator-amp-amp.md
@@ -188,7 +188,7 @@ items:
           href: ../cpp/scope-resolution-operator.md
         - name: sizeof operator
           href: ../cpp/sizeof-operator.md
-        - name: "Subscript operator:"
+        - name: "Subscript operator: []"
           href: ../cpp/subscript-operator.md
         - name: typeid operator
           href: ../cpp/typeid-operator.md


### PR DESCRIPTION
Add missing `[]` in the subscript operator toc yml name and standardize the left and right shift operators title/name.