### PR TITLE
Add example for C4066

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
@@ -1,13 +1,29 @@
 ---
 description: "Learn more about: Compiler Warning (level 3) C4066"
 title: "Compiler Warning (level 3) C4066"
-ms.date: "11/04/2016"
+ms.date: "03/06/2024"
 f1_keywords: ["C4066"]
 helpviewer_keywords: ["C4066"]
-ms.assetid: f2ae6465-a140-459a-87fd-c8f25fafedd4
 ---
 # Compiler Warning (level 3) C4066
 
 characters beyond first in wide-character constant ignored
 
 The compiler processes only the first character of a wide-character constant.
+
+```cpp
+// C4066.cpp
+// compile with: /W3
+#include <iostream>
+
+int main()
+{
+    wchar_t wc = L'AB';   // C4066
+
+    std::wcout << wc;
+}
+```
+
+```output
+A
+```


### PR DESCRIPTION
Add short example and demonstrated the behaviour mentioned:
> The compiler processes only the first character of a wide-character constant.