### PR TITLE
Update using-insertion-operators-and-controlling-format.md

### DIFF
--- a/docs/standard-library/using-insertion-operators-and-controlling-format.md
+++ b/docs/standard-library/using-insertion-operators-and-controlling-format.md
@@ -87,7 +87,7 @@ int main( )
 }
 ```
 
-The `width` member function is declared in `<iostream>`. If you use `setw` or any other manipulator with arguments, you must include `<iomanip>`. In the output, strings print in a field of width 6 and integers in a field of width 10:
+The `width` member function is declared in `<iostream>`. If you use `setw` or any other manipulator with arguments, you must include `<iomanip>`. In the output, strings print in a field of width 7 and integers in a field of width 10:
 
 ```Output
    Zoot      1.23


### PR DESCRIPTION
Changed the `setw` width value from 6, to 7, in the worded explanation to accurately reflect the example code provided.