### PR TITLE
Modifies the description of `self-assignment` in the move assignment operator

### DIFF
--- a/docs/cpp/move-constructors-and-move-assignment-operators-cpp.md
+++ b/docs/cpp/move-constructors-and-move-assignment-operators-cpp.md
@@ -125,12 +125,18 @@ The following procedures describe how to write a move constructor and a move ass
     }
     ```
 
-1. In the move assignment operator, add a conditional statement that performs no operation if you try to assign the object to itself.
+1. In the move assignment operator, we need to keep the self-assignment safe, and the simple way is to add a judgment directly.
 
     ```cpp
     if (this != &other)
     {
     }
+    ```
+
+    There are many other ways, too, such as `copy-and-swap`.
+
+    ```cpp
+    shared_ptr(_Right).swap(*this);
     ```
 
 1. In the conditional statement, free any resources (such as memory) from the object that is being assigned to.


### PR DESCRIPTION
**I think the description and handling of securing self-assignment is too simplistic.**

Not all cases should use self-assignment checking to ensure self-assignment security, and in many cases it is not necessary.

MSVC STL `std::unique_ptr`、`std::shared_ptr`：

```cpp
template <class _Dx2 = _Dx, enable_if_t<is_move_assignable_v<_Dx2>, int> = 0>
_CONSTEXPR23 unique_ptr& operator=(unique_ptr&& _Right) noexcept {
    reset(_Right.release());
    _Mypair._Get_first() = _STD forward<_Dx>(_Right._Mypair._Get_first());
    return *this;
}
```

```cpp
shared_ptr& operator=(shared_ptr&& _Right) noexcept { // take resource from _Right
    shared_ptr(_STD move(_Right)).swap(*this);
    return *this;
}
```

---

```cpp
class Foo {
    std::string s;
    int i;
};
```

Foo is inherently self-assignment safe and does not require any additional processing.

- **In short: I don't think we should just describe a simple self-assignment detection method.**