### PR TITLE
Update C2860

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2860.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2860.md
@@ -1,22 +1,22 @@
 ---
 description: "Learn more about: Compiler Error C2860"
 title: "Compiler Error C2860"
-ms.date: "11/04/2016"
+ms.date: "03/16/2024"
 f1_keywords: ["C2860"]
 helpviewer_keywords: ["C2860"]
-ms.assetid: ccc83553-90ed-4e94-b5e9-38b58ae38e31
 ---
 # Compiler Error C2860
 
-'void' cannot be an argument type, except for '(void)'
+'void' cannot be used as a function parameter except for '(void)'
 
-Type **`void`** cannot be used as an argument type with other arguments.
+A function parameter cannot be of type **`void`**.
 
 The following sample generates C2860:
 
 ```cpp
 // C2860.cpp
 // compile with: /c
-void profunc1(void, int i);   // C2860
-void func10(void);   // OK
+void func1(void x);   // C2860
+void func2(void, int y);   // C2860
+void func3(void);   // OK
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2800-through-c2899.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2800-through-c2899.md
@@ -76,7 +76,7 @@ The articles in this section of the documentation explain a subset of the error 
 | [Compiler error C2857](compiler-error-c2857.md) | '#include' statement specified with the /Yc*filename* command-line option was not found in the source file |
 | [Compiler error C2858](compiler-error-c2858.md) | command-line option '/Yc (/Fd*filename*)' inconsistent with precompiled header, which used '/Fd*filename*' (Obsolete in Visual Studio 2022.) |
 | [Compiler error C2859](compiler-error-c2859.md) | *filename* is not the *filetype* file that was used when this precompiled header was created, recreate the precompiled header. |
-| [Compiler error C2860](compiler-error-c2860.md) | 'void' cannot be an argument type, except for '(void)' |
+| [Compiler error C2860](compiler-error-c2860.md) | 'void' cannot be used as a function parameter except for '(void)' |
 | [Compiler error C2861](compiler-error-c2861.md) | '*declaration*': an interface member function cannot be defined |
 | [Compiler error C2862](compiler-error-c2862.md) | '*interface*': an interface can only have public members |
 | [Compiler error C2863](compiler-error-c2863.md) | '*interface*': an interface cannot have friends |


### PR DESCRIPTION
Updated the error message (changed since VS2022 17.2 (19.32)):
```diff
- 'void' cannot be an argument type, except for '(void)'
+ 'void' cannot be used as a function parameter except for '(void)'
```
Also tweaked the example.