### PR TITLE
Rectify example in C4178

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4178.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4178.md
@@ -1,10 +1,9 @@
 ---
 description: "Learn more about: Compiler Warning (level 1) C4178"
 title: "Compiler Warning (level 1) C4178"
-ms.date: "11/04/2016"
+ms.date: "03/06/2024"
 f1_keywords: ["C4178"]
 helpviewer_keywords: ["C4178"]
-ms.assetid: 2c2c8f97-a5c4-47cd-8dd2-beea172613f3
 ---
 # Compiler Warning (level 1) C4178
 
@@ -16,16 +15,16 @@ A case constant in a **`switch`** expression does not fit in the type to which i
 
 ```cpp
 // C4178.cpp
-// compile with: /W1
+// compile with: /W1 /permissive
 int main()
 {
-    int i;  // maximum size of unsigned long int is 4294967295
-    switch( i )
+    unsigned int u = 1;
+    switch (u)
     {
-        case 4294967295:   // OK
-            break;
-        case 4294967296:   // C4178
-            break;
+    case 4294967295:   // OK, maximum value for type unsigned int
+        break;
+    case 4294967296:   // C4178, exceeded maximum value
+        break;
     }
 }
 ```


### PR DESCRIPTION
Rectified some errors in the previous example, namely:
- The usage of an uninitialized variable `i`, which is UB
- The comments on the maximum value being for `unsigned int` but the type of `i` is `int`

The warning is also not emitted with just `/W1` and the default settings of a fresh latest VS2022 C++ project. For some reason, the `/permissive` flag must be set for the warning to be shown. WIth the default of `/permissive-`, the warning is not emitted even with `/Wall` and/or `/w14178`. Not sure if the root cause is some other more granular flag being implicitly set by the permissive flag.