### PR TITLE
Tweak nolock function descriptions

### DIFF
--- a/docs/c-runtime-library/reference/fclose-nolock.md
+++ b/docs/c-runtime-library/reference/fclose-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fclose_nolock"
 title: "_fclose_nolock"
+description: "Learn more about: _fclose_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fclose_nolock", "_o__fclose_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["fclose_nolock", "_fclose_nolock"]
 helpviewer_keywords: ["streams, closing", "fclose_nolock function", "_fclose_nolock function"]
-ms.assetid: b4af4392-5fc8-49bb-9fe2-ca7293d3ce04
 ---
 # `_fclose_nolock`
 
-Closes a stream without thread-locking.
+Closes a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fflush-nolock.md
+++ b/docs/c-runtime-library/reference/fflush-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fflush_nolock"
 title: "_fflush_nolock"
+description: "Learn more about: _fflush_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fflush_nolock", "_o__fflush_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["fflush_nolock", "_fflush_nolock"]
 helpviewer_keywords: ["fflush_nolock function", "_fflush_nolock function", "streams, flushing", "flushing"]
-ms.assetid: 5e33c4a1-b10c-4001-ad01-210757919291
 ---
 # `_fflush_nolock`
 
-Flushes a stream without locking the thread.
+Flushes a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fgetc-nolock-fgetwc-nolock.md
+++ b/docs/c-runtime-library/reference/fgetc-nolock-fgetwc-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fgetc_nolock, _fgetwc_nolock"
 title: "_fgetc_nolock, _fgetwc_nolock"
+description: "Learn more about: _fgetc_nolock, _fgetwc_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fgetc_nolock", "_fgetwc_nolock", "_o__fgetc_nolock", "_o__fgetwc_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fgetwc_nolock", "fgettc_nolock", "fgetwc_nolock", "_fgetc_nolock", "_fgettc_nolock", "fgetc_nolock"]
 helpviewer_keywords: ["fgetc_nolock function", "fgetwc_nolock function", "_fgetwc_nolock function", "characters, reading", "_fgetc_nolock function", "streams, reading characters from", "fgettc_nolock function", "reading characters from streams", "_fgettc_nolock function"]
-ms.assetid: fb8e7c5b-4503-493a-879e-6a1db75aa114
 ---
 # `_fgetc_nolock`, `_fgetwc_nolock`
 
-Reads a character from a stream without locking the thread.
+Reads a character from a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fputc-nolock-fputwc-nolock.md
+++ b/docs/c-runtime-library/reference/fputc-nolock-fputwc-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fputc_nolock, _fputwc_nolock"
 title: "_fputc_nolock, _fputwc_nolock"
+description: "Learn more about: _fputc_nolock, _fputwc_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fputwc_nolock", "_fputc_nolock", "_o__fputc_nolock", "_o__fputwc_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fputc_nolock", "fputwc_nolock", "fputc_nolock", "fputtc_nolock", "_fputwc_nolock", "_fputtc_nolock"]
 helpviewer_keywords: ["streams, writing characters to", "fputwc_nolock function", "fputtc_nolock function", "_fputc_nolock function", "fputc_nolock function", "_fputtc_nolock function", "_fputwc_nolock function"]
-ms.assetid: c63eb3ad-58fa-46d0-9249-9c25f815eab9
 ---
 # `_fputc_nolock`, `_fputwc_nolock`
 
-Writes a character to a stream without locking the thread.
+Writes a character to a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fread-nolock-s2.md
+++ b/docs/c-runtime-library/reference/fread-nolock-s2.md
@@ -1,17 +1,16 @@
 ---
-description: "Learn more about: _fread_nolock_s"
 title: "_fread_nolock_s2"
+description: "Learn more about: _fread_nolock_s"
 ms.date: "4/2/2020"
 api_name: ["_fread_nolock_s", "_o__fread_nolock_s"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fread_nolock_s", "stdio/_fread_nolock_s"]
-ms.assetid: 5badb9ab-11df-4e17-8162-30bda2a4572e
 ---
 # `_fread_nolock_s`
 
-Reads data from a stream, without locking other threads. This version of [`fread_nolock`](fread-nolock.md) has security enhancements, as described in [Security features in the CRT](../security-features-in-the-crt.md).
+Reads data from a stream without locking. This version of [`fread_nolock`](fread-nolock.md) has security enhancements, as described in [Security features in the CRT](../security-features-in-the-crt.md).
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fread-nolock.md
+++ b/docs/c-runtime-library/reference/fread-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fread_nolock"
 title: "_fread_nolock"
+description: "Learn more about: _fread_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fread_nolock", "_o__fread_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fread_nolock", "fread_nolock"]
 helpviewer_keywords: ["reading data [C++], from input streams", "data [C++], reading from input stream", "fread_nolock function", "_fread_nolock function", "streams [C++], reading data from"]
