### PR TITLE
Update C2640 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2640.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2640.md
@@ -1,23 +1,25 @@
 ---
-description: "Learn more about: Compiler Error C2640"
 title: "Compiler Error C2640"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2640"
+ms.date: "03/17/2025"
 f1_keywords: ["C2640"]
 helpviewer_keywords: ["C2640"]
-ms.assetid: e4d137ab-ed1d-457c-9eec-b70d97f1b0b4
 ---
 # Compiler Error C2640
 
-'identifier' : __based modifier illegal on reference
+> 'abstract declarator': __based modifier illegal on reference
 
-The **`__based`** modifier can be used on pointers only.
+The [**`__based`**](../../cpp/based-pointers-cpp.md) modifier can be used on pointers only.
 
 The following sample generates C2640:
 
 ```cpp
 // C2640.cpp
-void f(int i) {
-    void *vp;
-    int _based(vp) &vr = I;  // C2640
+int* ptr;
+
+int main()
+{
+    int __based(ptr)& based_ref;   // C2640
+    int __based(ptr)* based_ptr;   // OK
 }
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2600-through-c2699.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2600-through-c2699.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler errors C2600 Through C2699"
 title: "Compiler errors C2600 Through C2699"
+description: "Learn more about: Compiler errors C2600 Through C2699"
 ms.date: "04/21/2019"
 f1_keywords: ["C2604", "C2606", "C2607", "C2608", "C2609", "C2610", "C2615", "C2618", "C2620", "C2621", "C2622", "C2623", "C2625", "C2629", "C2631", "C2639", "C2641", "C2642", "C2643", "C2644", "C2684", "C2685", "C2686", "C2697"]
 helpviewer_keywords: ["C2604", "C2606", "C2607", "C2608", "C2609", "C2610", "C2615", "C2618", "C2620", "C2621", "C2622", "C2623", "C2625", "C2629", "C2631", "C2639", "C2641", "C2642", "C2643", "C2644", "C2684", "C2685", "C2686", "C2697"]
@@ -55,7 +55,7 @@ The articles in this section of the documentation explain a subset of the error 
 |[Compiler error C2637](compiler-error-c2637.md)|'*identifier*': cannot modify pointers to data members|
 |[Compiler error C2638](compiler-error-c2638.md)|'*identifier*': __based modifier illegal on pointer to member|
 |Compiler error C2639|trailing return type '*type*' of deduction guide should be a specialization of '*class template*'|
-|[Compiler error C2640](compiler-error-c2640.md)|'*identifier*': __based modifier illegal on reference|
+|[Compiler error C2640](compiler-error-c2640.md)|'abstract declarator': __based modifier illegal on reference|
 |Compiler error C2641|cannot deduce template arguments for '*template name*'|
 |Compiler error C2642|two deduction guide declarations for the same class template cannot have equivalent parameter list and template head|
 |Compiler error C2643|deduction guide should be declared in the same scope as the corresponding class template '*template name*'|


### PR DESCRIPTION
Summary:
- Update error message to the latest one and add blockquotes
- Add link to the C++ based pointers article
- Replace example with a new one as the old one has multiple issues:
  - No `main` without the `/c` flag
  - Invalid identifier `I`
  - Erroneous assignment to `vr` as it causes an error even if the reference is changed to a pointer (due to incompatible types between `int` and `int __based(vp)*`)
- Edit metadata