### PR TITLE
Fix typo: VSCode -> VS Code

### DIFF
--- a/.acrolinx-config.edn
+++ b/.acrolinx-config.edn
@@ -21,7 +21,7 @@
 "
 **More info about Acrolinx**
 
-- [Install Acrolinx locally for VSCode](https://review.docs.microsoft.com/en-us/help/contribute/contribute-acrolinx-vscode)
+- [Install Acrolinx locally for VS Code](https://review.docs.microsoft.com/en-us/help/contribute/contribute-acrolinx-vscode)
 - [Report false positives or issues](https://aka.ms/acrolinxbug)
 
 "}

--- a/docs/embedded/rtos-view.md
+++ b/docs/embedded/rtos-view.md
@@ -18,7 +18,7 @@ The RTOS Object View allows users to view various components of an RTOS while de
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-![RTOS View in VSCode](media/rtos-threads-vscode.png)
+![RTOS View in VS Code](media/rtos-threads-vscode.png)
 
 ---
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.