### PR TITLE
Fix unclosed links

### DIFF
--- a/docs/build/reference/commands-in-a-makefile.md
+++ b/docs/build/reference/commands-in-a-makefile.md
@@ -18,7 +18,7 @@ A command preceded by a semicolon (**`;`**) can appear on a dependency line or i
 project.obj : project.c project.h ; cl /c project.c
 ```
 
-## <a name="command-modifiers"> Command modifiers
+## <a name="command-modifiers" /> Command modifiers
 
 You can specify one or more command modifiers preceding a command, optionally separated by spaces or tabs. As with commands, modifiers must be indented.
 
@@ -28,7 +28,7 @@ You can specify one or more command modifiers preceding a command, optionally se
 | **`-`**\[*number*] *command* | Turns off error checking for *command*. By default, NMAKE halts when a command returns a nonzero exit code. If *-number* is used, NMAKE stops if the exit code exceeds *number*. Spaces or tabs can't appear between the dash and *number.* At least one space or tab must appear between *number* and *command*. Use **`/I`** to turn off error checking for the entire makefile; use **`.IGNORE`** to turn off error checking for part of the makefile. |
 | **`!`** *command* | Executes *command* for each dependent file if *command* uses **`$**`** (all dependent files in the dependency) or **`$?`** (all dependent files in the dependency with a later timestamp than the target). |
 
-## <a name="filename-parts-syntax"> Filename-parts syntax
+## <a name="filename-parts-syntax" /> Filename-parts syntax
 
 Filename-parts syntax in commands represents components of the first dependent filename (which may be an implied dependent). Filename components are the file's drive, path, base name, and extension as specified, not as it exists on disk. Use **`%s`** to represent the complete filename. Use **`%|`**\[*parts*]**`F`** (a vertical bar character follows the percent symbol) to represent parts of the filename, where *parts* can be zero or more of the following letters, in any order.
 

--- a/docs/build/reference/contents-of-a-makefile.md
+++ b/docs/build/reference/contents-of-a-makefile.md
@@ -24,11 +24,11 @@ For a sample, see [Sample makefile](sample-makefile.md).
 
 NMAKE supports other features, such as wildcards, long filenames, comments, and escapes for special characters.
 
-## <a name="wildcards-and-nmake"> Wildcards and NMAKE
+## <a name="wildcards-and-nmake" /> Wildcards and NMAKE
 
 NMAKE expands filename wildcards (**`*`** and **`?`**) in dependency lines. A wildcard specified in a command is passed to the command; NMAKE doesn't expand it.
 
-## <a name="long-filenames-in-a-makefile"> Long filenames in a makefile
+## <a name="long-filenames-in-a-makefile" /> Long filenames in a makefile
 
 Enclose long filenames in double quotation marks, as follows:
 
@@ -36,7 +36,7 @@ Enclose long filenames in double quotation marks, as follows:
 all : "VeryLongFileName.exe"
 ```
 
-## <a name="comments-in-a-makefile"> Comments in a makefile
+## <a name="comments-in-a-makefile" /> Comments in a makefile
 
 Precede a comment with a number sign (**`#`**). NMAKE ignores text from the number sign to the next newline character.
 
