### PR TITLE
Update c-enumeration-declarations.md 

### DIFF
--- a/docs/c-language/c-enumeration-declarations.md
+++ b/docs/c-language/c-enumeration-declarations.md
@@ -133,4 +133,4 @@ enum { yes, no } response;
 
 ## See also
 
-[Enumerations(c++)](../cpp/enumerations-cpp.md)
+[Enumerations(C++)](../cpp/enumerations-cpp.md)

--- a/docs/c-language/c-enumeration-declarations.md
+++ b/docs/c-language/c-enumeration-declarations.md
@@ -133,4 +133,4 @@ enum { yes, no } response;
 
 ## See also
 
-[Enumerations](../cpp/enumerations-cpp.md)
+[Enumerations(c++)](../cpp/enumerations-cpp.md)


### PR DESCRIPTION
reference to the Enumerations(C++) file should have a link with anchor text "Enumerations(C++)" i.e. different from ANSI C