### PR TITLE
Add example for C28020 warning

### DIFF
--- a/docs/code-quality/c28020.md
+++ b/docs/code-quality/c28020.md
@@ -1,15 +1,32 @@
 ---
-description: "Learn more about: Warning C28020"
 title: Warning C28020
-ms.date: 11/04/2016
+description: "Learn more about: Warning C28020"
+ms.date: 03/25/2025
 f1_keywords: ["C28020"]
 helpviewer_keywords: ["C28020"]
-ms.assetid: 3612185a-0858-4ba9-b795-4a0681073cf7
 ---
 # Warning C28020
 
-> The expression '*expr*' is not true at this call
+> The expression '*expr*' is not true at this call.
 
 This warning is reported when the `_Satisfies_` expression listed isn't true. Frequently, the warning indicates an incorrect parameter.
 
 If this warning occurs on a function declaration, the annotations indicate an impossible condition.
+
+## Example
+
+The following example generates C28020:
+
+```cpp
+#include <sal.h>
+
+int func(_In_range_(0, 10) int value)
+{
+    return value;
+}
+
+int main()
+{
+    func(11);   // C28020
+}
+```


### PR DESCRIPTION
Summary:
- Append period character to end of warning message (verbatim from the latest version of VS)
- Add new example
  - `func` returns a value so as to prevent an unreferenced formal parameter warning
- Edit metadata