@@ -66,7 +66,7 @@ To specify a literal number sign, precede it with a caret (**`^`**), as follows:
 DEF = ^#define  #Macro for a C preprocessing directive
 ```
 
-## <a name="special-characters-in-a-makefile"> Special characters in a makefile
+## <a name="special-characters-in-a-makefile" /> Special characters in a makefile
 
 To use an NMAKE special character as a literal character, place a caret (**`^`**) in front of it as an escape. NMAKE ignores carets that precede other characters. The special characters are:
 

--- a/docs/build/reference/creating-a-makefile-project.md
+++ b/docs/build/reference/creating-a-makefile-project.md
@@ -16,7 +16,7 @@ If you have an existing makefile project, you have these choices if you want to 
 - **Visual Studio 2017 and later**: Use the **Open Folder** feature to edit and build a makefile project as-is without any involvement of the MSBuild system. For more information, see [Open Folder projects for C++](../open-folder-projects-cpp.md).
 - **Visual Studio 2019 and later**: Create a UNIX makefile project for Linux.
 
-## <a name="create_a_makefile_project"> To create a makefile project with the makefile project template
+## <a name="create_a_makefile_project" /> To create a makefile project with the makefile project template
 
 In Visual Studio 2017 and later, the Makefile project template is available when the C++ Desktop Development workload is installed.
 

--- a/docs/build/reference/defining-an-nmake-macro.md
+++ b/docs/build/reference/defining-an-nmake-macro.md
@@ -16,7 +16,7 @@ The *macro_name* is a case-sensitive combination of letters, digits, and undersc
 
 The *string* can be any sequence of zero or more characters. A *null* string contains zero characters or only spaces or tabs. The *string* can contain a macro invocation.
 
-## <a name="special-characters-in-macros"> Special characters in macros
+## <a name="special-characters-in-macros" /> Special characters in macros
 
 A number sign (**`#`**) after a definition specifies a comment. To specify a literal number sign in a macro, use a caret (**`^`**) to escape it, as in **`^#`**.
 
@@ -31,11 +31,11 @@ CMDS = cls^
 dir
 ```
 
-## <a name="null-and-undefined-macros"> Null and undefined macros
+## <a name="null-and-undefined-macros" /> Null and undefined macros
 
 Both null and undefined macros expand to null strings, but a macro defined as a null string is considered defined in preprocessing expressions. To define a macro as a null string, specify no characters except spaces or tabs after the equal sign (**`=`**) in a command line or command file, and enclose the null string or definition in double quotation marks (**`" "`**). To undefine a macro, use **`!UNDEF`**. For more information, see [Makefile preprocessing directives](makefile-preprocessing.md#makefile-preprocessing-directives).
 
-## <a name="where-to-define-macros"> Where to define macros
+## <a name="where-to-define-macros" /> Where to define macros
 
 Define macros in a command line, command file, makefile, or the *`Tools.ini`* file.
 
@@ -43,7 +43,7 @@ In a makefile or the *`Tools.ini`* file, each macro definition must appear on a 
 
 In a command line or command file, spaces and tabs delimit arguments and can't surround the equal sign. If *string* has embedded spaces or tabs, enclose either the string itself or the entire macro in double quotation marks (**`" "`**).
 
-## <a name="precedence-in-macro-definitions"> Precedence in macro definitions
+## <a name="precedence-in-macro-definitions" /> Precedence in macro definitions
 
 If a macro has multiple definitions, NMAKE uses the highest-precedence definition. The following list shows the order of precedence, from highest to lowest:
 

--- a/docs/build/reference/inference-rules.md
+++ b/docs/build/reference/inference-rules.md
@@ -10,7 +10,7 @@ Inference rules in NMAKE supply commands to update targets and to infer dependen
 
 If an out-of-date dependency has no commands, and if [`.SUFFIXES`](dot-directives.md) contains the dependent's extension, NMAKE uses a rule whose extensions match the target and an existing file in the current or specified directory. If more than one rule matches existing files, the **`.SUFFIXES`** list determines which to use; list priority descends from left to right. If a dependent file doesn't exist and isn't listed as a target in another description block, an inference rule can create the missing dependent from another file that has the same base name. If a description block's target has no dependents or commands, an inference rule can update the target. Inference rules can build a command-line target even if no description block exists. NMAKE may invoke a rule for an inferred dependent even if an explicit dependent is specified.
 
-## <a name="defining-a-rule"> Defining a rule
+## <a name="defining-a-rule" /> Defining a rule
 
 The *from_ext* represents the extension of a dependent file, and *to_ext* represents the extension of a target file.
 
@@ -21,7 +21,7 @@ The *from_ext* represents the extension of a dependent file, and *to_ext* repres
 
 Extensions aren't case-sensitive. Macros can be invoked to represent *from_ext* and *to_ext*; the macros are expanded during preprocessing. The period (**`.`**) that precedes *from_ext* must appear at the beginning of the line. The colon (**`:`**) is preceded by zero or more spaces or tabs. It can be followed only by spaces or tabs, a semicolon (**`;`**) to specify a command, a number sign (**`#`**) to specify a comment, or a newline character. No other spaces are allowed. Commands are specified as in description blocks.
 
