### PR TITLE
Clarify that arguments on the stack are 8-byte aligned.

### DIFF
--- a/docs/build/x64-calling-convention.md
+++ b/docs/build/x64-calling-convention.md
@@ -33,7 +33,7 @@ Prologs and epilogs are highly restricted so that they can be properly described
 
 ## Parameter passing
 
-By default, the x64 calling convention passes the first four arguments to a function in registers. The registers used for these arguments depend on the position and type of the argument. Remaining arguments get pushed on the stack in right-to-left order.
+By default, the x64 calling convention passes the first four arguments to a function in registers. The registers used for these arguments depend on the position and type of the argument. Remaining arguments get pushed on the stack in right-to-left order. All arguments passed on the stack are 8-byte aligned.
 
 Integer valued arguments in the leftmost four positions are passed in left-to-right order in RCX, RDX, R8, and R9, respectively. The fifth and higher arguments are passed on the stack as previously described. All integer arguments in registers are right-justified, so the callee can ignore the upper bits of the register and access only the portion of the register necessary.
 


### PR DESCRIPTION
An important aspect of the ABI is how parameters are passed, so that code generated by different compilers can interoperate. This document was lacking clear guidance about the storage locations of arguments passed on the stack, leaving it up to compiler authors to deduce it from empirical tests.

This change adds a single clarification that parameters passed on the stack are 8-byte aligned.