### PR TITLE
_controlfp_s: Describe effects of FPCR changes on ARM

### DIFF
--- a/docs/c-runtime-library/reference/controlfp-s.md
+++ b/docs/c-runtime-library/reference/controlfp-s.md
@@ -75,6 +75,9 @@ _controlfp_s(&current_word, _DN_FLUSH, _MCW_DN);
 // and x64 processors with SSE2 support. Ignored on other x86 platforms.
 ```
 
+> [!NOTE]
+> On ARM platforms, unmasking `_MCW_EM`, `_EM_INEXACT`, `_EM_UNDERFLOW`, `_EM_OVERFLOW`, `_EM_ZERODIVIDE`, and `_EM_INVALID` will correctly change the FPCR register. However, instead of raising an unmasked exception, Windows will reset the FPCR register to its defaults every time an FP exception is about to be raised from the user’s math expressions, effectively making changes to the FPCR register pointless on ARM. FP exceptions explicitly raised by standard math functions, like Invalid operation from std::acos, are not subject to this behavior and can be ignored or raised properly depending on the FPCR register. More: [Overview of ARM32 ABI Conventions](../../build/overview-of-arm-abi-conventions.md#floating-point-exceptions)
+
 On ARM platforms, the **`_controlfp_s`** function applies to the FPSCR register. On x64 architectures, only the SSE2 control word that's stored in the MXCSR register is affected. On Intel (x86) platforms, **`_controlfp_s`** affects the control words for both the x87 and the SSE2, if present. It's possible for the two control words to be inconsistent with each other (because of a previous call to [`__control87_2`](control87-controlfp-control87-2.md), for example); if there's an inconsistency between the two control words, **`_controlfp_s`** sets the `EM_AMBIGUOUS` flag in *`currentControl`*. It's a warning that the returned control word might not represent the state of both floating-point control words accurately.
 
 On the ARM and x64 architectures, changing the infinity mode or the floating-point precision isn't supported. If the precision control mask is used on the x64 platform, the function raises an assertion and the invalid parameter handler is invoked, as described in [Parameter validation](../parameter-validation.md).


### PR DESCRIPTION
We believe this note should be somewhere close to `_controlfp_s` documentation.
More details:
https://stackoverflow.com/questions/78917793/windows-on-arm-math-is-not-trapping