### PR TITLE
Add missing space between asterisk and open parenthesis

### DIFF
--- a/docs/c-runtime-library/heapset.md
+++ b/docs/c-runtime-library/heapset.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _heapset"
 title: "_heapset"
+description: "Learn more about: _heapset"
 ms.date: "11/04/2016"
 api_name: ["_heapset"]
 api_location: ["msvcr90.dll", "msvcr80.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcrt.dll", "msvcr120.dll", "msvcr100.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_heapset", "heapset"]
 helpviewer_keywords: ["checking heap", "heapset function", "heaps, checking", "debugging [CRT], heap-related problems", "_heapset function"]
-ms.assetid: 9667eeb0-55bc-4c19-af5f-d1fd0a142b3c
 ---
 # `_heapset`
 
@@ -47,7 +46,7 @@ In addition, if an error occurs, **`_heapset`** sets `errno` to `ENOSYS`.
 
 The **`_heapset`** function shows free memory locations or nodes that have been unintentionally overwritten.
 
-**`_heapset`** checks for minimal consistency on the heap and then sets each byte of the heap's free entries to the `fill` value. This known value shows which memory locations of the heap contain free nodes and which contain data that were unintentionally written to freed memory. If the operating system doesn't support **`_heapset`**(for example, Windows 98), the function returns `_HEAPOK` and sets `errno` to `ENOSYS`.
+**`_heapset`** checks for minimal consistency on the heap and then sets each byte of the heap's free entries to the `fill` value. This known value shows which memory locations of the heap contain free nodes and which contain data that were unintentionally written to freed memory. If the operating system doesn't support **`_heapset`** (for example, Windows 98), the function returns `_HEAPOK` and sets `errno` to `ENOSYS`.
 
 ## Requirements
 

--- a/docs/c-runtime-library/reference/heapchk.md
+++ b/docs/c-runtime-library/reference/heapchk.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _heapchk"
 title: "_heapchk"
+description: "Learn more about: _heapchk"
 ms.date: "4/2/2020"
 api_name: ["_heapchk", "_o__heapchk"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-heap-l1-1-0.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_heapchk", "heapchk"]
 helpviewer_keywords: ["debugging [CRT], heap-related problems", "consistency checking of heaps", "heapchk function", "heaps, checking consistency", "_heapchk function"]
-ms.assetid: 859619a5-1e35-4f02-9e09-11d9fa266ec0
 ---
 # `_heapchk`
 
@@ -36,7 +35,7 @@ In addition, if an error occurs, **`_heapchk`** sets `errno` to `ENOSYS`.
 
 ## Remarks
 
-The **`_heapchk`** function helps debug heap-related problems by checking for minimal consistency of the heap. If the operating system doesn't support **`_heapchk`**(for example, Windows 98), the function returns `_HEAPOK` and sets `errno` to `ENOSYS`.
+The **`_heapchk`** function helps debug heap-related problems by checking for minimal consistency of the heap. If the operating system doesn't support **`_heapchk`** (for example, Windows 98), the function returns `_HEAPOK` and sets `errno` to `ENOSYS`.
 
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).
 

--- a/docs/c-runtime-library/reference/heapmin.md
+++ b/docs/c-runtime-library/reference/heapmin.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _heapmin"
 title: "_heapmin"
+description: "Learn more about: _heapmin"
 ms.date: "4/2/2020"
 api_name: ["_heapmin", "_o__heapmin"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-heap-l1-1-0.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_heapmin", "heapmin"]
 helpviewer_keywords: ["heap memory", "minimizing heaps", "memory, releasing", "heaps, releasing unused memory", "_heapmin function", "heapmin function"]
-ms.assetid: c0bccdf6-2d14-4d7b-a7ff-d6a17bdb410f
 ---
 # `_heapmin`
 
@@ -28,7 +27,7 @@ For more information about this and other return codes, see [`errno`, `_doserrno
 
 ## Remarks
 
-The **`_heapmin`** function minimizes the heap by releasing unused heap memory to the operating system. If the operating system doesn't support **`_heapmin`**(for example, Windows 98), the function returns -1 and sets `errno` to `ENOSYS`.
+The **`_heapmin`** function minimizes the heap by releasing unused heap memory to the operating system. If the operating system doesn't support **`_heapmin`** (for example, Windows 98), the function returns -1 and sets `errno` to `ENOSYS`.
 
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).
 

--- a/docs/cpp/unhook.md
+++ b/docs/cpp/unhook.md
@@ -64,7 +64,7 @@ A pointer to the event handler method to be unhooked from an event. The handler 
 
 - Managed events: *`ReceiverClass`* is the event receiver class and *`HandlerMethod`* is the handler.
 
-*`receiver`*(optional)
+*`receiver`* (optional)
 A pointer to an instance of the event receiver class. If you don't specify a receiver, the default is the receiver class or structure in which **`__unhook`** is called.
 
 ## Usage


### PR DESCRIPTION
Add a couple of space characters before open parentheses, together with metadata cleanups.