-ms.assetid: 60e4958b-1097-46f5-a77b-94af5e7dba40
 ---
 # `_fread_nolock`
 
-Reads data from a stream, without locking other threads.
+Reads data from a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fseek-nolock-fseeki64-nolock.md
+++ b/docs/c-runtime-library/reference/fseek-nolock-fseeki64-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fseek_nolock, _fseeki64_nolock"
 title: "_fseek_nolock, _fseeki64_nolock"
+description: "Learn more about: _fseek_nolock, _fseeki64_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fseek_nolock", "_fseeki64_nolock", "_o__fseek_nolock", "_o__fseeki64_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fseek_nolock", "_fseeki64_nolock", "fseek_nolock", "fseeki64_nolock"]
 helpviewer_keywords: ["_fseek_nolock function", "fseeki64_nolock function", "file pointers [C++], moving", "fseek_nolock function", "_fseeki64_nolock function", "seek file pointers"]
-ms.assetid: 2dd4022e-b715-462b-b935-837561605a02
 ---
 # `_fseek_nolock`, `_fseeki64_nolock`
 
-Moves the file pointer to a specified location.
+Moves the file pointer to a specified location without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/ftell-nolock-ftelli64-nolock.md
+++ b/docs/c-runtime-library/reference/ftell-nolock-ftelli64-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _ftell_nolock, _ftelli64_nolock"
 title: "_ftell_nolock, _ftelli64_nolock"
+description: "Learn more about: _ftell_nolock, _ftelli64_nolock"
 ms.date: "4/2/2020"
 api_name: ["_ftelli64_nolock", "_ftell_nolock", "_o__ftell_nolock", "_o__ftelli64_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_ftelli64_nolock", "ftelli64_nolock", "ftell_nolock", "_ftell_nolock"]
 helpviewer_keywords: ["ftelli64_nolock function", "_ftelli64_nolock function", "_ftell_nolock function", "ftell_nolock function", "file pointers [C++], getting current position"]
-ms.assetid: 84e68b0a-32f8-4c4a-90ad-3f2387685ede
 ---
 # `_ftell_nolock`, `_ftelli64_nolock`
 
-Gets the current position of a file pointer, without locking the thread.
+Gets the current position of a file pointer without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/fwrite-nolock.md
+++ b/docs/c-runtime-library/reference/fwrite-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _fwrite_nolock"
 title: "_fwrite_nolock"
+description: "Learn more about: _fwrite_nolock"
 ms.date: "4/2/2020"
 api_name: ["_fwrite_nolock", "_o__fwrite_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_fwrite_nolock", "fwrite_nolock"]
 helpviewer_keywords: ["fwrite_nolock function", "streams, writing data to", "_fwrite_nolock function"]
-ms.assetid: 2b4ec6ce-742e-4615-8407-44a0a18ec1d7
 ---
 # `_fwrite_nolock`
 
-Writes data to a stream, without locking the thread.
+Writes data to a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/getc-nolock-getwc-nolock.md
+++ b/docs/c-runtime-library/reference/getc-nolock-getwc-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _getc_nolock, _getwc_nolock"
 title: "_getc_nolock, _getwc_nolock"
