### PR TITLE
Add example for C2526

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
@@ -21,6 +21,6 @@ class A {};
 
 extern "C" A<int> func()   // C2526
 {
-    return {};
+    return A<int>();
 }
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
@@ -11,6 +11,8 @@ helpviewer_keywords: ["C2526"]
 
 A function defined with C linkage cannot return a user-defined type.
 
+The following sample generates C2526:
+
 ```cpp
 // C2526.cpp
 // compile with: /c

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2526.md
@@ -1,13 +1,24 @@
 ---
 description: "Learn more about: Compiler Error C2526"
 title: "Compiler Error C2526"
-ms.date: "11/04/2016"
+ms.date: "03/08/2024"
 f1_keywords: ["C2526"]
 helpviewer_keywords: ["C2526"]
-ms.assetid: 0f8c554c-f990-457e-bcae-b6f273481825
 ---
 # Compiler Error C2526
 
 'identifier1' : C linkage function cannot return C++ class 'identifier2'
 
 A function defined with C linkage cannot return a user-defined type.
+
+```cpp
+// C2526.cpp
+// compile with: /c
+template <typename T>
+class A {};
+
+extern "C" A<int> func()   // C2526
+{
+    return {};
+}
+```


### PR DESCRIPTION
A templated class `A` is used as an un-templated one does not seem to trigger the error.