### PR TITLE
Clean up unneeded space between code block backticks and language

### DIFF
--- a/docs/build/cmake-remote-debugging.md
+++ b/docs/build/cmake-remote-debugging.md
@@ -1,8 +1,8 @@
 ---
 title: "Tutorial: Debug a CMake project on a remote Windows machine"
+description: "How to use Visual Studio C++ on Windows to create and build a CMake project. You'll then deploy and debug it on a remote Windows machine."
 ms.date: "12/4/2020"
 ms.topic: tutorial
-description: "How to use Visual Studio C++ on Windows to create and build a CMake project. You'll then deploy and debug it on a remote Windows machine."
 ---
 
 # Tutorial: Debug a CMake project on a remote Windows machine
@@ -115,7 +115,7 @@ For example, on the remote machine, from the Visual Studio Remote Debugger menu 
 
 Then, in Visual Studio on the host machine, update the *`launch.vs.json`* file to match. For example, if you choose **No Authentication** on the remote debugger, update the *`launch.vs.json`* file in your project by adding `"authenticationType": "none"` to the `configurations` section *`launch.vs.json`*. Otherwise, `"authenticationType"` defaults to `"windows"` and doesn't need to be explicitly stated. This example shows a *`launch.vs.json`* file configured for no authentication:
 
