### PR TITLE
Fix invalid `helpviewer_keywords` metadata for C6701 warning

### DIFF
--- a/docs/code-quality/c6701.md
+++ b/docs/code-quality/c6701.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6701"
 title: Warning C6701
+description: "Learn more about: Warning C6701"
 ms.date: 11/04/2016
 f1_keywords: ["C6701"]
-helpviewer_keywords: ["C67901"]
-ms.assetid: c48484e2-542c-4f7b-93ea-98c6367cb3d9
+helpviewer_keywords: ["C6701"]
 ---
 # Warning C6701
 


### PR DESCRIPTION
Remove extra "9" character in the `helpviewer_keywords` metadata, with some other edits.