### PR TITLE
Clean up huge spacing in `base-clause` of C++/CX exception references

### DIFF
--- a/docs/cppcx/platform-accessdeniedexception-class.md
+++ b/docs/cppcx/platform-accessdeniedexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::AccessDeniedException Class"
 title: "Platform::AccessDeniedException Class"
+description: "Learn more about: Platform::AccessDeniedException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::AccessDeniedException", "VCCORLIB/Platform::AccessDeniedException::AccessDeniedException"]
 helpviewer_keywords: ["Platform::AccessDeniedException"]
-ms.assetid: 6ae2155b-7b16-4587-8d2d-da05eab4c7e9
 ---
 # Platform::AccessDeniedException Class
 
@@ -14,7 +13,7 @@ Thrown when access to a resource or feature is denied.
 ## Syntax
 
 ```cpp
-public ref class AccessDeniedException : COMException,    IException,    IPrintable,   IEquatable
+public ref class AccessDeniedException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-changedstateexception-class.md
+++ b/docs/cppcx/platform-changedstateexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::ChangedStateException Class"
 title: "Platform::ChangedStateException Class"
+description: "Learn more about: Platform::ChangedStateException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::ChangedStateException", "VCCORLIB/Platform::ChangedStateException::ChangedStateException"]
 helpviewer_keywords: ["Platform::ChangedStateException"]
-ms.assetid: f894beac-9e80-4fac-ac25-89f1dbc0a6a4
 ---
 # Platform::ChangedStateException Class
 
@@ -14,7 +13,7 @@ Thrown when the internal state of an object has changed, thereby invalidating th
 ## Syntax
 
 ```cpp
-public ref class ChangedStateException : COMException,    IException,    IPrintable,    IEquatable
+public ref class ChangedStateException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-classnotregisteredexception-class.md
+++ b/docs/cppcx/platform-classnotregisteredexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::ClassNotRegisteredException Class"
 title: "Platform::ClassNotRegisteredException Class"
+description: "Learn more about: Platform::ClassNotRegisteredException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::ClassNotRegisteredException::ClassNotRegisteredException", "VCCORLIB/Platform::ClassNotRegisteredException"]
 helpviewer_keywords: ["Platform::ClassNotRegisteredException"]
-ms.assetid: 8f8871d8-51b9-46e8-902e-ae023c9f1de9
 ---
 # Platform::ClassNotRegisteredException Class
 
@@ -14,7 +13,7 @@ Thrown when a COM class has not been registered.
 ## Syntax
 
 ```cpp
-public ref class ClassNotRegisteredException : COMException,    IException,    IPrintable,    IEquatable
+public ref class ClassNotRegisteredException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-comexception-class.md
+++ b/docs/cppcx/platform-comexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::COMException Class"
 title: "Platform::COMException Class"
+description: "Learn more about: Platform::COMException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::COMException", "VCCORLIB/Platform::COMException::HResult", "VCCORLIB/Platform::COMException::Message"]
 helpviewer_keywords: ["Platform::COMException Class"]
-ms.assetid: 44fda4e5-574f-4d12-ab5f-4ff3f277448d
 ---
 # Platform::COMException Class
 
@@ -14,7 +13,7 @@ Represents COM errors that occur during application execution. COMException is t
 ## Syntax
 
 ```cpp
-public ref class COMException : Exception,    IException,    IPrintable,    IEquatable
+public ref class COMException : Exception, IException, IPrintable, IEquatable
 ```
 
 ### Members
@@ -79,12 +78,12 @@ Intializes a new instance of the COMException class.
 ### Syntax
 
 ```cpp
-COMException( int hresult )
+COMException(int hresult);
 ```
 
 ### Parameters
 
-*hresult*<br/>
+*hresult*\
 The error HRESULT that is represented by the exception.
 
 ## <a name="hresult"></a> COMException::HResult Property
@@ -95,7 +94,7 @@ The HRESULT that corresponds to the exception.
 
 ```cpp
 public:
-    property int HResult { int get();}
+    property int HResult { int get(); }
 ```
 
 ## Property Value
@@ -113,7 +112,8 @@ Message that describes the exception.
 ### Syntax
 
 ```cpp
-public:property String^ Message {    String^ get();}
+public:
+    property String^ Message { String^ get(); }
 ```
 
 ### Property Value

--- a/docs/cppcx/platform-disconnectedexception-class.md
+++ b/docs/cppcx/platform-disconnectedexception-class.md
@@ -1,20 +1,19 @@
 ---
-description: "Learn more about: Platform::DisconnectedException Class"
 title: "Platform::DisconnectedException Class"
+description: "Learn more about: Platform::DisconnectedException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::DisconnectedException", "VCCORLIB/Platform::DisconnectedException::DisconnectedException"]
 helpviewer_keywords: ["Platform::DisconnectedException"]
-ms.assetid: c25e0d64-5bff-4c21-88e5-c4ec2776fa7f
 ---
 # Platform::DisconnectedException Class
 
-Thrown when a COM proxy object attempts to reference a COM server that no longer exists
+Thrown when a COM proxy object attempts to reference a COM server that no longer exists.
 
 ## Syntax
 
-```
-public ref class DisconnectedException : COMException,    IException,    IPrintable,    IEquatable
+```cpp
+public ref class DisconnectedException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-exception-class.md
+++ b/docs/cppcx/platform-exception-class.md
@@ -13,7 +13,7 @@ Represents errors that occur during application execution. Custom exception clas
 ## Syntax
 
 ```cpp