-``` XAML
+```XAML
 {
   "version": "0.2.1",
   "defaults": {},

--- a/docs/build/how-to-use-build-events-in-msbuild-projects.md
+++ b/docs/build/how-to-use-build-events-in-msbuild-projects.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: How to: Use Build Events in MSBuild Projects"
 title: "How to: Use Build Events in MSBuild Projects"
+description: "Learn more about: How to: Use Build Events in MSBuild Projects"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["msbuild (c++), howto: use build events in projects"]
-ms.assetid: 2a58dc9d-3d50-4e49-97c1-86c5a05ce218
 ---
 # How to: Use Build Events in MSBuild Projects
 
@@ -33,7 +32,7 @@ The following table lists each *use-in-build* element:
 
 The following example can be added inside of the Project element of the myproject.vcxproj file created in [Walkthrough: Using MSBuild to Create a C++ Project](walkthrough-using-msbuild-to-create-a-visual-cpp-project.md). A *pre-build* event makes a copy of main.cpp; a *pre-link* event makes a copy of main.obj; and a *post-build* event makes a copy of myproject.exe. If the project is built using a release configuration, the build events are executed. If the project is built using a debug configuration, the build events are not executed.
 
-``` xml
+```xml
 <ItemDefinitionGroup>
   <PreBuildEvent>
     <Command>copy $(ProjectDir)main.cpp $(ProjectDir)copyOfMain.cpp</Command>
@@ -64,5 +63,5 @@ The following example can be added inside of the Project element of the myprojec
 
 ## See also
 
-[MSBuild on the command line - C++](msbuild-visual-cpp.md)<br/>
+[MSBuild on the command line - C++](msbuild-visual-cpp.md)\
 [Walkthrough: Using MSBuild to Create a C++ Project](walkthrough-using-msbuild-to-create-a-visual-cpp-project.md)

--- a/docs/dotnet/data-access-using-adonet-cpp-cli.md
+++ b/docs/dotnet/data-access-using-adonet-cpp-cli.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Data Access Using ADO.NET (C++/CLI)"
 title: "Data Access Using ADO.NET (C++/CLI)"
+description: "Learn more about: Data Access Using ADO.NET (C++/CLI)"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["ADO.NET [C++]", ".NET Framework [C++], data access", "databases [C++], accessing in C++", "data access [C++], ADO.NET", "data [C++], ADO.NET", "native strings [C++]", "ADO.NET [C++], marshaling ANSI strings", "strings [C++], ADO.NET", "BSTRs, strings", "ADO.NET [C++], marshaling BSTR strings", "strings [C++], marshaling BSTR strings", "ADO.NET [C++], marshaling Unicode strings", "Unicode [C++], strings", "strings [C++], Unicode", "VARIANT, marshaling", "ADO.NET [C++], marshaling VARIANT types", "VARIANT", "SAFEARRAY, marshaling", "ADO.NET [C++], marshaling SAFEARRAY types"]
-ms.assetid: b0cd987d-1ea7-4f76-ba01-cbd52503d06d
 ---
 # Data Access Using ADO.NET (C++/CLI)
 
@@ -152,7 +151,7 @@ The rest of the code in this example is native C++ code, as is indicated by the 
 > [!NOTE]
 > The memory allocated by <xref:System.Runtime.InteropServices.Marshal.StringToBSTR%2A> must be deallocated by calling either <xref:System.Runtime.InteropServices.Marshal.FreeBSTR%2A> or `SysFreeString`.
 
-``` cpp
+```cpp
 // adonet_marshal_string_bstr.cpp
 // compile with: /clr /FU System.dll /FU System.Data.dll /FU System.Xml.dll
 #include <comdef.h>

--- a/docs/extensions/compiler-support-for-type-traits-cpp-component-extensions.md
+++ b/docs/extensions/compiler-support-for-type-traits-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Compiler Support for Type Traits (C++/CLI and C++/CX)"
 title: "Compiler Support for Type Traits (C++/CLI and C++/CX)"
+description: "Learn more about: Compiler Support for Type Traits (C++/CLI and C++/CX)"
 ms.date: "10/12/2018"
 ms.topic: "reference"
 f1_keywords: ["__is_simple_value_class", "__has_trivial_destructor", "__has_assign", "__is_union", "__is_class", "__is_abstract", "__has_trivial_assign", "__has_virtual_destructor", "__is_ref_array", "__is_base_of", "__has_copy", "__is_polymorphic", "__has_nothrow_constructor", "__is_ref_class", "__is_delegate", "__is_convertible_to", "__is_value_class", "__is_interface_class", "__has_nothrow_copy", "__is_sealed", "__has_trivial_constructor", "__has_trivial_copy", "__is_enum", "__has_nothrow_assign", "__has_finalizer", "__is_empty", "__is_pod", "__has_user_destructor"]
 helpviewer_keywords: ["__is_class keyword [C++]", "__is_pod keyword [C++]", "__is_delegate keyword [C++]", "__is_value_class keyword [C++]", "__has_copy keyword [C++]", "__has_nothrow_copy keyword [C++]", "__is_interface_class keyword [C++]", "__is_sealed keyword [C++]", "__is_convertible_to keyword [C++]", "__is_ref_class keyword [C++]", "__has_trivial_copy keyword [C++]", "__has_user_destructor keyword [C++]", "__is_abstract keyword [C++]", "__is_empty keyword [C++]", "__has_trivial_assign keyword [C++]", "__has_nothrow_constructor keyword [C++]", "__is_ref_array keyword [C++]", "__is_base_of keyword [C++]", "__has_nothrow_assign keyword [C++]", "__has_virtual_destructor keyword [C++]", "__has_finalizer keyword [C++]", "__is_union keyword [C++]", "__has_assign keyword [C++]", "__has_trivial_destructor keyword [C++]", "__is_polymorphic keyword [C++]", "__is_enum keyword [C++]", "__is_simple_value_class keyword [C++]", "__has_trivial_constructor keyword [C++]"]
-ms.assetid: cd440630-0394-48c0-a16b-1580b6ef5844
 ---
 # Compiler Support for Type Traits (C++/CLI and C++/CX)
 
@@ -160,7 +159,7 @@ The following list contains the type traits that are supported by the compiler. 
 
    Returns **`true`** if the type has a trivial, compiler-generated destructor.
 
-    ``` cpp
+    ```cpp
     // has_trivial_destructor.cpp
     #include <stdio.h>
     struct S {};

--- a/docs/mfc/reference/buffercommand-enumeration.md
+++ b/docs/mfc/reference/buffercommand-enumeration.md
@@ -11,7 +11,7 @@ Used by [CMemFile::GetBufferPtr](cmemfile-class.md#getbufferptr) to determine wh
 
 ## Syntax
 
-``` cpp
+```cpp
 public enum BufferCommand
 {
    bufferRead,


### PR DESCRIPTION
Simple cleanup of unneeded space between code block backticks and language (even though they don't affect the rendered output).