### PR TITLE
Update arm64-intrinsics.md to include intrin.h mention

### DIFF
--- a/docs/intrinsics/arm64-intrinsics.md
+++ b/docs/intrinsics/arm64-intrinsics.md
@@ -19,6 +19,8 @@ NEON intrinsics are supported, as provided in the header file `arm64_neon.h`. Th
 
 ## <a name="A"></a> ARM64-specific intrinsics listing
 
+ARM64-specific intrinsics are supported, as provided in the header file `intrin.h`.
+
 |Function Name|Instruction|Function Prototype|
 |-------------------|-----------------|------------------------|
 |__break|BRK|void __break(int)|

--- a/docs/intrinsics/arm64-intrinsics.md
+++ b/docs/intrinsics/arm64-intrinsics.md
@@ -15,7 +15,7 @@ The Microsoft C++ compiler (MSVC) makes the following intrinsics available on th
 
 The NEON vector instruction set extensions for ARM64 provide Single Instruction Multiple Data (SIMD) capabilities. They resemble the ones in the MMX and SSE vector instruction sets that are common to x86 and x64 architecture processors.
 
-NEON intrinsics are supported, as provided in the header file *arm64_neon.h*. The MSVC support for NEON intrinsics resembles that of the ARM64 compiler, which is documented in the [ARM NEON Intrinsic Reference](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics) on the ARM Infocenter website.
+NEON intrinsics are supported, as provided in the header files *arm64_neon.h* and *intrin.h*. The MSVC support for NEON intrinsics resembles that of the ARM64 compiler, which is documented in the [ARM NEON Intrinsic Reference](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics) on the ARM Infocenter website.
 
 ## <a name="A"></a> ARM64-specific intrinsics listing
 

--- a/docs/intrinsics/arm64-intrinsics.md
+++ b/docs/intrinsics/arm64-intrinsics.md
@@ -15,7 +15,7 @@ The Microsoft C++ compiler (MSVC) makes the following intrinsics available on th
 
 The NEON vector instruction set extensions for ARM64 provide Single Instruction Multiple Data (SIMD) capabilities. They resemble the ones in the MMX and SSE vector instruction sets that are common to x86 and x64 architecture processors.
 
-NEON intrinsics are supported, as provided in the header files *arm64_neon.h* and *intrin.h*. The MSVC support for NEON intrinsics resembles that of the ARM64 compiler, which is documented in the [ARM NEON Intrinsic Reference](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics) on the ARM Infocenter website.
+NEON intrinsics are supported, as provided in the header file `arm64_neon.h`. The MSVC support for NEON intrinsics resembles that of the ARM64 compiler, which is documented in the [ARM NEON Intrinsic Reference](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics) on the ARM Infocenter website.
 
 ## <a name="A"></a> ARM64-specific intrinsics listing
 


### PR DESCRIPTION
Some intrinsics, such as `__prefetch` come from `intrin.h` header file.