### PR TITLE
Elide more extraneous periods

### DIFF
--- a/docs/atl/reference/cw2wex-class.md
+++ b/docs/atl/reference/cw2wex-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CW2WEX Class"
 title: "CW2WEX Class"
+description: "Learn more about: CW2WEX Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CW2WEX", "ATLCONV/ATL::CW2WEX", "ATLCONV/ATL::CW2WEX::CW2WEX", "ATLCONV/ATL::CW2WEX::m_psz", "ATLCONV/ATL::CW2WEX::m_szBuffer"]
 helpviewer_keywords: ["CW2WEX class"]
-ms.assetid: 46262e56-e0d2-41fe-855b-0b67ecc8fcd7
 ---
 # CW2WEX Class
 
@@ -100,7 +99,7 @@ Creates the buffer required for the translation.
 
 ## <a name="dtor"></a> CW2WEX::~CW2WEX
 
-The destructor..
+The destructor.
 
 ```
 ~CW2WEX() throw();
@@ -140,9 +139,9 @@ Returns the text string as type LPWSTR.
 
 ## See also
 
-[CA2AEX Class](../../atl/reference/ca2aex-class.md)<br/>
-[CA2CAEX Class](../../atl/reference/ca2caex-class.md)<br/>
-[CA2WEX Class](../../atl/reference/ca2wex-class.md)<br/>
-[CW2AEX Class](../../atl/reference/cw2aex-class.md)<br/>
-[CW2CWEX Class](../../atl/reference/cw2cwex-class.md)<br/>
+[CA2AEX Class](../../atl/reference/ca2aex-class.md)\
+[CA2CAEX Class](../../atl/reference/ca2caex-class.md)\
+[CA2WEX Class](../../atl/reference/ca2wex-class.md)\
+[CW2AEX Class](../../atl/reference/cw2aex-class.md)\
+[CW2CWEX Class](../../atl/reference/cw2cwex-class.md)\
 [Class Overview](../../atl/atl-class-overview.md)

--- a/docs/cpp/compiler-limits.md
+++ b/docs/cpp/compiler-limits.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Limits"
 title: "Compiler Limits"
+description: "Learn more about: Compiler Limits"
 ms.date: "06/05/2023"
 helpviewer_keywords: ["cl.exe compiler, limits for language constructs"]
 ---
@@ -22,7 +22,7 @@ The C++ standard recommends limits for various language constructs. The followin
 
 - Scope qualifications of one identifier - C++ standard: 256, Microsoft C++ compiler: 127.
 
-- Nested **`extern`** specifications - C++ standard: 1024, Microsoft C++ compiler: 9 (not counting the implicit **`extern`** specification in global scope, or 10, if you count the implicit **`extern`** specification in global scope..
+- Nested **`extern`** specifications - C++ standard: 1024, Microsoft C++ compiler: 9 (not counting the implicit **`extern`** specification in global scope, or 10, if you count the implicit **`extern`** specification in global scope.
 
 - Template arguments in a template declaration - C++ standard: 1024, Microsoft C++ compiler: 2046.
 

--- a/docs/cppcx/collections-c-cx.md
+++ b/docs/cppcx/collections-c-cx.md
@@ -103,7 +103,7 @@ A modifiable, associative collection. Map elements are key-value pairs. Looking 
 A read-only version of a `Map`.
 
 [Platform::Collections::Vector class](../cppcx/platform-collections-vector-class.md)<br/>
-A modifiable sequence collection. `Vector<T>` supports constant-time random access and amortized-constant-time [Append](../cppcx/platform-collections-vector-class.md#append) operations..
+A modifiable sequence collection. `Vector<T>` supports constant-time random access and amortized-constant-time [Append](../cppcx/platform-collections-vector-class.md#append) operations.
 
 [Platform::Collections::VectorView class](../cppcx/platform-collections-vectorview-class.md)<br/>
 A read-only version of a `Vector`.

--- a/docs/cppcx/platform-metadata-runtimeclassname.md
+++ b/docs/cppcx/platform-metadata-runtimeclassname.md
@@ -1,15 +1,14 @@
 ---
-description: "Learn more about: Platform::Metadata::RuntimeClassName"
 title: "Platform::Metadata::RuntimeClassName"
+description: "Learn more about: Platform::Metadata::RuntimeClassName"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::Metadata::RuntimeClassName"]
 helpviewer_keywords: ["RuntimeClassName", "Platform::Metadata::RuntimeClassName"]
-ms.assetid: fdef8f85-ab94-4edd-ba50-ee0da9358ff6
 ---
 # Platform::Metadata::RuntimeClassName
 
-When applied to a class definition, ensures that a private class returns a valid name from the GetRuntimeClassName function..
+When applied to a class definition, ensures that a private class returns a valid name from the GetRuntimeClassName function.
 
 ## Syntax
 

--- a/docs/cppcx/value-classes-and-structs-c-cx.md
+++ b/docs/cppcx/value-classes-and-structs-c-cx.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Value classes and structs (C++/CX)"
 title: "Value classes and structs (C++/CX)"
+description: "Learn more about: Value classes and structs (C++/CX)"
 ms.date: "12/30/2016"
 helpviewer_keywords: ["value struct", "value class"]
-ms.assetid: 262a0992-9721-4c02-8297-efc07d90e5a4
 ---
 # Value classes and structs (C++/CX)
 
@@ -48,7 +47,7 @@ A value struct or value class can contain as fields only fundamental numeric typ
 
 A value class or value struct that contains a `Platform::String^` or `IBox<T>^` type as a member is not `memcpy`-able.
 
-Because all members of a **`value class`** or **`value struct`** are public and are emitted into metadata, standard C++ types are not allowed as members. This is different from ref classes, which may contain **`private`** or **`internal`** standard C++ types..
+Because all members of a **`value class`** or **`value struct`** are public and are emitted into metadata, standard C++ types are not allowed as members. This is different from ref classes, which may contain **`private`** or **`internal`** standard C++ types.
 
 The following code fragment declares the `Coordinates` and `City` types as value structs. Notice that one of the `City` data members is a `GeoCoordinates` type. A **`value struct`** can contain other value structs as members.
 
@@ -140,7 +139,7 @@ public:
 
 ## See also
 
-[Type System (C++/CX)](../cppcx/type-system-c-cx.md)<br/>
-[C++/CX Language Reference](../cppcx/visual-c-language-reference-c-cx.md)<br/>
-[Namespaces Reference](../cppcx/namespaces-reference-c-cx.md)<br/>
+[Type System (C++/CX)](../cppcx/type-system-c-cx.md)\
+[C++/CX Language Reference](../cppcx/visual-c-language-reference-c-cx.md)\
+[Namespaces Reference](../cppcx/namespaces-reference-c-cx.md)\
 [Ref classes and structs (C++/CX)](../cppcx/ref-classes-and-structs-c-cx.md)

--- a/docs/dotnet/deque-stl-clr.md
+++ b/docs/dotnet/deque-stl-clr.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: deque (STL/CLR)"
 title: "deque (STL/CLR)"
+description: "Learn more about: deque (STL/CLR)"
 ms.date: "11/04/2016"
 ms.topic: "reference"
 f1_keywords: ["cliext::deque", "cliext::deque::assign", "cliext::deque::at", "cliext::deque::back", "cliext::deque::back_item", "cliext::deque::begin", "cliext::deque::clear", "cliext::deque::const_iterator", "cliext::deque::const_reference", "cliext::deque::const_reverse_iterator", "cliext::deque::deque", "cliext::deque::difference_type", "cliext::deque::empty", "cliext::deque::end", "cliext::deque::erase", "cliext::deque::front", "cliext::deque::front_item", "cliext::deque::generic_container", "cliext::deque::generic_iterator", "cliext::deque::generic_reverse_iterator", "cliext::deque::generic_value", "cliext::deque::insert", "cliext::deque::iterator", "cliext::deque::operator!=", "cliext::deque::operator[]", "cliext::deque::pop_back", "cliext::deque::pop_front", "cliext::deque::push_back", "cliext::deque::push_front", "cliext::deque::rbegin", "cliext::deque::reference", "cliext::deque::rend", "cliext::deque::resize", "cliext::deque::reverse_iterator", "cliext::deque::size", "cliext::deque::size_type", "cliext::deque::swap", "cliext::deque::to_array", "cliext::deque::value_type", "cliext::deque::operator<", "cliext::deque::operator<=", "cliext::deque::operator=", "cliext::deque::operator==", "cliext::deque::operator>", "cliext::deque::operator>="]
 helpviewer_keywords: ["deque class [STL/CLR]", "<deque> header [STL/CLR]", "<cliext/deque> header [STL/CLR]", "assign member [STL/CLR]", "assign member [STL/CLR]", "at member [STL/CLR]", "back member [STL/CLR]", "back_item member [STL/CLR]", "begin member [STL/CLR]", "clear member [STL/CLR]", "const_iterator member [STL/CLR]", "const_reference member [STL/CLR]", "const_reverse_iterator member [STL/CLR]", "deque member [STL/CLR]", "difference_type member [STL/CLR]", "empty member [STL/CLR]", "end member [STL/CLR]", "erase member [STL/CLR]", "front member [STL/CLR]", "front_item member [STL/CLR]", "generic_container member [STL/CLR]", "generic_iterator member [STL/CLR]", "generic_reverse_iterator member [STL/CLR]", "generic_value member [STL/CLR]", "insert member [STL/CLR]", "iterator member [STL/CLR]", "operator!= member [STL/CLR]", "operator member [] [STL/CLR]", "pop_back member [STL/CLR]", "pop_front member [STL/CLR]", "push_back member [STL/CLR]", "push_front member [STL/CLR]", "rbegin member [STL/CLR]", "reference member [STL/CLR]", "rend member [STL/CLR]", "resize member [STL/CLR]", "reverse_iterator member [STL/CLR]", "size member [STL/CLR]", "size_type member [STL/CLR]", "swap member [STL/CLR]", "to_array member [STL/CLR]", "value_type member [STL/CLR]", "operator< member [STL/CLR]", "operator<= member [STL/CLR]", "operator= member [STL/CLR]", "operator== member [STL/CLR]", "operator> member [STL/CLR]", "operator>= member [STL/CLR]"]
-ms.assetid: dd669da3-3c0e-45e9-8596-f6b483720941
 ---
 # deque (STL/CLR)
 
@@ -561,7 +560,7 @@ a b c
 
 ## <a name="const_reverse_iterator"></a> deque::const_reverse_iterator (STL/CLR)
 
-The type of a constant reverse iterator for the controlled sequence..
+The type of a constant reverse iterator for the controlled sequence.
 
 ### Syntax
 

--- a/docs/dotnet/how-to-do-ddx-ddv-data-binding-with-windows-forms.md
+++ b/docs/dotnet/how-to-do-ddx-ddv-data-binding-with-windows-forms.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: How to: Do DDX/DDV Data Binding with Windows Forms"
 title: "How to: Do DDX-DDV Data Binding with Windows Forms"
+description: "Learn more about: How to: Do DDX/DDV Data Binding with Windows Forms"
 ms.custom: "get-started-article"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["MFC [C++], hosting a Windows Forms Control", "Windows Forms [C++], MFC support"]
-ms.assetid: b2957370-cf1f-4779-94ac-228cd393686c
 ---
 # How to: Do DDX/DDV Data Binding with Windows Forms
 
@@ -53,7 +52,7 @@ void CMFC01Dlg::DoDataExchange(CDataExchange* pDX)
 
 ## Example: Add handler method
 
-Now we will add the handler method for a click on the OK button. Click the **Resource View** tab. In Resource View, double-click on `IDD_MFC01_DIALOG`. The dialog resource appears in Resource Editor. Then double click the OK button..
+Now we will add the handler method for a click on the OK button. Click the **Resource View** tab. In Resource View, double-click on `IDD_MFC01_DIALOG`. The dialog resource appears in Resource Editor. Then double click the OK button.
 
 Define the handler as follows.
 
@@ -77,6 +76,6 @@ You can now build and run the application. Notice that any text in the text box 
 
 ## See also
 
-[CWinFormsControl Class](../mfc/reference/cwinformscontrol-class.md)<br/>
-[DDX_ManagedControl](../mfc/reference/standard-dialog-data-exchange-routines.md#ddx_managedcontrol)<br/>
+[CWinFormsControl Class](../mfc/reference/cwinformscontrol-class.md)\
+[DDX_ManagedControl](../mfc/reference/standard-dialog-data-exchange-routines.md#ddx_managedcontrol)\
 [CWnd::DoDataExchange](../mfc/reference/cwnd-class.md#dodataexchange)

--- a/docs/dotnet/list-stl-clr.md
+++ b/docs/dotnet/list-stl-clr.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: list (STL/CLR)"
 title: "list (STL/CLR)"
+description: "Learn more about: list (STL/CLR)"
 ms.date: "11/04/2016"
 ms.topic: "reference"
 f1_keywords: ["cliext::list", "cliext::list::assign", "cliext::list::back", "cliext::list::back_item", "cliext::list::begin", "cliext::list::clear", "cliext::list::const_iterator", "cliext::list::const_reference", "cliext::list::const_reverse_iterator", "cliext::list::difference_type", "cliext::list::empty", "cliext::list::end", "cliext::list::erase", "cliext::list::front", "cliext::list::front_item", "cliext::list::generic_container", "cliext::list::generic_iterator", "cliext::list::generic_reverse_iterator", "cliext::list::generic_value", "cliext::list::insert", "cliext::list::iterator", "cliext::list::list", "cliext::list::merge", "cliext::list::operator=", "cliext::list::pop_back", "cliext::list::pop_front", "cliext::list::push_back", "cliext::list::push_front", "cliext::list::rbegin", "cliext::list::reference", "cliext::list::remove", "cliext::list::remove_if", "cliext::list::rend", "cliext::list::resize", "cliext::list::reverse", "cliext::list::reverse_iterator", "cliext::list::size", "cliext::list::size_type", "cliext::list::sort", "cliext::list::splice", "cliext::list::swap", "cliext::list::to_array", "cliext::list::unique", "cliext::list::value_type", "cliext::operator!=(list)", "cliext::operator<(list)", "cliext::operator<=(list)", "cliext::operator==(list)", "cliext::operator>(list)", "cliext::operator>=(list)"]
 helpviewer_keywords: ["<cliext/list> header [STL/CLR]", "list class [STL/CLR]", "<list> header [STL/CLR]", "assign member [STL/CLR]", "assign member [STL/CLR]", "back member [STL/CLR]", "back_item member [STL/CLR]", "begin member [STL/CLR]", "clear member [STL/CLR]", "const_iterator member [STL/CLR]", "const_reference member [STL/CLR]", "const_reverse_iterator member [STL/CLR]", "difference_type member [STL/CLR]", "empty member [STL/CLR]", "end member [STL/CLR]", "erase member [STL/CLR]", "front member [STL/CLR]", "front_item member [STL/CLR]", "generic_container member [STL/CLR]", "generic_iterator member [STL/CLR]", "generic_reverse_iterator member [STL/CLR]", "generic_value member [STL/CLR]", "insert member [STL/CLR]", "iterator member [STL/CLR]", "list member [STL/CLR]", "merge member [STL/CLR]", "operator= member [STL/CLR]", "pop_back member [STL/CLR]", "pop_front member [STL/CLR]", "push_back member [STL/CLR]", "push_front member [STL/CLR]", "rbegin member [STL/CLR]", "reference member [STL/CLR]", "remove member [STL/CLR]", "remove_if member [STL/CLR]", "rend member [STL/CLR]", "resize member [STL/CLR]", "reverse member [STL/CLR]", "reverse_iterator member [STL/CLR]", "size member [STL/CLR]", "size_type member [STL/CLR]", "sort member [STL/CLR]", "splice member [STL/CLR]", "swap member [STL/CLR]", "to_array member [STL/CLR]", "unique member [STL/CLR]", "value_type member [STL/CLR]", "operator!=(list) member [STL/CLR]", "operator<(list) member [STL/CLR]", "operator<=(list) member [STL/CLR]", "operator==(list) member [STL/CLR]", "operator>(list) member [STL/CLR]", "operator>=(list) member [STL/CLR]"]
-ms.assetid: a70c45c8-a257-4f6b-8434-b27ff6685bac
 ---
 # list (STL/CLR)
 
@@ -510,7 +509,7 @@ a b c
 
 ## <a name="const_reverse_iterator"></a> list::const_reverse_iterator (STL/CLR)
 
-The type of a constant reverse iterator for the controlled sequence..
+The type of a constant reverse iterator for the controlled sequence.
 
 ### Syntax
 

--- a/docs/dotnet/vector-stl-clr.md
+++ b/docs/dotnet/vector-stl-clr.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: vector (STL/CLR)"
 title: "vector (STL/CLR)"
+description: "Learn more about: vector (STL/CLR)"
 ms.date: "11/04/2016"
 ms.topic: "reference"
 f1_keywords: ["cliext::vector", "cliext::vector::assign", "cliext::vector::at", "cliext::vector::back", "cliext::vector::back_item", "cliext::vector::begin", "cliext::vector::capacity", "cliext::vector::clear", "cliext::vector::const_iterator", "cliext::vector::const_reference", "cliext::vector::const_reverse_iterator", "cliext::vector::difference_type", "cliext::vector::empty", "cliext::vector::end", "cliext::vector::erase", "cliext::vector::front", "cliext::vector::front_item", "cliext::vector::generic_container", "cliext::vector::generic_iterator", "cliext::vector::generic_reverse_iterator", "cliext::vector::generic_value", "cliext::vector::insert", "cliext::vector::iterator", "cliext::vector::operator=", "cliext::vector::operator", "cliext::vector::pop_back", "cliext::vector::push_back", "cliext::vector::rbegin", "cliext::vector::reference", "cliext::vector::rend", "cliext::vector::reserve", "cliext::vector::resize", "cliext::vector::reverse_iterator", "cliext::vector::size", "cliext::vector::size_type", "cliext::vector::swap", "cliext::vector::to_array", "cliext::vector::value_type", "cliext::vector::vector"]
 helpviewer_keywords: ["vector class [STL/CLR]", "<cliext/vector> header [STL/CLR]", "<vector> header [STL/CLR]", "operator!= member [STL/CLR]", "operator< member [STL/CLR]", "operator<= member [STL/CLR]", "operator== member [STL/CLR]", "operator> (vector) member [STL/CLR]", "operator>= member [STL/CLR]", "assign member [STL/CLR]", "at member [STL/CLR]", "back member [STL/CLR]", "back_item member [STL/CLR]", "begin member [STL/CLR]", "capacity member [STL/CLR]", "clear member [STL/CLR]", "const_iterator member [STL/CLR]", "const_reference member [STL/CLR]", "const_reverse_iterator member [STL/CLR]", "difference_type member [STL/CLR]", "empty member [STL/CLR]", "end member [STL/CLR]", "erase member [STL/CLR]", "front member [STL/CLR]", "front_item member [STL/CLR]", "generic_container member [STL/CLR]", "generic_iterator member [STL/CLR]", "generic_reverse_iterator member [STL/CLR]", "generic_value member [STL/CLR]", "insert member [STL/CLR]", "iterator member [STL/CLR]", "operator= member [STL/CLR]", "operator member [STL/CLR]", "pop_back member [STL/CLR]", "push_back member [STL/CLR]", "rbegin member [STL/CLR]", "reference member [STL/CLR]", "rend member [STL/CLR]", "reserve member [STL/CLR]", "resize member [STL/CLR]", "reverse_iterator member [STL/CLR]", "size member [STL/CLR]", "size_type member [STL/CLR]", "swap member [STL/CLR]", "to_array member [STL/CLR]", "value_type member [STL/CLR]", "vector member [STL/CLR]"]
-ms.assetid: f90060d5-097a-4e9d-9a26-a634b5b9c6c2
 ---
 # vector (STL/CLR)
 
@@ -608,7 +607,7 @@ a b c
 
 ## <a name="const_reverse_iterator"></a> vector::const_reverse_iterator (STL/CLR)
 
-The type of a constant reverse iterator for the controlled sequence..
+The type of a constant reverse iterator for the controlled sequence.
 
 ### Syntax
 

--- a/docs/mfc/reference/cd2dbitmap-class.md
+++ b/docs/mfc/reference/cd2dbitmap-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CD2DBitmap Class"
 title: "CD2DBitmap Class"
+description: "Learn more about: CD2DBitmap Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CD2DBitmap", "AFXRENDERTARGET/CD2DBitmap", "AFXRENDERTARGET/CD2DBitmap::CD2DBitmap", "AFXRENDERTARGET/CD2DBitmap::Attach", "AFXRENDERTARGET/CD2DBitmap::CopyFromBitmap", "AFXRENDERTARGET/CD2DBitmap::CopyFromMemory", "AFXRENDERTARGET/CD2DBitmap::CopyFromRenderTarget", "AFXRENDERTARGET/CD2DBitmap::Create", "AFXRENDERTARGET/CD2DBitmap::Destroy", "AFXRENDERTARGET/CD2DBitmap::Detach", "AFXRENDERTARGET/CD2DBitmap::Get", "AFXRENDERTARGET/CD2DBitmap::GetDPI", "AFXRENDERTARGET/CD2DBitmap::GetPixelFormat", "AFXRENDERTARGET/CD2DBitmap::GetPixelSize", "AFXRENDERTARGET/CD2DBitmap::GetSize", "AFXRENDERTARGET/CD2DBitmap::IsValid", "AFXRENDERTARGET/CD2DBitmap::CommonInit", "AFXRENDERTARGET/CD2DBitmap::m_bAutoDestroyHBMP", "AFXRENDERTARGET/CD2DBitmap::m_hBmpSrc", "AFXRENDERTARGET/CD2DBitmap::m_lpszType", "AFXRENDERTARGET/CD2DBitmap::m_pBitmap", "AFXRENDERTARGET/CD2DBitmap::m_sizeDest", "AFXRENDERTARGET/CD2DBitmap::m_strPath", "AFXRENDERTARGET/CD2DBitmap::m_uiResID"]
 helpviewer_keywords: ["CD2DBitmap [MFC], CD2DBitmap", "CD2DBitmap [MFC], CD2DBitmap", "CD2DBitmap [MFC], Attach", "CD2DBitmap [MFC], CopyFromBitmap", "CD2DBitmap [MFC], CopyFromMemory", "CD2DBitmap [MFC], CopyFromRenderTarget", "CD2DBitmap [MFC], Create", "CD2DBitmap [MFC], Destroy", "CD2DBitmap [MFC], Detach", "CD2DBitmap [MFC], Get", "CD2DBitmap [MFC], GetDPI", "CD2DBitmap [MFC], GetPixelFormat", "CD2DBitmap [MFC], GetPixelSize", "CD2DBitmap [MFC], GetSize", "CD2DBitmap [MFC], IsValid", "CD2DBitmap [MFC], CommonInit", "CD2DBitmap [MFC], m_bAutoDestroyHBMP", "CD2DBitmap [MFC], m_hBmpSrc", "CD2DBitmap [MFC], m_lpszType", "CD2DBitmap [MFC], m_pBitmap", "CD2DBitmap [MFC], m_sizeDest", "CD2DBitmap [MFC], m_strPath", "CD2DBitmap [MFC], m_uiResID"]
-ms.assetid: 2b3686f1-812c-462b-b449-9f0cb6949bf6
 ---
 # CD2DBitmap Class
 
@@ -327,7 +326,7 @@ CD2DSizeU GetPixelSize() const;
 
 ### Return Value
 
-The size, in pixels, of the bitmap..
+The size, in pixels, of the bitmap.
 
 ## <a name="getsize"></a> CD2DBitmap::GetSize
 

--- a/docs/mfc/reference/cmfcmenubar-class.md
+++ b/docs/mfc/reference/cmfcmenubar-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CMFCMenuBar Class"
 title: "CMFCMenuBar Class"
+description: "Learn more about: CMFCMenuBar Class"
 ms.date: "10/18/2018"
 f1_keywords: ["CMFCMenuBar", "AFXMENUBAR/CMFCMenuBar", "AFXMENUBAR/CMFCMenuBar::AdjustLocations", "AFXMENUBAR/CMFCMenuBar::AllowChangeTextLabels", "AFXMENUBAR/CMFCMenuBar::AllowShowOnPaneMenu", "AFXMENUBAR/CMFCMenuBar::CalcFixedLayout", "AFXMENUBAR/CMFCMenuBar::CalcLayout", "AFXMENUBAR/CMFCMenuBar::CalcMaxButtonHeight", "AFXMENUBAR/CMFCMenuBar::CanBeClosed", "AFXMENUBAR/CMFCMenuBar::CanBeRestored", "AFXMENUBAR/CMFCMenuBar::Create", "AFXMENUBAR/CMFCMenuBar::CreateEx", "AFXMENUBAR/CMFCMenuBar::CreateFromMenu", "AFXMENUBAR/CMFCMenuBar::EnableHelpCombobox", "AFXMENUBAR/CMFCMenuBar::EnableMenuShadows", "AFXMENUBAR/CMFCMenuBar::GetAvailableExpandSize", "AFXMENUBAR/CMFCMenuBar::GetColumnWidth", "AFXMENUBAR/CMFCMenuBar::GetDefaultMenu", "AFXMENUBAR/CMFCMenuBar::GetDefaultMenuResId", "AFXMENUBAR/CMFCMenuBar::GetFloatPopupDirection", "AFXMENUBAR/CMFCMenuBar::GetForceDownArrows", "AFXMENUBAR/CMFCMenuBar::GetHelpCombobox", "AFXMENUBAR/CMFCMenuBar::GetHMenu", "AFXMENUBAR/CMFCMenuBar::GetMenuFont", "AFXMENUBAR/CMFCMenuBar::GetMenuItem", "AFXMENUBAR/CMFCMenuBar::GetRowHeight", "AFXMENUBAR/CMFCMenuBar::GetSystemButton", "AFXMENUBAR/CMFCMenuBar::GetSystemButtonsCount", "AFXMENUBAR/CMFCMenuBar::GetSystemMenu", "AFXMENUBAR/CMFCMenuBar::HighlightDisabledItems", "AFXMENUBAR/CMFCMenuBar::IsButtonExtraSizeAvailable", "AFXMENUBAR/CMFCMenuBar::IsHighlightDisabledItems", "AFXMENUBAR/CMFCMenuBar::IsMenuShadows", "AFXMENUBAR/CMFCMenuBar::IsRecentlyUsedMenus", "AFXMENUBAR/CMFCMenuBar::IsShowAllCommands", "AFXMENUBAR/CMFCMenuBar::IsShowAllCommandsDelay", "AFXMENUBAR/CMFCMenuBar::LoadState", "AFXMENUBAR/CMFCMenuBar::OnChangeHot", "AFXMENUBAR/CMFCMenuBar::OnDefaultMenuLoaded", "AFXMENUBAR/CMFCMenuBar::OnSendCommand", "AFXMENUBAR/CMFCMenuBar::OnSetDefaultButtonText", "AFXMENUBAR/CMFCMenuBar::OnToolHitTest", "AFXMENUBAR/CMFCMenuBar::PreTranslateMessage", "AFXMENUBAR/CMFCMenuBar::RestoreOriginalstate", "AFXMENUBAR/CMFCMenuBar::SaveState", "AFXMENUBAR/CMFCMenuBar::SetDefaultMenuResId", "AFXMENUBAR/CMFCMenuBar::SetForceDownArrows", "AFXMENUBAR/CMFCMenuBar::SetMaximizeMode", "AFXMENUBAR/CMFCMenuBar::SetMenuButtonRTC", "AFXMENUBAR/CMFCMenuBar::SetMenuFont", "AFXMENUBAR/CMFCMenuBar::SetRecentlyUsedMenus", "AFXMENUBAR/CMFCMenuBar::SetShowAllCommands"]
 helpviewer_keywords: ["CMFCMenuBar [MFC], AdjustLocations", "CMFCMenuBar [MFC], AllowChangeTextLabels", "CMFCMenuBar [MFC], AllowShowOnPaneMenu", "CMFCMenuBar [MFC], CalcFixedLayout", "CMFCMenuBar [MFC], CalcLayout", "CMFCMenuBar [MFC], CalcMaxButtonHeight", "CMFCMenuBar [MFC], CanBeClosed", "CMFCMenuBar [MFC], CanBeRestored", "CMFCMenuBar [MFC], Create", "CMFCMenuBar [MFC], CreateEx", "CMFCMenuBar [MFC], CreateFromMenu", "CMFCMenuBar [MFC], EnableHelpCombobox", "CMFCMenuBar [MFC], EnableMenuShadows", "CMFCMenuBar [MFC], GetAvailableExpandSize", "CMFCMenuBar [MFC], GetColumnWidth", "CMFCMenuBar [MFC], GetDefaultMenu", "CMFCMenuBar [MFC], GetDefaultMenuResId", "CMFCMenuBar [MFC], GetFloatPopupDirection", "CMFCMenuBar [MFC], GetForceDownArrows", "CMFCMenuBar [MFC], GetHelpCombobox", "CMFCMenuBar [MFC], GetHMenu", "CMFCMenuBar [MFC], GetMenuFont", "CMFCMenuBar [MFC], GetMenuItem", "CMFCMenuBar [MFC], GetRowHeight", "CMFCMenuBar [MFC], GetSystemButton", "CMFCMenuBar [MFC], GetSystemButtonsCount", "CMFCMenuBar [MFC], GetSystemMenu", "CMFCMenuBar [MFC], HighlightDisabledItems", "CMFCMenuBar [MFC], IsButtonExtraSizeAvailable", "CMFCMenuBar [MFC], IsHighlightDisabledItems", "CMFCMenuBar [MFC], IsMenuShadows", "CMFCMenuBar [MFC], IsRecentlyUsedMenus", "CMFCMenuBar [MFC], IsShowAllCommands", "CMFCMenuBar [MFC], IsShowAllCommandsDelay", "CMFCMenuBar [MFC], LoadState", "CMFCMenuBar [MFC], OnChangeHot", "CMFCMenuBar [MFC], OnDefaultMenuLoaded", "CMFCMenuBar [MFC], OnSendCommand", "CMFCMenuBar [MFC], OnSetDefaultButtonText", "CMFCMenuBar [MFC], OnToolHitTest", "CMFCMenuBar [MFC], PreTranslateMessage", "CMFCMenuBar [MFC], RestoreOriginalstate", "CMFCMenuBar [MFC], SaveState", "CMFCMenuBar [MFC], SetDefaultMenuResId", "CMFCMenuBar [MFC], SetForceDownArrows", "CMFCMenuBar [MFC], SetMaximizeMode", "CMFCMenuBar [MFC], SetMenuButtonRTC", "CMFCMenuBar [MFC], SetMenuFont", "CMFCMenuBar [MFC], SetRecentlyUsedMenus", "CMFCMenuBar [MFC], SetShowAllCommands"]
-ms.assetid: 8a3ce4c7-b012-4dc0-b4f8-53c10b4b86b8
 ---
 # CMFCMenuBar Class
 
@@ -663,7 +662,7 @@ When you configure a menu bar to display recently used items, the menu bar displ
 
 - Display the full menu after the user clicks the arrow at the bottom of the menu.
 
-By default, all `CMFCMenuBar` objects use the option to display the full menu after a short delay. This option cannot be changed programmatically in the `CMFCMenuBar` class. However, a user can change the behavior during toolbar customization by using the **Customize** dialog box..
+By default, all `CMFCMenuBar` objects use the option to display the full menu after a short delay. This option cannot be changed programmatically in the `CMFCMenuBar` class. However, a user can change the behavior during toolbar customization by using the **Customize** dialog box.
 
 ## <a name="loadstate"></a> CMFCMenuBar::LoadState
 
@@ -977,6 +976,6 @@ If a menu does not display all the menu commands, it hides the commands that are
 
 ## See also
 
-[Hierarchy Chart](../../mfc/hierarchy-chart.md)<br/>
-[Classes](../../mfc/reference/mfc-classes.md)<br/>
+[Hierarchy Chart](../../mfc/hierarchy-chart.md)\
+[Classes](../../mfc/reference/mfc-classes.md)\
 [CMFCToolBar Class](../../mfc/reference/cmfctoolbar-class.md)

--- a/docs/mfc/reference/cmfcribbonfontcombobox-class.md
+++ b/docs/mfc/reference/cmfcribbonfontcombobox-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CMFCRibbonFontComboBox Class"
 title: "CMFCRibbonFontComboBox Class"
+description: "Learn more about: CMFCRibbonFontComboBox Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CMFCRibbonFontComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::CMFCRibbonFontComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::BuildFonts", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::GetCharSet", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::GetFontDesc", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::GetFontType", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::GetPitchAndFamily", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::RebuildFonts", "AFXRIBBONCOMBOBOX/CMFCRibbonFontComboBox::SetFont"]
 helpviewer_keywords: ["CMFCRibbonFontComboBox [MFC], CMFCRibbonFontComboBox", "CMFCRibbonFontComboBox [MFC], BuildFonts", "CMFCRibbonFontComboBox [MFC], GetCharSet", "CMFCRibbonFontComboBox [MFC], GetFontDesc", "CMFCRibbonFontComboBox [MFC], GetFontType", "CMFCRibbonFontComboBox [MFC], GetPitchAndFamily", "CMFCRibbonFontComboBox [MFC], RebuildFonts", "CMFCRibbonFontComboBox [MFC], SetFont"]
-ms.assetid: 33b4db50-df4f-45fa-8f05-2e6e73c31435
 ---
 # CMFCRibbonFontComboBox Class
 
@@ -110,7 +109,7 @@ CMFCRibbonFontComboBox(
 [in] Specifies which font types to display in the combo box. Valid options are DEVICE_FONTTYPE, RASTER_FONTTYPE, and TRUETYPE_FONTTYPE, or any bitwise combination thereof.
 
 *nCharSet*<br/>
-[in] Filters the fonts in the combo box to those that belong to the specified character set..
+[in] Filters the fonts in the combo box to those that belong to the specified character set.
 
 *nPitchAndFamily*<br/>
 [in] Specifies the pitch and the family of the fonts that are displayed in the combo box.
@@ -224,6 +223,6 @@ Pitch and the family (see LOGFONT in the Windows SDK documentation).
 
 ## See also
 
-[Hierarchy Chart](../../mfc/hierarchy-chart.md)<br/>
-[Classes](../../mfc/reference/mfc-classes.md)<br/>
+[Hierarchy Chart](../../mfc/hierarchy-chart.md)\
+[Classes](../../mfc/reference/mfc-classes.md)\
 [CMFCRibbonComboBox Class](../../mfc/reference/cmfcribboncombobox-class.md)

--- a/docs/mfc/reference/cmousemanager-class.md
+++ b/docs/mfc/reference/cmousemanager-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CMouseManager Class"
 title: "CMouseManager Class"
+description: "Learn more about: CMouseManager Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CMouseManager", "AFXMOUSEMANAGER/CMouseManager", "AFXMOUSEMANAGER/CMouseManager::AddView", "AFXMOUSEMANAGER/CMouseManager::GetViewDblClickCommand", "AFXMOUSEMANAGER/CMouseManager::GetViewIconId", "AFXMOUSEMANAGER/CMouseManager::GetViewIdByName", "AFXMOUSEMANAGER/CMouseManager::GetViewNames", "AFXMOUSEMANAGER/CMouseManager::LoadState", "AFXMOUSEMANAGER/CMouseManager::SaveState", "AFXMOUSEMANAGER/CMouseManager::SetCommandForDblClk"]
 helpviewer_keywords: ["CMouseManager [MFC], AddView", "CMouseManager [MFC], GetViewDblClickCommand", "CMouseManager [MFC], GetViewIconId", "CMouseManager [MFC], GetViewIdByName", "CMouseManager [MFC], GetViewNames", "CMouseManager [MFC], LoadState", "CMouseManager [MFC], SaveState", "CMouseManager [MFC], SetCommandForDblClk"]
-ms.assetid: a4d05017-4e44-4a40-8b57-4ece0de20481
 ---
 # CMouseManager Class
 
@@ -33,7 +32,7 @@ class CMouseManager : public CObject
 
 ## Remarks
 
-The `CMouseManager` class maintains a collection of `CView` objects. Each view is identified by a name and by an ID. These views are shown in the **Customization** dialog box. The user can change the command that is associated with any view through the **Customization** dialog box. The associated command is executed when the user double-clicks in that view. To support this from a coding perspective, you must process the WM_LBUTTONDBLCLK message and call the [CWinAppEx::OnViewDoubleClick](../../mfc/reference/cwinappex-class.md#onviewdoubleclick) function in the code for that `CView` object..
+The `CMouseManager` class maintains a collection of `CView` objects. Each view is identified by a name and by an ID. These views are shown in the **Customization** dialog box. The user can change the command that is associated with any view through the **Customization** dialog box. The associated command is executed when the user double-clicks in that view. To support this from a coding perspective, you must process the WM_LBUTTONDBLCLK message and call the [CWinAppEx::OnViewDoubleClick](../../mfc/reference/cwinappex-class.md#onviewdoubleclick) function in the code for that `CView` object.
 
 You should not create a `CMouseManager` object manually. It will be created by the framework of your application. It will also be destroyed automatically when the user exits the application. To get a pointer to the mouse manager for your application, call [CWinAppEx::GetMouseManager](../../mfc/reference/cwinappex-class.md#getmousemanager).
 
@@ -246,7 +245,7 @@ If *uiCmd* is set to 0, the specified view is no longer associated with a comman
 
 ## See also
 
-[Hierarchy Chart](../../mfc/hierarchy-chart.md)<br/>
-[Classes](../../mfc/reference/mfc-classes.md)<br/>
-[CWinAppEx Class](../../mfc/reference/cwinappex-class.md)<br/>
+[Hierarchy Chart](../../mfc/hierarchy-chart.md)\
+[Classes](../../mfc/reference/mfc-classes.md)\
+[CWinAppEx Class](../../mfc/reference/cwinappex-class.md)\
 [Keyboard and Mouse Customization](../../mfc/keyboard-and-mouse-customization.md)

--- a/docs/mfc/reference/coledocument-class.md
+++ b/docs/mfc/reference/coledocument-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: COleDocument Class"
 title: "COleDocument Class"
+description: "Learn more about: COleDocument Class"
 ms.date: "11/04/2016"
 f1_keywords: ["COleDocument", "AFXOLE/COleDocument", "AFXOLE/COleDocument::COleDocument", "AFXOLE/COleDocument::AddItem", "AFXOLE/COleDocument::ApplyPrintDevice", "AFXOLE/COleDocument::EnableCompoundFile", "AFXOLE/COleDocument::GetInPlaceActiveItem", "AFXOLE/COleDocument::GetNextClientItem", "AFXOLE/COleDocument::GetNextItem", "AFXOLE/COleDocument::GetNextServerItem", "AFXOLE/COleDocument::GetPrimarySelectedItem", "AFXOLE/COleDocument::GetStartPosition", "AFXOLE/COleDocument::HasBlankItems", "AFXOLE/COleDocument::OnShowViews", "AFXOLE/COleDocument::RemoveItem", "AFXOLE/COleDocument::UpdateModifiedFlag", "AFXOLE/COleDocument::OnEditChangeIcon", "AFXOLE/COleDocument::OnEditConvert", "AFXOLE/COleDocument::OnEditLinks", "AFXOLE/COleDocument::OnFileSendMail", "AFXOLE/COleDocument::OnUpdateEditChangeIcon", "AFXOLE/COleDocument::OnUpdateEditLinksMenu", "AFXOLE/COleDocument::OnUpdateObjectVerbMenu", "AFXOLE/COleDocument::OnUpdatePasteLinkMenu", "AFXOLE/COleDocument::OnUpdatePasteMenu"]
 helpviewer_keywords: ["COleDocument [MFC], COleDocument", "COleDocument [MFC], AddItem", "COleDocument [MFC], ApplyPrintDevice", "COleDocument [MFC], EnableCompoundFile", "COleDocument [MFC], GetInPlaceActiveItem", "COleDocument [MFC], GetNextClientItem", "COleDocument [MFC], GetNextItem", "COleDocument [MFC], GetNextServerItem", "COleDocument [MFC], GetPrimarySelectedItem", "COleDocument [MFC], GetStartPosition", "COleDocument [MFC], HasBlankItems", "COleDocument [MFC], OnShowViews", "COleDocument [MFC], RemoveItem", "COleDocument [MFC], UpdateModifiedFlag", "COleDocument [MFC], OnEditChangeIcon", "COleDocument [MFC], OnEditConvert", "COleDocument [MFC], OnEditLinks", "COleDocument [MFC], OnFileSendMail", "COleDocument [MFC], OnUpdateEditChangeIcon", "COleDocument [MFC], OnUpdateEditLinksMenu", "COleDocument [MFC], OnUpdateObjectVerbMenu", "COleDocument [MFC], OnUpdatePasteLinkMenu", "COleDocument [MFC], OnUpdatePasteMenu"]
-ms.assetid: dc2ecb99-03e1-44c7-bb69-48056dd1b672
 ---
 # COleDocument Class
 
@@ -64,9 +63,9 @@ class COleDocument : public CDocument
 
 If you are writing a simple container application, derive your document class from `COleDocument`. If you are writing a container application that supports linking to the embedded items contained by its documents, derive your document class from [COleLinkingDoc](../../mfc/reference/colelinkingdoc-class.md). If you are writing a server application or combination container/server, derive your document class from [COleServerDoc](../../mfc/reference/coleserverdoc-class.md). `COleLinkingDoc` and `COleServerDoc` are derived from `COleDocument`, so these classes inherit all the services available in `COleDocument` and `CDocument`.
 
-To use `COleDocument`, derive a class from it and add functionality to manage the application's non-OLE data as well as embedded or linked items. If you define `CDocItem`-derived classes to store the application's native data, you can use the default implementation defined by `COleDocument` to store both your OLE and non-OLE data. You can also design your own data structures for storing your non-OLE data separately from the OLE items. For more information, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md)..
+To use `COleDocument`, derive a class from it and add functionality to manage the application's non-OLE data as well as embedded or linked items. If you define `CDocItem`-derived classes to store the application's native data, you can use the default implementation defined by `COleDocument` to store both your OLE and non-OLE data. You can also design your own data structures for storing your non-OLE data separately from the OLE items. For more information, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md).
 
-`CDocument` supports sending your document via mail if mail support (MAPI) is present. `COleDocument` has updated [OnFileSendMail](#onfilesendmail) to handle compound documents correctly. For more information, see the articles [MAPI](../../mfc/mapi.md) and [MAPI Support in MFC](../../mfc/mapi-support-in-mfc.md)..
+`CDocument` supports sending your document via mail if mail support (MAPI) is present. `COleDocument` has updated [OnFileSendMail](#onfilesendmail) to handle compound documents correctly. For more information, see the articles [MAPI](../../mfc/mapi.md) and [MAPI Support in MFC](../../mfc/mapi-support-in-mfc.md).
 
 ## Inheritance Hierarchy
 
@@ -153,7 +152,7 @@ Specifies whether compound file support is enabled or disabled.
 
 ### Remarks
 
-This is also called structured storage. You typically call this function from the constructor of your `COleDocument`-derived class. For more information about compound documents, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md)..
+This is also called structured storage. You typically call this function from the constructor of your `COleDocument`-derived class. For more information about compound documents, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md).
 
 If you do not call this member function, documents will be stored in a nonstructured ("flat") file format.
 
@@ -356,7 +355,7 @@ afx_msg void OnFileSendMail();
 
 Unlike the implementation of `OnFileSendMail` for `CDocument`, this function handles compound files correctly.
 
-For more information, see the [MAPI Topics](../../mfc/mapi.md) and [MAPI Support in MFC](../../mfc/mapi-support-in-mfc.md) articles..
+For more information, see the [MAPI Topics](../../mfc/mapi.md) and [MAPI Support in MFC](../../mfc/mapi-support-in-mfc.md) articles.
 
 ## <a name="onshowviews"></a> COleDocument::OnShowViews
 
@@ -491,7 +490,7 @@ This allows the framework to prompt the user to save the document before closing
 
 ## See also
 
-[MFC Sample CONTAINER](../../overview/visual-cpp-samples.md)<br/>
-[MFC Sample MFCBIND](../../overview/visual-cpp-samples.md)<br/>
-[CDocument Class](../../mfc/reference/cdocument-class.md)<br/>
+[MFC Sample CONTAINER](../../overview/visual-cpp-samples.md)\
+[MFC Sample MFCBIND](../../overview/visual-cpp-samples.md)\
+[CDocument Class](../../mfc/reference/cdocument-class.md)\
 [Hierarchy Chart](../../mfc/hierarchy-chart.md)

--- a/docs/mfc/reference/coleserverdoc-class.md
+++ b/docs/mfc/reference/coleserverdoc-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: COleServerDoc Class"
 title: "COleServerDoc Class"
+description: "Learn more about: COleServerDoc Class"
 ms.date: "11/04/2016"
 f1_keywords: ["COleServerDoc", "AFXOLE/COleServerDoc", "AFXOLE/COleServerDoc::COleServerDoc", "AFXOLE/COleServerDoc::ActivateDocObject", "AFXOLE/COleServerDoc::ActivateInPlace", "AFXOLE/COleServerDoc::DeactivateAndUndo", "AFXOLE/COleServerDoc::DiscardUndoState", "AFXOLE/COleServerDoc::GetClientSite", "AFXOLE/COleServerDoc::GetEmbeddedItem", "AFXOLE/COleServerDoc::GetItemClipRect", "AFXOLE/COleServerDoc::GetItemPosition", "AFXOLE/COleServerDoc::GetZoomFactor", "AFXOLE/COleServerDoc::IsDocObject", "AFXOLE/COleServerDoc::IsEmbedded", "AFXOLE/COleServerDoc::IsInPlaceActive", "AFXOLE/COleServerDoc::NotifyChanged", "AFXOLE/COleServerDoc::NotifyClosed", "AFXOLE/COleServerDoc::NotifyRename", "AFXOLE/COleServerDoc::NotifySaved", "AFXOLE/COleServerDoc::OnDeactivate", "AFXOLE/COleServerDoc::OnDeactivateUI", "AFXOLE/COleServerDoc::OnDocWindowActivate", "AFXOLE/COleServerDoc::OnResizeBorder", "AFXOLE/COleServerDoc::OnShowControlBars", "AFXOLE/COleServerDoc::OnUpdateDocument", "AFXOLE/COleServerDoc::RequestPositionChange", "AFXOLE/COleServerDoc::SaveEmbedding", "AFXOLE/COleServerDoc::ScrollContainerBy", "AFXOLE/COleServerDoc::UpdateAllItems", "AFXOLE/COleServerDoc::CreateInPlaceFrame", "AFXOLE/COleServerDoc::DestroyInPlaceFrame", "AFXOLE/COleServerDoc::GetDocObjectServer", "AFXOLE/COleServerDoc::OnClose", "AFXOLE/COleServerDoc::OnExecOleCmd", "AFXOLE/COleServerDoc::OnFrameWindowActivate", "AFXOLE/COleServerDoc::OnGetEmbeddedItem", "AFXOLE/COleServerDoc::OnReactivateAndUndo", "AFXOLE/COleServerDoc::OnSetHostNames", "AFXOLE/COleServerDoc::OnSetItemRects", "AFXOLE/COleServerDoc::OnShowDocument"]
 helpviewer_keywords: ["COleServerDoc [MFC], COleServerDoc", "COleServerDoc [MFC], ActivateDocObject", "COleServerDoc [MFC], ActivateInPlace", "COleServerDoc [MFC], DeactivateAndUndo", "COleServerDoc [MFC], DiscardUndoState", "COleServerDoc [MFC], GetClientSite", "COleServerDoc [MFC], GetEmbeddedItem", "COleServerDoc [MFC], GetItemClipRect", "COleServerDoc [MFC], GetItemPosition", "COleServerDoc [MFC], GetZoomFactor", "COleServerDoc [MFC], IsDocObject", "COleServerDoc [MFC], IsEmbedded", "COleServerDoc [MFC], IsInPlaceActive", "COleServerDoc [MFC], NotifyChanged", "COleServerDoc [MFC], NotifyClosed", "COleServerDoc [MFC], NotifyRename", "COleServerDoc [MFC], NotifySaved", "COleServerDoc [MFC], OnDeactivate", "COleServerDoc [MFC], OnDeactivateUI", "COleServerDoc [MFC], OnDocWindowActivate", "COleServerDoc [MFC], OnResizeBorder", "COleServerDoc [MFC], OnShowControlBars", "COleServerDoc [MFC], OnUpdateDocument", "COleServerDoc [MFC], RequestPositionChange", "COleServerDoc [MFC], SaveEmbedding", "COleServerDoc [MFC], ScrollContainerBy", "COleServerDoc [MFC], UpdateAllItems", "COleServerDoc [MFC], CreateInPlaceFrame", "COleServerDoc [MFC], DestroyInPlaceFrame", "COleServerDoc [MFC], GetDocObjectServer", "COleServerDoc [MFC], OnClose", "COleServerDoc [MFC], OnExecOleCmd", "COleServerDoc [MFC], OnFrameWindowActivate", "COleServerDoc [MFC], OnGetEmbeddedItem", "COleServerDoc [MFC], OnReactivateAndUndo", "COleServerDoc [MFC], OnSetHostNames", "COleServerDoc [MFC], OnSetItemRects", "COleServerDoc [MFC], OnShowDocument"]
-ms.assetid: a9cdd96a-e0ac-43bb-9203-2c29237e965c
 ---
 # COleServerDoc Class
 
@@ -477,7 +476,7 @@ This function restores the container application's user interface to its origina
 
 The undo state information should be unconditionally released at this point.
 
-For more information, see the article [Activation](../../mfc/activation-cpp.md)..
+For more information, see the article [Activation](../../mfc/activation-cpp.md).
 
 ## <a name="ondeactivateui"></a> COleServerDoc::OnDeactivateUI
 
@@ -515,7 +514,7 @@ Specifies whether the document window is to be activated or deactivated.
 
 The default implementation removes or adds the frame-level user interface elements as appropriate. Override this function if you want to perform additional actions when the document containing your item is activated or deactivated.
 
-For more information, see the article [Activation](../../mfc/activation-cpp.md)..
+For more information, see the article [Activation](../../mfc/activation-cpp.md).
 
 ## <a name="onexecolecmd"></a> COleServerDoc::OnExecOleCmd
 
@@ -599,7 +598,7 @@ Specifies whether the frame window is to be activated or deactivated.
 
 The default implementation cancels any help modes the frame window might be in. Override this function if you want to perform special processing when the frame window is activated or deactivated.
 
-For more information, see the article [Activation](../../mfc/activation-cpp.md)..
+For more information, see the article [Activation](../../mfc/activation-cpp.md).
 
 ## <a name="ongetembeddeditem"></a> COleServerDoc::OnGetEmbeddedItem
 
@@ -860,9 +859,9 @@ This function calls the `OnUpdate` member function for each of the document's it
 
 ## See also
 
-[MFC Sample HIERSVR](../../overview/visual-cpp-samples.md)<br/>
-[COleLinkingDoc Class](../../mfc/reference/colelinkingdoc-class.md)<br/>
-[Hierarchy Chart](../../mfc/hierarchy-chart.md)<br/>
-[COleDocument Class](../../mfc/reference/coledocument-class.md)<br/>
-[COleLinkingDoc Class](../../mfc/reference/colelinkingdoc-class.md)<br/>
+[MFC Sample HIERSVR](../../overview/visual-cpp-samples.md)\
+[COleLinkingDoc Class](../../mfc/reference/colelinkingdoc-class.md)\
+[Hierarchy Chart](../../mfc/hierarchy-chart.md)\
+[COleDocument Class](../../mfc/reference/coledocument-class.md)\
+[COleLinkingDoc Class](../../mfc/reference/colelinkingdoc-class.md)\
 [COleTemplateServer Class](../../mfc/reference/coletemplateserver-class.md)

--- a/docs/mfc/reference/colestreamfile-class.md
+++ b/docs/mfc/reference/colestreamfile-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: COleStreamFile Class"
 title: "COleStreamFile Class"
+description: "Learn more about: COleStreamFile Class"
 ms.date: "11/04/2016"
 f1_keywords: ["COleStreamFile", "AFXOLE/COleStreamFile", "AFXOLE/COleStreamFile::COleStreamFile", "AFXOLE/COleStreamFile::Attach", "AFXOLE/COleStreamFile::CreateMemoryStream", "AFXOLE/COleStreamFile::CreateStream", "AFXOLE/COleStreamFile::Detach", "AFXOLE/COleStreamFile::GetStream", "AFXOLE/COleStreamFile::OpenStream"]
 helpviewer_keywords: ["COleStreamFile [MFC], COleStreamFile", "COleStreamFile [MFC], Attach", "COleStreamFile [MFC], CreateMemoryStream", "COleStreamFile [MFC], CreateStream", "COleStreamFile [MFC], Detach", "COleStreamFile [MFC], GetStream", "COleStreamFile [MFC], OpenStream"]
-ms.assetid: e4f93698-e17c-4a18-a7c0-4b4df8eb4d93
 ---
 # COleStreamFile Class
 
@@ -41,7 +40,7 @@ An `IStorage` object must exist before the stream can be opened or created unles
 
 `COleStreamFile` objects are manipulated exactly like [CFile](../../mfc/reference/cfile-class.md) objects.
 
-For more information about manipulating streams and storages, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md)..
+For more information about manipulating streams and storages, see the article [Containers: Compound Files](../../mfc/containers-compound-files.md).
 
 For more information, see [IStream](/windows/win32/api/objidl/nn-objidl-istream) and [IStorage](/windows/win32/api/objidl/nn-objidl-istorage) in the Windows SDK.
 
@@ -222,5 +221,5 @@ For more information, see [IStorage::OpenStream](/windows/win32/api/objidl/nf-ob
 
 ## See also
 
-[CFile Class](../../mfc/reference/cfile-class.md)<br/>
+[CFile Class](../../mfc/reference/cfile-class.md)\
 [Hierarchy Chart](../../mfc/hierarchy-chart.md)

--- a/docs/mfc/reference/cspinbuttonctrl-class.md
+++ b/docs/mfc/reference/cspinbuttonctrl-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CSpinButtonCtrl Class"
 title: "CSpinButtonCtrl Class"
+description: "Learn more about: CSpinButtonCtrl Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CSpinButtonCtrl", "AFXCMN/CSpinButtonCtrl", "AFXCMN/CSpinButtonCtrl::CSpinButtonCtrl", "AFXCMN/CSpinButtonCtrl::Create", "AFXCMN/CSpinButtonCtrl::CreateEx", "AFXCMN/CSpinButtonCtrl::GetAccel", "AFXCMN/CSpinButtonCtrl::GetBase", "AFXCMN/CSpinButtonCtrl::GetBuddy", "AFXCMN/CSpinButtonCtrl::GetPos", "AFXCMN/CSpinButtonCtrl::GetRange", "AFXCMN/CSpinButtonCtrl::SetAccel", "AFXCMN/CSpinButtonCtrl::SetBase", "AFXCMN/CSpinButtonCtrl::SetBuddy", "AFXCMN/CSpinButtonCtrl::SetPos", "AFXCMN/CSpinButtonCtrl::SetRange"]
 helpviewer_keywords: ["CSpinButtonCtrl [MFC], CSpinButtonCtrl", "CSpinButtonCtrl [MFC], Create", "CSpinButtonCtrl [MFC], CreateEx", "CSpinButtonCtrl [MFC], GetAccel", "CSpinButtonCtrl [MFC], GetBase", "CSpinButtonCtrl [MFC], GetBuddy", "CSpinButtonCtrl [MFC], GetPos", "CSpinButtonCtrl [MFC], GetRange", "CSpinButtonCtrl [MFC], SetAccel", "CSpinButtonCtrl [MFC], SetBase", "CSpinButtonCtrl [MFC], SetBuddy", "CSpinButtonCtrl [MFC], SetPos", "CSpinButtonCtrl [MFC], SetRange"]
-ms.assetid: 509bfd76-1c5a-4af6-973f-e133c0b87734
 ---
 # CSpinButtonCtrl Class
 
@@ -71,7 +70,7 @@ For more information on using `CSpinButtonCtrl`, see [Controls](../../mfc/contro
 
 ## <a name="create"></a> CSpinButtonCtrl::Create
 
-Creates a spin button control and attaches it to a `CSpinButtonCtrl` object..
+Creates a spin button control and attaches it to a `CSpinButtonCtrl` object.
 
 ```
 virtual BOOL Create(
@@ -366,7 +365,7 @@ The member function `SetRange32` sets the 32-bit range for the spin button contr
 
 ## See also
 
-[MFC Sample CMNCTRL2](../../overview/visual-cpp-samples.md)<br/>
-[CWnd Class](../../mfc/reference/cwnd-class.md)<br/>
-[Hierarchy Chart](../../mfc/hierarchy-chart.md)<br/>
+[MFC Sample CMNCTRL2](../../overview/visual-cpp-samples.md)\
+[CWnd Class](../../mfc/reference/cwnd-class.md)\
+[Hierarchy Chart](../../mfc/hierarchy-chart.md)\
 [CSliderCtrl Class](../../mfc/reference/csliderctrl-class.md)

--- a/docs/parallel/concrt/reference/concurrency-namespace-functions.md
+++ b/docs/parallel/concrt/reference/concurrency-namespace-functions.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: concurrency namespace functions"
 title: "concurrency namespace functions"
+description: "Learn more about: concurrency namespace functions"
 ms.date: "11/04/2016"
 f1_keywords: ["concrt/concurrency::Alloc", "concrt/concurrency::DisableTracing", "concrt/concurrency::EnableTracing", "concrtrm/concurrency::GetExecutionContextId", "concrtrm/concurrency::GetOSVersion", "concrtrm/concurrency::GetProcessorNodeCount", "concrtrm/concurrency::GetSchedulerId", "agents/concurrency::asend", "ppltasks/concurrency::cancel_current_task", "ppltasks/concurrency::create_async", "ppltasks/concurrency::create_task", "concurrent_vector/concurrency::internal_assign_iterators", "ppl/concurrency::interruption_point", "agents/concurrency::make_choice", "agents/concurrency::make_greedy_join", "ppl/concurrency::make_task", "ppl/concurrency::parallel_buffered_sort", "ppl/concurrency::parallel_for_each", "ppl/concurrency::parallel_invoke", "ppl/concurrency::parallel_reduce", "ppl/concurrency::parallel_sort", "agents/concurrency::receive", "ppl/concurrency::run_with_cancellation_token", "pplconcrt/concurrency::set_ambient_scheduler", "concrt/concurrency::set_task_execution_resources", "ppltasks/concurrency::task_from_exception", "ppltasks/concurrency::task_from_result", "concrt/concurrency::wait", "ppltasks/concurrency::when_all", "ppltasks/concurrency::when_any"]
-ms.assetid: 520a6dff-9324-4df2-990d-302e3050af6a
 ---
 # concurrency namespace functions
 
@@ -175,7 +174,7 @@ The lambda may take either zero, one or two arguments. The valid arguments are `
 
 If the body of the lambda or function object returns a result (and not a task\<TResult>), the lamdba will be executed asynchronously within the process MTA in the context of a task the Runtime implicitly creates for it. The `IAsyncInfo::Cancel` method will cause cancellation of the implicit task.
 
-If the body of the lambda returns a task, the lamba executes inline, and by declaring the lambda to take an argument of type `cancellation_token` you can trigger cancellation of any tasks you create within the lambda by passing that token in when you create them. You may also use the `register_callback` method on the token to cause the Runtime to invoke a callback when you call `IAsyncInfo::Cancel` on the async operation or action produced..
+If the body of the lambda returns a task, the lamba executes inline, and by declaring the lambda to take an argument of type `cancellation_token` you can trigger cancellation of any tasks you create within the lambda by passing that token in when you create them. You may also use the `register_callback` method on the token to cause the Runtime to invoke a callback when you call `IAsyncInfo::Cancel` on the async operation or action produced.
 
 This function is only available to Windows Runtime apps.
 

--- a/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
@@ -475,7 +475,7 @@ void max_load_factor(float _Newmax);
 
 ### Return Value
 
-The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid..
+The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid.
 
 ## <a name="max_size"></a> max_size
 

--- a/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: concurrent_unordered_multimap Class"
 title: "concurrent_unordered_multimap Class"
+description: "Learn more about: concurrent_unordered_multimap Class"
 ms.date: "11/04/2016"
 f1_keywords: ["concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::hash_function", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::insert", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::key_eq", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::swap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_multimap class"]
-ms.assetid: 4dada5d7-15df-4382-b9c9-348e75b2f3c1
 ---
 # concurrent_unordered_multimap Class
 
@@ -449,7 +448,7 @@ void max_load_factor(float _Newmax);
 
 ### Return Value
 
-The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid..
+The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid.
 
 ## <a name="max_size"></a> max_size
 
@@ -708,5 +707,5 @@ The maximum number of buckets in this container.
 
 ## See also
 
-[concurrency Namespace](concurrency-namespace.md)<br/>
+[concurrency Namespace](concurrency-namespace.md)\
 [Parallel Containers and Objects](../../../parallel/concrt/parallel-containers-and-objects.md)

--- a/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: concurrent_unordered_multiset Class"
 title: "concurrent_unordered_multiset Class"
+description: "Learn more about: concurrent_unordered_multiset Class"
 ms.date: "11/04/2016"
 f1_keywords: ["concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::hash_function", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::insert", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::key_eq", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::swap", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_multiset class"]
-ms.assetid: 219d7d67-1ff0-45f4-9400-e9cc272991a4
 ---
 # concurrent_unordered_multiset Class
 
@@ -437,7 +436,7 @@ void max_load_factor(float _Newmax);
 
 ### Return Value
 
-The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid..
+The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid.
 
 ## <a name="max_size"></a> max_size
 
@@ -694,5 +693,5 @@ The maximum number of buckets in this container.
 
 ## See also
 
-[concurrency Namespace](concurrency-namespace.md)<br/>
+[concurrency Namespace](concurrency-namespace.md)\
 [Parallel Containers and Objects](../../../parallel/concrt/parallel-containers-and-objects.md)

--- a/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: concurrent_unordered_set Class"
 title: "concurrent_unordered_set Class"
+description: "Learn more about: concurrent_unordered_set Class"
 ms.date: "11/04/2016"
 f1_keywords: ["concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::hash_function", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::insert", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::key_eq", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::swap", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_set class"]
-ms.assetid: c61f9a9a-4fd9-491a-9251-e300737ecf4b
 ---
 # concurrent_unordered_set Class
 
@@ -439,7 +438,7 @@ void max_load_factor(float _Newmax);
 
 ### Return Value
 
-The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid..
+The first member function returns the stored maximum load factor. The second member function does not return a value but throws an [out_of_range](../../../standard-library/out-of-range-class.md) exception if the supplied load factor is invalid.
 
 ## <a name="max_size"></a> max_size
 
@@ -698,5 +697,5 @@ The maximum number of buckets in this container.
 
 ## See also
 
-[concurrency Namespace](concurrency-namespace.md)<br/>
+[concurrency Namespace](concurrency-namespace.md)\
 [Parallel Containers and Objects](../../../parallel/concrt/parallel-containers-and-objects.md)


### PR DESCRIPTION
Part 2 of #5142.

Changes:
- Remove extra periods
- Replace `<br/>` in "See also" sections with backslash
- Update metadata