-## <a name="search-paths-in-rules"> Search paths in rules
+## <a name="search-paths-in-rules" /> Search paths in rules
 
 ```makefile
 {from_path}.from_ext{to_path}.to_ext:
@@ -61,7 +61,7 @@ An inference rule applies to a dependency only if paths specified in the depende
         $(CC) $(CFLAGS) $<
 ```
 
-## <a name="batch-mode-rules"> Batch-mode rules
+## <a name="batch-mode-rules" /> Batch-mode rules
 
 ```makefile
 {from_path}.from_ext{to_path}.to_ext::
@@ -135,7 +135,7 @@ foo4.cpp
 Generating Code...
 ```
 
-## <a name="predefined-rules"> Predefined rules
+## <a name="predefined-rules" /> Predefined rules
 
 Predefined inference rules use NMAKE-supplied command and options macros.
 
@@ -155,7 +155,7 @@ Predefined inference rules use NMAKE-supplied command and options macros.
 | `.cxx.obj` | `$(CXX) $(CXXFLAGS) /c $<` | `cl /c $<` | yes | all |
 | `.rc.res` | `$(RC) $(RFLAGS) /r $<` | `rc /r $<` | no | all |
 
-## <a name="inferred-dependents-and-rules"> Inferred dependents and rules
+## <a name="inferred-dependents-and-rules" /> Inferred dependents and rules
 
 NMAKE assumes an inferred dependent for a target if an applicable inference rule exists. A rule applies if:
 
@@ -169,7 +169,7 @@ NMAKE assumes an inferred dependent for a target if an applicable inference rule
 
 Inferred dependents can cause unexpected side effects. If the target's description block contains commands, NMAKE executes those commands instead of the commands in the rule.
 
-## <a name="precedence-in-inference-rules"> Precedence in inference rules
+## <a name="precedence-in-inference-rules" /> Precedence in inference rules
 
 If an inference rule is defined more than once, NMAKE uses the highest-precedence definition. The following list shows the order of precedence from highest to lowest:
 

--- a/docs/build/reference/inline-files-in-a-makefile.md
+++ b/docs/build/reference/inline-files-in-a-makefile.md
@@ -8,7 +8,7 @@ helpviewer_keywords: ["inline files [C++], in makefiles", "inline files [C++]", 
 
 An inline file contains text you specify in the makefile. Its name can be used in commands as input (for example, a LINK command file), or it can pass commands to the operating system. The file is created on disk when a command that creates the file is run.
 
-## <a name="specifying-an-inline-file"> Specify an inline file
+## <a name="specifying-an-inline-file" /> Specify an inline file
 
 Specify two angle brackets (**`<<`**) in the command where *filename* is to appear. The angle brackets can't be a macro expansion. The *filename* is optional:
 
@@ -18,7 +18,7 @@ Specify two angle brackets (**`<<`**) in the command where *filename* is to appe
 
 When the command is run, the angle brackets are replaced by *filename*, if specified, or by a unique NMAKE-generated name. If specified, *filename* must follow angle brackets without a space or tab. A path is permitted. No extension is required or assumed. If *filename* is specified, the file is created in the current or specified directory, overwriting any existing file by that name. Otherwise, it's created in the `TMP` directory (or the current directory, if the `TMP` environment variable isn't defined). If a previous *filename* is reused, NMAKE replaces the previous file.
 
-## <a name="creating-inline-file-text"> Create inline file text
+## <a name="creating-inline-file-text" /> Create inline file text
 
 Inline files are temporary or permanent.
 
@@ -34,11 +34,11 @@ Specify your *inline_text* on the first line after the command. Mark the end wit
 
 A temporary file exists for the duration of the session and can be reused by other commands. Specify **`KEEP`** after the closing angle brackets to retain the file after the NMAKE session; an unnamed file is preserved on disk with the generated filename. Specify **`NOKEEP`** or nothing for a temporary file. **`KEEP`** and **`NOKEEP`** are not case sensitive.
 
