### PR TITLE
C26135: Update comments to use correct annotation

### DIFF
--- a/docs/code-quality/c26135.md
+++ b/docs/code-quality/c26135.md
@@ -25,14 +25,14 @@ typedef struct _DATA
 void MyEnter(DATA* p)
 {
     // Warning C26135:
-    // Missing side effect annotation _Acquires_lock_(&p->cs)
+    // Missing side effect annotation _Acquires_lock_(p->cs)
     EnterCriticalSection(&p->cs);
 }
 
 void MyLeave(DATA* p)
 {
     // warning C26135:
-    // Missing side effect annotation _Releases_lock_(&p->cs)
+    // Missing side effect annotation _Releases_lock_(p->cs)
     LeaveCriticalSection(&p->cs);
 }
 ```


### PR DESCRIPTION
The lock is the critical section, not the pointer to it.

![Annotation uses p->cs](https://github.com/user-attachments/assets/a5a85c78-63d0-4584-96f0-7c23394ba5b3)

By the way, the [contributing guide](https://github.com/MicrosoftDocs/cpp-docs/blob/main/CONTRIBUTING.md) is outdated as it continues to make references to Issues, even though this repository has them disabled. What is the new way to start discussions as listed in the do's/don'ts section?