### PR TITLE
Remove use of code block language `unstlib`

### DIFF
--- a/docs/standard-library/deque-class.md
+++ b/docs/standard-library/deque-class.md
@@ -11,9 +11,9 @@ Arranges elements of a given type in a linear arrangement and, like a vector, en
 
 ## Syntax
 
-```unstlib
-template <class Type, class Allocator =allocator<Type>>
-class deque
+```cpp
+template <class Type, class Allocator = allocator<Type>>
+class deque;
 ```
 
 ### Parameters
@@ -1634,7 +1634,7 @@ int main( )
 
 Provides a pointer to an element in a [`deque`](../standard-library/deque-class.md).
 
-```unstlib
+```cpp
 typedef typename Allocator::pointer pointer;
 ```
 


### PR DESCRIPTION
Not sure what `unstlib` is, given that there are only 2 occurrences in the whole repository. Hence, this PR replaces `unstlib` with `cpp` and tweaked the `deque` syntax.