### PR TITLE
Fix MASM dot-code and dot-data to indicate they also work on x64

### DIFF
--- a/docs/assembler/masm/dot-code.md
+++ b/docs/assembler/masm/dot-code.md
@@ -8,7 +8,9 @@ ms.assetid: 2b8c882c-c0d2-4fa3-8335-e6b12717a4f4
 ---
 # .CODE
 
-(32-bit MASM only.) When used with [.MODEL](dot-model.md), indicates the start of a code segment.
+Indicates the start of a code segment.
+
+When using 32-bit MASM, this should be used along with [.MODEL](dot-model.md).
 
 ## Syntax
 

--- a/docs/assembler/masm/dot-data.md
+++ b/docs/assembler/masm/dot-data.md
@@ -8,7 +8,9 @@ ms.assetid: 32797935-9c79-46e0-bf6f-07d0c2bf1dc1
 ---
 # .DATA
 
- (32-bit MASM only.) When used with [.MODEL](dot-model.md), starts a near data segment for initialized data (segment name _DATA).
+Indicates the start of a data segment.
+
+When using 32-bit MASM, this starts a near data segment for initialized data (segment name _DATA) and should be used along with [.MODEL](dot-model.md).
 
 ## Syntax
 


### PR DESCRIPTION
Problem: Current documentation of .DATA and .CODE is confusing since it starts with a sentence that says 32 bit only which can lead to a misunderstanding that it is not supported in x64