### PR TITLE
Elide extraneous leading empty lines in code snippets

### DIFF
--- a/docs/c-language/extern-storage-class-specifier.md
+++ b/docs/c-language/extern-storage-class-specifier.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: extern Storage-Class Specifier"
 title: "extern Storage-Class Specifier"
+description: "Learn more about: extern Storage-Class Specifier"
 ms.date: "07/10/2018"
 helpviewer_keywords: ["extern keyword [C]", "storage class specifiers, extern", "extern keyword [C], storage class specifier", "external linkage, storage-class specifiers", "external linkage, extern modifier"]
-ms.assetid: 6e16d927-291f-49e4-986c-9d91a482a441
 ---
 # extern Storage-Class Specifier
 
@@ -14,12 +13,11 @@ A variable declared with the **`extern`** storage-class specifier is a reference
 This example illustrates internal- and external-level declarations:
 
 ```c
-
 // Source1.c
 
 int i = 1;
 
-// Source2. c
+// Source2.c
 
 #include <stdio.h>
 

--- a/docs/c-runtime-library/reference/and.md
+++ b/docs/c-runtime-library/reference/and.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: and"
 title: "and"
+description: "Learn more about: and"
 ms.date: "11/04/2016"
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["ISO646/and", "and", "std.and", "std::and"]
 helpviewer_keywords: ["and macro"]
-ms.assetid: 2644ab57-8e1b-48f0-9021-cafe3e26bdc4
 ---
 # `and`
 
@@ -16,7 +15,6 @@ An alternative to the && operator.
 ## Syntax
 
 ```C
-
 #define and &&
 ```
 

--- a/docs/c-runtime-library/reference/bitand.md
+++ b/docs/c-runtime-library/reference/bitand.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: bitand"
 title: "bitand"
+description: "Learn more about: bitand"
 ms.date: "11/04/2016"
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["std::bitand", "std.bitand", "ISO646/bitand", "bitand"]
 helpviewer_keywords: ["bitand function"]
-ms.assetid: 279cf9b5-fac1-49de-b329-f1a31b3481fe
 ---
 # `bitand`
 
@@ -16,7 +15,6 @@ An alternative to the & operator.
 ## Syntax
 
 ```C
-
 #define bitand &
 ```
 

--- a/docs/c-runtime-library/reference/bitor.md
+++ b/docs/c-runtime-library/reference/bitor.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: bitor"
 title: "bitor"
+description: "Learn more about: bitor"
 ms.date: "11/04/2016"
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["ISO646/bitor", "bitor", "std.bitor", "std::bitor"]
 helpviewer_keywords: ["bitor function"]
-ms.assetid: 3c0a3711-9c74-41f2-b400-2f7797da30d1
 ---
 # `bitor`
 
@@ -16,7 +15,6 @@ An alternative to the `|` operator.
 ## Syntax
 
 ```C
-
 #define bitor |
 ```
 

--- a/docs/c-runtime-library/reference/crtcheckmemory.md
+++ b/docs/c-runtime-library/reference/crtcheckmemory.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _CrtCheckMemory"
 title: "_CrtCheckMemory"
+description: "Learn more about: _CrtCheckMemory"
 ms.date: "11/04/2016"
 api_name: ["_CrtCheckMemory"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["CrtCheckMemory", "_CrtCheckMemory"]
 helpviewer_keywords: ["_CrtCheckMemory function", "CrtCheckMemory function"]
-ms.assetid: 457cc72e-60fd-4177-ab5c-6ae26a420765
 ---
 # `_CrtCheckMemory`
 
@@ -17,7 +16,6 @@ Confirms the integrity of the memory blocks allocated in the debug heap (debug v
 ## Syntax
 
 ```C
-
 int _CrtCheckMemory( void );
 ```
 

--- a/docs/c-runtime-library/reference/crtdumpmemoryleaks.md
+++ b/docs/c-runtime-library/reference/crtdumpmemoryleaks.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _CrtDumpMemoryLeaks"
 title: "_CrtDumpMemoryLeaks"
+description: "Learn more about: _CrtDumpMemoryLeaks"
 ms.date: "11/04/2016"
 api_name: ["_CrtDumpMemoryLeaks"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -16,7 +16,6 @@ Dumps all the memory blocks in the debug heap when a memory leak has occurred (d
 ## Syntax
 
 ```C
-
 int _CrtDumpMemoryLeaks( void );
 ```
 

--- a/docs/c-runtime-library/reference/kbhit.md
+++ b/docs/c-runtime-library/reference/kbhit.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _kbhit"
 title: "_kbhit"
+description: "Learn more about: _kbhit"
 ms.date: "4/2/2020"
 api_name: ["_kbhit", "_o__kbhit"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_kbhit", "conio/_kbhit"]
 helpviewer_keywords: ["keyboard input", "user input, checking for keyboard", "kbhit function", "console", "console, checking", "keyboards, keyboard input", "_kbhit function", "keyboards, checking input"]
-ms.assetid: e82a1cc9-bbec-4150-b678-a7e433220fe4
 ---
 # `_kbhit`
 
@@ -20,7 +19,6 @@ Checks the console for keyboard input.
 ## Syntax
 
 ```C
