### PR TITLE
Remove extra trailing comma in istream iterator

### DIFF
--- a/docs/standard-library/istream-iterator-class.md
+++ b/docs/standard-library/istream-iterator-class.md
@@ -15,7 +15,7 @@ Describes an input iterator object. It extracts objects of class `Type` from an 
 ## Syntax
 
 ```cpp
-template <class Type, class CharType = char, class Traits = char_traits<CharType>, class Distance = ptrdiff_t,>
+template <class Type, class CharType = char, class Traits = char_traits<CharType>, class Distance = ptrdiff_t>
 class istream_iterator
 : public iterator<
     input_iterator_tag, Type, Distance,


### PR DESCRIPTION
A trailing comma at the end of the template parameter list is an error.