### PR TITLE
Improve C2548

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
@@ -15,7 +15,7 @@ The default parameter list is missing a parameter. If you supply a default param
 
 The following sample generates C2548 for:
 
-- `func1` because it's missing the default argument `b`
+- `func1` because it's missing the default argument `b`.
 - `func3` because it's missing the default argument `c`.
 
 The following sample doesn't generate C2548 for:

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
@@ -4,7 +4,6 @@ title: "Compiler Error C2548"
 ms.date: "03/01/2024"
 f1_keywords: ["C2548"]
 helpviewer_keywords: ["C2548"]
-ms.assetid: 01e9c835-9bf3-4020-9295-5ee448c519f3
 ---
 # Compiler Error C2548
 
@@ -14,7 +13,16 @@ The default parameter list is missing a parameter. If you supply a default param
 
 ## Example
 
-The following sample generates C2548 as function declaration `func1` is missing the default argument `b`, while `func3` is missing the default argument `c`. Function declaration `func2` is valid as all required default arguments are supplied. The second function declaration of `func4` is fine because the default argument `c` is supplied in a preceding declaration within the same scope. Similarly, the third declaration of `func4` is fine as both default arguments `b` and `c` are previously provided.
+The following sample generates C2548 for:
+
+- `func1` because it's missing the default argument `b`
+- `func3` because it's missing the default argument `c`.
+
+The following sample doesn't generate C2548 for:
+
+- `func2` because all the required default arguments are supplied.
+-  The second `func4` declaration because the default argument `c` is supplied in the preceding declaration and is in the same scope.
+-  The third `func4` declaration because both default arguments `b` and `c` are provided previously.
 
 ```cpp
 // C2548.cpp
@@ -25,7 +33,7 @@ void func2(int a = 1, int b = 2, int c = 3);   // OK
 
 void func3(int a, int b = 2, int c);   // C2548
 
-void func4(int a, int b, int c = 3);
+void func4(int a, int b, int c = 3);   // OK
 void func4(int a, int b = 2, int c);   // OK
 void func4(int a = 1, int b, int c);   // OK
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
@@ -1,11 +1,11 @@
 ---
 description: "Learn more about: Compiler Error C2548"
-title: "Compiler Error C2548"
+title: "Compiler error C2548"
 ms.date: "03/01/2024"
 f1_keywords: ["C2548"]
 helpviewer_keywords: ["C2548"]
 ---
-# Compiler Error C2548
+# Compiler error C2548
 
 'class::member' : missing default parameter for parameter parameter
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2548.md
@@ -1,7 +1,7 @@
 ---
 description: "Learn more about: Compiler Error C2548"
 title: "Compiler Error C2548"
-ms.date: "11/04/2016"
+ms.date: "03/01/2024"
 f1_keywords: ["C2548"]
 helpviewer_keywords: ["C2548"]
 ms.assetid: 01e9c835-9bf3-4020-9295-5ee448c519f3
@@ -10,18 +10,22 @@ ms.assetid: 01e9c835-9bf3-4020-9295-5ee448c519f3
 
 'class::member' : missing default parameter for parameter parameter
 
-The default parameter list is missing a parameter. If you supply a default parameter anywhere in a parameter list, you must define default parameters for all subsequent parameters.
+The default parameter list is missing a parameter. If you supply a default parameter anywhere in a parameter list, you must define default parameters for all subsequent parameters in the current declaration or any previous declarations within the same scope.
 
 ## Example
 
-The following sample generates C2548:
+The following sample generates C2548 as function declaration `func1` is missing the default argument `b`, while `func3` is missing the default argument `c`. Function declaration `func2` is valid as all required default arguments are supplied. The second function declaration of `func4` is fine because the default argument `c` is supplied in a preceding declaration within the same scope. Similarly, the third declaration of `func4` is fine as both default arguments `b` and `c` are previously provided.
 
 ```cpp
 // C2548.cpp
 // compile with: /c
-void func( int = 1, int, int = 3);  // C2548
+void func1(int a = 1, int b, int c = 3);   // C2548
 
-// OK
-void func2( int, int, int = 3);
-void func3( int, int = 2, int = 3);
+void func2(int a = 1, int b = 2, int c = 3);   // OK
+
+void func3(int a, int b = 2, int c);   // C2548
+
+void func4(int a, int b, int c = 3);
+void func4(int a, int b = 2, int c);   // OK
+void func4(int a = 1, int b, int c);   // OK
 ```


### PR DESCRIPTION
Gave the function argument names so as to not confuse people unfamiliar with the `int = 1` syntax, and it is needed for the example explanation. The example explanation is slightly verbose to prevent it from being ambiguous or imprecise, since the default argument requirement is technically the "union" of all preceding declarations within the same scope. Happy to receive feedback on a terser method.