### PR TITLE
Correct return value of `CTaskDialog::OnHelp()`

### DIFF
--- a/docs/mfc/reference/ctaskdialog-class.md
+++ b/docs/mfc/reference/ctaskdialog-class.md
@@ -685,7 +685,7 @@ virtual HRESULT OnHelp();
 
 ### Return Value
 
-The default implementation returns S_OK.
+The default implementation returns S_FALSE.
 
 ### Remarks
 


### PR DESCRIPTION
It returns `S_FALSE`, not `S_OK`, according to `afxtaskdialog.cpp` in 14.42.34433.
![image](https://github.com/user-attachments/assets/3eea3966-6379-41e1-bf7a-1ae35278f41a)

In testing, returning `S_OK` from an overridden implementation to match the described "default" implementation may result in another window (e.g., a main frame window) also presenting help.