### PR TITLE
Improve `<system_error>` functions page

### DIFF
--- a/docs/standard-library/system-error-functions.md
+++ b/docs/standard-library/system-error-functions.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <system_error> functions"
 title: "<system_error> functions"
+description: "Learn more about: <system_error> functions"
 ms.date: "03/15/2019"
 f1_keywords: ["system_error/std::generic_category", "system_error/std::make_error_code", "system_error/std::make_error_condition", "system_error/std::system_category"]
-ms.assetid: 57d6f15f-f0b7-4e2f-80fe-31d3c320ee33
 helpviewer_keywords: ["std::generic_category", "std::make_error_code", "std::make_error_condition", "std::system_category"]
 ---
 # `<system_error>` functions
@@ -18,7 +17,7 @@ const error_category& generic_category() noexcept;
 
 ### Remarks
 
-The `generic_category` object is an implementation of [error_category](../standard-library/error-category-class.md).
+The `generic_category` object is an implementation of [error_category](error-category-class.md).
 
 ## <a name="is_error_code_enum_v"></a> is_error_code_enum_v
 
@@ -55,8 +54,6 @@ The `std::errc` enumeration value to store in the error code object.
 
 The error code object.
 
-### Remarks
-
 ## <a name="make_error_condition"></a> make_error_condition
 
 Creates an error condition object.
@@ -74,8 +71,6 @@ The `std::errc` enumeration value to store in the error condition object.
 
 The error condition object.
 
-### Remarks
-
 ## <a name="system_category"></a> system_category
 
 Represents the category for operating system errors.
@@ -86,4 +81,4 @@ const error_category& system_category() noexcept;
 
 ### Remarks
 
-The `system_category` object is an implementation of [error_category](../standard-library/error-category-class.md).
+The `system_category` object is an implementation of [error_category](error-category-class.md).

--- a/docs/standard-library/system-error-functions.md
+++ b/docs/standard-library/system-error-functions.md
@@ -22,16 +22,20 @@ The `generic_category` object is an implementation of [error_category](../standa
 
 ## <a name="is_error_code_enum_v"></a> is_error_code_enum_v
 
+A helper variable template for the [`is_error_code_enum`](is-error-code-enum-class.md) value.
+
 ```cpp
 template <class T>
-    inline constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
+constexpr bool is_error_code_enum_v = is_error_code_enum<T>::value;
 ```
 
 ## <a name="is_error_condition_enum_v"></a> is_error_condition_enum_v
 
+A helper variable template for the [`is_error_condition_enum`](is-error-condition-enum-class.md) value.
+
 ```cpp
 template <class T>
-    inline constexpr bool is_error_condition_enum_v = is_error_condition_enum<T>::value;
+constexpr bool is_error_condition_enum_v = is_error_condition_enum<T>::value;
 ```
 
 ## <a name="make_error_code"></a> make_error_code
@@ -64,7 +68,7 @@ error_condition make_error_condition(std::errc error) noexcept;
 ### Parameters
 
 *error*\
-The `std::errc` enumeration value to store in the error code object.
+The `std::errc` enumeration value to store in the error condition object.
 
 ### Return Value
 
@@ -74,7 +78,7 @@ The error condition object.
 
 ## <a name="system_category"></a> system_category
 
-Represents the category for errors caused by low-level system overflows.
+Represents the category for operating system errors.
 
 ```cpp
 const error_category& system_category() noexcept;


### PR DESCRIPTION
Improvements (first commit):
- Add descriptions for `is_error_code_enum_v` and `is_error_condition_enum_v` helper variable templates
- Remove indent and `inline` keyword for `is_error_code_enum_v` and `is_error_condition_enum_v` syntax
  - https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/inc/system_error#L48-L49
  - https://github.com/microsoft/STL/blob/1f6e5b16ec02216665624c1e762f3732605cf2b4/stl/inc/system_error#L57-L58
  - https://eel.is/c++draft/system.error.syn
- Fix wrong mention of "error code" in `error` parameter description of `make_error_condition`
- Update description for `system_category` (not sure what "low-level system overflows" is, hence changed it to be inlined with the description of `generic_category`)

Cleanups (second commit):
- Edit metadata
- Simplify redundant page links
- Remove 2 empty `Remarks` section

(Will propagate the new descriptions in bulk to https://learn.microsoft.com/en-us/cpp/standard-library/system-error?view=msvc-170 in a future PR)