### PR TITLE
Fix "identifier" typos

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2283.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2283.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: Compiler Error C2283"
 title: "Compiler Error C2283"
+description: "Learn more about: Compiler Error C2283"
 ms.date: "11/04/2016"
 f1_keywords: ["C2283"]
 helpviewer_keywords: ["C2283"]
-ms.assetid: 8a5b3175-b480-4598-a1f7-0b50504c5caa
 ---
 # Compiler Error C2283
 
-'identifier' : pure specifier or abstract override specifier not allowed on unnamed struct
+> '*identifier*': pure specifier or abstract override specifier not allowed on unnamed struct
 
 A member function of an unnamed class or structure is declared with a pure specifier, which is not permitted.
 

--- a/docs/error-messages/compiler-errors-1/compiler-errors-c2200-through-c2299.md
+++ b/docs/error-messages/compiler-errors-1/compiler-errors-c2200-through-c2299.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler errors C2200 through C2299"
 title: "Compiler errors C2200 through C2299"
+description: "Learn more about: Compiler errors C2200 through C2299"
 ms.date: "04/21/2019"
 f1_keywords: ["C2202", "C2209", "C2210", "C2211", "C2214", "C2215", "C2221", "C2225", "C2230", "C2235", "C2237", "C2239", "C2240", "C2257", "C2260", "C2263", "C2265", "C2269", "C2278", "C2281", "C2282", "C2284", "C2288", "C2291", "C2294"]
 helpviewer_keywords: ["C2202", "C2209", "C2210", "C2211", "C2214", "C2215", "C2221", "C2225", "C2230", "C2235", "C2237", "C2239", "C2240", "C2257", "C2260", "C2263", "C2265", "C2269", "C2278", "C2281", "C2282", "C2284", "C2288", "C2291", "C2294"]
@@ -98,7 +98,7 @@ The articles in this section of the documentation explain a subset of the error 
 |[Compiler error C2280](compiler-error-c2280.md)|'*class*::*function*': attempting to reference a deleted function|
 |Compiler error C2281|'*class*::*function*': a function can only be deleted on the first declaration|
 |Compiler error C2282|'*function1*' cannot override '*function2*'|
-|[Compiler error C2283](compiler-error-c2283.md)|'*identifer*': pure specifier or abstract override specifier not allowed on unnamed class/struct|
+|[Compiler error C2283](compiler-error-c2283.md)|'*identifier*': pure specifier or abstract override specifier not allowed on unnamed struct|
 |Compiler error C2284|'*function*': illegal argument to intrinsic function, parameter *number*|
 |[Compiler error C2285](compiler-error-c2285.md)|pointers to members representation has already been determined - pragma ignored|
 |[Compiler error C2286](compiler-error-c2286.md)|pointers to members of '*identifier*' representation is already set to *inheritance* - declaration ignored|

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4251.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4251.md
@@ -1,13 +1,13 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4251"
 title: "Compiler Warning (level 2) C4251"
+description: "Learn more about: Compiler Warning (level 2) C4251"
 ms.date: 12/01/2023
 f1_keywords: ["C4251"]
 helpviewer_keywords: ["C4251"]
 ---
 # Compiler Warning (level 2) C4251
 
-> '*type*' : class '*type1*' needs to have dll-interface to be used by clients of class '*type2*'
+> '*type*': '*type1*' needs to have dll-interface to be used by clients of '*type2*'
 
 ## Remarks
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4099.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4099.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4099"
 title: "Compiler Warning (level 2) C4099"
+description: "Learn more about: Compiler Warning (level 2) C4099"
 ms.date: "11/04/2016"
 f1_keywords: ["C4099"]
 helpviewer_keywords: ["C4099"]
-ms.assetid: 00bb803d-cae7-4ab8-8969-b46f54139ac8
 ---
 # Compiler Warning (level 2) C4099
 
-'identifier' : type name first seen using 'objecttype1' now seen using 'objecttype2'
+> '*identifier*': type name first seen using '*object_type1*' now seen using '*object_type2*'
 
 An object declared as a structure is defined as a class, or an object declared as a class is defined as a structure. The compiler uses the type given in the definition.
 
@@ -20,5 +19,5 @@ The following sample generates C4099.
 // C4099.cpp
 // compile with: /W2 /c
 struct A;
-class A {};   // C4099, use different identifer or use same object type
+class A {};   // C4099, use different identifier or use same object type
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199.md
@@ -1,6 +1,6 @@
 ---
-description: "Table of Microsoft C/C++ compiler (MSVC) warning messages C4000 through C4199"
 title: "Microsoft C/C++ compiler (MSVC) warnings C4000 through C4199"
+description: "Table of Microsoft C/C++ compiler (MSVC) warning messages C4000 through C4199"
 ms.date: "04/21/2019"
 f1_keywords: ["C4023", "C4035", "C4051", "C4060", "C4063", "C4064", "C4065", "C4069", "C4123", "C4137", "C4181", "C4188", "C4193", "C4194", "C4195", "C4196", "C4199"]
 helpviewer_keywords: ["C4023", "C4035", "C4051", "C4060", "C4063", "C4064", "C4065", "C4069", "C4123", "C4137", "C4181", "C4188", "C4193", "C4194", "C4195", "C4196", "C4199"]

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4200-through-c4399.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4200-through-c4399.md
@@ -55,7 +55,7 @@ The articles in this section describe Microsoft C/C++ compiler warning messages 
 |[Compiler warning (level 2 and level 3 and level 4) C4244](compiler-warning-levels-3-and-4-c4244.md)|'*conversion_type*': conversion from '*type1*' to '*type2*', possible loss of data|
 |[Compiler warning (level 4) C4245](compiler-warning-level-4-c4245.md)|'*conversion_type*': conversion from '*type1*' to '*type2*', signed/unsigned mismatch|
 |[Compiler warning (level 2) C4250](compiler-warning-level-2-c4250.md)|'*classname*': inherits '*base_classname*::*member*' via dominance|
-|[Compiler warning (level 2) C4251](compiler-warning-level-1-c4251.md)|'*object_type1*': '*identifier1*' needs to have dll-interface to be used by clients of '*identfier2*'|
+|[Compiler warning (level 2) C4251](compiler-warning-level-1-c4251.md)|'*type*': '*type1*' needs to have dll-interface to be used by clients of '*type2*'|
 |[Compiler warning (level 4, off) C4254](compiler-warning-level-4-c4254.md)|'*operator*': conversion from '*type1*':'*field_bits*' to '*type2*':'*field_bits*', possible loss of data|
 |[Compiler warning (level 4, off) C4255](compiler-warning-level-4-c4255.md)|'*function*': no function prototype given: converting '()' to '(void)'|
 |[Compiler warning (level 4) C4256](compiler-warning-level-4-c4256.md)|'*function*': constructor for class with virtual bases has '`...`'; calls may not be compatible with older versions of Visual C++|


### PR DESCRIPTION
Summary:
- Fix some "identifier" typos
- Update `C2283`, `C4099`, and `C4251` messages to the latest one and ensure it matches with the respective list entry
- Edit metadata