### PR TITLE
cl.exe CLI clarify default for space being allowed between option and arg

### DIFF
--- a/docs/build/reference/compiler-command-line-syntax.md
+++ b/docs/build/reference/compiler-command-line-syntax.md
@@ -17,7 +17,7 @@ The following table describes input to the CL command.
 
 |Entry|Meaning|
 |-----------|-------------|
-|*option*|One or more [CL options](compiler-options.md). Note that all options apply to all specified source files. Options are specified by either a forward slash (/) or a dash (-). If an option takes an argument, the option's description documents whether a space is allowed between the option and the arguments. Option names (except for the /HELP option) are case sensitive. For more information, see [Order of CL Options](order-of-cl-options.md).|
+|*option*|One or more [CL options](compiler-options.md). Note that all options apply to all specified source files. Options are specified by either a forward slash (/) or a dash (-). If an option takes an argument, by default there can be no space between the option and argument.  Some options can have a space allowed after the option, the option's description will state when this is the case. Option names (except for the /HELP option) are case sensitive. For more information, see [Order of CL Options](order-of-cl-options.md).|
 |`file`|The name of one or more source files, .obj files, or libraries. CL compiles source files and passes the names of the .obj files and libraries to the linker. For more information, see [CL Filename Syntax](cl-filename-syntax.md).|
 |*lib*|One or more library names. CL passes these names to the linker.|
 |*command-file*|A file that contains multiple options and filenames. For more information, see [CL Command Files](cl-command-files.md).|

--- a/docs/build/reference/compiler-command-line-syntax.md
+++ b/docs/build/reference/compiler-command-line-syntax.md
@@ -17,7 +17,7 @@ The following table describes input to the CL command.
 
 |Entry|Meaning|
 |-----------|-------------|
-|*option*|One or more [CL options](compiler-options.md). Note that all options apply to all specified source files. Options are specified by either a forward slash (/) or a dash (-). If an option takes an argument, by default there can be no space between the option and argument.  Some options can have a space allowed after the option, the option's description will state when this is the case. Option names (except for the /HELP option) are case sensitive. For more information, see [Order of CL Options](order-of-cl-options.md).|
+|*option*|One or more [CL options](compiler-options.md). All options apply to all specified source files. Specify options using either a forward slash (/) or a dash (-). Generally, there can't be a space between the option and argument. The option's description states when a space is allowed. Options are case-sensitive--except for `/HELP`. For more information, see [Order of CL Options](order-of-cl-options.md).|
 |`file`|The name of one or more source files, .obj files, or libraries. CL compiles source files and passes the names of the .obj files and libraries to the linker. For more information, see [CL Filename Syntax](cl-filename-syntax.md).|
 |*lib*|One or more library names. CL passes these names to the linker.|
 |*command-file*|A file that contains multiple options and filenames. For more information, see [CL Command Files](cl-command-files.md).|


### PR DESCRIPTION
This clarifies the possible mis-understanding of spaces between arg and option in cl.exe. The docs are technically currently correct(ish) that when space is allowed it is specified (although I didn't check to make sure that was actually true on every command).  The problem is it would likely be easy to read an option and not know if a space was allowed.  For example:
[/Fe](https://learn.microsoft.com/en-us/cpp/build/reference/fe-name-exe-file?view=msvc-170)

It seems to show that it allows a space after Fe but only if a colon is used.  The remarks do not explicitly mention how to use a space or not with an option.

[/Fd](https://learn.microsoft.com/en-us/cpp/build/reference/fd-program-database-file-name?view=msvc-170) would seem to behave like /Fe although it doesn't mention if a colon and space is allowed (and no example of it) so no space?

[/Fi](https://learn.microsoft.com/en-us/cpp/build/reference/fi-preprocess-output-file-name?view=msvc-170) is a bit more fun, the syntax shows a space but actually space is not allowed. This is specified in Parameters (to not use space).

[/Fa](https://learn.microsoft.com/en-us/cpp/build/reference/fa-fa-listing-file?view=msvc-170) 
shows a gap between the /Fa and pathname but doesn't mention space and given the coloring im guessing means no space.

[/D](https://learn.microsoft.com/en-us/cpp/build/reference/d-preprocessor-definitions?view=msvc-170) here we specifically note a space inside brackets `[ ]` so it is clear a space can go there, and the remark specifies it is allowed but not required. 

I don't know if my interpretations are all correct, probably the syntax description should be standardized.  At a minimum though the goal of this commit is to specify the default of space not being allowed, as seems true for most commands.  This also makes it a bit more clear that the absence of talk about a space means do not use a space (minus maybe with a colon?:)).

This might seem minor, id assume most people try it if it doesn't work they catch it pretty soon.  I am sure some options might be a bit harder to detect but still.  Some projects / developers may not support Windows as a primary platform, or even test/have easy access to a Windows machine.  I can't say they reference the documentation but I would assume when writing code for a platform you don't have that would be a good starting place.

As an example of this is GNU's libtool part of their autotools suite.  It is a utility for developers to assist in building libraries in a standardized way across many platforms/situations.  I don't know how many projects use libtool, but excluding forks there are 1.4 million references to [libtool on github](https://github.com/search?utf8=%E2%9C%93&q=libtool+NOT+is%3Afork&type=code).

Often libtool is combined with other compatibility scripts to make some projects build with MSVC.

Recently there has been some more love given towards its Windows support, by those who likely don't use Windows/MSVC often.  Sadly in one case it made things worse.

A commit in January of 2024 tried switching MSVC to use the -Fe flag for output https://github.com/mitchcapper/libtool/commit/81e8abf3ddb341e1e86d57fd4d7f318c264276f1 now I am not saying they checked the documentation but it being ambiguous if they did wouldn't help.  Clearly this code never worked, but it was many months before it was detected and fixed.  In the mean time there was one major and 3 minor releases that all had this bug.  Someone using a windows nixish build environment installed or updated in that 11 month period will be broken on this until they realize to update again.   To further exacerbate the problem some projects that use libtool include a copy of it in their source so those could be broken for an unknown amount of time.

Now obviously libtool / MSVC cl.exe combo doesn't get a lot of use or this probably would have been detected sooner.  Still some of those people who do try to use the combination may give us when it just doesn't work.