### PR TITLE
Clean up superfluous semicolons

### DIFF
--- a/docs/standard-library/ctype-class.md
+++ b/docs/standard-library/ctype-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: ctype Class"
 title: "ctype Class"
+description: "Learn more about: ctype Class"
 ms.date: "11/04/2016"
 f1_keywords: ["xlocale/std::ctype", "xlocale/std::ctype::char_type", "xlocale/std::ctype::do_is", "xlocale/std::ctype::do_narrow", "xlocale/std::ctype::do_scan_is", "xlocale/std::ctype::do_scan_not", "xlocale/std::ctype::do_tolower", "xlocale/std::ctype::do_toupper", "xlocale/std::ctype::do_widen", "xlocale/std::ctype::is", "xlocale/std::ctype::narrow", "xlocale/std::ctype::scan_is", "xlocale/std::ctype::scan_not", "xlocale/std::ctype::tolower", "xlocale/std::ctype::toupper", "xlocale/std::ctype::widen"]
 helpviewer_keywords: ["std::ctype [C++]", "std::ctype [C++], char_type", "std::ctype [C++], do_is", "std::ctype [C++], do_narrow", "std::ctype [C++], do_scan_is", "std::ctype [C++], do_scan_not", "std::ctype [C++], do_tolower", "std::ctype [C++], do_toupper", "std::ctype [C++], do_widen", "std::ctype [C++], is", "std::ctype [C++], narrow", "std::ctype [C++], scan_is", "std::ctype [C++], scan_not", "std::ctype [C++], tolower", "std::ctype [C++], toupper", "std::ctype [C++], widen"]
-ms.assetid: 3627154c-49d9-47b5-b28f-5bbedee38e3b
 ---
 # ctype Class
 
@@ -466,7 +465,7 @@ int main() {
       cout << string[i] << ": "
            << (maskarray[i] & ctype_base::alpha  "alpha"
                                                 : "not alpha")
-           << endl;;
+           << endl;
    };
 }
 ```

--- a/docs/standard-library/raw-storage-iterator-class.md
+++ b/docs/standard-library/raw-storage-iterator-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: raw_storage_iterator Class"
 title: "raw_storage_iterator Class"
+description: "Learn more about: raw_storage_iterator Class"
 ms.date: 06/17/2022
 f1_keywords: ["memory/std::raw_storage_iterator", "memory/std::raw_storage_iterator::element_type", "memory/std::raw_storage_iterator::iter_type"]
 helpviewer_keywords: ["std::raw_storage_iterator [C++]", "std::raw_storage_iterator [C++], element_type", "std::raw_storage_iterator [C++], iter_type"]
-ms.assetid: 6f033f15-f48e-452a-a326-647ea2cf346f
 ms.custom: devdivchpfy22
 ---
 # raw_storage_iterator Class
@@ -264,7 +263,7 @@ int main( void )
       *it = 2 * i;
    };
 
-   for ( int i = 0; i < 5; i++ ) cout << "array " << i << " = " << pInt[i] << endl;;
+   for ( int i = 0; i < 5; i++ ) cout << "array " << i << " = " << pInt[i] << endl;
 
    delete[] pInt;
 }
@@ -335,7 +334,7 @@ int main( void )
 
    std::copy( l.begin( ), l.end( ), pInt );  // C4996
    for (unsigned int i = 0; i < l.size( ); i++)
-      cout << "array " << i << " = " << pInt[i].x << endl;;
+      cout << "array " << i << " = " << pInt[i].x << endl;
 
    memset (pInt, 0, sizeof(Int)*l.size( ));
    // hack: make sure bIsConstructed is false


### PR DESCRIPTION
Remove 3 superfluous semicolons in the examples, together with metadata changes.