### PR TITLE
Disambiguate "Visual Studio Code" and "Visual Studio Code *"

### DIFF
--- a/docs/code-quality/quick-start-code-analysis-for-c-cpp.md
+++ b/docs/code-quality/quick-start-code-analysis-for-c-cpp.md
@@ -100,7 +100,7 @@ The Error List window lists the code analysis warnings found. The results are di
 
 For detailed information about the warning, including possible solutions to the issue, choose the warning ID in the Code column to display its corresponding online help article.
 
-Double-click a warning to move the cursor to the line of code that caused the warning in the Visual Studio code editor. Or, press Enter on the selected warning.
+Double-click a warning to move the cursor to the line of code that caused the warning in the code editor. Or, press Enter on the selected warning.
 
 After you understand the problem, you can resolve it in your code. Then, rerun code analysis to make sure that the warning no longer appears in the Error List.
 

--- a/docs/code-quality/quick-start-code-analysis-for-c-cpp.md
+++ b/docs/code-quality/quick-start-code-analysis-for-c-cpp.md
@@ -19,7 +19,7 @@ You can improve the quality of your application by running code analysis regular
 
 1. To run code analysis every time the project is built using the selected configuration, select the **Enable Code Analysis on Build** check box. You can also run code analysis manually by opening the **Analyze** menu and then choosing **Run Code Analysis on** *ProjectName* or **Run Code Analysis on File**.
 
-1. Choose the [rule set](using-rule-sets-to-specify-the-cpp-rules-to-run.md) that you want to use or create a [custom rule set](using-rule-sets-to-specify-the-cpp-rules-to-run.md#to-create-a-rule-set-in-a-text-editor). If using LLVM/clang-cl, see [Using Clang-Tidy in Visual Studio](../code-quality/clang-tidy.md) to configure Clang-Tidy analysis options.
+1. Choose the [rule set](using-rule-sets-to-specify-the-cpp-rules-to-run.md) that you want to use or create a [custom rule set](using-rule-sets-to-specify-the-cpp-rules-to-run.md#to-create-a-rule-set-in-a-text-editor). If using LLVM/clang-cl, see [Using Clang-Tidy in Visual Studio](clang-tidy.md) to configure Clang-Tidy analysis options.
 
 ### Standard C/C++ rule sets
 
@@ -128,4 +128,4 @@ You can search long lists of warning messages and you can filter warnings in mul
 
 ## See also
 
-- [Code analysis for C/C++](../code-quality/code-analysis-for-c-cpp-overview.md)
+- [Code analysis for C/C++](code-analysis-for-c-cpp-overview.md)

--- a/docs/code-quality/understanding-sal.md
+++ b/docs/code-quality/understanding-sal.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Understanding SAL"
 title: Understanding SAL
+description: "Learn more about: Understanding SAL"
 ms.date: 11/04/2016
 ms.topic: "conceptual"
-ms.assetid: a94d6907-55f2-4874-9571-51d52d6edcfd
 ---
 # Understanding SAL
 
@@ -384,7 +383,7 @@ Here are some guidelines:
 
 - Annotate value-range annotations so that Code Analysis can ensure buffer and pointer safety.
 
-- Annotate locking rules and locking side effects. For more information, see [Annotating Locking Behavior](../code-quality/annotating-locking-behavior.md).
+- Annotate locking rules and locking side effects. For more information, see [Annotating Locking Behavior](annotating-locking-behavior.md).
 
 - Annotate driver properties and other domain-specific properties.
 
@@ -392,10 +391,10 @@ Or you can annotate all parameters to make your intent clear throughout and to m
 
 ## See also
 
-- [Using SAL Annotations to Reduce C/C++ Code Defects](../code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md)
-- [Annotating Function Parameters and Return Values](../code-quality/annotating-function-parameters-and-return-values.md)
-- [Annotating Function Behavior](../code-quality/annotating-function-behavior.md)
-- [Annotating Structs and Classes](../code-quality/annotating-structs-and-classes.md)
-- [Annotating Locking Behavior](../code-quality/annotating-locking-behavior.md)
-- [Specifying When and Where an Annotation Applies](../code-quality/specifying-when-and-where-an-annotation-applies.md)
-- [Best Practices and Examples](../code-quality/best-practices-and-examples-sal.md)
+- [Using SAL Annotations to Reduce C/C++ Code Defects](using-sal-annotations-to-reduce-c-cpp-code-defects.md)
+- [Annotating Function Parameters and Return Values](annotating-function-parameters-and-return-values.md)
+- [Annotating Function Behavior](annotating-function-behavior.md)
+- [Annotating Structs and Classes](annotating-structs-and-classes.md)
+- [Annotating Locking Behavior](annotating-locking-behavior.md)
+- [Specifying When and Where an Annotation Applies](specifying-when-and-where-an-annotation-applies.md)
+- [Best Practices and Examples](best-practices-and-examples-sal.md)

--- a/docs/code-quality/understanding-sal.md
+++ b/docs/code-quality/understanding-sal.md
@@ -94,9 +94,9 @@ These annotations help identify possible uninitialized values and invalid null p
 
 This section shows code examples for the basic SAL annotations.
 
-### Using the Visual Studio Code Analysis Tool to Find Defects
+### Using the Visual Studio code analysis tool to find defects
 
-In the examples, the Visual Studio Code Analysis tool is used together with SAL annotations to find code defects. Here's how to do that.
+In the examples, the Visual Studio code analysis tool is used together with SAL annotations to find code defects. Here's how to do that.
 
 #### To use Visual Studio code analysis tools and SAL
 
@@ -145,7 +145,7 @@ void BadInCaller()
 }
 ```
 
-If you use Visual Studio Code Analysis on this example, it validates that the callers pass a non-Null pointer to an initialized buffer for `pInt`. In this case, `pInt` pointer cannot be NULL.
+If you use Visual Studio code analysis on this example, it validates that the callers pass a non-Null pointer to an initialized buffer for `pInt`. In this case, `pInt` pointer cannot be NULL.
 
 ### Example: The \_In\_opt\_ Annotation
 
@@ -172,7 +172,7 @@ void InOptCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that the function checks for NULL before it accesses the buffer.
+Visual Studio code analysis validates that the function checks for NULL before it accesses the buffer.
 
 ### Example: The \_Out\_ Annotation
 
@@ -198,7 +198,7 @@ void OutCaller()
 }
 ```
 
-Visual Studio Code Analysis Tool validates that the caller passes a non-NULL pointer to a buffer for `pInt` and that the buffer is initialized by the function before it returns.
+Visual Studio code analysis validates that the caller passes a non-NULL pointer to a buffer for `pInt` and that the buffer is initialized by the function before it returns.
 
 ### Example: The \_Out\_opt\_ Annotation
 
@@ -225,7 +225,7 @@ void OutOptCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that this function checks for NULL before `pInt` is dereferenced, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
+Visual Studio code analysis validates that this function checks for NULL before `pInt` is dereferenced, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
 
 ### Example: The \_Inout\_ Annotation
 
@@ -256,7 +256,7 @@ void BadInOutCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that callers pass a non-NULL pointer to an initialized buffer for `pInt`, and that, before return, `pInt` is still non-NULL and the buffer is initialized.
+Visual Studio code analysis validates that callers pass a non-NULL pointer to an initialized buffer for `pInt`, and that, before return, `pInt` is still non-NULL and the buffer is initialized.
 
 ### Example: The \_Inout\_opt\_ Annotation
 
@@ -285,7 +285,7 @@ void InOutOptCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that this function checks for NULL before it accesses the buffer, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
+Visual Studio code analysis validates that this function checks for NULL before it accesses the buffer, and if `pInt` is not NULL, that the buffer is initialized by the function before it returns.
 
 ### Example: The \_Outptr\_ Annotation
 
@@ -315,7 +315,7 @@ void OutPtrCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that the caller passes a non-NULL pointer for `*pInt`, and that the buffer is initialized by the function before it returns.
+Visual Studio code analysis validates that the caller passes a non-NULL pointer for `*pInt`, and that the buffer is initialized by the function before it returns.
 
 ### Example: The \_Outptr\_opt\_ Annotation
 
@@ -347,7 +347,7 @@ void OutPtrOptCaller()
 }
 ```
 
-Visual Studio Code Analysis validates that this function checks for NULL before `*pInt` is dereferenced, and that the buffer is initialized by the function before it returns.
+Visual Studio code analysis validates that this function checks for NULL before `*pInt` is dereferenced, and that the buffer is initialized by the function before it returns.
 
 ### Example: The \_Success\_ Annotation in Combination with \_Out\_
 
@@ -366,7 +366,7 @@ bool GetValue(_Out_ int *pInt, bool flag)
 }
 ```
 