-
 int _kbhit( void );
 ```
 

--- a/docs/c-runtime-library/reference/mkdir-wmkdir.md
+++ b/docs/c-runtime-library/reference/mkdir-wmkdir.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _mkdir, _wmkdir"
 title: "_mkdir, _wmkdir"
+description: "Learn more about: _mkdir, _wmkdir"
 ms.date: "4/2/2020"
 api_name: ["_wmkdir", "_mkdir", "_o__mkdir", "_o__wmkdir"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-filesystem-l1-1-0.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_mkdir", "tmkdir", "_tmkdir", "wmkdir", "_wmkdir"]
 helpviewer_keywords: ["_wmkdir function", "folders [C++], creating", "wmkdir function", "directories [C++], creating", "mkdir function", "tmkdir function", "_mkdir function", "_tmkdir function"]
-ms.assetid: 7f22d01d-63a5-4712-a6e7-d34878b2d840
 ---
 # `_mkdir`, `_wmkdir`
 
@@ -17,7 +16,6 @@ Creates a new directory.
 ## Syntax
 
 ```C
-
 int _mkdir(
    const char *dirname
 );

--- a/docs/c-runtime-library/reference/not.md
+++ b/docs/c-runtime-library/reference/not.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: not"
 title: "not"
+description: "Learn more about: not"
 ms.date: "11/04/2016"
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["std::not", "std.not", "ISO646/not", "not"]
 helpviewer_keywords: ["not function"]
-ms.assetid: d2ddbd5c-33c0-4aff-8961-feac155b4ba1
 ---
 # `not`
 
@@ -16,7 +15,6 @@ An alternative to the **`!`** operator.
 ## Syntax
 
 ```C
-
 #define not !
 ```
 

--- a/docs/c-runtime-library/reference/or-eq.md
+++ b/docs/c-runtime-library/reference/or-eq.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: or_eq"
 title: "or_eq"
+description: "Learn more about: or_eq"
 ms.date: "11/04/2016"
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["std::or_eq", "ISO646/or_eq", "or_eq", "std.or_eq"]
 helpviewer_keywords: ["or_eq function"]
-ms.assetid: 1eb92464-ed58-40d8-a30e-f0a6aa2f4318
 ---
 # `or_eq`
 
@@ -16,7 +15,6 @@ An alternative to the `|=` operator.
 ## Syntax
 
 ```C
-
 #define or_eq |=
 ```
 

--- a/docs/c-runtime-library/reference/rmtmp.md
+++ b/docs/c-runtime-library/reference/rmtmp.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _rmtmp"
 title: "_rmtmp"
