### PR TITLE
Improve `/dynamicdeopt` compiler switch reference page

### DIFF
--- a/docs/build/reference/dynamic-deopt.md
+++ b/docs/build/reference/dynamic-deopt.md
@@ -1,11 +1,12 @@
 ---
 title: "/dynamicdeopt (Enable C++ Dynamic Debugging (Preview))"
-description: "Use the Microsoft C++ compiler option /dynamicdeopt to use C++ Dynamic Debugging."
+description: "Enable the Microsoft C++ compiler option /dynamicdeopt to use C++ Dynamic Debugging."
 ms.date: 03/14/2025
 f1_keywords: ["/dynamicdeopt", "VC.Project.VCNMakeTool.CompileAsManaged", "VC.Project.VCCLCompilerTool.CompileAsManaged"]
 helpviewer_keywords: ["cl.exe compiler, common language runtime option", "-dynamicdeopt compiler option [C++]", "dynamicdeopt compiler option [C++]", "/clr compiler option [C++]", "Managed Extensions for C++, compiling", "common language runtime, /clr compiler option"]
 ---
 # `/dynamicdeopt` (Enable C++ Dynamic Debugging) (Preview)
+
 > [!IMPORTANT]
 > The `/dynamicdeopt` compiler switch is currently in PREVIEW.
 > This information relates to a prerelease feature that might be substantially modified before release. Microsoft makes no warranties, expressed or implied, with respect to the information provided here.
@@ -14,8 +15,8 @@ Enable [C++ Dynamic Debugging (Preview)](/visualstudio/debugger/cpp-dynamic-debu
 
 ## Syntax
 
-> **`/dynamicdeopt`**
-> **`/dynamicdeopt:suffix <suffix>`**
+> **`/dynamicdeopt`**\
+> **`/dynamicdeopt:suffix <suffix>`**\
 > **`/dynamicdeopt:sync`**
 
 ## Arguments
@@ -26,13 +27,13 @@ Specify the file extension for the deoptimized output.
 With no options and given `test.cpp` as input, your output includes `test.obj`, `test.exe`, and `test.pdb`, as well as `test.alt.obj`, `test.alt.exe`, and `test.alt.pdb`. This switch allows you to change the suffix of the unoptimized binary build artifacts from `.alt` to something else. If you change the suffix, all files must use the new suffix, and it needs to match the name passed to the linker using [`/dynamicdeopt:suffix` (Preview)](dynamic-deopt-linker.md). You typically don't use this switch unless you need to avoid filename collisions with other files that you have.
 
 *`sync`*\
-Builds the deoptimized output after building the optimized output instead of in parallel. By default, the compiler spawns a parallel instance of the code generator. This switch makes the them run serially, instead. This switch is provided in case this better suits your build environment.
+Builds the deoptimized output after building the optimized output instead of in parallel. By default, the compiler spawns a parallel instance of the code generator. This switch makes them run serially instead. This switch is provided in case this better suits your build environment.
 
 ## Remarks
 
 This preview flag, available starting with Visual Studio 2022 Version 17.14 Preview 2, applies only to x64 projects and must be used with the corresponding linker flag, [`/DYNAMICDEOPT`](dynamic-deopt-linker.md).
 
-Compiling with `/dynamicdeopt` generates other binaries that are used for debugging. When you debug an optimized file and debug into an optimized function, the debugger steps into the alternate binary instead. This allows you to debug as if you're debugging unoptimized code while still getting the performance advantages of optimized code. 
+Compiling with `/dynamicdeopt` generates other binaries that are used for debugging. When you debug an optimized function in an optimized file, the debugger steps into the alternate binary instead. This allows you to debug as if you're debugging unoptimized code while still getting the performance advantages of optimized code. 
 
 `/dynamicdeopt` requires:
 
@@ -54,8 +55,8 @@ If you specify `/OPT:ICF`, the compiler generates a warning that the debug exper
 /fastcap
 /callcap
 /ZW
-fsanitize=address
-fsanitize=kernel-address
+/fsanitize=address
+/fsanitize=kernel-address
 All of the CLR flags
 ```
 

--- a/docs/build/reference/dynamic-deopt.md
+++ b/docs/build/reference/dynamic-deopt.md
@@ -1,9 +1,9 @@
 ---
 title: "/dynamicdeopt (Enable C++ Dynamic Debugging (Preview))"
 description: "Enable the Microsoft C++ compiler option /dynamicdeopt to use C++ Dynamic Debugging."
-ms.date: 03/14/2025
-f1_keywords: ["/dynamicdeopt", "VC.Project.VCNMakeTool.CompileAsManaged", "VC.Project.VCCLCompilerTool.CompileAsManaged"]
-helpviewer_keywords: ["cl.exe compiler, common language runtime option", "-dynamicdeopt compiler option [C++]", "dynamicdeopt compiler option [C++]", "/clr compiler option [C++]", "Managed Extensions for C++, compiling", "common language runtime, /clr compiler option"]
+ms.date: 03/20/2025
+f1_keywords: ["/dynamicdeopt"]
+helpviewer_keywords: ["-dynamicdeopt compiler option [C++]", "dynamicdeopt compiler option [C++]"]
 ---
 # `/dynamicdeopt` (Enable C++ Dynamic Debugging) (Preview)
 


### PR DESCRIPTION
Summary:
- Fix awkward double "use" phrasing in metadata description
- Add new line after page heading
- Add escapes for syntax to prevent all 3 lines rendering as 1
- Remove superfluous "the" and comma in "This switch makes the them run serially, instead."
- Fix awkward double "debug" phrasing in "When you debug an optimized file and debug into an optimized function," (an alternative is to just remove the "optimized file" part, which I kept, so as to not change the meaning too much)
- Add forward slash for ASan and KASan compiler switches