### PR TITLE
Fix missing start bracket in `ccomsafearray-class.md`

### DIFF
--- a/docs/atl/reference/ccomsafearray-class.md
+++ b/docs/atl/reference/ccomsafearray-class.md
@@ -526,7 +526,7 @@ Retrieves an element from the array.
 
 ```cpp
 T& operator[](long lindex) const;
-T& operator[]int nindex) const;
+T& operator[](int nindex) const;
 ```
 
 ### Parameters


### PR DESCRIPTION
Fixes the missing start parenthesis in the second overload of `operator[]` [here](https://learn.microsoft.com/en-us/cpp/atl/reference/ccomsafearray-class?view=msvc-170#operator_at).