### PR TITLE
Update the ABI to support Floating-Point Exceptions.

### DIFF
--- a/docs/build/arm64-windows-abi-conventions.md
+++ b/docs/build/arm64-windows-abi-conventions.md
@@ -118,7 +118,7 @@ Like AArch32, the AArch64 specification provides three system-controlled "thread
 
 ## Floating-point exceptions
 
-Support for IEEE floating-point exceptions is optional on AArch64 systems. For processor variants that do have hardware floating-point exceptions, the Windows kernel silently catches the exceptions and implicitly disables them in the FPCR register. This trap ensures normalized behavior across processor variants. Otherwise, code developed on a platform without exception support may find itself taking unexpected exceptions when running on a platform with support.
+Support for IEEE floating-point exceptions on AArch64 systems is optional. This can be verified by writing a value that enables exceptions to the `FPCR` register and then reading it back. The bits corresponding to supported exceptions will remain set, while the bits corresponding to unsupported exceptions will be reset by the CPU.
 
 ## Parameter passing
 


### PR DESCRIPTION
Update the ABI to be in concordance, with the introduction of the first officially supported CPU with FP exceptions.

While the original rule was a good intention, it was at odds with the Arm ABI, which is also adopted by Linux and macOS, making code harder to port.

It was also at odds with the Arm Architecture in the sense that if offers a direct way to convey to software when FP exceptions are supported and when they are enabled, and this rule was negating such contract.