-## <a name="reusing-inline-files"> Reuse inline files
+## <a name="reusing-inline-files" /> Reuse inline files
 
 To reuse an inline file, specify `<<filename` where the file is defined and first used, then reuse *filename* without `<<` later in the same or another command. The command to create the inline file must run before all commands that use the file.
 
-## <a name="multiple-inline-files"> Multiple inline files
+## <a name="multiple-inline-files" /> Multiple inline files
 
 A command can create more than one inline file:
 

--- a/docs/build/reference/makefile-preprocessing.md
+++ b/docs/build/reference/makefile-preprocessing.md
@@ -9,7 +9,7 @@ helpviewer_keywords: ["preprocessing makefiles", "makefiles, preprocessing", "!C
 
 You can control the NMAKE session by using preprocessing directives and expressions. Preprocessing instructions can be placed in the makefile or in *`Tools.ini`*. Using directives, you can conditionally process your makefile, display error messages, include other makefiles, undefine a macro, and turn certain options on or off.
 
-## <a name="makefile-preprocessing-directives"> Makefile Preprocessing Directives
+## <a name="makefile-preprocessing-directives" /> Makefile Preprocessing Directives
 
 Preprocessing directives aren't case-sensitive. The initial exclamation point (**`!`**) must appear at the beginning of the line. Zero or more spaces or tabs can appear after the exclamation point, for indentation.
 
@@ -67,13 +67,13 @@ Preprocessing directives aren't case-sensitive. The initial exclamation point (*
 
    Undefines *macro_name*.
 
-## <a name="expressions-in-makefile-preprocessing"> Expressions in makefile preprocessing
+## <a name="expressions-in-makefile-preprocessing" /> Expressions in makefile preprocessing
 
 The **`!IF`** or **`!ELSE IF`** *constant_expression* consists of integer constants (in decimal or C-language notation), string constants, or commands. Use parentheses to group expressions. Expressions use C-style signed long integer arithmetic; numbers are in 32-bit two's-complement form in the range -2147483648 to 2147483647.
 
 Expressions can use operators that act on constant values, exit codes from commands, strings, macros, and file-system paths.
 
-## <a name="makefile-preprocessing-operators"> Makefile preprocessing operators
+## <a name="makefile-preprocessing-operators" /> Makefile preprocessing operators
 
 Makefile preprocessing expressions can use operators that act on constant values, exit codes from commands, strings, macros, and file-system paths. To evaluate the expression, the preprocessor first expands macros, and then executes commands, and then does the operations. It evaluates operations in order of explicit grouping in parentheses, and then in order of operator precedence. The result is a constant value.
 
@@ -125,7 +125,7 @@ Expressions can use the following operators. The operators of equal precedence a
 > [!NOTE]
 > The bitwise XOR operator (**`^`**) is the same as the escape character, and must be escaped (as **`^^`**) when it's used in an expression.
 
-## <a name="executing-a-program-in-preprocessing"> Executing a program in preprocessing
+## <a name="executing-a-program-in-preprocessing" /> Executing a program in preprocessing
 
 To use a command's exit code during preprocessing, specify the command, with any arguments, within brackets (**`[ ]`**). Any macros are expanded before the command is executed. NMAKE replaces the command specification with the command's exit code, which can be used in an expression to control preprocessing.
 

--- a/docs/build/reference/special-nmake-macros.md
+++ b/docs/build/reference/special-nmake-macros.md
@@ -9,7 +9,7 @@ no-loc: [AS, AFLAGS, CC, CFLAGS, CPP, CPPFLAGS, CXX, CXXFLAGS, RC, RFLAGS, ias, 
 
 NMAKE provides several special macros to represent various filenames and commands. One use for some of these macros is in the predefined inference rules. Like all macros, the macros provided by NMAKE are case sensitive.
 
-## <a name="filename-macros"> Filename Macros
+## <a name="filename-macros" /> Filename Macros
 
 Filename macros are predefined as filenames specified in the dependency (not full filename specifications on disk). These macros don't need to be enclosed in parentheses when invoked; specify only a **`$`** as shown.
 
@@ -31,7 +31,7 @@ To specify part of a predefined filename macro, append a macro modifier and encl
 | **`F`** | Base name plus extension |
 | **`R`** | Drive plus directory plus base name |
 
-## <a name="recursion-macros"> Recursion macros
+## <a name="recursion-macros" /> Recursion macros
 
 Use recursion macros to call NMAKE recursively. Recursive sessions inherit command-line and environment-variable macros and *`Tools.ini`* information. They don't inherit makefile-defined inference rules or `.SUFFIXES` and `.PRECIOUS` specifications. There are three ways to pass macros to a recursive NMAKE session:
 
@@ -45,7 +45,7 @@ Use recursion macros to call NMAKE recursively. Recursive sessions inherit comma
 | **`MAKEDIR`** | Current directory when NMAKE was invoked. |
 | **`MAKEFLAGS`** | Options currently in effect. Use as `/$(MAKEFLAGS)`. The **`/F`** option isn't included. |
 
-## <a name="command-macros-and-options-macros"> Command macros and options macros
+## <a name="command-macros-and-options-macros" /> Command macros and options macros
 
 Command macros are predefined for Microsoft products. Options macros represent options to these products and are undefined by default. Both are used in predefined inference rules and can be used in description blocks or user-defined inference rules. Command macros can be redefined to represent part or all of a command line, including options. Options macros generate a null string if left undefined.
 
@@ -57,7 +57,7 @@ Command macros are predefined for Microsoft products. Options macros represent o
 | C++ Compiler | **`CXX`** | `cl` | **`CXXFLAGS`** |
 | Resource Compiler | **`RC`** | `rc` | **`RFLAGS`** |
 
-## <a name="environment-variable-macros"> Environment-variable macros
+## <a name="environment-variable-macros" /> Environment-variable macros
 
 NMAKE inherits macro definitions for environment variables that exist before the start of the session. If a variable was set in the operating-system environment, it is available as an NMAKE macro. The inherited names are converted to uppercase. Inheritance occurs before preprocessing. Use the /E option to cause macros inherited from environment variables to override any macros with the same name in the makefile.
 

--- a/docs/build/reference/using-an-nmake-macro.md
+++ b/docs/build/reference/using-an-nmake-macro.md
@@ -14,7 +14,7 @@ $(macro_name)
 
 No spaces are allowed. The parentheses are optional if *macro_name* is a single character. The definition string replaces `$(macro_name)`; an undefined macro is replaced by a null string.
 
-## <a name="macro-substitution"> Macro substitution
+## <a name="macro-substitution" /> Macro substitution
 
 When *macro_name* is invoked, each occurrence of *string1* in its definition string is replaced by *string2*.
 
@@ -28,11 +28,11 @@ No spaces or tabs precede the colon (**`:`**); any spaces or tabs after the colo
 
 ::: moniker range=">=msvc-170"
 
-## <a name="functions"> Macro functions
+## <a name="functions" /> Macro functions
 
 NMAKE provides a set of functions that can be used to modify strings, lists of items and file paths. These functions are available in NMAKE starting in Visual Studio 2022.
 
-### <a name="functions-syntax"> Function syntax
+### <a name="functions-syntax" /> Function syntax
 
 Functions use the following syntax:
 
@@ -57,7 +57,7 @@ INPUT=a, b
 $(subst $(COMMA) , and ,$(INPUT)) # Evaluates to "a and b"
 ```
 
-### <a name="function-list-syntax"> List syntax
+### <a name="function-list-syntax" /> List syntax
 
 Some functions support a whitespace-separated list of items. Extra whitespace is ignored at the beginning of the list, the end of the list, or between each item. Lists produced by a function use a single space between each item as a separator, and don't have leading or trailing whitespace.
 
@@ -67,7 +67,7 @@ For example, the simplest list function is `strip`, which takes a single list ar
 $(strip a   b   c d    ) # Evaluates to "a b c d"
 ```
 
-### <a name="function-pattern-syntax"> Pattern syntax
+### <a name="function-pattern-syntax" /> Pattern syntax
 
 Some functions support using a *pattern*. A pattern is a string that contains a single wildcard that can match any number of characters. The first `%` in a pattern is the wildcard, and any later `%` characters are treated as literals. A `%` anywhere before the actual wildcard can be escaped by using `\` (that is, `\%` is treated as a literal `%`). Any `\` that would escape the wildcard can be escaped with another `\` (so `\\%` is treated as a literal `\` followed by the wildcard). To be considered a match, all of the input characters must be matched by the pattern; partial matches aren't supported.
 
@@ -86,7 +86,7 @@ $(filter a%c\\%d,abc\\%d) # Evaluates to "abc\\%d" - any `\` after the wildcard 
 $(filter \\a%f,\\abcdef) # Evaluates to "\\abcdef" - any `\\` that isn't directly before the wildcard isn't treated as an escape
 ```
 
-### <a name="functions-by-category"> Functions by category
+### <a name="functions-by-category" /> Functions by category
 
 | Function | Purpose | Supported |
 |--|--|--|

--- a/docs/cpp/if-else-statement-cpp.md
+++ b/docs/cpp/if-else-statement-cpp.md
@@ -164,7 +164,7 @@ setting shared_flag to false
 Error! Token must not be a keyword
 ```
 
-## <a name="if_constexpr"> if constexpr statements
+## <a name="if_constexpr" /> if constexpr statements
 
 Starting in C++17, you can use an **`if constexpr`** statement in function templates to make compile-time branching decisions without having to resort to multiple function overloads. **Microsoft-specific**: This form is available starting in Visual Studio 2017 version 15.3, and requires at least the [`/std:c++17`](../build/reference/std-specify-language-standard-version.md) compiler option.
 

--- a/docs/cppcx/platform-intptr-value-class.md
+++ b/docs/cppcx/platform-intptr-value-class.md
@@ -37,7 +37,7 @@ IntPtr has the following members:
 
 **Metadata:** platform.winmd
 
-## <a name="ctor"> </a> IntPtr::IntPtr Constructor
+## <a name="ctor" /> </a> IntPtr::IntPtr Constructor
 
 Initializes a new instance of an IntPtr with the specified value.
 

--- a/docs/parallel/amp/reference/concurrency-direct3d-namespace-functions-amp.md
+++ b/docs/parallel/amp/reference/concurrency-direct3d-namespace-functions-amp.md
@@ -262,7 +262,7 @@ An array on a Direct3D accelerator_view for which the underlying Direct3D buffer
 
 The IUnknown interface pointer corresponding to the Direct3D buffer underlying the array.
 
-## <a name="get_device"> get_device
+## <a name="get_device" /> get_device
 
 Get the D3D device interface underlying a accelerator_view.
 

--- a/docs/parallel/amp/reference/concurrency-precise-math-namespace-functions.md
+++ b/docs/parallel/amp/reference/concurrency-precise-math-namespace-functions.md
@@ -1049,7 +1049,7 @@ Floating-point value
 
 Returns the floor of the argument
 
-## <a name="fma"> fma
+## <a name="fma" /> fma
 
 Computes the product of the first and second specified arguments, then adds the third specified argument to the result; the entire computation is performed as a single operation.
 

--- a/docs/parallel/amp/reference/norm-3-class.md
+++ b/docs/parallel/amp/reference/norm-3-class.md
@@ -200,7 +200,7 @@ The value for initialization.
 *_Other*<br/>
 The object used to initialize.
 
-## <a name="size"> size Constant
+## <a name="size" /> size Constant
 
 ### Syntax
 

--- a/docs/parallel/amp/reference/tile-barrier-class.md
+++ b/docs/parallel/amp/reference/tile-barrier-class.md
@@ -79,7 +79,7 @@ Blocks execution of all threads in a tile until all threads in a tile have reach
 void wait_with_all_memory_fence() const restrict(amp);
 ```
 
-## <a name="wait_with_global_memory_fence"> wait_with_global_memory_fence
+## <a name="wait_with_global_memory_fence" /> wait_with_global_memory_fence
 
 Blocks execution of all threads in a tile until all threads in a tile have reached this call. This ensures that all global memory accesses are visible to other threads in the thread tile, and have been executed in program order.
 
@@ -89,7 +89,7 @@ Blocks execution of all threads in a tile until all threads in a tile have reach
 void wait_with_global_memory_fence() const  restrict(amp);
 ```
 
-## <a name="wait_with_tile_static_memory_fence"> wait_with_tile_static_memory_fence
+## <a name="wait_with_tile_static_memory_fence" /> wait_with_tile_static_memory_fence
 
 Blocks execution of all threads in a tile until all threads in a tile have reached this call. This ensures that `tile_static` memory accesses are visible to other threads in the thread tile, and have been executed in program order.
 

--- a/docs/parallel/concrt/reference/reader-writer-lock-class.md
+++ b/docs/parallel/concrt/reference/reader-writer-lock-class.md
@@ -158,7 +158,7 @@ explicit _CRTIMP scoped_lock_read(reader_writer_lock& _Reader_writer_lock);
 *_Reader_writer_lock*<br/>
 The `reader_writer_lock` object to acquire as a reader.
 
-## <a name="scoped_lock_read_dtor">  reader_writer_lock::scoped_lock_read::~scoped_lock_read Destructor
+## <a name="scoped_lock_read_dtor" />  reader_writer_lock::scoped_lock_read::~scoped_lock_read Destructor
 
 Destroys a `scoped_lock_read` object and releases the lock supplied in its constructor.
 

--- a/docs/standard-library/scoped-allocator-adaptor-class.md
+++ b/docs/standard-library/scoped-allocator-adaptor-class.md
@@ -240,14 +240,14 @@ size_type max_size();
 
 `Outer_traits::max_size(outer_allocator())`
 
-## <a name="op_as">  scoped_allocator_adaptor::operator=
+## <a name="op_as" />  scoped_allocator_adaptor::operator=
 
 ```cpp
 scoped_allocator_adaptor& operator=(const scoped_allocator_adaptor&) = default;
 scoped_allocator_adaptor& operator=(scoped_allocator_adaptor&&) = default;
 ```
 
-## <a name="op_eq_eq">  scoped_allocator_adaptor::operator==
+## <a name="op_eq_eq" />  scoped_allocator_adaptor::operator==
 
 ```cpp
 template <class OuterA1, class OuterA2, class... InnerAllocs>
@@ -255,7 +255,7 @@ bool operator==(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
 const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 ```
 
-## <a name="op_noeq">  scoped_allocator_adaptor::operator!=
+## <a name="op_noeq" />  scoped_allocator_adaptor::operator!=
 
 ```cpp
 template <class OuterA1, class OuterA2, class... InnerAllocs>
@@ -263,7 +263,7 @@ bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
 const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 ```
 
-## <a name="outer_allocator"></a> scoped_allocator_adaptor::outer_allocator
+## <a name="outer_allocator" /></a> scoped_allocator_adaptor::outer_allocator
 
 Retrieves a reference to the stored object of type `outer_allocator_type`.
 

--- a/docs/standard-library/scoped-allocator-adaptor-class.md
+++ b/docs/standard-library/scoped-allocator-adaptor-class.md
@@ -263,7 +263,7 @@ bool operator!=(const scoped_allocator_adaptor<OuterA1, InnerAllocs...>& a,
 const scoped_allocator_adaptor<OuterA2, InnerAllocs...>& b) noexcept;
 ```
 
-## <a name="outer_allocator" /></a> scoped_allocator_adaptor::outer_allocator
+## <a name="outer_allocator" /> scoped_allocator_adaptor::outer_allocator
 
 Retrieves a reference to the stored object of type `outer_allocator_type`.
 


### PR DESCRIPTION
Fix unclosed link tags causing the whole page to appear as a link.

e.g. After Filename Macros in Special NMAKE macros, the unclosed link makes the paragraph text appear as a link

![image](https://github.com/MicrosoftDocs/cpp-docs/assets/10196821/83691e06-f4dd-4770-b744-cdc7891e0c02)
