### PR TITLE
Fix typo in `c-compile-without-linking.md`.

### DIFF
--- a/docs/build/reference/c-compile-without-linking.md
+++ b/docs/build/reference/c-compile-without-linking.md
@@ -41,7 +41,7 @@ CL /c FIRST.C SECOND.C THIRD.OBJ
 To create an executable file, you must invoke LINK:
 
 ```
-LINK firsti.obj second.obj third.obj /OUT:filename.exe
+LINK first.obj second.obj third.obj /OUT:filename.exe
 ```
 
 ## See also


### PR DESCRIPTION
This commit fixes a typo in [/c (Compile Without Linking)](https://learn.microsoft.com/en-us/cpp/build/reference/c-compile-without-linking?view=msvc-170).