### PR TITLE
Adjust `is_error_code_enum` and `is_error_condition_enum` syntax

### DIFF
--- a/docs/standard-library/is-error-code-enum-class.md
+++ b/docs/standard-library/is-error-code-enum-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: is_error_code_enum Class"
 title: "is_error_code_enum Class"
+description: "Learn more about: is_error_code_enum Class"
 ms.date: "11/04/2016"
 f1_keywords: ["system_error/std::is_error_code_enum"]
 helpviewer_keywords: ["is_error_code_enum class"]
-ms.assetid: cee5be2d-7c20-4cec-a352-1ab8b7d32601
 ---
 # is_error_code_enum Class
 
@@ -13,8 +12,8 @@ Represents a type predicate that tests for the [error_code](../standard-library/
 ## Syntax
 
 ```cpp
-template <_Enum>
-    class is_error_code_enum;
+template <class _Enum>
+struct is_error_code_enum;
 ```
 
 ## Remarks

--- a/docs/standard-library/is-error-condition-enum-class.md
+++ b/docs/standard-library/is-error-condition-enum-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: is_error_condition_enum Class"
 title: "is_error_condition_enum Class"
+description: "Learn more about: is_error_condition_enum Class"
 ms.date: "11/04/2016"
 f1_keywords: ["system_error/std::is_error_condition_enum"]
 helpviewer_keywords: ["is_error_condition_enum class"]
-ms.assetid: 752bb87a-c61c-4304-9254-5aaf228b59c0
 ---
 # is_error_condition_enum Class
 
@@ -13,8 +12,8 @@ Represents a type predicate that tests for the [error_condition](../standard-lib
 ## Syntax
 
 ```cpp
-template <_Enum>
-    class is_error_condition_enum;
+template <class _Enum>
+struct is_error_condition_enum;
 ```
 
 ## Remarks


### PR DESCRIPTION
Summary:
- Add missing `class` keyword before `_Enum`
- Remove unneeded indent
- Change `class-key` to `struct` as it's more accurate
  - One downside is that the page names contain the word "Class", and we can't change them without a redirect (which is undesirable)
  - https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/inc/system_error#L42-L43
  - https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/inc/system_error#L51-L52
  - https://eel.is/c++draft/system.error.syn
- Edit metadata