### PR TITLE
Add example and augment C2200 page

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2200.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2200.md
@@ -1,13 +1,21 @@
 ---
-description: "Learn more about: Compiler Error C2200"
 title: "Compiler Error C2200"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2200"
+ms.date: "02/15/2025"
 f1_keywords: ["C2200"]
 helpviewer_keywords: ["C2200"]
-ms.assetid: a04139a6-ce18-404b-9bfd-2369fc0af3cb
 ---
 # Compiler Error C2200
 
-'function' : function has already been defined
+'function': function has already been defined
 
-An `alloc_text` pragma uses a function name already defined.
+An [`alloc_text`](../../preprocessor/alloc-text.md) pragma uses a function name already defined. Ensure the `alloc_text` pragma appears after the function declaration but before its definition.
+
+The following sample generates C2200:
+
+```cpp
+// C2200.cpp
+// compile with: /c
+extern "C" void func() {}
+#pragma alloc_text("section", func)   // C2200
+```


### PR DESCRIPTION
Summary:
- Remove space character before colon in error message (to match the generated one verbatim)
- Add link to the `alloc_text` pragma page
- Mention the correct placement of the `alloc_text` pragma (after declaration but before definition)
- Add short example that generates C2200
- Some metadata cleanup and updates