-public ref class Exception : Object,    IException,    IPrintable,    IEquatable
+public ref class Exception : Object, IException, IPrintable, IEquatable
 ```
 
 ### Members
@@ -68,10 +68,10 @@ Exception^ CreateException(int32 hr, Platform::String^ message);
 
 ### Parameters
 
-*hr*<br/>
+*hr*\
 An HRESULT value that you typically get from a call to a COM method. If the value is 0, which is equal to S_OK, this method throws [Platform::InvalidArgumentException](../cppcx/platform-invalidargumentexception-class.md) because COM methods that succeed should not throw exceptions.
 
-*message*<br/>
+*message*\
 A string that describes the error.
 
 ### Return Value
@@ -97,10 +97,10 @@ Exception(int32 hresult, ::Platform::String^ message);
 
 ### Parameters
 
-*hresult*<br/>
+*hresult*\
 The error HRESULT that is represented by the exception.
 
-*message*<br/>
+*message*\
 A user-specified message, such as prescriptive text, that is associated with the exception. In general you should prefer the second overload in order to provide a descriptive message that is as specific as possible about how and why the error has occurred.
 
 ## <a name="hresult"></a> Exception::HResult Property
@@ -129,7 +129,8 @@ Message that describes the error.
 ### Syntax
 
 ```cpp
-public:property String^ Message;
+public:
+    property String^ Message;
 ```
 
 ### Property Value

--- a/docs/cppcx/platform-failureexception-class.md
+++ b/docs/cppcx/platform-failureexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::FailureException Class"
 title: "Platform::FailureException Class"
+description: "Learn more about: Platform::FailureException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::FailureException::FailureException", "VCCORLIB/Platform::FailureException"]
 helpviewer_keywords: ["Platform::FailureException"]
-ms.assetid: 1729cd07-bfc2-448e-9db5-185d5cbf5b81
 ---
 # Platform::FailureException Class
 
@@ -14,7 +13,7 @@ Thrown when the operation has failed. It is the equivalent of the E_FAIL HRESULT
 ## Syntax
 
 ```cpp
-public ref class FailureException : COMException,    IException,    IPrintable,    IEquatable
+public ref class FailureException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-invalidargumentexception-class.md
+++ b/docs/cppcx/platform-invalidargumentexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::InvalidArgumentException Class"
 title: "Platform::InvalidArgumentException Class"
+description: "Learn more about: Platform::InvalidArgumentException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::InvalidArgumentException", "VCCORLIB/Platform::InvalidArgumentException::InvalidArgumentException"]
 helpviewer_keywords: ["Platform::InvalidArgumentException"]
-ms.assetid: 1a8d860b-3bcb-41a9-9346-6610616a0b46
 ---
 # Platform::InvalidArgumentException Class
 
@@ -14,7 +13,7 @@ Thrown when one of the arguments provided to a method is not valid.
 ## Syntax
 
 ```cpp
-public ref class InvalidArgumentException : COMException,    IException,    IPrintable,    IEquatable
+public ref class InvalidArgumentException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-invalidcastexception-class.md
+++ b/docs/cppcx/platform-invalidcastexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::InvalidCastException Class"
 title: "Platform::InvalidCastException Class"
+description: "Learn more about: Platform::InvalidCastException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::InvalidCastException::InvalidCastException", "VCCORLIB/Platform::InvalidCastException"]
 helpviewer_keywords: ["Platform::InvalidCastException"]
-ms.assetid: 0215131d-1251-4913-9561-824410e045b6
 ---
 # Platform::InvalidCastException Class
 
@@ -14,7 +13,7 @@ Thrown when a cast or explicit conversion is invalid.
 ## Syntax
 
 ```cpp
-public ref class InvalidCastException : COMException,    IException,    IPrintable,    IEquatable
+public ref class InvalidCastException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-notimplementedexception-class.md
+++ b/docs/cppcx/platform-notimplementedexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::NotImplementedException Class"
 title: "Platform::NotImplementedException Class"
+description: "Learn more about: Platform::NotImplementedException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::NotImplementedException", "VCCORLIB/Platform::NotImplementedException::NotImplementedException"]
 helpviewer_keywords: ["Platform::NotImplementedException"]
-ms.assetid: 6da26cc2-dde8-4aea-aa85-67aac55cf97b
 ---
 # Platform::NotImplementedException Class
 
