### PR TITLE
Tweak error C2466

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: Compiler Error C2466"
 title: "Compiler Error C2466"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2466"
+ms.date: "03/19/2025"
 f1_keywords: ["C2466"]
 helpviewer_keywords: ["C2466"]
-ms.assetid: 75b251d1-7d0b-4a86-afca-26adedf74486
 ---
 # Compiler Error C2466
 
-cannot allocate an array of constant size 0
+> cannot allocate an array of constant size 0
 
 An array is allocated or declared with size zero. The constant expression for the array size must be an integer greater than zero. An array declaration with a zero subscript is legal only for a class, structure, or union member and only with Microsoft extensions ([/Ze](../../build/reference/za-ze-disable-language-extensions.md)).
 
@@ -17,7 +16,6 @@ The following sample generates C2466:
 ```cpp
 // C2466.cpp
 // compile with: /c
-int i[0];   // C2466
-int j[1];   // OK
-char *p;
+int arr1[0];   // C2466
+int arr2[1];   // OK
 ```


### PR DESCRIPTION
Summary:
- Add blockquotes for error message
- Tweak example and remove superfluous `char *p;` line
- Edit metadata