### PR TITLE
Fix some unclosed links

### DIFF
--- a/docs/atl/atl-utilities-reference.md
+++ b/docs/atl/atl-utilities-reference.md
@@ -85,5 +85,5 @@ ATL provides code for manipulating paths and URLs in the form of [CPathT](../atl
 
 ## See also
 
-[Concepts](../atl/active-template-library-atl-concepts.md)<br/>
+[Concepts](../atl/active-template-library-atl-concepts.md)\
 [ATL COM desktop components](../atl/atl-com-desktop-components.md)

--- a/docs/atl/atl-utilities-reference.md
+++ b/docs/atl/atl-utilities-reference.md
@@ -1,8 +1,7 @@
 ---
-description: "Learn more about: ATL utilities reference"
 title: "ATL utilities reference"
+description: "Learn more about: ATL utilities reference"
 ms.date: "11/04/2016"
-ms.assetid: dd8a2888-34f4-461e-9bf4-834218f9b95b
 ---
 # ATL utilities reference
 
@@ -47,8 +46,7 @@ ATL provides code for manipulating paths and URLs in the form of [CPathT](../atl
 | [AtlIsUnsafeUrlChar](../atl/reference/atl-http-utility-functions.md#atlisunsafeurlchar) | Call this function to find out whether a character is safe for use in a URL. |
 | [AtlUnescapeUrl](../atl/reference/atl-http-utility-functions.md#atlunescapeurl) | Call this function to convert escaped characters back to their original values. |
 | [SystemTimeToHttpDate](../atl/reference/atl-http-utility-functions.md#systemtimetohttpdate) | Call this function to convert a system time to a string in a format suitable for using in HTTP headers. |
-| [ATLPath::AddBackslash](../atl/reference/atl-path-functions.md#addbackslash) | This function is an overloaded wrapper for [PathAddBackslash](/windows/desktop/api/shlwapi/nf-shlwapi-pathaddbackslasha |
-| ). |
+| [ATLPath::AddBackslash](../atl/reference/atl-path-functions.md#addbackslash) | This function is an overloaded wrapper for [PathAddBackslash](/windows/win32/api/shlwapi/nf-shlwapi-pathaddbackslasha). |
 | [ATLPath::AddExtension](../atl/reference/atl-path-functions.md#addextension) | This function is an overloaded wrapper for [PathAddExtension](/windows/win32/api/shlwapi/nf-shlwapi-pathaddextensionw). |
 | [ATLPath::Append](../atl/reference/atl-path-functions.md#append) | This function is an overloaded wrapper for [PathAppend](/windows/win32/api/shlwapi/nf-shlwapi-pathappendw). |
 | [ATLPath::BuildRoot](../atl/reference/atl-path-functions.md#buildroot) | This function is an overloaded wrapper for [PathBuildRoot](/windows/win32/api/shlwapi/nf-shlwapi-pathbuildrootw). |

--- a/docs/atl/reference/ccommultithreadmodel-class.md
+++ b/docs/atl/reference/ccommultithreadmodel-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CComMultiThreadModel Class"
 title: "CComMultiThreadModel Class"
+description: "Learn more about: CComMultiThreadModel Class"
 ms.date: "11/04/2016"
 f1_keywords: ["CComMultiThreadModel", "ATLBASE/ATL::CComMultiThreadModel", "ATLBASE/ATL::CComMultiThreadModel::AutoCriticalSection", "ATLBASE/ATL::CComMultiThreadModel::CriticalSection", "ATLBASE/ATL::CComMultiThreadModel::ThreadModelNoCS", "ATLBASE/ATL::CComMultiThreadModel::Decrement", "ATLBASE/ATL::CComMultiThreadModel::Increment"]
 helpviewer_keywords: ["ATL, multithreading", "CComMultiThreadModel class", "threading [ATL]"]
-ms.assetid: db8f1662-2f7a-44b3-b341-ffbfb6e422a3
 ---
 # CComMultiThreadModel Class
 
@@ -35,7 +34,7 @@ class CComMultiThreadModel
 
 ## Remarks
 
-Typically, you use `CComMultiThreadModel` through one of two **`typedef`** names, either [CComObjectThreadModel](atl-typedefs.md#ccomobjectthreadmodel or [CComGlobalsThreadModel](atl-typedefs.md#ccomglobalsthreadmodel. The class referenced by each **`typedef`** depends on the threading model used, as shown in the following table:
+Typically, you use `CComMultiThreadModel` through one of two **`typedef`** names, either [CComObjectThreadModel](atl-typedefs.md#ccomobjectthreadmodel) or [CComGlobalsThreadModel](atl-typedefs.md#ccomglobalsthreadmodel). The class referenced by each **`typedef`** depends on the threading model used, as shown in the following table:
 
 |typedef|Single threading|Apartment threading|Free threading|
 |-------------|----------------------|-------------------------|--------------------|

--- a/docs/atl/reference/ccommultithreadmodel-class.md
+++ b/docs/atl/reference/ccommultithreadmodel-class.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["ATL, multithreading", "CComMultiThreadModel class", "thre
 
 ## Syntax
 
-```
+```cpp
 class CComMultiThreadModel
 ```
 
@@ -53,7 +53,7 @@ S= `CComSingleThreadModel`; M= `CComMultiThreadModel`
 
 When using `CComMultiThreadModel`, the **`typedef`** name `AutoCriticalSection` references class [CComAutoCriticalSection](ccomautocriticalsection-class.md), which provides methods for obtaining and releasing ownership of a critical section object.
 
-```
+```cpp
 typedef CComAutoCriticalSection AutoCriticalSection;
 ```
 
@@ -119,7 +119,7 @@ The following tables show the results of the `InternalAddRef` and `Lock` methods
 
 When using `CComMultiThreadModel`, the **`typedef`** name `CriticalSection` references class [CComCriticalSection](ccomcriticalsection-class.md), which provides methods for obtaining and releasing ownership of a critical section object.
 
-```
+```cpp
 typedef CComCriticalSection CriticalSection;
 ```
 
@@ -143,13 +143,13 @@ See [CComMultiThreadModel::AutoCriticalSection](#autocriticalsection).
 
 This static function calls the Win32 function [InterlockedDecrement](/windows/win32/api/winnt/nf-winnt-interlockeddecrement), which decrements the value of the variable pointed to by *p*.
 
-```
+```cpp
 static ULONG WINAPI Decrement(LPLONG p) throw ();
 ```
 
 ### Parameters
 
-*p*<br/>
+*p*\
 [in] Pointer to the variable to be decremented.
 
 ### Return Value
@@ -164,13 +164,13 @@ If the result of the decrement is 0, then `Decrement` returns 0. If the result o
 
 This static function calls the Win32 function [InterlockedIncrement](/windows/win32/api/winnt/nf-winnt-interlockedincrement), which increments the value of the variable pointed to by *p*.
 
-```
+```cpp
 static ULONG WINAPI Increment(LPLONG p) throw ();
 ```
 
 ### Parameters
 
-*p*<br/>
+*p*\
 [in] Pointer to the variable to be incremented.
 
 ### Return Value
@@ -185,7 +185,7 @@ If the result of the increment is 0, then `Increment` returns 0. If the result o
 
 When using `CComMultiThreadModel`, the **`typedef`** name `ThreadModelNoCS` references class [CComMultiThreadModelNoCS](ccommultithreadmodelnocs-class.md).
 
-```
+```cpp
 typedef CComMultiThreadModelNoCS ThreadModelNoCS;
 ```
 
@@ -207,7 +207,7 @@ See [CComMultiThreadModel::AutoCriticalSection](#autocriticalsection).
 
 ## See also
 
-[CComSingleThreadModel Class](ccomsinglethreadmodel-class.md)<br/>
-[CComAutoCriticalSection Class](ccomautocriticalsection-class.md)<br/>
-[CComCriticalSection Class](ccomcriticalsection-class.md)<br/>
+[CComSingleThreadModel Class](ccomsinglethreadmodel-class.md)\
+[CComAutoCriticalSection Class](ccomautocriticalsection-class.md)\
+[CComCriticalSection Class](ccomcriticalsection-class.md)\
 [Class Overview](../atl-class-overview.md)

--- a/docs/cppcx/platform-guid-value-class.md
+++ b/docs/cppcx/platform-guid-value-class.md
@@ -73,43 +73,43 @@ Guid(
 
 ### Parameters
 
-*a*<br/>
+*a*\
 The first 4 bytes of the `GUID`.
 
-*b*<br/>
+*b*\
 The next 2 bytes of the `GUID`.
 
-*c*<br/>
+*c*\
 The next 2 bytes of the `GUID`.
 
-*d*<br/>
+*d*\
 The next byte of the `GUID`.
 
-*e*<br/>
+*e*\
 The next byte of the `GUID`.
 
-*f*<br/>
+*f*\
 The next byte of the `GUID`.
 
-*g*<br/>
+*g*\
 The next byte of the `GUID`.
 
-*h*<br/>
+*h*\
 The next byte of the `GUID`.
 
-*i*<br/>
+*i*\
 The next byte of the `GUID`.
 
-*j*<br/>
+*j*\
 The next byte of the `GUID`.
 
-*k*<br/>
+*k*\
 The next byte of the `GUID`.
 
-*m*<br/>
+*m*\
 A `GUID` in the form a [GUID structure](/windows/win32/api/guiddef/ns-guiddef-guid).
 
-*n*<br/>
+*n*\
 The remaining 8 bytes of the `GUID`.
 
 ## <a name="operator-equality"></a> Guid::operator== Operator
@@ -124,10 +124,10 @@ static bool Platform::Guid::operator==(Platform::Guid guid1, Platform::Guid guid
 
 ### Parameters
 
-*guid1*<br/>
+*guid1*\
 The first `Platform::Guid` to compare.
 
-*guid2*<br/>
+*guid2*\
 The second `Platform::Guid` to compare.
 
 ### Return Value
@@ -151,10 +151,10 @@ static bool Platform::Guid::operator!=(Platform::Guid guid1, Platform::Guid guid
 
 ### Parameters
 
-*guid1*<br/>
+*guid1*\
 The first `Platform::Guid` to compare.
 
-*guid2*<br/>
+*guid2*\
 The second `Platform::Guid` to compare.
 
 ### Return Value
@@ -173,10 +173,10 @@ static bool Platform::Guid::operator<(Platform::Guid guid1, Platform::Guid guid2
 
 ### Parameters
 
-*guid1*<br/>
+*guid1*\
 The first `Platform::Guid` to compare.
 
-*guid2*<br/>
+*guid2*\
 The second `Platform::Guid` to compare.
 
 ### Return Value

--- a/docs/cppcx/platform-guid-value-class.md
+++ b/docs/cppcx/platform-guid-value-class.md
@@ -1,15 +1,14 @@
 ---
-description: "Learn more about: Platform::Guid value class"
 title: "Platform::Guid value class"
+description: "Learn more about: Platform::Guid value class"
 ms.date: "01/15/2019"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::Guid"]
 helpviewer_keywords: ["Platform::Guid Struct"]
-ms.assetid: 25c0bfb2-7f93-44d8-bdf4-ef4fbac3424a
 ---
 # Platform::Guid value class
 
-Represents a [GUID](/windows/win32/api/guiddef/ns-guiddef-guid type in the Windows Runtime type system.
+Represents a [GUID](/windows/win32/api/guiddef/ns-guiddef-guid) type in the Windows Runtime type system.
 
 ## Syntax
 

--- a/docs/data/odbc/odbc-and-mfc.md
+++ b/docs/data/odbc/odbc-and-mfc.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: ODBC and MFC"
 title: "ODBC and MFC"
+description: "Learn more about: ODBC and MFC"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["ODBC [C++], MFC", "connections [C++], databases", "connections [C++], data source", "databases [C++], connecting to", "data sources [C++], connecting to", "MFC [C++], ODBC and", "database connections [C++], MFC ODBC classes"]
-ms.assetid: 98f02fd7-1235-437b-89a9-edfd0fc797f7
 ---
 # ODBC and MFC
 
 > [!NOTE]
-> To use the MFC database classes, you must have the appropriate ODBC driver for your data source. The lastest Microsoft ODBC driver for SQL Server is [Microsoft ODBC Driver 18 for SQL Server](/sql/connect/odbc/download-odbc-driver-for-sql-server. Most database vendors provide an ODBC driver for Windows.
+> To use the MFC database classes, you must have the appropriate ODBC driver for your data source. The lastest Microsoft ODBC driver for SQL Server is [Microsoft ODBC Driver 18 for SQL Server](/sql/connect/odbc/download-odbc-driver-for-sql-server). Most database vendors provide an ODBC driver for Windows.
 
 This topic introduces the main concepts of the Microsoft Foundation Classes (MFC) library's ODBC-based database classes and provides an overview of how the classes work together. For more information about ODBC and MFC, see the following topics:
 

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Diagnostic Services"
 title: "Diagnostic Services"
+description: "Learn more about: Diagnostic Services"
 ms.date: 06/29/2022
 helpviewer_keywords: ["diagnosi [MFC]s, diagnostic services", "diagnostic macros [MFC], list of general MFC", "services [MFC], diagnostic", "MFC, diagnostic services", "general diagnostic functions and variables [MFC]", "diagnostics [MFC], diagnostic functions and variables", "diagnostics [MFC], list of general MFC", "diagnosis [MFC], diagnostic functions and variables", "diagnosis [MFC], list of general MFC", "general diagnostic macros in MFC", "diagnostic macros [MFC]", "diagnostic services [MFC]", "object diagnostic functions in MFC", "diagnostics [MFC], diagnostic services", "diagnostic functions and variables [MFC]"]
-ms.assetid: 8d78454f-9fae-49c2-88c9-d3fabd5393e8
 ---
 # Diagnostic Services
 
@@ -178,7 +177,7 @@ Using the `ASSERT_KINDOF` macro is exactly the same as coding:
 
 [!code-cpp[NVC_MFCDocView#195](../../mfc/codesnippet/cpp/diagnostic-services_4.cpp)]
 
-This function works only for classes declared with the [DECLARE_DYNAMIC](run-time-object-model-services.md#declare_dynamic or [DECLARE_SERIAL](run-time-object-model-services.md#declare_serial) macro.
+This function works only for classes declared with the [DECLARE_DYNAMIC](run-time-object-model-services.md#declare_dynamic) or [DECLARE_SERIAL](run-time-object-model-services.md#declare_serial) macro.
 
 > [!NOTE]
 > This function is available only in the Debug version of MFC.

--- a/docs/mfc/reference/diagnostic-services.md
+++ b/docs/mfc/reference/diagnostic-services.md
@@ -76,7 +76,7 @@ Suppresses compiler warnings for the use of deprecated MFC functions.
 
 ### Syntax
 
-```
+```cpp
 _AFX_SECURE_NO_WARNINGS
 ```
 
@@ -104,7 +104,7 @@ Call this function to cause a break (at the location of the call to `AfxDebugBre
 ### Syntax
 
 ```cpp
-void AfxDebugBreak( );
+void AfxDebugBreak();
 ```
 
 ### Remarks
@@ -119,13 +119,13 @@ void AfxDebugBreak( );
 
 Evaluates its argument.
 
-```
+```cpp
 ASSERT(booleanExpression)
 ```
 
 ### Parameters
 
-*booleanExpression*<br/>
+*booleanExpression*\
 Specifies an expression (including pointer values) that evaluates to nonzero or 0.
 
 ### Remarks
@@ -155,16 +155,16 @@ In the Release version of MFC, ASSERT does not evaluate the expression and thus 
 
 This macro asserts that the object pointed to is an object of the specified class, or is an object of a class derived from the specified class.
 
-```
+```cpp
 ASSERT_KINDOF(classname, pobject)
 ```
 
 ### Parameters
 
-*classname*<br/>
+*classname*\
 The name of a `CObject`-derived class.
 
-*pobject*<br/>
+*pobject*\
 A pointer to a class object.
 
 ### Remarks
@@ -190,13 +190,13 @@ This function works only for classes declared with the [DECLARE_DYNAMIC](run-tim
 
 Use to test your assumptions about the validity of an object's internal state.
 
-```
+```cpp
 ASSERT_VALID(pObject)
 ```
 
 ### Parameters
 
-*pObject*<br/>
+*pObject*\
 Specifies an object of a class derived from `CObject` that has an overriding version of the `AssertValid` member function.
 
 ### Remarks
@@ -222,8 +222,8 @@ For more information and examples, see [Debugging MFC Applications](/visualstudi
 
 Assists in finding memory leaks.
 
-```
-#define  new DEBUG_NEW
+```cpp
+#define new DEBUG_NEW
 ```
 
 ### Remarks
@@ -249,7 +249,7 @@ Once you insert this directive, the preprocessor will insert DEBUG_NEW wherever 
 
 In debug mode (when the **_DEBUG** symbol is defined), DEBUG_ONLY evaluates its argument.
 
-```
+```cpp
 DEBUG_ONLY(expression)
 ```
 
@@ -273,14 +273,14 @@ Use to validate data correctness.
 
 ### Syntax
 
-```
-ENSURE(  booleanExpression )
-ENSURE_VALID( booleanExpression  )
+```cpp
+ENSURE(booleanExpression)
+ENSURE_VALID(booleanExpression)
 ```
 
 ### Parameters
 
-*booleanExpression*<br/>
+*booleanExpression*\
 Specifies a boolean expression to be tested.
 
 ### Remarks
@@ -305,7 +305,7 @@ Expands to the name of the file that is being compiled.
 
 ### Syntax
 
-```
+```cpp
 THIS_FILE
 ```
 
@@ -333,9 +333,9 @@ static char THIS_FILE[] = __FILE__;
 
 Sends the specified string to the debugger of the current application.
 
-```
+```cpp
 TRACE(exp)
-TRACE(DWORD  category,  UINT  level, LPCSTR lpszFormat, ...)
+TRACE(DWORD category, UINT level, LPCSTR lpszFormat, ...)
 ```
 
 ### Remarks
@@ -354,13 +354,13 @@ For more information, see [Debugging MFC Applications](/visualstudio/debugger/mf
 
 In the Debug version of MFC, evaluates its argument.
 
-```
+```cpp
 VERIFY(booleanExpression)
 ```
 
 ### Parameters
 
-*booleanExpression*<br/>
+*booleanExpression*\
 Specifies an expression (including pointer values) that evaluates to nonzero or 0.
 
 ### Remarks
@@ -387,8 +387,8 @@ In the Release version of MFC, VERIFY evaluates the expression but does not prin
 
 Provides basic object-dumping capability in your application.
 
-```
-CDumpContext  afxDump;
+```cpp
+CDumpContext afxDump;
 ```
 
 ### Remarks
@@ -419,7 +419,7 @@ void AfxDump(const CObject* pOb);
 
 ### Parameters
 
-*pOb*<br/>
+*pOb*\
 A pointer to an object of a class derived from `CObject`.
 
 ### Remarks
@@ -436,8 +436,8 @@ Your program code should not call `AfxDump`, but should instead call the `Dump` 
 
 This variable is accessible from a debugger or your program and allows you to tune allocation diagnostics.
 
-```
-int  afxMemDF;
+```cpp
+int afxMemDF;
 ```
 
 ### Remarks
@@ -489,8 +489,8 @@ This function can be used to check the return values of calls to OLE functions i
 
 This function validates the free memory pool and prints error messages as required.
 
-```
-BOOL  AfxCheckMemory();
+```cpp
+BOOL AfxCheckMemory();
 ```
 
 ### Return Value
@@ -532,7 +532,7 @@ void AfxDump(const CObject* pOb);
 
 ### Parameters
 
-*pOb*<br/>
+*pOb*\
 A pointer to an object of a class derived from `CObject`.
 
 ### Remarks
@@ -555,7 +555,7 @@ void AFXAPI AfxDumpStack(DWORD dwTarget = AFX_STACK_DUMP_TARGET_DEFAULT);
 
 ### Parameters
 
-*dwTarget*<br/>
+*dwTarget*\
 Indicates the target of the dump output. Possible values, which can be combined using the bitwise-OR (**`|`**) operator, are as follows:
 
 - AFX_STACK_DUMP_TARGET_TRACE Sends output by means of the [TRACE](#trace) macro. The TRACE macro generates output in debug builds only; it generates no output in release builds. Also, TRACE can be redirected to other targets besides the debugger.
@@ -625,13 +625,13 @@ To use this function successfully:
 
 Enables and disables the memory leak dump in the AFX_DEBUG_STATE destructor.
 
-```
+```cpp
 BOOL AFXAPI AfxEnableMemoryLeakDump(BOOL bDump);
 ```
 
 ### Parameters
 
-*bDump*<br/>
+*bDump*\
 [in] TRUE indicates the memory leak dump is enabled; FALSE indicates the memory leak dump is disabled.
 
 ### Return Value
@@ -655,13 +655,13 @@ If your application loads another library before the MFC library, some memory al
 
 Diagnostic memory tracking is normally enabled in the Debug version of MFC.
 
-```
+```cpp
 BOOL AfxEnableMemoryTracking(BOOL bTrack);
 ```
 
 ### Parameters
 
-*bTrack*<br/>
+*bTrack*\
 Setting this value to TRUE turns on memory tracking; FALSE turns it off.
 
 ### Return Value
@@ -689,7 +689,7 @@ For more information on `AfxEnableMemoryTracking`, see [Debugging MFC Applicatio
 
 Tests a memory address to make sure it represents a currently active memory block that was allocated by the diagnostic version of **`new`**.
 
-```
+```cpp
 BOOL AfxIsMemoryBlock(
     const void* p,
     UINT nBytes,
@@ -698,13 +698,13 @@ BOOL AfxIsMemoryBlock(
 
 ### Parameters
 
-*p*<br/>
+*p*\
 Points to the block of memory to be tested.
 
-*nBytes*<br/>
+*nBytes*\
 Contains the length of the memory block in bytes.
 
-*plRequestNumber*<br/>
+*plRequestNumber*\
 Points to a **`long`** integer that will be filled in with the memory block's allocation sequence number, or zero if it does not represent a currently active memory block.
 
 ### Return Value
@@ -727,7 +727,7 @@ It also checks the specified size against the original allocated size. If the fu
 
 Tests any memory address to ensure that it is contained entirely within the program's memory space.
 
-```
+```cpp
 BOOL AfxIsValidAddress(
     const void* lp,
     UINT nBytes,
@@ -736,13 +736,13 @@ BOOL AfxIsValidAddress(
 
 ### Parameters
 
-*lp*<br/>
+*lp*\
 Points to the memory address to be tested.
 
-*nBytes*<br/>
+*nBytes*\
 Contains the number of bytes of memory to be tested.
 
-*bReadWrite*<br/>
+*bReadWrite*\
 Specifies whether the memory is both for reading and writing (TRUE) or just reading (FALSE).
 
 ### Return Value
@@ -767,18 +767,18 @@ The address is not restricted to blocks allocated by **`new`**.
 
 Use this function to determine whether a pointer to a string is valid.
 
-```
-BOOL  AfxIsValidString(
+```cpp
+BOOL AfxIsValidString(
     LPCSTR lpsz,
     int nLength = -1);
 ```
 
 ### Parameters
 
-*lpsz*<br/>
+*lpsz*\
 The pointer to test.
 
-*nLength*<br/>
+*nLength*\
 Specifies the length of the string to be tested, in bytes. A value of -1 indicates that the string will be null-terminated.
 
 ### Return Value
@@ -799,13 +799,13 @@ In non-debug builds, nonzero if *lpsz* is not NULL; otherwise 0.
 
 Sets a hook that enables calling of the specified function before each memory block is allocated.
 
-```
+```cpp
 AFX_ALLOC_HOOK AfxSetAllocHook(AFX_ALLOC_HOOK pfnAllocHook);
 ```
 
 ### Parameters
 
-*pfnAllocHook*<br/>
+*pfnAllocHook*\
 Specifies the name of the function to call. See the Remarks for the prototype of an allocation function.
 
 ### Return Value
@@ -818,13 +818,13 @@ The Microsoft Foundation Class Library debug-memory allocator can call a user-de
 
 **BOOL AFXAPI AllocHook( size_t** `nSize`**, BOOL** `bObject`**, LONG** `lRequestNumber` **);**
 
-*nSize*<br/>
+*nSize*\
 The size of the proposed memory allocation.
 
-*bObject*<br/>
+*bObject*\
 TRUE if the allocation is for a `CObject`-derived object; otherwise FALSE.
 
-*lRequestNumber*<br/>
+*lRequestNumber*\
 The memory allocation's sequence number.
 
 Note that the AFXAPI calling convention implies that the callee must remove the parameters from the stack.
@@ -846,10 +846,10 @@ AFXAPI AfxDoForAllClasses(
 
 ### Parameters
 
-*pfn*<br/>
+*pfn*\
 Points to an iteration function to be called for each class. The function arguments are a pointer to a `CRuntimeClass` object and a void pointer to extra data that the caller supplies to the function.
 
-*pContext*<br/>
+*pContext*\
 Points to optional data that the caller can supply to the iteration function. This pointer can be NULL.
 
 ### Remarks
@@ -881,10 +881,10 @@ void AfxDoForAllObjects(
 
 ### Parameters
 
-*pfn*<br/>
+*pfn*\
 Points to an iteration function to execute for each object. The function arguments are a pointer to a `CObject` and a void pointer to extra data that the caller supplies to the function.
 
-*pContext*<br/>
+*pContext*\
 Points to optional data that the caller can supply to the iteration function. This pointer can be NULL.
 
 ### Remarks
@@ -902,5 +902,5 @@ Stack, global, or embedded objects are not enumerated. The pointer passed to `Af
 
 ## See also
 
-[Macros and Globals](mfc-macros-and-globals.md)<br/>
+[Macros and Globals](mfc-macros-and-globals.md)\
 [CObject::Dump](cobject-class.md#dump)

--- a/docs/parallel/concrt/reference/invalid-scheduler-policy-thread-specification-class.md
+++ b/docs/parallel/concrt/reference/invalid-scheduler-policy-thread-specification-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: invalid_scheduler_policy_thread_specification Class"
 title: "invalid_scheduler_policy_thread_specification Class"
+description: "Learn more about: invalid_scheduler_policy_thread_specification Class"
 ms.date: "11/04/2016"
 f1_keywords: ["concrt/concurrency::invalid_scheduler_policy_thread_specification"]
 helpviewer_keywords: ["invalid_scheduler_policy_thread_specification class"]
-ms.assetid: 2d0fafb2-18f8-4284-8040-3db640d33303
 ---
 # invalid_scheduler_policy_thread_specification Class
 
@@ -22,7 +21,7 @@ class invalid_scheduler_policy_thread_specification : public std::exception;
 
 |Name|Description|
 |----------|-----------------|
-|[invalid_scheduler_policy_thread_specification](invalid-scheduler-policy-value-class.md#ctor|Overloaded. Constructs an `invalid_scheduler_policy_value` object.|
+|[invalid_scheduler_policy_thread_specification](#ctor)|Overloaded. Constructs an `invalid_scheduler_policy_thread_specification` object.|
 
 ## Inheritance Hierarchy
 

--- a/docs/parallel/concrt/reference/invalid-scheduler-policy-thread-specification-class.md
+++ b/docs/parallel/concrt/reference/invalid-scheduler-policy-thread-specification-class.md
@@ -47,10 +47,10 @@ invalid_scheduler_policy_thread_specification() throw();
 
 ### Parameters
 
-*_Message*<br/>
+*_Message*\
 A descriptive message of the error.
 
 ## See also
 
-[concurrency Namespace](concurrency-namespace.md)<br/>
+[concurrency Namespace](concurrency-namespace.md)\
 [SchedulerPolicy Class](schedulerpolicy-class.md)

--- a/docs/parallel/concrt/reference/invalid-scheduler-policy-value-class.md
+++ b/docs/parallel/concrt/reference/invalid-scheduler-policy-value-class.md
@@ -47,10 +47,10 @@ invalid_scheduler_policy_value() throw();
 
 ### Parameters
 
-*_Message*<br/>
+*_Message*\
 A descriptive message of the error.
 
 ## See also
 
-[concurrency Namespace](concurrency-namespace.md)<br/>
+[concurrency Namespace](concurrency-namespace.md)\
 [SchedulerPolicy Class](schedulerpolicy-class.md)

--- a/docs/parallel/concrt/reference/invalid-scheduler-policy-value-class.md
+++ b/docs/parallel/concrt/reference/invalid-scheduler-policy-value-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: invalid_scheduler_policy_value Class"
 title: "invalid_scheduler_policy_value Class"
+description: "Learn more about: invalid_scheduler_policy_value Class"
 ms.date: "11/04/2016"
 f1_keywords: ["concrt/concurrency::invalid_scheduler_policy_value"]
 helpviewer_keywords: ["invalid_scheduler_policy_value class"]
-ms.assetid: 8c533e3f-2774-4192-8616-b2313b859bf7
 ---
 # invalid_scheduler_policy_value Class
 
@@ -22,7 +21,7 @@ class invalid_scheduler_policy_value : public std::exception;
 
 |Name|Description|
 |----------|-----------------|
-|[invalid_scheduler_policy_value](invalid-scheduler-policy-thread-specification-class.md#ctor|Overloaded. Constructs an `invalid_scheduler_policy_value` object.|
+|[invalid_scheduler_policy_value](#ctor)|Overloaded. Constructs an `invalid_scheduler_policy_value` object.|
 
 ## Inheritance Hierarchy
 

--- a/docs/standard-library/output-file-stream-member-functions.md
+++ b/docs/standard-library/output-file-stream-member-functions.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Output File Stream Member Functions"
 title: "Output File Stream Member Functions"
+description: "Learn more about: Output File Stream Member Functions"
 ms.date: "08/25/2021"
 helpviewer_keywords: ["output streams [C++], member functions"]
 ---
@@ -102,7 +102,7 @@ Use these member functions to test for errors while writing to a stream:
 |[`good`](basic-ios-class.md#good)|Returns **`true`** if there's no error condition (unrecoverable or otherwise) and the end-of-file flag isn't set.|
 |[`eof`](basic-ios-class.md#eof)|Returns **`true`** on the end-of-file condition.|
 |[`clear`](basic-ios-class.md#clear)|Sets the internal error state. If called with the default arguments, it clears all error bits.|
-|[`rdstate`](basic-ios-class.md#rdstate|Returns the current error state.|
+|[`rdstate`](basic-ios-class.md#rdstate)|Returns the current error state.|
 
 The **`!`** operator is overloaded to perform the same function as the `fail` function. Thus the expression:
 


### PR DESCRIPTION
Unclosed link fixes and metadata changes are in the first commit, while cleanups and updates are split into multiple other ones to keep things clean. Hence, it's better to review one commit at a time.

Updates (for second commit onwards):
- Replace `br` elements with escapes
- Add `cpp` as language to code blocks
- Format code snippet content