### PR TITLE
Normalize C++ code block language to `cpp`

### DIFF
--- a/docs/c-runtime-library/reference/floating-point-ordering.md
+++ b/docs/c-runtime-library/reference/floating-point-ordering.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: isgreater, isgreaterequal, isless, islessequal, islessgreater, isunordered"
 title: "isgreater, isgreaterequal, isless, islessequal, islessgreater, isunordered"
+description: "Learn more about: isgreater, isgreaterequal, isless, islessequal, islessgreater, isunordered"
 ms.date: "01/31/2019"
 f1_keywords: ["isgreater", "math/isgreater", "isgreaterequal", "math/isgreaterequal", "isless", "math/isless", "islessequal", "math/islessequal", "islessgreater", "math/islessgreater", "isunordered", "math/isunordered"]
 helpviewer_keywords: ["isgreater function", "isgreaterequal function", "isless function", "islessequal function", "islessgreater function", "isunordered function"]
@@ -43,7 +43,7 @@ int isunordered(
 ); /* C-only macro */
 ```
 
-```C++
+```cpp
 template <class FloatingType1, class FloatingType2>
 inline bool isgreater(
    FloatingType1 x,

--- a/docs/cpp/com-ptr-t-extractors.md
+++ b/docs/cpp/com-ptr-t-extractors.md
@@ -4,7 +4,6 @@ description: "Describes the extraction operators for the _com_ptr_t class."
 ms.date: 07/07/2020
 f1_keywords: ["_com_ptr_t::operatorInterface&", "_com_ptr_t::operatorbool", "_com_ptr_t::operator->", "_com_ptr_t::operator*"]
 helpviewer_keywords: ["operator Interface& [C++]", "* operator [C++], with specific objects", "operator& [C++]", "operator* [C++]", "-> operator [C++], with specific objects", "& operator [C++], with specific objects", "operator Interface* [C++]", "operator * [C++]", "operator->", "operator bool", "extractors, _com_ptr_t class", "extractors [C++]"]
-ms.assetid: 194b9e0e-123c-49ff-a187-0a7fcd68145a
 ---
 # `_com_ptr_t` Extractors
 
@@ -14,7 +13,7 @@ Extract the encapsulated COM interface pointer.
 
 ## Syntax
 
-```c++
+```cpp
 operator Interface*( ) const throw( );
 operator Interface&( ) const;
 Interface& operator*( ) const;

--- a/docs/overview/cpp-conformance-improvements.md
+++ b/docs/overview/cpp-conformance-improvements.md
@@ -525,7 +525,7 @@ bool b = S{} != S{};
 
 The compiler accepts this code, which means that the compiler is more strict with code such as:
 
-```c++
+```cpp
 struct S
 {
   operator bool() const;


### PR DESCRIPTION
Out of more than 3400 instances of C++ code blocks, only 3 use `c++`, hence this PR normalizes those to `cpp`.