### PR TITLE
Improve alert in "Declare Override Specifiers in Native Compilations"

### DIFF
--- a/docs/dotnet/how-to-declare-override-specifiers-in-native-compilations-cpp-cli.md
+++ b/docs/dotnet/how-to-declare-override-specifiers-in-native-compilations-cpp-cli.md
@@ -6,10 +6,10 @@ helpviewer_keywords: ["override specifiers in native compilation, overriding"]
 ---
 # How to: Declare Override Specifiers in Native Compilations (C++/CLI)
 
-[sealed](../extensions/sealed-cpp-component-extensions.md), [abstract](../extensions/abstract-cpp-component-extensions.md), and [override](../extensions/override-cpp-component-extensions.md) are available in compilations that do not use **/ZW** or [/clr](../build/reference/clr-common-language-runtime-compilation.md).
+[`sealed`](../extensions/sealed-cpp-component-extensions.md), [`abstract`](../extensions/abstract-cpp-component-extensions.md), and [`override`](../extensions/override-cpp-component-extensions.md) are available in compilations that do not use **/ZW** or [`/clr`](../build/reference/clr-common-language-runtime-compilation.md).
 
 > [!NOTE]
-> The ISO C++11 Standard language [override](../cpp/override-specifier.md) and [final](../cpp/final-specifier.md) specifiers are supported in Visual Studio. Use `final` instead of **`sealed`** in code that is meant to be compiled as native-only.
+> The ISO C++11 Standard language [`override`](../cpp/override-specifier.md) and [`final`](../cpp/final-specifier.md) specifiers are supported in Visual Studio. Use `final` instead of **`sealed`** in code that is meant to be compiled as native-only.
 
 ## Example: sealed is valid
 
@@ -66,7 +66,7 @@ public:
 
 ### Description
 
-This example shows that **`abstract`** is valid in native compilations.
+This example shows that `abstract` is valid in native compilations.
 
 ### Code
 

--- a/docs/dotnet/how-to-declare-override-specifiers-in-native-compilations-cpp-cli.md
+++ b/docs/dotnet/how-to-declare-override-specifiers-in-native-compilations-cpp-cli.md
@@ -1,16 +1,15 @@
 ---
-description: "Learn more about: How to: Declare Override Specifiers in Native Compilations (C++/CLI)"
 title: "How to: Declare Override Specifiers (C++/CLI)"
+description: "Learn more about: How to: Declare Override Specifiers in Native Compilations (C++/CLI)"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["override specifiers in native compilation, overriding"]
-ms.assetid: d0551836-9ac7-41eb-a6e9-a4b3ef60767d
 ---
 # How to: Declare Override Specifiers in Native Compilations (C++/CLI)
 
 [sealed](../extensions/sealed-cpp-component-extensions.md), [abstract](../extensions/abstract-cpp-component-extensions.md), and [override](../extensions/override-cpp-component-extensions.md) are available in compilations that do not use **/ZW** or [/clr](../build/reference/clr-common-language-runtime-compilation.md).
 
 > [!NOTE]
-> The ISO C++11 Standard language has the [override](../cpp/override-specifier.md) identifier and the [final](../cpp/final-specifier.md) identifier, and both are supported in Visual Studio  Use `final` instead of **`sealed`** in code that is meant to be compiled as native-only.
+> The ISO C++11 Standard language [override](../cpp/override-specifier.md) and [final](../cpp/final-specifier.md) specifiers are supported in Visual Studio. Use `final` instead of **`sealed`** in code that is meant to be compiled as native-only.
 
 ## Example: sealed is valid
 


### PR DESCRIPTION
Summary:
- Improve the slightly awkward first sentence and use "specifier" instead of "identifier"
- Add missing period character after the first sentence
- Edit metadata