### PR TITLE
Update namespaces-cpp.md - typo/grammar

### DIFF
--- a/docs/cpp/namespaces-cpp.md
+++ b/docs/cpp/namespaces-cpp.md
@@ -10,7 +10,7 @@ ms.assetid: d1a5a9ab-1cad-47e6-a82d-385bb77f4188
 
 A namespace is a declarative region that provides a scope to the identifiers (the names of types, functions, variables, etc) inside it. Namespaces are used to organize code into logical groups and to prevent name collisions that can occur especially when your code base includes multiple libraries. All identifiers at namespace scope are visible to one another without qualification. Identifiers outside the namespace can access the members by using the fully qualified name for each identifier, for example `std::vector<std::string> vec;`, or else by a [using Declaration](../cpp/using-declaration.md) for a single identifier (`using std::string`), or a [using Directive](../cpp/namespaces-cpp.md#using_directives) for all the identifiers in the namespace (`using namespace std;`). Code in header files should always use the fully qualified namespace name.
 
-The following example shows a namespace declaration and three ways that code outside the namespace can accesses their members.
+The following example shows a namespace declaration and three ways that code outside the namespace can access its members.
 
 ```cpp
 namespace ContosoData


### PR DESCRIPTION
Changed 3rd person present "accesses" to "access". Additionally changed "their" to "its", to align with rest of document.