### PR TITLE
Fix C2470 example

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
@@ -1,26 +1,34 @@
 ---
-description: "Learn more about: Compiler Error C2470"
 title: "Compiler Error C2470"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2470"
+ms.date: "03/29/2025"
 f1_keywords: ["C2470"]
 helpviewer_keywords: ["C2470"]
-ms.assetid: e17d2cb8-b84c-447c-976a-625f0c96f3fe
 ---
 # Compiler Error C2470
 
-'function' : looks like a function definition, but there is no parameter list; skipping apparent body
+> '*function*': looks like a function definition, but there is no parameter list; skipping apparent body
 
 A function definition is missing its argument list.
 
-The following sample generates C2470:
+## Example
+
+The following example generates C2470:
 
 ```cpp
 // C2470.cpp
-int MyFunc {};  // C2470
-void MyFunc2() {};  //OK
+// compile with: /c
+template <typename T>
+class C
+{
+    int func();
+};
 
-int main(){
-   MyFunc();
-   MyFunc2();
+template <typename T>
+int C<T>::func   // C2470
+// Use the following line to resolve the error:
+// int C<T>::func()
+{
+    return 0;
 }
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-errors-c2400-through-c2499.md
+++ b/docs/error-messages/compiler-errors-1/compiler-errors-c2400-through-c2499.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler errors C2400 Through C2499"
 title: "Compiler errors C2400 Through C2499"
+description: "Learn more about: Compiler errors C2400 Through C2499"
 ms.date: "04/21/2019"
 f1_keywords: ["C2416", "C2442", "C2453", "C2454", "C2455", "C2456", "C2468", "C2475", "C2478", "C2481", "C2497"]
 helpviewer_keywords: ["C2416", "C2442", "C2453", "C2454", "C2455", "C2456", "C2468", "C2475", "C2478", "C2481", "C2497"]


### PR DESCRIPTION
Summary:
- Update the error message
- Replace the old example with a new one
  - Old example no longer emits C2470 as `int MyFunc {};` just creates a global variable `MyFunc` initialized to `0`
    - Removing the semicolon to yield the following also does not emit C2470:

      ```cpp
      int MyFunc
      {

      }
      ```
  - Tried many ways but could not get the compiler to emit C2470 due to the "same issue" as the old example (i.e. omitting the parentheses just "converts" it from a function definition to a variable)
  - Settled with a class template member function definition which seems to emit C2470 cleanly (no other errors)
- Edit metadata