### PR TITLE
Tweaks for C6030 warning page

### DIFF
--- a/docs/code-quality/c6030.md
+++ b/docs/code-quality/c6030.md
@@ -6,17 +6,18 @@ f1_keywords: ["C6030", "USE_ATTRIBUTE_NORETURN", "__WARNING_USE_ATTRIBUTE_NORETU
 helpviewer_keywords: ["C6030"]
 ---
 
-# Warning  C6030
+# Warning C6030
 
 > Use attribute [[noreturn]] over __declspec(noreturn) in function '*function-name*'
 
 ## Remarks
 
-This warning suggests using the C++11 standard attribute `[[noreturn]]` in place of the declspec variant `__declspec(noreturn)`. The standard attribute provides better cross-platform support because it doesn't rely on language extensions.
+This warning suggests using the C++11 standard attribute [`[[noreturn]]`](../cpp/attributes.md#noreturn) in place of the declspec variant [`__declspec(noreturn)`](../cpp/noreturn.md). The standard attribute provides better cross-platform support because it doesn't rely on language extensions.
 
 This warning is off by default and isn't part of the `All Rules` rule set. To enable this warning, it must be added to the rule set file being used.
 
 This check is available in Visual Studio 2022 version 17.0 and later versions.
+
 Code analysis name: `USE_ATTRIBUTE_NORETURN`
 
 ## Example
@@ -24,15 +25,13 @@ Code analysis name: `USE_ATTRIBUTE_NORETURN`
 The following code generates C6030:
 
 ```cpp
-__declspec(noreturn) void TerminateApplication();
-
+__declspec(noreturn) void terminate_application();
 ```
 
 Fix the issue by using the `[[noreturn]]` attribute:
 
 ```cpp
-[[ noreturn ]] void TerminateApplication();
-
+[[noreturn]] void terminate_application();
 ```
 
 ## See also


### PR DESCRIPTION
Summary:
- Remove extra space character in header
- Add links for `[[noreturn]]` and `__declspec(noreturn)`
- Move "Code analysis name" to its own line (every other instance does it that way)
- Remove superfluous trailing empty line in both code snippets
- Format `[[ noreturn ]]` and the function name (prefer snake case for uniformity)