### PR TITLE
Clean up empty row in tables

### DIFF
--- a/docs/dotnet/auto-gcroot-class.md
+++ b/docs/dotnet/auto-gcroot-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: auto_gcroot Class"
 title: "auto_gcroot Class"
+description: "Learn more about: auto_gcroot Class"
 ms.date: "01/16/2019"
 ms.topic: "reference"
 f1_keywords: ["msclr::auto_gcroot::auto_gcroot", "msclr::auto_gcroot::attach", "msclr::auto_gcroot::get", "msclr::auto_gcroot::release", "msclr::auto_gcroot::reset", "msclr::auto_gcroot::swap", "msclr::auto_gcroot::operator=", "msclr::auto_gcroot::operator->", "msclr::auto_gcroot::operator!", "msclr::auto_gcroot::operator auto_gcroot"]
 helpviewer_keywords: ["msclr::auto_gcroot"]
-ms.assetid: b5790912-265d-463e-a486-47302e91042a
 ---
 # auto_gcroot Class
 
@@ -20,7 +19,7 @@ class auto_gcroot;
 
 ### Parameters
 
-*_element_type*<br/>
+*_element_type*\
 The managed type to be embedded.
 
 ## Members
@@ -77,10 +76,10 @@ auto_gcroot(
 
 ### Parameters
 
-*_ptr*<br/>
+*_ptr*\
 The object to own.
 
-*_right*<br/>
+*_right*\
 An existing `auto_gcroot`.
 
 ### Remarks
@@ -240,7 +239,7 @@ auto_gcroot<_element_type> & attach(
 
 ### Parameters
 
-*_right*<br/>
+*_right*\
 The object to attach, or an `auto_gcroot` containing the object to attach.
 
 ### Return value
@@ -451,7 +450,7 @@ void reset(
 
 ### Parameters
 
-*_new_ptr*<br/>
+*_new_ptr*\
 (Optional) The new object.
 
 ### Example
@@ -516,7 +515,7 @@ void swap(
 
 ### Parameters
 
-*_right*<br/>
+*_right*\
 The `auto_gcroot` with which to swap objects.
 
 ### Example
@@ -614,7 +613,7 @@ auto_gcroot<_element_type> & operator=(
 
 ### Parameters
 
-*_right*<br/>
+*_right*\
 The object or `auto_gcroot` to be assigned to the current `auto_gcroot`.
 
 ### Return value

--- a/docs/dotnet/auto-gcroot-class.md
+++ b/docs/dotnet/auto-gcroot-class.md
@@ -30,8 +30,7 @@ The managed type to be embedded.
 |Name|Description|
 |---------|-----------|
 |[auto_gcroot::auto_gcroot](#auto-gcroot)|The `auto_gcroot` constructor.|
-|[auto_gcroot::~auto_gcroot](#tilde-auto-gcroot)|The `auto_gcroot` destructor.
-|
+|[auto_gcroot::~auto_gcroot](#tilde-auto-gcroot)|The `auto_gcroot` destructor.|
 
 ### Public methods
 

--- a/docs/overview/what-s-new-for-visual-cpp-in-visual-studio.md
+++ b/docs/overview/what-s-new-for-visual-cpp-in-visual-studio.md
@@ -25,8 +25,7 @@ Visual Studio 2022 brings many updates and fixes to the Microsoft C++ compiler a
 | What's new for C++ developers | [What's New for C++ Developers in Visual Studio 2022 17.13](https://devblogs.microsoft.com/cppblog/whats-new-for-c-developers-in-visual-studio-2022-17-13/) |
 | Standard Library (STL) merged C++26 and C++23 features, LWG issue resolutions, performance improvements, enhanced behavior, and fixed bugs | [STL Changelog 17.13](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1713) |
 | New features in the IDE |[Visual Studio 2022 version 17.13 Release Notes](/visualstudio/releases/2022/release-notes) |
-| C++ language updates  | [MSVC compiler updates in Visual Studio 2022 17.13](https://devblogs.microsoft.com/cppblog/msvc-compiler-updates-in-visual-studio-2022-version-17-13/)
- |
+| C++ language updates  | [MSVC compiler updates in Visual Studio 2022 17.13](https://devblogs.microsoft.com/cppblog/msvc-compiler-updates-in-visual-studio-2022-version-17-13/) |
 | C++ language conformance improvements | [C++ Conformance improvements, behavior changes, and bug fixes in Visual Studio 2022 17.13](cpp-conformance-improvements.md#improvements_1713) |
 
 A quick highlight of some of the new features:


### PR DESCRIPTION
Fix 2 instances where the pipe character is misplaced onto a new line, causing the rendered table to have an empty row. The second commit is some basic metadata and `br` element updates.