### PR TITLE
MASM: Add PROC as another possible type for EXTERN

### DIFF
--- a/docs/assembler/masm/extern-masm.md
+++ b/docs/assembler/masm/extern-masm.md
@@ -19,6 +19,8 @@ The *language-type* argument is valid in 32-bit MASM only.
 
 The *type* can be [ABS](operator-abs.md), which imports *name* as a constant. Same as [EXTRN](extrn.md).
 
+The *type* can also be PROC, in which case *name* is treated as an external procedure.
+
 ## See also
 
 [Directives Reference](directives-reference.md)\


### PR DESCRIPTION
Problem: Current documentation for EXTERN misses an important possible type which is PROC.
This type is important since it enables calling external procedures, for instance, the following
is an example of calling Sleep from kernel32 (assuming the kernel32.lib is specified during linkage):

```
public main
extern Sleep : PROC

.CODE

main:
mov rcx, 1000
call Sleep
ret

END
```