### PR TITLE
Refresh "Inheritance (C++)"

### DIFF
--- a/docs/cpp/inheritance-cpp.md
+++ b/docs/cpp/inheritance-cpp.md
@@ -1,50 +1,54 @@
 ---
-description: "Learn more about: Inheritance  (C++)"
-title: "Inheritance  (C++)"
+title: "Inheritance (C++)"
+description: "Learn more about: Inheritance (C++)"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["derived classes [C++]", "derived classes [C++], about derived classes", "classes [C++], derived"]
-ms.assetid: 3534ca19-d9ed-4a40-be1b-b921ad0e6956
 ---
-# Inheritance  (C++)
+# Inheritance (C++)
 
 This section explains how to use derived classes to produce extensible programs.
 
 ## Overview
 
-New classes can be derived from existing classes using a mechanism called "inheritance" (see the information beginning in [Single Inheritance](../cpp/single-inheritance.md)). Classes that are used for derivation are called "base classes" of a particular derived class. A derived class is declared using the following syntax:
+New classes can be derived from existing classes using a mechanism called "inheritance" (see the information beginning in [Single Inheritance](single-inheritance.md)). Classes that are used for derivation are called "base classes" of a particular derived class. A derived class is declared using the following syntax:
 
 ```cpp
-class Derived : [virtual] [access-specifier] Base
+class DerivedSingleBase : [virtual] [access-specifier] Base
 {
-   // member list
+    // member list
 };
-class Derived : [virtual] [access-specifier] Base1,
-   [virtual] [access-specifier] Base2, . . .
+
+class DerivedMultipleBases : [virtual] [access-specifier] Base1,
+    [virtual] [access-specifier] Base2, ...
 {
-   // member list
+    // member list
 };
 ```
 
-After the tag (name) for the class, a colon appears followed by a list of base specifications.  The base classes so named must have been declared previously.  The base specifications may contain an access specifier, which is one of the keywords **`public`**, **`protected`** or **`private`**.  These access specifiers appear before the base class name and apply only to that base class.  These specifiers control the derived class's permission to use to members of the base class.  See [Member-Access Control](../cpp/member-access-control-cpp.md) for information on access to base class members.  If the access specifier is omitted, the access to that base is considered **`private`**.  The base specifications may contain the keyword **`virtual`** to indicate virtual inheritance.  This keyword may appear before or after the access specifier, if any.  If virtual inheritance is used, the base class is referred to as a virtual base class.
+After the tag (name) for the class, a colon appears followed by a list of base specifications. The base classes so named must have been declared previously. The base specifications may contain an access specifier, which is one of the keywords [**`public`**](public-cpp.md), [**`protected`**](protected-cpp.md) or [**`private`**](private-cpp.md). These access specifiers appear before the base class name and apply only to that base class. These specifiers control the derived class's permission to use members of the base class. See [Member-Access Control](member-access-control-cpp.md) for information on access to base class members. If the access specifier is omitted, the access to that base is considered **`private`**. The base specifications may contain the keyword [**`virtual`**](virtual-cpp.md) to indicate virtual inheritance. This keyword may appear before or after the access specifier, if any. If virtual inheritance is used, the base class is referred to as a virtual base class.
 
-Multiple base classes can be specified, separated by commas.  If a single base class is specified, the inheritance model is [Single inheritance](../cpp/single-inheritance.md). If more than one base class is specified, the inheritance model is called [Multiple inheritance](../cpp/multiple-base-classes.md).
+Multiple base classes can be specified, separated by commas. If a single base class is specified, the inheritance model is [Single inheritance](single-inheritance.md). If more than one base class is specified, the inheritance model is called [Multiple inheritance](multiple-base-classes.md).
 
 The following topics are included:
 
-- [Single inheritance](../cpp/single-inheritance.md)
+- [Single inheritance](single-inheritance.md)
 
-- [Multiple base classes](../cpp/multiple-base-classes.md)
+- [Multiple base classes](multiple-base-classes.md)
 
-- [Virtual functions](../cpp/virtual-functions.md)
+- [Virtual functions](virtual-functions.md)
 
-- [Explicit overrides](../cpp/explicit-overrides-cpp.md)
+- [Explicit overrides](explicit-overrides-cpp.md)
 
-- [Abstract classes](../cpp/abstract-classes-cpp.md)
+- [Abstract classes](abstract-classes-cpp.md)
 
-- [Summary of scope rules](../cpp/summary-of-scope-rules.md)
+- [Summary of scope rules](summary-of-scope-rules.md)
 
-The [__super](../cpp/super.md) and [__interface](../cpp/interface.md) keywords are documented in this section.
+**Microsoft Specific**
+
+The [`__super`](super.md) and [`__interface`](interface.md) keywords are documented in this section.
+
+**END Microsoft Specific**
 
 ## See also
 
-[C++ Language Reference](../cpp/cpp-language-reference.md)
+[C++ Language Reference](cpp-language-reference.md)


### PR DESCRIPTION
Summary:
- Format syntax code snippet and make the 2 classes have different names for clarity
- Add bunch of links to other pages and backticks for terms, where appropriate
- Add "Microsoft Specific" for the `__super` and `__interface` links at the bottom to make it explicit that those are non-standard (feel free to revert if undesirable)
- Edit metadata, minor typo fix, simplify links, and remove extra spaces