### PR TITLE
Update `__m64` reference page

### DIFF
--- a/docs/cpp/m64.md
+++ b/docs/cpp/m64.md
@@ -1,12 +1,11 @@
 ---
-description: "Learn more about: __m64"
 title: "__m64"
+description: "Learn more about: __m64"
 ms.date: "11/04/2016"
 f1_keywords: ["__m64_cpp"]
 helpviewer_keywords: ["__m64 keyword [C++]"]
-ms.assetid: df0410e8-67c9-4954-88c8-fe2653575252
 ---
-# __m64
+# `__m64`
 
 **Microsoft Specific**
 
@@ -15,9 +14,10 @@ The **`__m64`** data type is for use with the MMX and 3DNow! intrinsics, and is 
 ```cpp
 // data_types__m64.cpp
 #include <xmmintrin.h>
+
 int main()
 {
-   __m64 x;
+    __m64 x;
 }
 ```
 
@@ -25,14 +25,14 @@ int main()
 
 You should not access the **`__m64`** fields directly. You can, however, see these types in the debugger. A variable of type **`__m64`** maps to the MM[0-7] registers.
 
-Variables of type **_m64** are automatically aligned on 8-byte boundaries.
+Variables of type **`__m64`** are automatically aligned on 8-byte boundaries.
 
-The **`__m64`** data type is not supported on x64 processors. Applications that use __m64 as part of MMX intrinsics must be rewritten to use equivalent SSE and SSE2 intrinsics.
+The **`__m64`** data type is not supported on x64 processors. Applications that use **`__m64`** as part of MMX intrinsics must be rewritten to use equivalent SSE and SSE2 intrinsics.
 
 **END Microsoft Specific**
 
 ## See also
 
-[Keywords](../cpp/keywords-cpp.md)<br/>
-[Built-in types](../cpp/fundamental-types-cpp.md)<br/>
-[Data Type Ranges](../cpp/data-type-ranges.md)
+[Keywords](keywords-cpp.md)\
+[Built-in types](fundamental-types-cpp.md)\
+[Data Type Ranges](data-type-ranges.md)


### PR DESCRIPTION
Summary:
- Enclose heading in backticks
- Format code snippet
- Fix invalid mention of `_m64` (missing an underscore)
- Standardize formatting of `__m64` (with backticks and bolded)
- Replace `br` elements with escapes
- Clean up redundant relative links
- Edit metadata