### PR TITLE
Update C2537

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2537.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2537.md
@@ -1,26 +1,22 @@
 ---
 description: "Learn more about: Compiler Error C2537"
 title: "Compiler Error C2537"
-ms.date: "11/04/2016"
+ms.date: "03/08/2024"
 f1_keywords: ["C2537"]
 helpviewer_keywords: ["C2537"]
-ms.assetid: aee81d8e-300e-4a8b-b6c4-b3828398b34e
 ---
 # Compiler Error C2537
 
 'specifier' : illegal linkage specification
 
-Possible causes:
-
-1. The linkage specifier is not supported. Only the "C" linkage specifier is supported.
-
-1. "C" linkage is specified for more than one function in a set of overloaded functions. This is not allowed.
+The linkage specifier is not supported. Only the "C" and "C++" linkage specifiers are supported.
 
 The following sample generates C2537:
 
 ```cpp
 // C2537.cpp
 // compile with: /c
-extern "c" void func();   // C2537
+extern "c" void func1();   // C2537
 extern "C" void func2();   // OK
+extern "C++" void func3();   // OK
 ```


### PR DESCRIPTION
The second possible cause is removed as it emits [C2733](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2733) instead of this error. In addition, the previous wording implies that "C" is the only supported linkage specifier, which is incorrect.