### PR TITLE
Make built-in operators title consistent

### DIFF
--- a/docs/cpp/additive-operators-plus-and.md
+++ b/docs/cpp/additive-operators-plus-and.md
@@ -6,7 +6,7 @@ f1_keywords: ["+", "-"]
 helpviewer_keywords: ["operators [C++], addition", "subtraction operator [C++], additive operators", "+ operator [C++], additive operators", "additive operators [C++]", "arithmetic operators [C++], additive operators", "- operator [C++], additive operators in C++"]
 ms.assetid: d4afafe7-e201-4c69-a649-37f17756e784
 ---
-# Additive Operators: + and -
+# Additive Operators: `+` and `-`
 
 ## Syntax
 
@@ -102,6 +102,6 @@ One of the operands can be of integral type, as long as it is the second operand
 
 ## See also
 
-[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C Additive Operators](../c-language/c-additive-operators.md)

--- a/docs/cpp/assignment-operators.md
+++ b/docs/cpp/assignment-operators.md
@@ -168,6 +168,6 @@ In ANSI C, the result of an assignment expression isn't an l-value. That means t
 
 ## See also
 
-[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)\
+[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C assignment operators](../c-language/c-assignment-operators.md)

--- a/docs/cpp/bitwise-exclusive-or-operator-hat.md
+++ b/docs/cpp/bitwise-exclusive-or-operator-hat.md
@@ -6,7 +6,7 @@ f1_keywords: ["xor_cpp", "^"]
 helpviewer_keywords: ["operators [C++], bitwise", "exclusive OR operator", "XOR operator", "bitwise operators [C++], OR operator", "^ operator", "OR operator [C++], bitwise exclusive", "operators [C++], logical"]
 ms.assetid: f9185d85-65d5-4f64-a6d6-679758d52217
 ---
-# Bitwise exclusive OR operator: ^
+# Bitwise exclusive OR operator: `^`
 
 ## Syntax
 

