### PR TITLE
Update compiler-warning-level-2-c4307.md

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4307.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4307.md
@@ -8,7 +8,7 @@ ms.assetid: 7cca11e9-be61-49e4-8b15-88b84f0cbf07
 ---
 # Compiler Warning (level 2) C4307
 
-'operator' : integral constant overflow
+'operator' : signed integral constant overflow
 
 The operator is used in an expression that results in an integer constant overflowing the space allocated for it. You may need to use a larger type for the constant. A **`signed int`** holds a smaller value than an **`unsigned int`** because the **`signed int`** uses one bit to represent the sign.
 


### PR DESCRIPTION
The diagnostic currently contains the word "signed".  I added it to the text of the description.