### PR TITLE
improved description for C26435

### DIFF
--- a/docs/code-quality/c26435.md
+++ b/docs/code-quality/c26435.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C26435"]
 ---
 # Warning C26435
 
-> Function '*symbol*' should specify exactly one of 'virtual', 'override', or 'final' (c.128)
+> The virtual function '*symbol*' should specify exactly one of 'virtual', 'override', or 'final' (c.128)
 
 ## C++ Core Guidelines
 
@@ -39,6 +39,9 @@ public:
 class Circle : public Ellipse {
 public:
     void Draw() override final { // C26435, only 'final' is necessary.
+        //...
+    }
+    virtual void DrawCircumference() final { // C26435, should be neither 'virtual' nor 'final'.
         //...
     }
 };


### PR DESCRIPTION
Documentation improvement motivated by  https://developercommunity.visualstudio.com/t/Warning-C26435-contradicts-to-Compiler-E/10355159

When a `virtual` function declaration includes the `final` specifier, the warning message for C26435 incorrectly suggested specifying exactly one of the two. The correct solution is to specify zero of the two. The warning message has been updated in MSVC and this documentation change reflects that as well as provides an example of how to fix the incorrect pattern.