### PR TITLE
Update ASAN documentation

### DIFF
--- a/docs/sanitizers/error-global-buffer-overflow.md
+++ b/docs/sanitizers/error-global-buffer-overflow.md
@@ -126,8 +126,10 @@ int main(int argc, char **argv) {
     case 'g': return global[one * 11];     //Boom! simple global
     case 'c': return C::array[one * 11];   //Boom! class static
     case 'f':
+    {
         static int array[10] = {};
         return array[one * 11];            //Boom! function static
+    }
     case 'l':
         // literal global ptr created by compiler
         const char *str = "0123456789";

--- a/docs/sanitizers/error-global-buffer-overflow.md
+++ b/docs/sanitizers/error-global-buffer-overflow.md
@@ -126,8 +126,7 @@ int main(int argc, char **argv) {
     case 'g': return global[one * 11];     //Boom! simple global
     case 'c': return C::array[one * 11];   //Boom! class static
     case 'f':
-        static int array[10];
-        memset(array, 0, 10);
+        static int array[10] = {};
         return array[one * 11];            //Boom! function static
     case 'l':
         // literal global ptr created by compiler

--- a/docs/sanitizers/error-memcpy-param-overlap.md
+++ b/docs/sanitizers/error-memcpy-param-overlap.md
@@ -35,9 +35,11 @@ int main(int argc, char **argv) {
 To build and test this example, run these commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
 
 ```cmd
-cl example1.cpp /fsanitize=address /Zi
+cl example1.cpp /fsanitize=address /Zi /Oi
 devenv /debugexe example1.exe
 ```
+
+The [/Oi flag](../../build/reference/oi-generate-intrinsic-functions) tells the compiler to treat memcpy and memmove as intrinsic functions. This is necessary because some versions of the standard library implement memcpy and memmove in the same way and ASAN only detects bad code that is actually executed.
 
 ### Resulting error
 

--- a/docs/sanitizers/error-memcpy-param-overlap.md
+++ b/docs/sanitizers/error-memcpy-param-overlap.md
@@ -39,7 +39,7 @@ cl example1.cpp /fsanitize=address /Zi /Oi
 devenv /debugexe example1.exe
 ```
 
-The [/Oi flag](../../build/reference/oi-generate-intrinsic-functions) tells the compiler to treat memcpy and memmove as intrinsic functions. This is necessary because some versions of the standard library implement memcpy and memmove in the same way and ASAN only detects bad code that is actually executed.
+The [/Oi flag](../../build/reference/oi-generate-intrinsic-functions) tells the compiler to treat memcpy and memmove as intrinsic functions. This is necessary because some versions of the standard library implement memcpy and memmove in the same way. Because ASAN is a dynamic analysis tool, it only detects errors with an observable runtime effect.
 
 ### Resulting error
 

--- a/docs/sanitizers/error-stack-buffer-overflow.md
+++ b/docs/sanitizers/error-stack-buffer-overflow.md
@@ -86,7 +86,7 @@ public:
 
 class Child : public Parent {
 public:
-    int extra_field;
+    volatile int extra_field;
 };
 
 int main(void) {

--- a/docs/sanitizers/error-stack-buffer-overflow.md
+++ b/docs/sanitizers/error-stack-buffer-overflow.md
@@ -95,7 +95,7 @@ int main(void) {
     Child *c = (Child*)&p;
     c->extra_field = 42;  // Boom !
 
-    return 0;
+    return (c->extra_field == 42);
 }
 ```
 

--- a/docs/sanitizers/error-stack-buffer-underflow.md
+++ b/docs/sanitizers/error-stack-buffer-underflow.md
@@ -31,9 +31,11 @@ int main() {
 To build and test this example, run these commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
 
 ```cmd
-cl example1.cpp /fsanitize=address /Zi
+cl example1.cpp /fsanitize=address /Zi /Od
 devenv /debugexe example1.exe
 ```
+
+ASAN is a form of dynamic analysis, which means it can only detect bad code that is actually executed. An optimizer will remove the assignment to `buffer[subscript]` because `buffer[subscript]` is never read from. As a result, this example requires the `/Od` flag.
 
 ### Resulting error
 

--- a/docs/sanitizers/error-stack-use-after-return.md
+++ b/docs/sanitizers/error-stack-use-after-return.md
@@ -33,7 +33,7 @@ int main() {
     foo();
     *x = 42; // Boom!
 
-    return 0;
+    return (*x == 42);
 }
 ```
 
@@ -96,10 +96,12 @@ int main(int argc, char* argv[]) {
 To build and test this example, run these commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
 
 ```cmd
-cl example2.cpp /fsanitize=address /fsanitize-address-use-after-return /Zi
+cl example2.cpp /fsanitize=address /fsanitize-address-use-after-return /Zi /Od
 set ASAN_OPTIONS=detect_stack_use_after_return=1
 devenv /debugexe example2.exe 1
 ```
+
+ASAN is a form of dynamic analysis, which means it can only detect bad code that is actually executed. An optimizer may determine that the value of `t[100 + Idx]` or `sink` is never used and elide the assignment. As a result, this example requires the `/Od` flag.
 
 ### Resulting error - C++ and templates
 

--- a/docs/sanitizers/error-stack-use-after-return.md
+++ b/docs/sanitizers/error-stack-use-after-return.md
@@ -21,7 +21,7 @@ This check can slow your application down substantially. Consider the [Clang sum
 ```cpp
 // example1.cpp
 // stack-use-after-return error
-char* x;
+volatile char* x;
 
 void foo() {
     char stack_buffer[42];

--- a/docs/sanitizers/error-stack-use-after-scope.md
+++ b/docs/sanitizers/error-stack-use-after-scope.md
@@ -147,9 +147,11 @@ void main() {
 To build and test this example, run these commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
 
 ```cmd
-cl example4.cpp /EHsc /fsanitize=address /Zi
+cl example4.cpp /EHsc /fsanitize=address /Zi /Od
 devenv /debugexe example4.exe
 ```
+
+ASAN is a form of dynamic analysis, which means it can only detect bad code that is actually executed. An optimizer may propagate the value of `v` in these cases instead of reading from the address stored in `p`. As a result, this example requires the `/Od` flag.
 
 ### Resulting error - temporaries
 


### PR DESCRIPTION
Not all the ASAN code examples actually worked. Some of them require /Od.

This PR updates the examples to be more robust in the face of optimizations, and clarifies the examples where /Od is required and why. There is a corresponding internal PR to make sure we test that these examples still function every time we make changes.