### PR TITLE
Convert all right parenthesis in ordered lists to period

### DIFF
--- a/docs/code-quality/c26488.md
+++ b/docs/code-quality/c26488.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C26488 LIFETIMES_DEREF_NULL_POINTER"
 title: Warning C26488
+description: "Learn more about: Warning C26488 LIFETIMES_DEREF_NULL_POINTER"
 ms.date: 12/14/2018
 f1_keywords: ["C26488", "LIFETIMES_DEREF_NULL_POINTER"]
 helpviewer_keywords: ["C26488"]
-ms.assetid: 2ade0d31-f259-49de-8676-cce6092fabfc
 author: kylereedmsft
 ms.author: kylereed
 ---
@@ -28,9 +27,9 @@ void ex1()
 
 The Lifetime guidelines from the C++ core guidelines outline a contract that code can follow which will enable more thorough static memory leak and dangling pointer detection. The basic ideas behind the guidelines are:
 
-1) Never dereference an invalid (dangling) or known-null pointer
-2) Never return (either formal return or out parameter) any pointer from a function.
-3) Never pass an invalid (dangling) pointer to any function.
+1. Never dereference an invalid (dangling) or known-null pointer.
+1. Never return (either formal return or out parameter) any pointer from a function.
+1. Never pass an invalid (dangling) pointer to any function.
 
 ## See also
 

--- a/docs/code-quality/c26489.md
+++ b/docs/code-quality/c26489.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C26489 LIFETIMES_DEREF_INVALID_POINTER"
 title: Warning C26489
+description: "Learn more about: Warning C26489 LIFETIMES_DEREF_INVALID_POINTER"
 ms.date: 12/14/2018
 f1_keywords: ["C26489", "LIFETIMES_DEREF_INVALID_POINTER"]
 helpviewer_keywords: ["C26489"]
-ms.assetid: 15983d4f-f615-42e7-8521-ee094b87d066
 author: kylereedmsft
 ms.author: kylereed
 ---
@@ -30,9 +29,9 @@ int ex1()
 
 The Lifetime guidelines from the C++ core guidelines outline a contract that code can follow which will enable more thorough static memory leak and dangling pointer detection. The basic ideas behind the guidelines are:
 
-1) Never dereference an invalid (dangling) or known-null pointer
-2) Never return (either formal return or out parameter) any pointer from a function.
-3) Never pass an invalid (dangling) pointer to any function.
+1. Never dereference an invalid (dangling) or known-null pointer.
+1. Never return (either formal return or out parameter) any pointer from a function.
+1. Never pass an invalid (dangling) pointer to any function.
 
 ## See also
 


### PR DESCRIPTION
Practically all ordered lists use the `1.` syntax, hence this PR converts all `1)` to `1.`.