### PR TITLE
Update C2101

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2101.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2101.md
@@ -1,24 +1,22 @@
 ---
 description: "Learn more about: Compiler Error C2101"
 title: "Compiler Error C2101"
-ms.date: "11/04/2016"
+ms.date: "03/04/2024"
 f1_keywords: ["C2101"]
 helpviewer_keywords: ["C2101"]
-ms.assetid: 42f0136f-8cc1-4f2b-be1c-721ec9278e66
 ---
 # Compiler Error C2101
 
 '&' on constant
 
-The address-of operator ( `&` ) must have an l-value as operand.
+The [address-of operator (**`&`**)](../../cpp/address-of-operator-amp.md) must have an l-value as operand.
 
 The following sample generates C2101:
 
 ```cpp
 // C2101.cpp
-int main() {
-   char test;
-   test = &'a';   // C2101
-   test = 'a';   // OK
+int main()
+{
+    int* ptr = &123;   // C2101
 }
 ```


### PR DESCRIPTION
Tweaked the example to make it more concise. The previous example is slightly off since it tries to assign the invalid attempt of getting the address of a constant to a variable of type `char`.