### PR TITLE
Prefer standard main function signatures

### DIFF
--- a/docs/c-runtime-library/find-memory-leaks-using-the-crt-library.md
+++ b/docs/c-runtime-library/find-memory-leaks-using-the-crt-library.md
@@ -2,7 +2,7 @@
 title: Find memory leaks with the CRT library
 description: Learn how the C/C++ debugger and C Run-time Library (CRT) can help find memory leaks. The techniques include memory-leak reports and comparing memory snapshots.
 ms.date: 02/03/2023
-helpviewer_keywords: 
+helpviewer_keywords:
   - breakpoints, on memory allocation
   - _CrtMemState
   - _CrtMemCheckpoint
@@ -165,7 +165,7 @@ struct Pod {
     int x;
 };
 
-void main() {
+int main() {
     Pod* pPod = DBG_NEW Pod;
     pPod = DBG_NEW Pod; // Oops, leaked the original pPod!
     delete pPod;

--- a/docs/code-quality/c6387.md
+++ b/docs/code-quality/c6387.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6387"
 title: Warning C6387
+description: "Learn more about: Warning C6387"
 ms.date: 11/04/2016
 f1_keywords: ["C6387", "INVALID_PARAM_VALUE_1", "__WARNING_INVALID_PARAM_VALUE_1"]
 helpviewer_keywords: ["C6387"]
-ms.assetid: 3ea2fc4d-ffc3-4c3c-bfae-d42aa56235d8
 ---
 # Warning C6387
 
@@ -27,7 +26,7 @@ _Post_ _Null_ char * g();
 
 void f(_In_ char *pch);
 
-void main()
+int main()
 {
     char *pCh = g();
     f(pCh); // Warning C6387
@@ -43,7 +42,7 @@ _Post_ _Notnull_ char * g();
 
 void f(_In_ char *pch);
 
-void main()
+int main()
 {
     char *pCh = g();
     f(pCh);

--- a/docs/sanitizers/asan-continue-on-error.md
+++ b/docs/sanitizers/asan-continue-on-error.md
@@ -196,7 +196,7 @@ Create the example:
     
     char buffer[10] = {0,1,2,3,4,5,6,7,8,9}; 
     
-    void main()
+    int main()
     {   
         char* inverted_buf= func(buffer, 10); 
     }
@@ -317,7 +317,7 @@ int foo_redundant(unsigned long arg_var)
     return ret;
 }
 
-void main()
+int main()
 {
     int cnt = 0;
 

--- a/docs/sanitizers/error-stack-use-after-scope.md
+++ b/docs/sanitizers/error-stack-use-after-scope.md
@@ -80,7 +80,7 @@ devenv /debugexe example2.exe
 struct IntHolder {
     explicit IntHolder(int* val = 0) : val_(val) { }
     ~IntHolder() {
-        printf("Value: %d\n", *val_);  // Bom!
+        printf("Value: %d\n", *val_);  // Boom!
     }
     void set(int* val) { val_ = val; }
     int* get() { return val_; }
@@ -138,7 +138,7 @@ void temp_from_conversion() {
     a.print();
 }
 
-void main() {
+int main() {
     explicit_temp();
     temp_from_conversion(); 
 }

--- a/docs/standard-library/span-functions.md
+++ b/docs/standard-library/span-functions.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: <span> functions"
 title: "<span> functions"
+description: "Learn more about: <span> functions"
 ms.date: "05/28/2020"
 f1_keywords: ["span/std::span::as_bytes", "span/std::as_writable_bytes"]
 helpviewer_keywords: ["std::span [C++], as_writable_bytes", "std::as_bytes [C++]"]
@@ -47,7 +47,7 @@ A `span<const byte, S>` to the first item stored in the span where `S` is `{rein
 
 using namespace std;
 
-void main()
+int main()
 {
     int a[] = { 0,1,2 };
     span <int> mySpan(a);
@@ -87,7 +87,7 @@ A `span<byte, S>` to the first item stored in the span where `S` is `{reinterpre
 
 using namespace std;
 
-void main()
+int main()
 {
     int a[] = { 0,1,2 };
     span <int> mySpan(a);


### PR DESCRIPTION
Replace non-standard `void main()` signature with `int main()` and perform a few miscellaneous fixes and metadata edits.