### PR TITLE
Improve C2751

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
@@ -1,10 +1,9 @@
 ---
 description: "Learn more about: Compiler Error C2751"
 title: "Compiler Error C2751"
-ms.date: "11/04/2016"
+ms.date: "03/11/2024"
 f1_keywords: ["C2751"]
 helpviewer_keywords: ["C2751"]
-ms.assetid: 44a3abdf-8a87-4a09-b34b-532c220c310a
 ---
 # Compiler Error C2751
 
@@ -16,11 +15,11 @@ The following sample generates C2751:
 
 ```cpp
 // C2751.cpp
-namespace std {
-   template<typename T>
-   class list {};
+// compile with: /c
+namespace NS
+{
+    class C {};
 }
 
-#define list std::list
-void f(int &list){}   // C2751
+void func(int NS::C) {}   // C2751
 ```


### PR DESCRIPTION
Fix a few issues:
- Missing `/c` flag
- Adding definitions to the `std` namespace is UB
- Superfluous [C2955](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2955) (use of class template requires template argument list) error

Overall, the example is now slightly simpler.
