### PR TITLE
Updated integritycheck documentation to point to Trusted Signing Service

### DIFF
--- a/docs/build/reference/integritycheck-require-signature-check.md
+++ b/docs/build/reference/integritycheck-require-signature-check.md
@@ -17,7 +17,7 @@ The **`/INTEGRITYCHECK`** linker option sets a flag, `IMAGE_DLLCHARACTERISTICS_F
 
 ### Signing `/INTEGRITYCHECK` files
 
-Microsoft has new signing guidance for DLL and executable files linked by using **`/INTEGRITYCHECK`**. The guidance used to recommend a cross-signed certificate from the [cross-signing program](/windows-hardware/drivers/install/cross-certificates-for-kernel-mode-code-signing). However, the [cross-signing program is now deprecated](/windows-hardware/drivers/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates). You must now sign your **`/INTEGRITYCHECK`** files by using the Microsoft [Azure Code Signing](https://techcommunity.microsoft.com/t5/security-compliance-and-identity/azure-code-signing-democratizing-trust-for-developers-and/ba-p/3604669) program instead.
+Microsoft has new signing guidance for DLL and executable files linked by using **`/INTEGRITYCHECK`**. The guidance used to recommend a cross-signed certificate from the [cross-signing program](/windows-hardware/drivers/install/cross-certificates-for-kernel-mode-code-signing). However, the [cross-signing program is now deprecated](/windows-hardware/drivers/install/deprecation-of-software-publisher-certificates-and-commercial-release-certificates). You must now sign your **`/INTEGRITYCHECK`** files by using the Microsoft [Trusted Signing service](/azure/trusted-signing/) program instead.
 
 ### To set this linker option in Visual Studio
 


### PR DESCRIPTION
**What Changed**
- Azure Code Signing was renamed to Trusted Signing service
- Trusted Signing Service GA'ed and their documentation is now available. Replaced the link to point to their official documentation