### PR TITLE
Expand C2162 error page

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
@@ -20,7 +20,4 @@ The following example generates C2162:
 // compile with: /c
 #define make_string1(s) #    // C2162
 #define make_string2(s) #s   // OK
-
-#define make_char1(c) #@    // C2162
-#define make_char2(c) #@c   // OK
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
@@ -1,26 +1,26 @@
 ---
-description: "Learn more about: Compiler Error C2162"
 title: "Compiler Error C2162"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2162"
+ms.date: "03/30/2025"
 f1_keywords: ["C2162"]
 helpviewer_keywords: ["C2162"]
-ms.assetid: 34923628-d35e-48ab-9072-b95e3b5f6b45
 ---
 # Compiler Error C2162
 
-expected macro formal parameter
+> expected macro formal parameter
 
-The token following a stringizing operator (#) is not a formal parameter name.
+The token following a [stringizing operator (#)](../../preprocessor/stringizing-operator-hash.md) or a [charizing operator (#@)](../../preprocessor/charizing-operator-hash-at.md) is not a formal parameter.
 
 ## Example
 
-The following sample generates C2162:
+The following example generates C2162:
 
 ```cpp
 // C2162.cpp
 // compile with: /c
-#include <stdio.h>
+#define make_string1(s) #    // C2162
+#define make_string2(s) #s   // OK
 
-#define print(a) printf_s(b)   // OK
-#define print(a) printf_s(#b)    // C2162
+#define make_char1(c) #@    // C2162
+#define make_char2(c) #@c   // OK
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
+++ b/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler errors C2100 through C2199"
 title: "Compiler errors C2100 through C2199"
+description: "Learn more about: Compiler errors C2100 through C2199"
 ms.date: "04/21/2019"
 f1_keywords: ["C2119", "C2123", "C2125", "C2126", "C2127", "C2136", "C2176", "C2187", "C2189"]
 helpviewer_keywords: ["C2119", "C2123", "C2125", "C2126", "C2127", "C2136", "C2176", "C2187", "C2189"]
@@ -118,5 +118,5 @@ The articles in this section of the documentation explain a subset of the error 
 
 ## See also
 
-[C/C++ Compiler and build tools errors and warnings](../compiler-errors-1/c-cpp-build-errors.md) \
-[Compiler errors C2001 - C3999, C7000 - C7999](../compiler-errors-1/compiler-errors-c2000-c3999.md)
+[C/C++ Compiler and build tools errors and warnings](c-cpp-build-errors.md)\
+[Compiler errors C2001 - C3999, C7000 - C7999](compiler-errors-c2000-c3999.md)


### PR DESCRIPTION
Summary:
- Add blockquotes for error message
- Add link for stringizing operator
- Add mention of charizing operator which can also emit C2162
- Update example
  - Old example brings in `stdio.h` unnecessarily and redefines the `print` macro
  - New example also prevents any sort of macro redefinition warning
- Edit metadata and some cleanups in "Compiler errors C2100 through C2199" since I was checking the error message there