### PR TITLE
Fixing a dead link to the vcpkg toolchain file page

### DIFF
--- a/docs/build/customize-cmake-settings.md
+++ b/docs/build/customize-cmake-settings.md
@@ -44,7 +44,7 @@ Corresponds to the **inheritedEnvironments** setting. Defines the compiler envir
 
 ### CMake toolchain file
 
-Path to the [CMake toolchain file](https://cmake.org/cmake/help/latest/variable/CMAKE_TOOLCHAIN_FILE.html). This path is passed to CMake as "-DCMAKE_TOOLCHAIN_FILE = \<filepath>". Toolchain files specify locations of compilers and toolchain utilities, and other target platform and compiler-related information. By default, Visual Studio uses the [vcpkg toolchain file](https://github.com/microsoft/vcpkg/blob/master/docs/examples/installing-and-using-packages.md#cmake) if this setting is unspecified.
+Path to the [CMake toolchain file](https://cmake.org/cmake/help/latest/variable/CMAKE_TOOLCHAIN_FILE.html). This path is passed to CMake as "-DCMAKE_TOOLCHAIN_FILE = \<filepath>". Toolchain files specify locations of compilers and toolchain utilities, and other target platform and compiler-related information. By default, Visual Studio uses the [vcpkg toolchain file](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/installing-and-using-packages.md#cmake) if this setting is unspecified.
 
 ### Build root
 


### PR DESCRIPTION
Hi,

While reading https://learn.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-170#cmake-toolchain-file you refer to `vcpkg toolchain file` with this deadlink https://github.com/microsoft/vcpkg/blob/master/docs/examples/installing-and-using-packages.md#cmake.

They moved the repository from https://github.com/microsoft/vcpkg to https://github.com/microsoft/vcpkg-docs - so the new url is https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/installing-and-using-packages.md

There could be other dead link to that repository, but at least here's one fixed.