@@ -14,7 +13,7 @@ Thrown when an interface member is not been implemented in a derived type.
 ## Syntax
 
 ```cpp
-public ref class NotImplementedException : COMException,    IException,    IPrintable,    IEquatable
+public ref class NotImplementedException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-nullreferenceexception-class.md
+++ b/docs/cppcx/platform-nullreferenceexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::NullReferenceException Class"
 title: "Platform::NullReferenceException Class"
+description: "Learn more about: Platform::NullReferenceException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::NullReferenceException", "VCCORLIB/Platform::NullReferenceException::NullReferenceException"]
 helpviewer_keywords: ["Platform::NullReferenceException"]
-ms.assetid: be202577-d898-4716-83cd-e3556fe8a241
 ---
 # Platform::NullReferenceException Class
 
@@ -14,7 +13,7 @@ Thrown when there is an attempt to dereference a null object reference.
 ## Syntax
 
 ```cpp
-public ref class NullReferenceException : COMException,    IException,    IPrintable,    IEquatable
+public ref class NullReferenceException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-objectdisposedexception-class.md
+++ b/docs/cppcx/platform-objectdisposedexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::ObjectDisposedException Class"
 title: "Platform::ObjectDisposedException Class"
+description: "Learn more about: Platform::ObjectDisposedException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::ObjectDisposedException", "VCCORLIB/Platform::ObjectDisposedException::ObjectDisposedException"]
 helpviewer_keywords: ["Platform::ObjectDisposedException"]
-ms.assetid: 68506fe4-d09c-4407-999f-1e3edb261d41
 ---
 # Platform::ObjectDisposedException Class
 
@@ -14,7 +13,7 @@ Thrown when an operation is performed on a disposed object.
 ## Syntax
 
 ```cpp
-public ref class ObjectDisposedException : COMException,    IException,    IPrintable,    IEquatable
+public ref class ObjectDisposedException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-operationcanceledexception-class.md
+++ b/docs/cppcx/platform-operationcanceledexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::OperationCanceledException Class"
 title: "Platform::OperationCanceledException Class"
+description: "Learn more about: Platform::OperationCanceledException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::OperationCanceledException::OperationCanceledException", "VCCORLIB/Platform::OperationCanceledException"]
 helpviewer_keywords: ["Platform::OperationCanceledException"]
-ms.assetid: 5351bc20-5408-423a-8169-f09acc8a3fbb
 ---
 # Platform::OperationCanceledException Class
 
@@ -14,7 +13,7 @@ Thrown when an operation is aborted.
 ## Syntax
 
 ```cpp
-public ref class OperationCanceledException : COMException,    IException,    IPrintable,    IEquatable
+public ref class OperationCanceledException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-outofboundsexception-class.md
+++ b/docs/cppcx/platform-outofboundsexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::OutOfBoundsException Class"
 title: "Platform::OutOfBoundsException Class"
+description: "Learn more about: Platform::OutOfBoundsException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::OutOfBoundsException", "VCCORLIB/Platform::OutOfBoundsException::OutOfBoundsException"]
 helpviewer_keywords: ["Platform::OutOfBoundsException"]
-ms.assetid: 96f8bf75-1207-4049-964b-7771822cadf3
 ---
 # Platform::OutOfBoundsException Class
 
@@ -14,7 +13,7 @@ Thrown when an operation attempts to access data outside the valid range.
 ## Syntax
 
 ```cpp
-public ref class OutOfBoundsException : COMException,    IException,    IPrintable,    IEquatable
+public ref class OutOfBoundsException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-outofmemoryexception-class.md
+++ b/docs/cppcx/platform-outofmemoryexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::OutOfMemoryException Class"
 title: "Platform::OutOfMemoryException Class"
+description: "Learn more about: Platform::OutOfMemoryException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::OutOfMemoryException", "VCCORLIB/Platform::OutOfMemoryException::OutOfMemoryException"]
 helpviewer_keywords: ["Platform::OutOfMemoryException"]
-ms.assetid: 49c19f6b-f66c-4448-b861-91dcbf32de2c
 ---
 # Platform::OutOfMemoryException Class
 
@@ -14,7 +13,7 @@ Thrown when there's insufficient memory to complete the operation.
 ## Syntax
 
 ```cpp
-public ref class OutOfMemoryException : COMException,    IException,    IPrintable,    IEquatable
+public ref class OutOfMemoryException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks

--- a/docs/cppcx/platform-wrongthreadexception-class.md
+++ b/docs/cppcx/platform-wrongthreadexception-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform::WrongThreadException Class"
 title: "Platform::WrongThreadException Class"
+description: "Learn more about: Platform::WrongThreadException Class"
 ms.date: "12/30/2016"
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::WrongThreadException", "VCCORLIB/Platform::WrongThreadException::WrongThreadException"]
 helpviewer_keywords: ["Platform::WrongThreadException"]
-ms.assetid: c193f97e-0392-4535-a4c4-0711e4e4a836
 ---
 # Platform::WrongThreadException Class
 
@@ -14,7 +13,7 @@ Thrown when a thread calls by way of an interface pointer for a proxy object tha
 ## Syntax
 
 ```cpp
-public ref class WrongThreadException : COMException,    IException,    IPrintable,    IEquatable
+public ref class WrongThreadException : COMException, IException, IPrintable, IEquatable
 ```
 
 ### Remarks


### PR DESCRIPTION
Summary:
- Remove excessive spaces in various `base-clause`
- Add missing periods and `cpp` code block language
- Replace `br` elements with a backslash
- Format code snippets
- Clean up metadata