+description: "Learn more about: _getc_nolock, _getwc_nolock"
 ms.date: "4/2/2020"
 api_name: ["_getc_nolock", "_getwc_nolock", "_o__getc_nolock", "_o__getwc_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["getc_nolock", "_gettc_nolock", "_getc_nolock", "getwc_nolock", "gettc_nolock", "_getwc_nolock"]
 helpviewer_keywords: ["characters, reading", "_getc_nolock function", "_getwc_nolock function", "getwc_nolock function", "streams, reading characters from", "reading characters from streams", "getc_nolock function", "gettc_nolock function", "_gettc_nolock function"]
-ms.assetid: eb37b272-e177-41c9-b077-12ce7ffd3b88
 ---
 # `_getc_nolock`, `_getwc_nolock`
 
-Reads a character from a stream.
+Reads a character from a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
+++ b/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
@@ -1,6 +1,6 @@
 ---
 title: "_getch_nolock, _getwch_nolock"
-description: "API reference for _getch_nolock, and _getwch_nolock; which get a character from the console without echo and without locking the thread."
+description: "Learn more about: _getch_nolock, _getwch_nolock"
 ms.date: "4/2/2020"
 api_name: ["_getwch_nolock", "_getch_nolock", "_o__getch_nolock", "_o__getwch_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]

--- a/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
+++ b/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_getch_nolock", "getwch_nolock", "getch_nolock", "_getwch_nolock", "_gettch_nolock", "gettch_nolock"]
 helpviewer_keywords: ["characters, getting from console", "_getwch_nolock function", "_getch_nolock function", "getwch_nolock function", "_gettch_nolock function", "console, reading from", "getch_nolock function", "gettch_nolock function"]
-ms.assetid: 9d248546-26ca-482c-b0c6-55812a987e83
 ---
 # `_getch_nolock`, `_getwch_nolock`
 
-Gets a character from the console without echo and without locking the thread.
+Gets a character from the console without echo and without locking.
 
 > [!IMPORTANT]
 > This API cannot be used in applications that execute in the Windows Runtime. For more information, see [CRT functions not supported in Universal Windows Platform apps](../../cppcx/crt-functions-not-supported-in-universal-windows-platform-apps.md).

--- a/docs/c-runtime-library/reference/getchar-nolock-getwchar-nolock.md
+++ b/docs/c-runtime-library/reference/getchar-nolock-getwchar-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _getchar_nolock, _getwchar_nolock"
 title: "_getchar_nolock, _getwchar_nolock"
+description: "Learn more about: _getchar_nolock, _getwchar_nolock"
 ms.date: "11/04/2016"
 api_name: ["_getchar_nolock", "_getwchar_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["getwchar_nolock", "_getwchar_nolock", "_getchar_nolock", "getchar_nolock"]
 helpviewer_keywords: ["_getwchar_nolock function", "getwchar_nolock function", "characters, reading", "_getchar_nolock function", "getchar_nolock function", "standard input, reading from"]
-ms.assetid: dc49ba60-0647-4ae9-aa9a-a0618b1666de
 ---
 # `_getchar_nolock`, `_getwchar_nolock`
 
-Reads a character from standard input.
+Reads a character from the standard input without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
+++ b/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_getche_nolock", "_gettche_nolock", "_getwche_nolock", "getche_nolock", "getwche_nolock", "gettche_nolock"]
 helpviewer_keywords: ["characters, getting from console", "_gettche_nolock function", "getwche_nolock function", "_getche_nolock function", "getche_nolock function", "console, reading from", "_getwche_nolock function", "gettche_nolock function"]
-ms.assetid: 9e853ad4-4d8a-4442-9ae5-da4b434f0b8c
 ---
 # `_getche_nolock`, `_getwche_nolock`
 
-Gets a character from the console, with echo and without locking the thread.
+Gets a character from the console with echo and without locking.
 
 > [!IMPORTANT]
 > This API cannot be used in applications that execute in the Windows Runtime. For more information, see [CRT functions not supported in Universal Windows Platform apps](../../cppcx/crt-functions-not-supported-in-universal-windows-platform-apps.md).

--- a/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
+++ b/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
@@ -1,6 +1,6 @@
 ---
 title: "_getche_nolock, _getwche_nolock"
-description: "API reference for _getche_nolock, and _getwche_nolock; which gets a character from the console, with echo and without locking the thread."
+description: "Learn more about: _getche_nolock, _getwche_nolock"
 ms.date: "4/2/2020"
 api_name: ["_getche_nolock", "_getwche_nolock", "_o__getche_nolock", "_o__getwche_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]

--- a/docs/c-runtime-library/reference/getdcwd-nolock-wgetdcwd-nolock.md
+++ b/docs/c-runtime-library/reference/getdcwd-nolock-wgetdcwd-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _getdcwd_nolock, _wgetdcwd_nolock"
 title: "_getdcwd_nolock, _wgetdcwd_nolock"
+description: "Learn more about: _getdcwd_nolock, _wgetdcwd_nolock"
 ms.date: "11/04/2016"
 api_name: ["_wgetdcwd_nolock", "_getdcwd_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_wgetdcwd_nolock", "tgetdcwd_nolock", "wgetdcwd_nolock", "_getdcwd_nolock", "_tgetdcwd_nolock", "getdcwd_nolock"]
 helpviewer_keywords: ["getdcwd_nolock function", "_tgetdcwd_nolock function", "working directory", "tgetdcwd_nolock function", "_getdcwd_nolock function", "current working directory", "wgetdcwd_nolock function", "_wgetdcwd_nolock function", "directories [C++], current working"]
-ms.assetid: d9bdf712-43f8-4173-8f9a-844e82beaa97
 ---
 # `_getdcwd_nolock`, `_wgetdcwd_nolock`
 

--- a/docs/c-runtime-library/reference/putc-nolock-putwc-nolock.md
+++ b/docs/c-runtime-library/reference/putc-nolock-putwc-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _putc_nolock, _putwc_nolock"
 title: "_putc_nolock, _putwc_nolock"
+description: "Learn more about: _putc_nolock, _putwc_nolock"
 ms.date: "4/2/2020"
 api_name: ["_putc_nolock", "_putwc_nolock", "_o__putc_nolock", "_o__putwc_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_puttc_nolock", "puttc_nolock", "putwc_nolock", "_putwc_nolock", "_putc_nolock", "putc_nolock"]
 helpviewer_keywords: ["puttc_nolock function", "putc_nolock function", "_putc_nolock function", "streams, writing characters to", "characters, writing", "putwc_nolock function", "_puttc_nolock function", "_putwc_nolock function"]
-ms.assetid: 3cfc7f21-c9e8-4b7f-b0fb-af0d4d85e7e1
 ---
 # `_putc_nolock`, `_putwc_nolock`
 
-Writes a character to a stream without locking the thread.
+Writes a character to a stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/putch-nolock-putwch-nolock.md
+++ b/docs/c-runtime-library/reference/putch-nolock-putwch-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _putch_nolock, _putwch_nolock"
 title: "_putch_nolock, _putwch_nolock"
+description: "Learn more about: _putch_nolock, _putwch_nolock"
 ms.date: "4/2/2020"
 api_name: ["_putwch_nolock", "_putch_nolock", "_o__putch_nolock", "_o__putwch_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_putch_nolock", "_puttch_nolock", "putch_nolock", "putwch_nolock", "_putwch_nolock"]
 helpviewer_keywords: ["putwch_nolock function", "puttch_nolock function", "characters, writing", "putch_nolock function", "_putch_nolock function", "_puttch_nolock function", "console, writing characters to", "_putwch_nolock function"]
-ms.assetid: edbc811d-bac6-47fa-a872-fe4f3a1590b0
 ---
 # `_putch_nolock`, `_putwch_nolock`
 
-Writes a character to the console without locking the thread.
+Writes a character to the console without locking.
 
 > [!IMPORTANT]
 > This API cannot be used in applications that execute in the Windows Runtime. For more information, see [CRT functions not supported in Universal Windows Platform apps](../../cppcx/crt-functions-not-supported-in-universal-windows-platform-apps.md).

--- a/docs/c-runtime-library/reference/putchar-nolock-putwchar-nolock.md
+++ b/docs/c-runtime-library/reference/putchar-nolock-putwchar-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _putchar_nolock, _putwchar_nolock"
 title: "_putchar_nolock, _putwchar_nolock"
+description: "Learn more about: _putchar_nolock, _putwchar_nolock"
 ms.date: "11/04/2016"
 api_name: ["_putchar_nolock", "_putwchar_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["putwchar_nolock", "_puttchar_nolock", "_putchar_nolock", "_putwchar_nolock", "putchar_nolock"]
 helpviewer_keywords: ["_puttchar_nolock function", "putchar_nolock function", "characters, writing", "standard output, writing to", "putwchar_nolock function", "_putchar_nolock function", "_putwchar_nolock function", "puttchar_nolock function"]
-ms.assetid: 9ac68092-bfc3-4352-b486-c3e780220575
 ---
 # `_putchar_nolock`, `_putwchar_nolock`
 
-Writes a character to `stdout` without locking the thread.
+Writes a character to `stdout` without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/ungetc-nolock-ungetwc-nolock.md
+++ b/docs/c-runtime-library/reference/ungetc-nolock-ungetwc-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _ungetc_nolock, _ungetwc_nolock"
 title: "_ungetc_nolock, _ungetwc_nolock"
+description: "Learn more about: _ungetc_nolock, _ungetwc_nolock"
 ms.date: "4/2/2020"
 api_name: ["_ungetwc_nolock", "_ungetc_nolock", "_o__ungetc_nolock", "_o__ungetwc_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["STDIO/_ungetc_nolock", "CORECRT_WSTDIO/_ungetwc_nolock", "TCHAR/_ungettc_nolock", "_ungetc_nolock", "_ungetwc_nolock", "_ungettc_nolock"]
 helpviewer_keywords: ["_ungettc_nolock function", "_ungetwc_nolock function", "characters, pushing back onto stream", "_ungetc_nolock function", "ungetwc_nolock function", "ungettc_nolock function", "ungetc_nolock function"]
-ms.assetid: aa02d5c2-1be1-46d2-a8c4-b61269e9d465
 ---
 # `_ungetc_nolock`, `_ungetwc_nolock`
 
-Pushes a character back onto the stream.
+Pushes a character back onto the stream without locking.
 
 ## Syntax
 

--- a/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
+++ b/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["_ungetch function", "ungetwch function", "characters, pus
 ---
 # `_ungetch`, `_ungetwch`, `_ungetch_nolock`, `_ungetwch_nolock`
 
-Pushes back the last character that's read from the console without locking.
+Pushes back the last character that's read from the console.
 
 > [!IMPORTANT]
 > This API cannot be used in applications that execute in the Windows Runtime. For more information, see [CRT functions not supported in Universal Windows Platform apps](../../cppcx/crt-functions-not-supported-in-universal-windows-platform-apps.md).

--- a/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
+++ b/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _ungetch, _ungetwch, _ungetch_nolock, _ungetwch_nolock"
 title: "_ungetch, _ungetwch, _ungetch_nolock, _ungetwch_nolock"
+description: "Learn more about: _ungetch, _ungetwch, _ungetch_nolock, _ungetwch_nolock"
 ms.date: "4/2/2020"
 api_name: ["_ungetch_nolock", "_ungetwch_nolock", "_ungetwch", "_ungetch", "_o__ungetch", "_o__ungetch_nolock", "_o__ungetwch", "_o__ungetwch_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
@@ -8,11 +8,10 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["CONIO/_ungetch", "CONIO/_ungetch_nolock", "CORECRT_WCONIO/_ungetwch", "CORECRT_WCONIO/_ungetwch_nolock", "TCHAR/_ungettch", "TCHAR/_ungettch_nolock", "_ungetch", "_ungetch_nolock", "_ungetwch", "_ungetwch_nolock", "_ungettch", "_ungettch_nolock"]
 helpviewer_keywords: ["_ungetch function", "ungetwch function", "characters, pushing back to console", "_ungettch_nolock function", "ungettch function", "_ungettch function", "ungetch_nolock function", "ungettch_nolock function", "_ungetwch_nolock function", "_ungetch_nolock function", "ungetwch_nolock function", "_ungetwch function"]
-ms.assetid: 70ae71c6-228c-4883-a57d-de6d5f873825
 ---
 # `_ungetch`, `_ungetwch`, `_ungetch_nolock`, `_ungetwch_nolock`
 
-Pushes back the last character that's read from the console.
+Pushes back the last character that's read from the console without locking.
 
 > [!IMPORTANT]
 > This API cannot be used in applications that execute in the Windows Runtime. For more information, see [CRT functions not supported in Universal Windows Platform apps](../../cppcx/crt-functions-not-supported-in-universal-windows-platform-apps.md).


### PR DESCRIPTION
The wording "locking the thread" seems a little off since it should either be "locking the stream" or some other "item". Omitting the "item" being locked seems to work the best at the expense of being less "specific" (as compared to using the phrase "locking the stream" etc). The large majority of locking for the normal analog of `_nolock` APIs are done via `_lock_file` with a `FILE*` for the stream, with some others being done via `__acrt_lock` with `__acrt_conio_lock` of type `__acrt_lock_id` (both locking functions are implemented using `EnterCriticalSection`) (the term "locking the stream" cannot be used for all `_nolock` APIs). Hence, using the generic term "without locking" for all applicable `_nolock` APIs make things uniform and the idea of "not locking" is decently conveyed.

@TylerMSFT Does this sound like an improvement? Happy to hear some feedback.

Note 1) Some descriptions (e.g. `_fseek_nolock`) are identical to their normal analog, therefore the notion of "not locking" is added.

Note 2) The descriptions of `_getdcwd_nolock` and `_wgetdcwd_nolock` are not modified as they are just macros to the normal analog.