### PR TITLE
Remove stray trailing escapes

### DIFF
--- a/docs/build-insights/reference/sdk/cpp-event-data-types/compiler-pass.md
+++ b/docs/build-insights/reference/sdk/cpp-event-data-types/compiler-pass.md
@@ -56,7 +56,7 @@ Along with the inherited members from its [Activity](activity.md) base class, th
 
 [InputSourcePath](#input-source-path)\
 [OutputObjectPath](#output-object-path)\
-[PassCode](#pass-code)\
+[PassCode](#pass-code)
 
 ## <a name="compiler-pass"></a> CompilerPass
 

--- a/docs/build/reference/zc-zerosizearraynew.md
+++ b/docs/build/reference/zc-zerosizearraynew.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about the /Zc:zeroSizeArrayNew (Call member new/delete on arrays) compiler option."
 title: "/Zc:zeroSizeArrayNew (Call member new/delete on arrays)"
+description: "Learn more about the /Zc:zeroSizeArrayNew (Call member new/delete on arrays) compiler option."
 ms.date: 11/08/2022
 f1_keywords: ["/Zc:zeroSizeArrayNew"]
 helpviewer_keywords: ["-Zc:zeroSizeArrayNew compiler option (C++)", "/Zc:zeroSizeArrayNew compiler option (C++)"]
@@ -29,4 +29,4 @@ The **`/Zc:zeroSizeArrayNew`** option may cause a breaking change in code that r
 
 ## See also
 
-[`/Zc` (Conformance)](zc-conformance.md)\
+[`/Zc` (Conformance)](zc-conformance.md)

--- a/docs/c-language/typeof-c.md
+++ b/docs/c-language/typeof-c.md
@@ -56,4 +56,4 @@ To use `typeof`, compile with [`/std:clatest`](../build/reference/std-specify-la
 
 ## See also
 
-[`/std` (Specify Language Standard Version)](../build/reference/std-specify-language-standard-version.md)\
+[`/std` (Specify Language Standard Version)](../build/reference/std-specify-language-standard-version.md)

--- a/docs/c-language/typeof-unqual-c.md
+++ b/docs/c-language/typeof-unqual-c.md
@@ -54,4 +54,4 @@ To use `typeof_unqual`, compile with [`/std:clatest`](../build/reference/std-spe
 
 ## See also
 
-[`/std` (Specify Language Standard Version)](../build/reference/std-specify-language-standard-version.md)\
+[`/std` (Specify Language Standard Version)](../build/reference/std-specify-language-standard-version.md)

--- a/docs/c-runtime-library/reference/crtmemdifference.md
+++ b/docs/c-runtime-library/reference/crtmemdifference.md
@@ -63,4 +63,4 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 ## See also
 
 [Debug routines](../debug-routines.md)\
-[`_crtDbgFlag`](../crtdbgflag.md)\
+[`_crtDbgFlag`](../crtdbgflag.md)

--- a/docs/c-runtime-library/reference/crtmemdumpstatistics.md
+++ b/docs/c-runtime-library/reference/crtmemdumpstatistics.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _CrtMemDumpStatistics"
 title: "_CrtMemDumpStatistics"
+description: "Learn more about: _CrtMemDumpStatistics"
 ms.date: "11/04/2016"
 api_name: ["_CrtMemDumpStatistics"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["CrtMemDumpStatistics", "_CrtMemDumpStatistics"]
 helpviewer_keywords: ["_CrtMemDumpStatistics function", "CrtMemDumpStatistics function"]
-ms.assetid: 27b9d731-3184-4a2d-b9a7-6566ab28a9fe
 ---
 # `_CrtMemDumpStatistics`
 
@@ -47,4 +46,4 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ## See also
 
-[Debug routines](../debug-routines.md)\
+[Debug routines](../debug-routines.md)

--- a/docs/c-runtime-library/reference/crtsetbreakalloc.md
+++ b/docs/c-runtime-library/reference/crtsetbreakalloc.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _CrtSetBreakAlloc"
 title: "_CrtSetBreakAlloc"
+description: "Learn more about: _CrtSetBreakAlloc"
 ms.date: "11/04/2016"
 api_name: ["_CrtSetBreakAlloc"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["CrtSetBreakAlloc", "_CrtSetBreakAlloc"]
 helpviewer_keywords: ["CrtSetBreakAlloc function", "_CrtSetBreakAlloc function"]
-ms.assetid: 33bfc6af-a9ea-405b-a29f-1c2d4d9880a1
 ---
 # `_CrtSetBreakAlloc`
 
@@ -99,4 +98,4 @@ int main( )
 
 ## See also
 
-[Debug routines](../debug-routines.md)\
+[Debug routines](../debug-routines.md)

--- a/docs/c-runtime-library/reference/crtsetreportfile.md
+++ b/docs/c-runtime-library/reference/crtsetreportfile.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _CrtSetReportFile"
 title: "_CrtSetReportFile"
+description: "Learn more about: _CrtSetReportFile"
 ms.date: "11/04/2016"
 api_name: ["_CrtSetReportFile"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["CrtSetReportFile", "_CrtSetReportFile"]
 helpviewer_keywords: ["CrtSetReportFile function", "_CrtSetReportFile function"]
-ms.assetid: 3126537e-511b-44af-9c1c-0605265eabc4
 ---
 # `_CrtSetReportFile`
 
@@ -91,4 +90,4 @@ The console isn't supported in Universal Windows Platform (UWP) apps. The standa
 
 ## See also
 
-[Debug routines](../debug-routines.md)\
+[Debug routines](../debug-routines.md)

--- a/docs/c-runtime-library/reference/fdim-fdimf-fdiml.md
+++ b/docs/c-runtime-library/reference/fdim-fdimf-fdiml.md
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["fdim", "fdimf", "fdiml", "math/fdim", "math/fdimf", "math/fdiml"]
 helpviewer_keywords: ["fdim function", "fdimf function", "fdiml function"]
-ms.assetid: 2d4ac639-51e9-462d-84ab-fb03b06971a0
 ---
 # `fdim`, `fdimf`, `fdiml`
 
@@ -93,4 +92,4 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 [Alphabetical function reference](crt-alphabetical-function-reference.md)\
 [`fmax`, `fmaxf`, `fmaxl`](fmax-fmaxf-fmaxl.md)\
-[`abs`, `labs`, `llabs`, `_abs64`](abs-labs-llabs-abs64.md)\
+[`abs`, `labs`, `llabs`, `_abs64`](abs-labs-llabs-abs64.md)

--- a/docs/c-runtime-library/reference/freopen-wfreopen.md
+++ b/docs/c-runtime-library/reference/freopen-wfreopen.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: freopen, _wfreopen"
 title: "freopen, _wfreopen"
+description: "Learn more about: freopen, _wfreopen"
 ms.date: "2/23/2021"
 api_name: ["freopen", "_wfreopen", "_o__wfreopen", "_o_freopen"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -141,4 +141,4 @@ This will go to the file 'freopen.out'
 [`_fileno`](fileno.md)\
 [`fopen`, `_wfopen`](fopen-wfopen.md)\
 [`_open`, `_wopen`](open-wopen.md)\
-[`_setmode`](setmode.md)\
+[`_setmode`](setmode.md)

--- a/docs/c-runtime-library/reference/memcpy-wmemcpy.md
+++ b/docs/c-runtime-library/reference/memcpy-wmemcpy.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: memcpy, wmemcpy"
 title: "memcpy, wmemcpy"
+description: "Learn more about: memcpy, wmemcpy"
 ms.date: "1/14/2021"
 api_name: ["memcpy", "wmemcpy"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "ntoskrnl.exe"]
@@ -91,4 +91,4 @@ See [`memmove`](memmove-wmemmove.md) for a sample of how to use **`memcpy`**.
 [`memmove`, `wmemmove`](memmove-wmemmove.md)\
 [`memset`, `wmemset`](memset-wmemset.md)\
 [`strcpy_s`, `wcscpy_s`, `_mbscpy_s`](strcpy-s-wcscpy-s-mbscpy-s.md)\
-[`strncpy_s`, `_strncpy_s_l`, `wcsncpy_s`, `_wcsncpy_s_l`, `_mbsncpy_s`, `_mbsncpy_s_l`](strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l.md)\
+[`strncpy_s`, `_strncpy_s_l`, `wcsncpy_s`, `_wcsncpy_s_l`, `_mbsncpy_s`, `_mbsncpy_s_l`](strncpy-s-strncpy-s-l-wcsncpy-s-wcsncpy-s-l-mbsncpy-s-mbsncpy-s-l.md)

--- a/docs/c-runtime-library/reference/memmove-wmemmove.md
+++ b/docs/c-runtime-library/reference/memmove-wmemmove.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: memmove, wmemmove"
 title: "memmove, wmemmove"
+description: "Learn more about: memmove, wmemmove"
 ms.date: "1/14/2021"
 api_name: ["memmove", "wmemmove"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ntdll.dll", "ucrtbase.dll", "ntoskrnl.exe"]
@@ -114,4 +114,4 @@ New string: aaaabb
 [`_memccpy`](memccpy.md)\
 [`memcpy`, `wmemcpy`](memcpy-wmemcpy.md)\
 [`strcpy`, `wcscpy`, `_mbscpy`](strcpy-wcscpy-mbscpy.md)\
-[`strncpy`, `_strncpy_l`, `wcsncpy`, `_wcsncpy_l`, `_mbsncpy`, `_mbsncpy_l`](strncpy-strncpy-l-wcsncpy-wcsncpy-l-mbsncpy-mbsncpy-l.md)\
+[`strncpy`, `_strncpy_l`, `wcsncpy`, `_wcsncpy_l`, `_mbsncpy`, `_mbsncpy_l`](strncpy-strncpy-l-wcsncpy-wcsncpy-l-mbsncpy-mbsncpy-l.md)

--- a/docs/c-runtime-library/reference/read.md
+++ b/docs/c-runtime-library/reference/read.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _read"
 title: "_read"
+description: "Learn more about: _read"
 ms.date: "4/2/2020"
 api_name: ["_read", "_o__read"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -123,4 +123,4 @@ Read 19 bytes from file
 [`_creat`, `_wcreat`](creat-wcreat.md)\
 [`fread`](fread.md)\
 [`_open`, `_wopen`](open-wopen.md)\
-[`_write`](write.md)\
+[`_write`](write.md)

--- a/docs/c-runtime-library/reference/set-se-translator.md
+++ b/docs/c-runtime-library/reference/set-se-translator.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _set_se_translator"
 title: "_set_se_translator"
+description: "Learn more about: _set_se_translator"
 ms.date: "1/14/2021"
 api_name: ["_set_se_translator"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -212,4 +212,4 @@ Caught SE_Exception, error c0000094
 [`set_terminate`](set-terminate-crt.md)\
 [`set_unexpected`](set-unexpected-crt.md)\
 [`terminate`](terminate-crt.md)\
-[`unexpected`](unexpected-crt.md)\
+[`unexpected`](unexpected-crt.md)

--- a/docs/c-runtime-library/reference/set-unexpected-crt.md
+++ b/docs/c-runtime-library/reference/set-unexpected-crt.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: set_unexpected (CRT)"
 title: "set_unexpected (CRT)"
+description: "Learn more about: set_unexpected (CRT)"
 ms.date: "1/14/2021"
 api_name: ["set_unexpected"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["set_unexpected"]
 helpviewer_keywords: ["set_unexpected function", "unexpected function", "exception handling, termination"]
-ms.assetid: ebcef032-4771-48e5-88aa-2a1ab8750aa6
 ---
 # `set_unexpected` (CRT)
 
@@ -62,4 +61,4 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 [`_get_unexpected`](get-unexpected.md)\
 [`set_terminate`](set-terminate-crt.md)\
 [`terminate`](terminate-crt.md)\
-[`unexpected`](unexpected-crt.md)\
+[`unexpected`](unexpected-crt.md)

--- a/docs/c-runtime-library/reference/sin-sinf-sinl.md
+++ b/docs/c-runtime-library/reference/sin-sinf-sinl.md
@@ -96,4 +96,4 @@ cos( 1.570796 ) = 0.000000
 [`atan`, `atanf`, `atanl`, `atan2`, `atan2f`, `atan2l`](atan-atanf-atanl-atan2-atan2f-atan2l.md)\
 [`cos`, `cosf`, `cosl`](cos-cosf-cosl.md)\
 [`tan`, `tanf`, `tanl`](tan-tanf-tanl.md)\
-[`_CIsin`](../cisin.md)\
+[`_CIsin`](../cisin.md)

--- a/docs/c-runtime-library/reference/sqrt-sqrtf-sqrtl.md
+++ b/docs/c-runtime-library/reference/sqrt-sqrtf-sqrtl.md
@@ -97,4 +97,4 @@ The square root of 45.35 is 6.73
 [`exp`, `expf`, `expl`](exp-expf.md)\
 [`log`, `logf`, `log10`, `log10f`](log-logf-log10-log10f.md)\
 [`pow`, `powf`, `powl`](pow-powf-powl.md)\
-[`_CIsqrt`](../cisqrt.md)\
+[`_CIsqrt`](../cisqrt.md)

--- a/docs/c-runtime-library/reference/strncat-strncat-l-wcsncat-wcsncat-l-mbsncat-mbsncat-l.md
+++ b/docs/c-runtime-library/reference/strncat-strncat-l-wcsncat-wcsncat-l-mbsncat-mbsncat-l.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: strncat, _strncat_l, wcsncat, _wcsncat_l, _mbsncat, _mbsncat_l"
 title: "strncat, _strncat_l, wcsncat, _wcsncat_l, _mbsncat, _mbsncat_l"
+description: "Learn more about: strncat, _strncat_l, wcsncat, _wcsncat_l, _mbsncat, _mbsncat_l"
 ms.date: "1/20/2021"
 api_name: ["strncat", "_strncat_l", "_mbsncat", "_mbsncat_l", "wcsncat", "wcsncat_l", "_o__mbsncat", "_o__mbsncat_l"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-multibyte-l1-1-0.dll", "api-ms-win-crt-string-l1-1-0.dll", "ntoskrnl.exe"]
@@ -184,4 +184,4 @@ You can see that `BadAppend` caused a buffer overrun.
 [`_strset`, `_strset_l`, `_wcsset`, `_wcsset_l`, `_mbsset`, `_mbsset_l`](strset-strset-l-wcsset-wcsset-l-mbsset-mbsset-l.md)\
 [`strspn`, `wcsspn`, `_mbsspn`, `_mbsspn_l`](strspn-wcsspn-mbsspn-mbsspn-l.md)\
 [Locale](../locale.md)\
-[Interpretation of multibyte-character sequences](../interpretation-of-multibyte-character-sequences.md)\
+[Interpretation of multibyte-character sequences](../interpretation-of-multibyte-character-sequences.md)

--- a/docs/c-runtime-library/reference/vscprintf-p-vscprintf-p-l-vscwprintf-p-vscwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vscprintf-p-vscprintf-p-l-vscwprintf-p-vscwprintf-p-l.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _vscprintf_p, _vscprintf_p_l, _vscwprintf_p, _vscwprintf_p_l"
 title: "_vscprintf_p, _vscprintf_p_l, _vscwprintf_p, _vscwprintf_p_l"
+description: "Learn more about: _vscprintf_p, _vscprintf_p_l, _vscwprintf_p, _vscwprintf_p_l"
 ms.date: "10/21/2021"
 api_name: ["_vscprintf_p_l", "_vscprintf_p", "_vscwprintf_p_l", "_vscwprintf_p"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -89,4 +89,4 @@ See the example for [`vsprintf`](vsprintf-vsprintf-l-vswprintf-vswprintf-l-vswpr
 
 [`vprintf` functions](../vprintf-functions.md)\
 [`_scprintf_p`, `_scprintf_p_l`, `_scwprintf_p`, `_scwprintf_p_l`](scprintf-p-scprintf-p-l-scwprintf-p-scwprintf-p-l.md)\
-[`_vscprintf`, `_vscprintf_l`, `_vscwprintf`, `_vscwprintf_l`](vscprintf-vscprintf-l-vscwprintf-vscwprintf-l.md)\
+[`_vscprintf`, `_vscprintf_l`, `_vscwprintf`, `_vscwprintf_l`](vscprintf-vscprintf-l-vscwprintf-vscwprintf-l.md)

--- a/docs/standard-library/chrono-operators.md
+++ b/docs/standard-library/chrono-operators.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: <chrono> operators"
 title: "<chrono> operators"
+description: "Learn more about: <chrono> operators"
 ms.date: 09/17/2021
 f1_keywords: ["chrono/std::operator modulo", "chrono/std::operator+", "chrono/std::chrono::day::operator+", "chrono/std::chrono::duration::operator+", "chrono/std::chrono::month::operator+", "chrono/std::chrono::time_point::operator+", "chrono/std::chrono::weekday::operator+", "chrono/std::chrono::year_month::operator+", "chrono/std::chrono::year::operator+", "chrono/std::chrono::year_month_day::operator+", "chrono/std::chrono::year_month_day_last::operator+", "chrono/std::chrono::year_month_weekday::operator+", "chrono/std::chrono::year_month_weekday_last::operator+", "chrono/std::operator!=", "chrono/std::operator*", "chrono/std::operator/", "chrono/std::operator-", "chrono/std::operator<", "chrono/std::operator<=", "chrono/std::operator<", "chrono/std::operator==", "chrono/std::operator>>", "chrono/std::operator<=>", "chrono/std::chrono::day::operator<=>", "chrono/std::chrono::month::operator<=>", "chrono/std::chrono::year::operator<=>", "chrono/std::chrono::year_month::operator<=>", "chrono/std::chrono::time_point::operator<=>", "chrono/std::chrono::time_zone_link::operator<=>", "chrono/std::chrono::time_zone_link::operator==", "chrono/std::chrono::duration::operator<=>", "chrono/std::chrono::month_day_last::operator<=>", "chrono/std::chrono::year_month_day_last::operator<=>", "chrono/std::operator==", "chrono/std::chrono::year::operator<==>", "chrono/std::chrono::day::operator==", "chrono/std::chrono::duration::operator==", "chrono/std::chrono::month::operator==", "chrono/std::chrono::month_day::operator==", "chrono/std::chrono::month_day_last::operator==", "chrono/std::chrono::month_weekday::operator==", "chrono/std::chrono::month_weekday_last::operator==", "chrono/std::chrono::time_point::operator==", "chrono/std::chrono::weekday::operator==", "chrono/std::chrono::year_month::operator==", "chrono/std::chrono::year::operator==", "chrono/std::chrono::year_month_day::operator==", "chrono/std::chrono::year_month_day_last::operator==", "chrono/std::chrono::year_month_weekday_last::operator==", "chrono/std::chrono::year_month_weekday::operator==", "chrono/std::chrono::month_weekday_last::operator==", "chrono/std::chrono::weekday::operator==", "chrono/std::chrono::weekday_last::operator==", "chrono/std::chrono::year_month_weekday_indexed::operator==", "chrono/std::chrono::year_month_weekday_last::operator==", "chrono/std::chrono::year::operator==", "chrono/std::chrono::year_month::operator==",  "chrono/std::chrono::year_month_day::operator==", "chrono/std::chrono::year_month_day_last::operator==", "chrono/std::chrono::zoned_time::operator==", "chrono/std::operator-", "chrono/std::chrono::day::operator-", "chrono/std::chrono::duration::operator-", "chrono/std::chrono::month::operator-", "chrono/std::chrono::time_point::operator-", "chrono/std::chrono::weekday::operator-", "chrono/std::chrono::year_month::operator-", "chrono/std::chrono::year::operator-", "chrono/std::chrono::year_month_day::operator-", "chrono/std::chrono::year_month_day_last::operator-", "chrono/std::chrono::year_month_weekday::operator-", "chrono/std::chrono::year_month_weekday_last::operator-", "chrono/std::chrono::day::operator<<", "chrono/std::chrono::hh_mm_ss::operator<<", "chrono/std::chrono::month_day::operator<<", "chrono/std::chrono::month_day_last::operator<<", "chrono/std::chrono::month_weekday::operator<<", "chrono/std::chrono::month_weekday_last::operator<<", "chrono/std::chrono::weekday::operator<<", "chrono/std::chrono::weekday_indexed::operator<<", "chrono/std::chrono::weekday_last::operator<<", "chrono/std::chrono::year::operator<<", "chrono/std::chrono::year_month_day::operator<<", "chrono/std::chrono::year_month_day_last::operator<<", "chrono/std::chrono::year_month_weekday::operator<<", "chrono/std::chrono::utc_time::operator<<", "chrono/std::chrono::tai_time::operator<<", "chrono/std::chrono::gps_time::operator<<", "chrono/std::chrono::local_time::operator<<", "chrono/std::chrono::file_time::operator<<", "chrono/std::chrono::sys_info::operator<<", "chrono/std::chrono::local_info::operator<<", "chrono/std::chrono::zoned_time::operator<<"]
 ---
@@ -431,7 +431,7 @@ int main()
 Determines whether:
 
 1\) Two [`duration`](duration-class.md) objects don't represent the same number of ticks.\
-2\) Two [`time_point`](time-point-class.md) objects don't represent the same point in time.\
+2\) Two [`time_point`](time-point-class.md) objects don't represent the same point in time.
 
 ```cpp
 1)
@@ -458,7 +458,7 @@ The right `duration` or `time_point` object.
 ### Return value
 
 1\) Returns **`true`** if the number of ticks for the type common to *`Left`* and *`Right`* aren't equal. Otherwise, returns **`false`**.\
-2\) Returns **`true`**  if the two [`time_point`](time-point-class.md) objects don't represent the same point in time. Otherwise, returns **`false`**.\
+2\) Returns **`true`**  if the two [`time_point`](time-point-class.md) objects don't represent the same point in time. Otherwise, returns **`false`**.
 
 ## <a name="op_star"></a> `operator*`
 
@@ -1504,9 +1504,9 @@ The year and month.
 33\) `year_month_weekday(year(y), mwd.month(), mwd.weekday_indexed())`\
 34\) `year_month_weekday(y, mwd.month(), mwd.weekday_indexed())`\
 35\) `year_month_weekday(year(y), mwd.month(), mwd.weekday_indexed())`\
-36) `year_month_weekday_last(ym.year(), ym.month(), wdl)`\
+36\) `year_month_weekday_last(ym.year(), ym.month(), wdl)`\
 37\) `year_month_weekday_last(y, mwdl.month(), mwdl.weekday_last())`\
-38) `year_month_weekday_last(year(y), mwdl.month(), mwdl.weekday_last())`\
+38\) `year_month_weekday_last(year(y), mwdl.month(), mwdl.weekday_last())`\
 39\) `year_month_weekday_last(y, mwdl.month(), mwdl.weekday_last())`\
 40\) `year_month_weekday_last(year(y), mwdl.month(), mwdl.weekday_last())`
 


### PR DESCRIPTION
Remove some trailing escapes as they are rendered as a stray backslash at the end of the link or sentence. This PR also contains some rudimentary drive-bys.