--- a/docs/cpp/bitwise-inclusive-or-operator-pipe.md
+++ b/docs/cpp/bitwise-inclusive-or-operator-pipe.md
@@ -41,5 +41,5 @@ int main() {
 
 ## See also
 
-[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C bitwise operators](../c-language/c-bitwise-operators.md)

--- a/docs/cpp/comma-operator.md
+++ b/docs/cpp/comma-operator.md
@@ -6,7 +6,7 @@ f1_keywords: ["%2C"]
 helpviewer_keywords: ["comma operator"]
 ms.assetid: 38e0238e-19da-42ba-ae62-277bfdab6090
 ---
-# Comma Operator: ,
+# Comma Operator: `,`
 
 Allows grouping two statements where one is expected.
 
@@ -55,6 +55,6 @@ int main () {
 
 ## See also
 
-[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [Sequential-Evaluation Operator](../c-language/sequential-evaluation-operator.md)

--- a/docs/cpp/conditional-operator-q.md
+++ b/docs/cpp/conditional-operator-q.md
@@ -63,5 +63,5 @@ int main() {
 
 ## See also
 
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [Conditional-Expression Operator](../c-language/conditional-expression-operator.md)

--- a/docs/cpp/equality-operators-equal-equal-and-exclpt-equal.md
+++ b/docs/cpp/equality-operators-equal-equal-and-exclpt-equal.md
@@ -6,7 +6,7 @@ f1_keywords: ["!=", "==", "not_eq_cpp"]
 helpviewer_keywords: ["!= operator", "equality operator", "not equal to comparison operator", "equality operator [C++], syntax", "== operator", "not_eq operator", "equal to operator"]
 ms.assetid: ba4e9659-2392-4fb4-be5a-910a2a6df45a
 ---
-# Equality operators: == and !=
+# Equality operators: `==` and `!=`
 
 ## Syntax
 
@@ -47,6 +47,6 @@ Equality operators can compare pointers to members of the same type. In such a c
 
 ## See also
 
-[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ built-in operators, precedence; and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with binary operators](../cpp/expressions-with-binary-operators.md)\
+[C++ built-in operators, precedence; and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C relational and equality operators](../c-language/c-relational-and-equality-operators.md)

--- a/docs/cpp/explicit-type-conversion-operator-parens.md
+++ b/docs/cpp/explicit-type-conversion-operator-parens.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["explicit data type conversion operator", "conversions [C++], explicit", "operators [C++], explicit type conversion", "data type conversion [C++], explicit", "type conversion [C++], explicit conversions"]
 ms.assetid: 54272006-5ffb-45ed-8283-27152ab97529
 ---
-# Explicit Type Conversion Operator: ()
+# Explicit Type Conversion Operator: `()`
 
 C++ allows explicit type conversion using syntax similar to the function-call syntax.
 
@@ -117,5 +117,5 @@ Type definition within casts is illegal.
 
 ## See also
 
-[Postfix Expressions](../cpp/postfix-expressions.md)<br/>
+[Postfix Expressions](../cpp/postfix-expressions.md)\
 [C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)

--- a/docs/cpp/function-call-operator-parens.md
+++ b/docs/cpp/function-call-operator-parens.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["( ) function call operator", "function calls, C++ functio
 ms.assetid: 50c92e59-a4bf-415a-a6ab-d66c679ee80a
 no-loc: [ opt ]
 ---
-# Function Call Operator: ()
+# Function Call Operator: `()`
 
 A function call is a kind of *`postfix-expression`*, formed by an expression that evaluates to a function or callable object followed by the function-call operator, **`()`**. An object can declare an `operator ()` function, which provides function call semantics for the object.
 
@@ -172,6 +172,6 @@ Functions can be called recursively. For more information about function declara
 
 ## See also
 
-[Postfix expressions](../cpp/postfix-expressions.md)<br/>
-[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Postfix expressions](../cpp/postfix-expressions.md)\
+[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [Function call](../c-language/function-call-c.md)

--- a/docs/cpp/indirection-operator-star.md
+++ b/docs/cpp/indirection-operator-star.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["* operator", "indirection operator", "operators [C++], indirection", "indirection operator [C++], syntax"]
 ms.assetid: c50309e1-6c02-4184-9fcb-2e13c1f4ac03
 ---
-# Indirection Operator: *
+# Indirection Operator: `*`
 
 ## Syntax
 
@@ -15,7 +15,7 @@ ms.assetid: c50309e1-6c02-4184-9fcb-2e13c1f4ac03
 
 ## Remarks
 
-The unary indirection operator (<strong>\*</strong>) dereferences a pointer; that is, it converts a pointer value to an l-value. The operand of the indirection operator must be a pointer to a type. The result of the indirection expression is the type from which the pointer type is derived. The use of the <strong>\*</strong> operator in this context is different from its meaning as a binary operator, which is multiplication.
+The unary indirection operator (**`*`**) dereferences a pointer; that is, it converts a pointer value to an l-value. The operand of the indirection operator must be a pointer to a type. The result of the indirection expression is the type from which the pointer type is derived. The use of the **`*`** operator in this context is different from its meaning as a binary operator, which is multiplication.
 
 If the operand points to a function, the result is a function designator. If it points to a storage location, the result is an l-value designating the storage location.
 
@@ -53,7 +53,7 @@ If the pointer value is invalid, the result is undefined. The following list inc
 
 ## See also
 
-[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
-[Address-of Operator: &](../cpp/address-of-operator-amp.md)<br/>
+[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
+[Address-of Operator: &](../cpp/address-of-operator-amp.md)\
 [Indirection and Address-of Operators](../c-language/indirection-and-address-of-operators.md)

--- a/docs/cpp/logical-negation-operator-exclpt.md
+++ b/docs/cpp/logical-negation-operator-exclpt.md
@@ -6,7 +6,7 @@ f1_keywords: ["!"]
 helpviewer_keywords: ["! operator", "NOT operator", "logical negation"]
 ms.assetid: 650add9f-a7bc-426c-b01d-5fc6a81c8b62
 ---
-# Logical negation operator: !
+# Logical negation operator: `!`
 
 ## Syntax
 
@@ -39,6 +39,6 @@ int main() {
 
 ## See also
 
-[Expressions with unary operators](../cpp/expressions-with-unary-operators.md)<br/>
-[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
-[Unary arithmetic operators](../c-language/unary-arithmetic-operators.md)<br/>
+[Expressions with unary operators](../cpp/expressions-with-unary-operators.md)\
+[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
+[Unary arithmetic operators](../c-language/unary-arithmetic-operators.md)

--- a/docs/cpp/logical-or-operator-pipe-pipe.md
+++ b/docs/cpp/logical-or-operator-pipe-pipe.md
@@ -54,5 +54,5 @@ int main() {
 
 ## See also
 
-[C++ built-in operators, precedence, and associativity](cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[C++ built-in operators, precedence, and associativity](cpp-built-in-operators-precedence-and-associativity.md)\
 [C logical operators](../c-language/c-logical-operators.md)

--- a/docs/cpp/multiplicative-operators-and-the-modulus-operator.md
+++ b/docs/cpp/multiplicative-operators-and-the-modulus-operator.md
@@ -20,11 +20,11 @@ expression % expression
 
 The multiplicative operators are:
 
-- Multiplication (<strong>\*</strong>)
+- Multiplication (**`*`**)
 
-- Division (**/**)
+- Division (**`/`**)
 
-- Modulus (remainder from division) (**%**)
+- Modulus (remainder from division) (**`%`**)
 
 These binary operators have left-to-right associativity.
 
@@ -78,6 +78,6 @@ int main() {
 
 ## See also
 
-[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C Multiplicative Operators](../c-language/c-multiplicative-operators.md)

--- a/docs/cpp/one-s-complement-operator-tilde.md
+++ b/docs/cpp/one-s-complement-operator-tilde.md
@@ -6,7 +6,7 @@ f1_keywords: ["~", "compl_cpp"]
 helpviewer_keywords: ["tilde (~) one's complement operator", "one's complement operator", "bitwise-complement operator", "compl operator", "~ operator [C++], syntax"]
 ms.assetid: 4bf81967-34f7-4b4b-aade-fd03d5da0174
 ---
-# One's complement operator: ~
+# One's complement operator: `~`
 
 ## Syntax
 
@@ -45,6 +45,6 @@ Integral promotion is performed on integral operands. The type the operand is pr
 
 ## See also
 
-[Expressions with unary operators](expressions-with-unary-operators.md)<br/>
-[C++ built-in operators, precedence, and associativity](cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with unary operators](expressions-with-unary-operators.md)\
+[C++ built-in operators, precedence, and associativity](cpp-built-in-operators-precedence-and-associativity.md)\
 [Unary arithmetic operators](../c-language/unary-arithmetic-operators.md)

--- a/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
@@ -6,7 +6,7 @@ f1_keywords: ["--", "++"]
 helpviewer_keywords: ["increment operators [C++], syntax", "member-selection operators [C++]", "-- operator [C++], postfix decrement operators", "postfix operators [C++]", "++ operator [C++], postfix increment operators", "decrement operators [C++], syntax", "operators [C++], postfix", "decrement operators [C++]"]
 ms.assetid: 0204d5c8-51b0-4108-b8a1-074c5754d89c
 ---
-# Postfix Increment and Decrement Operators: ++ and --
+# Postfix Increment and Decrement Operators: `++` and `--`
 
 ## Syntax
 
@@ -23,7 +23,7 @@ C++ provides prefix and postfix increment and decrement operators; this section 
 i++;
 ```
 
-The effect of applying the postfix increment operator (**++**) is that the operand's value is increased by one unit of the appropriate type. Similarly, the effect of applying the postfix decrement operator (**--**) is that the operand's value is decreased by one unit of the appropriate type.
+The effect of applying the postfix increment operator (**`++`**) is that the operand's value is increased by one unit of the appropriate type. Similarly, the effect of applying the postfix decrement operator (**`--`**) is that the operand's value is decreased by one unit of the appropriate type.
 
 It is important to note that a postfix increment or decrement expression evaluates to the value of the expression *prior to* application of the respective operator. The increment or decrement operation occurs *after* the operand is evaluated. This issue arises only when the postfix increment or decrement operation occurs in the context of a larger expression.
 
@@ -60,6 +60,6 @@ for( myCompass = North; myCompass != West; myCompass++ ) // Error
 
 ## See also
 
-[Postfix Expressions](../cpp/postfix-expressions.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Postfix Expressions](../cpp/postfix-expressions.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C Postfix Increment and Decrement Operators](../c-language/c-postfix-increment-and-decrement-operators.md)

--- a/docs/cpp/prefix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/prefix-increment-and-decrement-operators-increment-and-decrement.md
@@ -6,7 +6,7 @@ f1_keywords: ["--", "++"]
 helpviewer_keywords: ["increment operators [C++], syntax", "++ operator [C++], prefix increment operators", "operators [C++], decrement", "-- operator [C++], prefix decrement operators [C++]", "operators [C++], increment", "decrement operators [C++], syntax", "decrement operators [C++]"]
 ms.assetid: 45ea7fc7-f279-4be9-a216-1d9a0ef9eb7b
 ---
-# Prefix Increment and Decrement Operators: ++ and --
+# Prefix Increment and Decrement Operators: `++` and `--`
 
 ## Syntax
 
@@ -17,9 +17,9 @@ ms.assetid: 45ea7fc7-f279-4be9-a216-1d9a0ef9eb7b
 
 ## Remarks
 
-The prefix increment operator (**++**) adds one to its operand; this incremented value is the result of the expression. The operand must be an l-value not of type **`const`**. The result is an l-value of the same type as the operand.
+The prefix increment operator (**`++`**) adds one to its operand; this incremented value is the result of the expression. The operand must be an l-value not of type **`const`**. The result is an l-value of the same type as the operand.
 
-The prefix decrement operator (**--**) is analogous to the prefix increment operator, except that the operand is decremented by one and the result is this decremented value.
+The prefix decrement operator (**`--`**) is analogous to the prefix increment operator, except that the operand is decremented by one and the result is this decremented value.
 
 **Visual Studio 2017 version 15.3 and later** (available in [`/std:c++17`](../build/reference/std-specify-language-standard-version.md) mode and later): The operand of an increment or decrement operator may not be of type **`bool`**.
 
@@ -66,6 +66,6 @@ If `i` is greater than or equal to `j` or less than `j` by 1, it will be increme
 
 ## See also
 
-[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [Prefix Increment and Decrement Operators](../c-language/prefix-increment-and-decrement-operators.md)

--- a/docs/cpp/relational-operators-equal-and-equal.md
+++ b/docs/cpp/relational-operators-equal-and-equal.md
@@ -21,13 +21,13 @@ expression >= expression
 
 The binary relational operators determine the following relationships:
 
-- Less than (**\<**)
+- Less than (**`<`**)
 
-- Greater than (**>**)
+- Greater than (**`>`**)
 
-- Less than or equal to (**\<=**)
+- Less than or equal to (**`<=`**)
 
-- Greater than or equal to (**>=**)
+- Greater than or equal to (**`>=`**)
 
 The relational operators have left-to-right associativity. Both operands of relational operators must be of arithmetic or pointer type. They yield values of type **`bool`**. The value returned is **`false`** (0) if the relationship in the expression is false; otherwise, the value returned is **`true`** (1).
 
@@ -48,7 +48,7 @@ int main() {
 }
 ```
 
-The expressions in the preceding example must be enclosed in parentheses because the stream insertion operator (**<<**) has higher precedence than the relational operators. Therefore, the first expression without the parentheses would be evaluated as:
+The expressions in the preceding example must be enclosed in parentheses because the stream insertion operator (**`<<`**) has higher precedence than the relational operators. Therefore, the first expression without the parentheses would be evaluated as:
 
 ```cpp
 (cout << "The true expression 3 > 2 yields: " << 3) < (2 << "\n");
@@ -78,6 +78,6 @@ If two pointers point to elements of the same array or to the element one beyond
 
 ## See also
 
-[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)<br/>
-[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Expressions with Binary Operators](../cpp/expressions-with-binary-operators.md)\
+[C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [C Relational and Equality Operators](../c-language/c-relational-and-equality-operators.md)

--- a/docs/cpp/scope-resolution-operator.md
+++ b/docs/cpp/scope-resolution-operator.md
@@ -168,5 +168,5 @@ int main() {
 
 ## See also
 
-[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[C++ built-in operators, precedence, and associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 [Namespaces](../cpp/namespaces-cpp.md)

--- a/docs/cpp/sizeof-operator.md
+++ b/docs/cpp/sizeof-operator.md
@@ -6,7 +6,7 @@ f1_keywords: ["sizeof_cpp"]
 helpviewer_keywords: ["sizeof operator"]
 ms.assetid: 8bc3b6fb-54a1-4eb7-ada0-05f8c5efc532
 ---
-# sizeof Operator
+# `sizeof` Operator
 
 Yields the size of its operand with respect to the size of type **`char`**.
 
@@ -17,7 +17,7 @@ Yields the size of its operand with respect to the size of type **`char`**.
 
 ```
 sizeof unary-expression
-sizeof  ( type-name )
+sizeof ( type-name )
 ```
 
 ## Remarks
@@ -98,5 +98,5 @@ sizeof array / sizeof array[0]
 
 ## See also
 
-[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)<br/>
+[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)\
 [Keywords](../cpp/keywords-cpp.md)

--- a/docs/cpp/subscript-operator.md
+++ b/docs/cpp/subscript-operator.md
@@ -15,7 +15,7 @@ postfix-expression [ expression ]
 
 ## Remarks
 
-A postfix expression (which can also be a primary expression) followed by the subscript operator, **[ ]**, specifies array indexing.
+A postfix expression (which can also be a primary expression) followed by the subscript operator, **`[ ]`**, specifies array indexing.
 
 For information about managed arrays in C++/CLI, see [Arrays](../extensions/arrays-cpp-component-extensions.md).
 
@@ -43,7 +43,7 @@ A subscript expression can also have multiple subscripts, as follows:
 
 *expression1* **[** *expression2* **] [** *expression3* **]** ...
 
-Subscript expressions associate from left to right. The leftmost subscript expression, *expression1* **[** *expression2* **]**, is evaluated first. The address that results from adding *expression1* and *expression2* forms a pointer expression; then *expression3* is added to this pointer expression to form a new pointer expression, and so on until the last subscript expression has been added. The indirection operator (<strong>\*</strong>) is applied after the last subscripted expression is evaluated, unless the final pointer value addresses an array type.
+Subscript expressions associate from left to right. The leftmost subscript expression, *expression1* **[** *expression2* **]**, is evaluated first. The address that results from adding *expression1* and *expression2* forms a pointer expression; then *expression3* is added to this pointer expression to form a new pointer expression, and so on until the last subscript expression has been added. The [indirection operator (**`*`**)](../cpp/indirection-operator-star.md) is applied after the last subscripted expression is evaluated, unless the final pointer value addresses an array type.
 
 Expressions with multiple subscripts refer to elements of multidimensional arrays. A multidimensional array is an array whose elements are arrays. For example, the first element of a three-dimensional array is an array with two dimensions. The following example declares and initializes a simple two-dimensional array of characters:
 

--- a/docs/cpp/typeid-operator.md
+++ b/docs/cpp/typeid-operator.md
@@ -5,7 +5,7 @@ ms.date: "10/04/2019"
 helpviewer_keywords: ["typeid operator"]
 ms.assetid: 8871cee6-d6b9-4301-a5cb-bf3dc9798d61
 ---
-# typeid Operator
+# `typeid` Operator
 
 ## Syntax
 
@@ -26,9 +26,9 @@ The **`typeid`** operator does a run-time check when applied to an l-value of a 
 
 - A reference to a class
 
-- A pointer, dereferenced with `*`
+- A pointer, dereferenced with **`*`**
 
-- A subscripted pointer (`[ ]`). (It's not safe to use a subscript with a pointer to a polymorphic type.)
+- A subscripted pointer (**`[ ]`**). (It's not safe to use a subscript with a pointer to a polymorphic type.)
 
 If the *expression* points to a base class type, yet the object is actually of a type derived from that base class, a `type_info` reference for the derived class is the result. The *expression* must point to a polymorphic type (a class with virtual functions). Otherwise, the result is the `type_info` for the static class referred to in the *expression*. Further, the pointer must be dereferenced so that the object used is the one it points to. Without dereferencing the pointer, the result will be the `type_info` for the pointer, not what it points to. For example:
 

--- a/docs/cpp/unary-plus-and-negation-operators-plus-and.md
+++ b/docs/cpp/unary-plus-and-negation-operators-plus-and.md
@@ -6,7 +6,7 @@ f1_keywords: ["+", "-"]
 helpviewer_keywords: ["unary operators [C++], plus", "- operator", "negation operator", "+ operator [C++], unary operators", "+ operator"]
 ms.assetid: 2c58c4f4-0d92-4ae3-9d0c-1a6157875cc1
 ---
-# Unary Plus and Negation Operators: + and -
+# Unary Plus and Negation Operators: `+` and `-`
 
 ## Syntax
 
@@ -15,15 +15,15 @@ ms.assetid: 2c58c4f4-0d92-4ae3-9d0c-1a6157875cc1
 - cast-expression
 ```
 
-## + operator
+## `+` operator
 
-The result of the unary plus operator (**+**) is the value of its operand. The operand to the unary plus operator must be of an arithmetic type.
+The result of the unary plus operator (**`+`**) is the value of its operand. The operand to the unary plus operator must be of an arithmetic type.
 
 Integral promotion is performed on integral operands. The resultant type is the type to which the operand is promoted. Thus, the expression `+ch`, where `ch` is of type **`char`**, results in type **`int`**; the value is unmodified. See [Standard Conversions](standard-conversions.md) for more information about how the promotion is done.
 
-## - operator
+## `-` operator
 
-The unary negation operator (**-**) produces the negative of its operand. The operand to the unary negation operator must be an arithmetic type.
+The unary negation operator (**`-`**) produces the negative of its operand. The operand to the unary negation operator must be an arithmetic type.
 
 Integral promotion is performed on integral operands, and the resultant type is the type to which the operand is promoted. See [Standard Conversions](standard-conversions.md) for more information about how the promotion is performed.
 
@@ -35,5 +35,5 @@ Unary negation of unsigned quantities is performed by subtracting the value of t
 
 ## See also
 
-[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)<br/>
+[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)\
 [C++ Built-in Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)

--- a/docs/cpp/uuidof-operator.md
+++ b/docs/cpp/uuidof-operator.md
@@ -70,5 +70,5 @@ StringFromCLSID(__LIBID_, &lpolestr);
 
 ## See also
 
-[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)<br/>
+[Expressions with Unary Operators](../cpp/expressions-with-unary-operators.md)\
 [Keywords](../cpp/keywords-cpp.md)


### PR DESCRIPTION
Continuation of #4960 for all built-in operators, together with a few cleanups and minor improvements.