### PR TITLE
Update check-stack.md

### DIFF
--- a/docs/preprocessor/check-stack.md
+++ b/docs/preprocessor/check-stack.md
@@ -25,8 +25,8 @@ If you don't give an argument for the **`check_stack`** pragma, stack checking r
 
 | Syntax | Compiled with<br /><br /> `/Gs` option? | Action |
 |--|--|--|
-| `#pragma check_stack( )` or<br /><br /> `#pragma check_stack` | Yes | Turns off stack checking for functions that follow |
-| `#pragma check_stack( )` or<br /><br /> `#pragma check_stack` | No | Turns on stack checking for functions that follow |
+| `#pragma check_stack( )` or<br /><br /> `#pragma check_stack` | Yes | Turns on stack checking for functions that follow |
+| `#pragma check_stack( )` or<br /><br /> `#pragma check_stack` | No | Turns off stack checking for functions that follow |
 | `#pragma check_stack(on)`<br /><br /> or `#pragma check_stack +` | Yes or No | Turns on stack checking for functions that follow |
 | `#pragma check_stack(off)`<br /><br /> or `#pragma check_stack -` | Yes or No | Turns off stack checking for functions that follow |
 


### PR DESCRIPTION
`#pragma check_stack( )` and `#pragma check_stack` will make stack checking reverts to the behavior specified on the command line, so if `/Gs` presents in command line, stack checking is turn on, otherwise it's turn off.