### PR TITLE
Update C4799 warning page

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4799.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4799.md
@@ -1,17 +1,35 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4799"
 title: "Compiler Warning (level 1) C4799"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4799"
+ms.date: "03/28/2025"
 f1_keywords: ["C4799"]
 helpviewer_keywords: ["C4799"]
-ms.assetid: 8ecbd06f-c778-4371-a2fb-c690b6743ec8
 ---
 # Compiler Warning (level 1) C4799
 
-> No EMMS at end of function '*function*'
+> function '*function*' has no EMMS instruction
 
-The function has at least one MMX instruction, but does not have an `EMMS` instruction. When a multimedia instruction is used, an `EMMS` instruction or `_mm_empty` intrinsic should also be used to clear the multimedia tag word at the end of the MMX code.
+The function has at least one MMX instruction, but does not have an `EMMS` instruction. When a multimedia instruction is used, an `EMMS` instruction or [`_mm_empty`](https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_empty) intrinsic should also be used to clear the multimedia tag word at the end of the MMX code.
 
-You may get C4799 when using ivec.h, indicating that the code does not use properly execute the EMMS instruction before returning. This is a false warning for these headers. You may turn these off by defining _SILENCE_IVEC_C4799 in ivec.h. However, be aware that this will also keep the compiler from giving correct warnings of this type.
+You may get C4799 when using `ivec.h`, indicating that the code does not properly execute the `EMMS` instruction before returning. This is a false warning for these headers. You may turn these off by defining `_SILENCE_IVEC_C4799` in `ivec.h`. However, be aware that this will also keep the compiler from giving correct warnings of this type.
 
 For related information, see [Intel's MMX Instruction Set](../../assembler/inline/intel-s-mmx-instruction-set.md).
+
+## Example
+
+The following example generates C4799:
+
+```cpp
+// C4799.cpp
+// compile with: /W1
+// processor: x86
+#include <mmintrin.h>
+
+int main()
+{
+    __m64 m = _mm_setzero_si64();
+
+    // Uncomment the following line to resolve the warning:
+    // _mm_empty();
+}   // C4799
+```

--- a/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-by-compiler-version.md
@@ -953,7 +953,7 @@ These warnings, and all warnings in later versions, are suppressed by using the 
 | [C4792](compiler-warning-level-3-c4792.md) | `function 'function' declared using sysimport and referenced from native code; import library required to link` |
 | [C4794](compiler-warning-level-1-c4794.md) | `segment of thread local storage variable 'name' changed from 'segment' to 'segment'` |
 | C4798 | `native code generated for p-code function 'name' with exception handler or unwind semantics` |
-| [C4799](compiler-warning-level-1-c4799.md) | `function 'name' has no EMMS instruction` |
+| [C4799](compiler-warning-level-1-c4799.md) | `function 'function' has no EMMS instruction` |
 | [C4803](compiler-warning-level-1-c4803.md) | `'declaration': the raise method has a different storage class from that of the event, 'declaration'` |
 | [C4810](compiler-warning-level-1-c4810.md) | `value of pragma pack(show) == number` |
 | [C4811](compiler-warning-level-1-c4811.md) | `value of pragma conform(forScope, show) == value` |

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4600-through-c4799.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4600-through-c4799.md
@@ -170,7 +170,7 @@ The articles in this section describe Microsoft C/C++ compiler warning messages 
 |[Compiler warning (level 1 and level 3) C4793](compiler-warning-level-1-and-3-c4793.md)|'*function*': function compiled as native:<br> *reason*|
 |[Compiler warning (level 1) C4794](compiler-warning-level-1-c4794.md)|segment of thread local storage variable '%s' changed from '%s' to '%s'|
 |Compiler warning C4798|native code generated for p-code function 'name' with exception handler or unwind semantics|
-|[Compiler warning (level 1) C4799](compiler-warning-level-1-c4799.md)|function 'function' has no `EMMS` instruction|
+|[Compiler warning (level 1) C4799](compiler-warning-level-1-c4799.md)|function '*function*' has no EMMS instruction|
 
 ## See also
 


### PR DESCRIPTION
Summary:
- Update the warning message to the latest one, together with the other occurrences
- Add link for `_mm_empty` intrinsic
- Remove extra "use" word
- Add backticks for a bunch of terms
- Add new example
  - Variable `m` is initialized to zero since it's better practice as opposed to keeping it uninitialized
- Edit metadata