### PR TITLE
P0859R0 was implemented in VS 2022 17.1

### DIFF
--- a/docs/overview/visual-cpp-language-conformance.md
+++ b/docs/overview/visual-cpp-language-conformance.md
@@ -87,7 +87,7 @@ For details on conformance improvements, see [C++ conformance improvements in Vi
 | &emsp;[`P1825R0 Merged wording for P0527R1 and P1155R3, more implicit moves`](https://wg21.link/p1825r0) | VS 2019 16.4 <sup>[17](#note_17)</sup> |
 | &emsp;[`P0929R2 Checking for abstract class types`](https://wg21.link/P0929R2) | VS 2019 16.5 <sup>[17](#note_17)</sup> |
 | &emsp;[`P0962R1 Relaxing the range-for loop customization point finding rules`](https://wg21.link/p0962r1) | VS 2019 16.5 <sup>[17](#note_17)</sup> |
-| &emsp;[`P0859R0 CWG 1581: When are constexpr member functions defined`](https://wg21.link/p0859r0) | Partial in VS 2019 16.7 <sup>[E](#note_E)</sup> |
+| &emsp;[`P0859R0 CWG 1581: When are constexpr member functions defined`](https://wg21.link/p0859r0) | Partial in VS 2019 16.7 <sup>[E](#note_E)</sup>, Full in VS 2022 17.1 |
 | &emsp;[`P1009R2 Array size deduction in new-expressions`](https://wg21.link/P1009R2) | VS 2019 16.7 <sup>[17](#note_17)</sup> |
 | &emsp;[`P1286R2 Contra CWG DR1778`](https://wg21.link/P1286R2) | VS 2019 16.8 <sup>[17](#note_17)</sup> |
 | **C++20 Core language features** | **Supported** |


### PR DESCRIPTION
Could you recheck the change please? @cdacamar told me that the feature is implemented if I understood correctly.
If not then I will change the same line at https://en.cppreference.com/w/cpp/compiler_support/20 to partial.