+description: "Learn more about: _rmtmp"
 ms.date: "4/2/2020"
 api_name: ["_rmtmp", "_o__rmtmp"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_rmtmp"]
 helpviewer_keywords: ["removing temporary files", "_rmtmp function", "files [C++], temporary", "rmtmp function", "files [C++], removing", "temporary files [C++], removing"]
-ms.assetid: 7419501e-2587-4f2a-b469-0dca07f84736
 ---
 # `_rmtmp`
 
@@ -17,7 +16,6 @@ Removes temporary files.
 ## Syntax
 
 ```C
-
 int _rmtmp( void );
 ```
 

--- a/docs/c-runtime-library/reference/rotl-rotl64-rotr-rotr64.md
+++ b/docs/c-runtime-library/reference/rotl-rotl64-rotr-rotr64.md
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_rotr64", "rotl64", "_rotl64", "rotr64", "rotr", "_rotr", "_rotl", "rotl"]
 helpviewer_keywords: ["rotl64 function", "_rotl function", "rotr function", "rotr64 function", "_rotr function", "rotl function", "_rotl64 function", "rotating bits", "_rotr64 function", "bits, rotating"]
-ms.assetid: cfce439b-366f-4584-8ab1-d527b13fcfc6
 ---
 # `_rotl`, `_rotl64`, `_rotr`, `_rotr64`
 
@@ -17,7 +16,6 @@ Rotates bits to the left (**`_rotl`**) or right (**`_rotr`**).
 ## Syntax
 
 ```C
-
 unsigned int _rotl(
    unsigned int value,
    int shift

--- a/docs/c-runtime-library/reference/rtc-numerrors.md
+++ b/docs/c-runtime-library/reference/rtc-numerrors.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _RTC_NumErrors"
 title: "_RTC_NumErrors"
+description: "Learn more about: _RTC_NumErrors"
 ms.date: "11/04/2016"
 api_name: ["_RTC_NumErrors"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
@@ -8,7 +8,6 @@ api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_RTC_NumErrors", "RTC_NumErrors"]
 helpviewer_keywords: ["run-time errors", "_RTC_NumErrors function", "RTC_NumErrors function"]
-ms.assetid: 7e82adae-38e2-4f8b-bc0b-37bda8109fd1
 ---
 # `_RTC_NumErrors`
 
@@ -17,7 +16,6 @@ Returns the total number of errors that can be detected by run-time error checks
 ## Syntax
 
 ```C
-
 int _RTC_NumErrors( void );
 ```
 

--- a/docs/code-quality/annotating-structs-and-classes.md
+++ b/docs/code-quality/annotating-structs-and-classes.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Annotating Structs and Classes"
 title: Annotating Structs and Classes
+description: "Learn more about: Annotating Structs and Classes"
 ms.date: 06/28/2019
 ms.topic: "conceptual"
 f1_keywords:
@@ -19,7 +19,6 @@ f1_keywords:
   - "_Field_size_full_"
   - "_Field_size_full_opt_"
   - "_Field_z_"
-ms.assetid: b8278a4a-c86e-4845-aa2a-70da21a1dd52
 ---
 # Annotating Structs and Classes
 
@@ -52,13 +51,11 @@ You can annotate struct and class members by using annotations that act like inv
      Applies to struct or class declaration.  Indicates that a valid object of that type may be larger than the declared type, with the number of bytes being specified by `size`.  For example:
 
     ```cpp
-
     typedef _Struct_size_bytes_(nSize)
     struct MyStruct {
         size_t nSize;
         ...
     };
-
     ```
 
      The buffer size in bytes of a parameter `pM` of type `MyStruct *` is then taken to be:

--- a/docs/cpp/codesnippet/CPP/how-to-create-and-use-shared-ptr-instances_1.cpp
+++ b/docs/cpp/codesnippet/CPP/how-to-create-and-use-shared-ptr-instances_1.cpp
@@ -1,4 +1,3 @@
-
     // Use make_shared function when possible.
     auto sp1 = make_shared<Song>(L"The Beatles", L"Im Happy Just to Dance With You");
 

--- a/docs/cpp/codesnippet/CPP/how-to-create-and-use-shared-ptr-instances_6.cpp
+++ b/docs/cpp/codesnippet/CPP/how-to-create-and-use-shared-ptr-instances_6.cpp
@@ -1,4 +1,3 @@
-
     // Initialize two separate raw pointers.
     // Note that they contain the same values.
     auto song1 = new Song(L"Village People", L"YMCA");

--- a/docs/cpp/codesnippet/CPP/how-to-create-and-use-unique-ptr-instances_3.cpp
+++ b/docs/cpp/codesnippet/CPP/how-to-create-and-use-unique-ptr-instances_3.cpp
@@ -1,4 +1,3 @@
-
 class MyClass
 {
 private:

--- a/docs/cpp/codesnippet/CPP/smart-pointers-modern-cpp_2.cpp
+++ b/docs/cpp/codesnippet/CPP/smart-pointers-modern-cpp_2.cpp
@@ -1,4 +1,3 @@
-
 class LargeObject
 {
 public:

--- a/docs/linux/deploy-run-and-debug-your-linux-project.md
+++ b/docs/linux/deploy-run-and-debug-your-linux-project.md
@@ -135,7 +135,6 @@ The **Content** property specifies whether the file will be deployed to the remo
 In some cases, you may require more control over your project's deployment. For example, some files that you want to deploy might be outside of your solution or you want to customize your remote deploy directory per file or directory. In these cases, append the following code block(s) to your .vcxproj file and replace "example.cpp" with the actual file names:
 
 ```xml
-
 <ItemGroup>
    <RemoteDeploy Include="__example.cpp">
 <!-- This is the source Linux machine, can be empty if DeploymentType is LocalRemote -->

--- a/docs/mfc/codesnippet/CPP/accessing-the-embedded-month-calendar-control_2.cpp
+++ b/docs/mfc/codesnippet/CPP/accessing-the-embedded-month-calendar-control_2.cpp
@@ -1,4 +1,3 @@
-
 //create and initialize the font to be used
 LOGFONT logFont = {0};
 logFont.lfHeight = -12;

--- a/docs/mfc/codesnippet/CPP/cbitmapbutton-class_3.cpp
+++ b/docs/mfc/codesnippet/CPP/cbitmapbutton-class_3.cpp
@@ -1,4 +1,3 @@
-
 // Create the bitmap button (must include the BS_OWNERDRAW style).
 pmyButton->Create(NULL, WS_CHILD | WS_VISIBLE | BS_OWNERDRAW,
                   CRect(10, 10, 100, 100), pParentWnd, 1);

--- a/docs/mfc/reference/codesnippet/CPP/cpagerctrl-class_5.cpp
+++ b/docs/mfc/reference/codesnippet/CPP/cpagerctrl-class_5.cpp
@@ -1,4 +1,3 @@
-
 void CCSplitButton_s2Dlg::OnXIsbuttoninvisible()
 {
    BOOL bLeft = m_pager.IsButtonInvisible(PGB_TOPORLEFT);


### PR DESCRIPTION
Remove extraneous leading empty lines in code snippets which are rendered, along with the usual metadata changes and some minor drive-by fixes.