### PR TITLE
Enhance /std documentation with reference to /Zc:__cplusplus

### DIFF
--- a/docs/build/reference/std-specify-language-standard-version.md
+++ b/docs/build/reference/std-specify-language-standard-version.md
@@ -28,6 +28,8 @@ The Microsoft C++ compiler in Visual Studio 2017 and later versions doesn't supp
 
 The **`/std`** option in effect during a C++ compilation can be detected by use of the [`_MSVC_LANG`](../../preprocessor/predefined-macros.md) preprocessor macro. For more information, see [Preprocessor Macros](../../preprocessor/predefined-macros.md).
 
+The [`/Zc:__cplusplus`](zc-cplusplus.md) option must additionally be used for the `__cplusplus` macro to be correctly defined for the appropriate C++ standard. 
+
 **`/std:c++14`**\
 The **`/std:c++14`** option enables C++14 standard-specific features implemented by the MSVC compiler. This option is the default for code compiled as C++. It's available starting in Visual Studio 2015 Update 3.
 
@@ -123,5 +125,6 @@ For more information, see the C Standard library features section of [Microsoft 
 
 ## See also
 
+[`/Zc:__cplusplus[-]`](zc-cplusplus.md)<br/>
 [MSVC compiler options](compiler-options.md)<br/>
 [MSVC compiler command-line syntax](compiler-command-line-syntax.md)

--- a/docs/build/reference/std-specify-language-standard-version.md
+++ b/docs/build/reference/std-specify-language-standard-version.md
@@ -1,7 +1,7 @@
 ---
 title: "/std (Specify Language Standard Version)"
 description: "The MSVC compiler option /std specifies the C or C++ language standard supported by the compiler."
-ms.date: 11/13/2023
+ms.date: 4/5/2023
 f1_keywords: ["/std", "-std", "/std:c++14", "/std:c++17", "/std:c++20", "/std:c11", "/std:c17", "/std:clatest", "VC.Project.VCCLCompilerTool.CppLanguageStandard"]
 ---
 # `/std` (Specify Language Standard Version)
@@ -130,6 +130,6 @@ For more information, see the C Standard library features section of [Microsoft 
 
 ## See also
 
-[`/Zc:__cplusplus[-]`](zc-cplusplus.md)<br/>
-[MSVC compiler options](compiler-options.md)<br/>
+[`/Zc:__cplusplus[-]`](zc-cplusplus.md)\
+[MSVC compiler options](compiler-options.md)\
 [MSVC compiler command-line syntax](compiler-command-line-syntax.md)

--- a/docs/build/reference/std-specify-language-standard-version.md
+++ b/docs/build/reference/std-specify-language-standard-version.md
@@ -32,6 +32,7 @@ The **`/std`** option in effect during a C++ compilation can be detected by use 
 > Because some existing code depends on the value of the macro `__cplusplus` being 199711L, the MSVC compiler doesn't change the value of this macro unless you explicitly opt in by setting [`/Zc:__cplusplus`](zc-cplusplus.md). Here are the values for `__cplusplus` depending on the language version you are compiling with:
 >
 > | Language version | __cplusplus value |
+> |------------------|-------------------|
 > | `/std:c++14` | 201402 |
 > | `/std:c++17` | 201703 |
 > | `/std:c++20` | 202002 |

--- a/docs/build/reference/std-specify-language-standard-version.md
+++ b/docs/build/reference/std-specify-language-standard-version.md
@@ -28,7 +28,12 @@ The Microsoft C++ compiler in Visual Studio 2017 and later versions doesn't supp
 
 The **`/std`** option in effect during a C++ compilation can be detected by use of the [`_MSVC_LANG`](../../preprocessor/predefined-macros.md) preprocessor macro. For more information, see [Preprocessor Macros](../../preprocessor/predefined-macros.md).
 
-The [`/Zc:__cplusplus`](zc-cplusplus.md) option must additionally be used for the `__cplusplus` macro to be correctly defined for the appropriate C++ standard. 
+> [!IMPORTANT]
+> Because some existing code depends on the value of the macro `__cplusplus` being 199711L, the MSVC compiler doesn't change the value of this macro unless you explicitly opt in by setting [`/Zc:__cplusplus`](zc-cplusplus.md). Here are the values for `__cplusplus` depending on the language version you are compiling with:
+> | Language version | __cplusplus value |
+> | `/std:c++14` | 201402 |
+> | `/std:c++17` | 201703 |
+> | `/std:c++20` | 202002 |
 
 **`/std:c++14`**\
 The **`/std:c++14`** option enables C++14 standard-specific features implemented by the MSVC compiler. This option is the default for code compiled as C++. It's available starting in Visual Studio 2015 Update 3.

--- a/docs/build/reference/std-specify-language-standard-version.md
+++ b/docs/build/reference/std-specify-language-standard-version.md
@@ -30,6 +30,7 @@ The **`/std`** option in effect during a C++ compilation can be detected by use 
 
 > [!IMPORTANT]
 > Because some existing code depends on the value of the macro `__cplusplus` being 199711L, the MSVC compiler doesn't change the value of this macro unless you explicitly opt in by setting [`/Zc:__cplusplus`](zc-cplusplus.md). Here are the values for `__cplusplus` depending on the language version you are compiling with:
+>
 > | Language version | __cplusplus value |
 > | `/std:c++14` | 201402 |
 > | `/std:c++17` | 201703 |


### PR DESCRIPTION
This change makes it much clearer as to what is required for  C++ standards conformance when using the /std option - Specify Language Standard Version for C++.

Motivation: The /std option implies standards conformance to C++ standards, yet it does not provide the most basic of conformance as it does not predefine the __cplusplus macro as mandated by the C++ standard (in section "Predefined macro names" - [cpp.predefined]). In order to conform to the standard, the /Zc:__cplusplus option is additionally required and this should be very clear in the documentation.