-The `_Out_` annotation causes Visual Studio Code Analysis to validate that the caller passes a non-NULL pointer to a buffer for `pInt`, and that the buffer is initialized by the function before it returns.
+The `_Out_` annotation causes Visual Studio code analysis to validate that the caller passes a non-NULL pointer to a buffer for `pInt`, and that the buffer is initialized by the function before it returns.
 
 ## SAL Best Practice
 

--- a/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
+++ b/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
@@ -321,7 +321,7 @@ Because of the way the code analysis rules get loaded within Visual Studio 2015,
 
 1. Select the Microsoft.CppCoreCheck package and then choose the **Install** button to add the rules to your project.
 
-   The NuGet package adds an MSBuild *`.targets`* file to your project that is invoked when you enable code analysis on your project. The *`.targets`* file adds the C++ Core Check rules as another extension to the Visual Studio Code analysis tool. When the package is installed, you can use the Property Pages dialog to enable or disable the released and experimental rules.
+   The NuGet package adds an MSBuild *`.targets`* file to your project that is invoked when you enable code analysis on your project. The *`.targets`* file adds the C++ Core Check rules as another extension to the Visual Studio code analysis tool. When the package is installed, you can use the Property Pages dialog to enable or disable the released and experimental rules.
 
 ::: moniker-end
 

--- a/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
+++ b/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
@@ -317,7 +317,7 @@ Because of the way the code analysis rules get loaded within Visual Studio 2015,
 
 1. In the **NuGet Package Manager** window, search for Microsoft.CppCoreCheck.
 
-    ![Nuget Package Manager window showing the CppCoreCheck package.](../code-quality/media/cppcorecheck_nuget_window.png)
+    ![Nuget Package Manager window showing the CppCoreCheck package.](media/cppcorecheck_nuget_window.png)
 
 1. Select the Microsoft.CppCoreCheck package and then choose the **Install** button to add the rules to your project.
 

--- a/docs/embedded/toc.yml
+++ b/docs/embedded/toc.yml
@@ -1,5 +1,5 @@
 items: 
-- name: Embedded development with Visual Studio and Visual Studio code
+- name: Embedded development with Visual Studio and Visual Studio Code
   href: ./index.yml
 - name: Download and install the Embedded Tools
   href: download-and-install-the-embedded-tooling.md


### PR DESCRIPTION
Summary:
- Remove capitalization of "Code Analysis [Tool]" to prevent possible misinterpretation as being associated with Visual Studio Code (i.e. "Visual Studio Code, Analysis Tool")
- Capitalize "code" in one instance of "VIsual Studio code"
- Edit metadata and simplify links (in second commit)