### PR TITLE
Augment C6296 warning reference

### DIFF
--- a/docs/code-quality/c6296.md
+++ b/docs/code-quality/c6296.md
@@ -1,47 +1,35 @@
 ---
-description: "Learn more about: Warning C6296"
 title: Warning C6296
-ms.date: 11/04/2016
+description: "Learn more about: Warning C6296"
+ms.date: 03/30/2025
 f1_keywords: ["C6296", "LOOP_ONLY_EXECUTED_ONCE", "__WARNING_LOOP_ONLY_EXECUTED_ONCE"]
 helpviewer_keywords: ["C6296"]
-ms.assetid: 226573e0-db18-4c44-8fc6-0bc09d1028bc
 ---
 # Warning C6296
 
-> Ill-defined for-loop: Loop body only executed once
+> Ill-defined for-loop.  Loop body only executed once.
 
 ## Remarks
 
-This warning indicates that a for-loop might not function as intended. When the index is unsigned and a loop counts down from zero, its body is run only once.
+This warning indicates that a for-loop might unintentionally execute only once. A loop with an unsigned index counting down from zero or a mistaken use of `==` might cause this warning.
 
 Code analysis name: `LOOP_ONLY_EXECUTED_ONCE`
 
 ## Example
 
-The following code generates this warning:
+The following example generates C6296. Each for-loop shown executes exactly once.
 
 ```cpp
-void f( )
+int main()
 {
-   unsigned int i;
+    for (unsigned int i = 0; i < 10; i--) {}   // C6296
+    // Use the following line to resolve the warning:
+    // for (unsigned int i = 0; i < 10; i++) {}
 
-   for (i = 0; i < 100; i--)
-   {
-      // code ...
-   }
-}
-```
+    for (int i = 0; i == 0; i++) {}   // C6296
 
-To correct this warning, use the following code:
+    for (int i = 0; i < 1; i++) {}   // OK
 
-```cpp
-void f( )
-{
-   unsigned int i;
-
-   for (i = 0; i < 100; i++)
-   {
-      // code ...
-   }
+    for (int i = 1; i > 0; i--) {}   // OK
 }
 ```


### PR DESCRIPTION
Summary:
- Update warning message (the double spaces are preserved verbatim)
- Improve the generic "might not function as intended." with an emphasis on both *unintentional* and *executes once*
- Augment the possible cause line with the `==` example
- Overhaul example
  - Old example has some flaws (inconsistent formatting and unnecessary splitting of iteration variable)
  - New example incorporates the old one and another `==` instance which emits C6296, together with 2 "normal" for-loops that also execute once showing the "unintentional heuristics"
- Edit metadata