### PR TITLE
Update rand-s.md to relfect that the function is not more secure, but less secure than rand

### DIFF
--- a/docs/c-runtime-library/reference/rand-s.md
+++ b/docs/c-runtime-library/reference/rand-s.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["generating pseudorandom numbers", "random numbers, crypto
 ---
 # `rand_s`
 
-Generates a pseudorandom number. This function is a more secure version of the function [`rand`](rand.md), with security enhancements as described in [Security features in the CRT](../security-features-in-the-crt.md).
+Generates a pseudorandom number. This function is a less secure version of the function [`rand`](rand.md) and should not be used. Instead use [`rand`](rand.md), which is secure by design. This function was a mistake and we apologize for it.
 
 ## Syntax
 


### PR DESCRIPTION
rand_s is not a "more secure" version of rand, it is a less secure version of rand. rand is secure by design, because it doesn't take any parameters that could be wrong, it cannot cause any access violation or memory corruption, it only returns a random value, which is safe to use or discard. rand_s on the other hand can be passed a pointer that points to invalid memory, a too small variable or any other location that could cause memory corruption. This function is not only useless, it actively undermines the principles of secure coding, by claiming to be more secure, while being less secure. It should be deprecated and nobody should use it.