### PR TITLE
Remove stray backtick in "MFC Classes" title and some cleanups

### DIFF
--- a/docs/mfc/reference/mfc-classes.md
+++ b/docs/mfc/reference/mfc-classes.md
@@ -16,1285 +16,1285 @@ The classes in the following list are included in the Microsoft Foundation Class
 
 ## In This Section
 
-[`CAccelerateDecelerateTransition` Class](../../mfc/reference/cacceleratedeceleratetransition-class.md)\
+[`CAccelerateDecelerateTransition` Class](cacceleratedeceleratetransition-class.md)\
 Implements an accelerate-decelerate transition.
 
-[`CAnimateCtrl` Class](../../mfc/reference/canimatectrl-class.md)\
+[`CAnimateCtrl` Class](canimatectrl-class.md)\
 Provides the functionality of the Windows common animation control.
 
-[`CAnimationBaseObject` Class](../../mfc/reference/canimationbaseobject-class.md)\
+[`CAnimationBaseObject` Class](canimationbaseobject-class.md)\
 The base class for all animation objects.
 
-[`CAnimationColor` Class](../../mfc/reference/canimationcolor-class.md)\
+[`CAnimationColor` Class](canimationcolor-class.md)\
 Implements the functionality of a color whose red, green, and blue components can be animated.
 
-[`CAnimationController` Class](../../mfc/reference/canimationcontroller-class.md)\
+[`CAnimationController` Class](canimationcontroller-class.md)\
 Implements the animation controller, which provides a central interface for creating and managing animations.
 
-[`CAnimationGroup` Class](../../mfc/reference/canimationgroup-class.md)\
+[`CAnimationGroup` Class](canimationgroup-class.md)\
 Implements the animation controller, which provides a central interface for creating and managing animations.
 
-[`CAnimationManagerEventHandler` Class](../../mfc/reference/canimationmanagereventhandler-class.md)\
+[`CAnimationManagerEventHandler` Class](canimationmanagereventhandler-class.md)\
 Implements a callback, which is called by the Animation API when a status of an animation manager is changed.
 
-[`CAnimationPoint` Class](../../mfc/reference/canimationpoint-class.md)\
+[`CAnimationPoint` Class](canimationpoint-class.md)\
 Implements the functionality of a point whose coordinates can be animated.
 
-[`CAnimationRect` Class](../../mfc/reference/canimationrect-class.md)\
+[`CAnimationRect` Class](canimationrect-class.md)\
 Implements the functionality of a rectangle whose sides can be animated.
 
-[`CAnimationSize` Class](../../mfc/reference/canimationsize-class.md)\
+[`CAnimationSize` Class](canimationsize-class.md)\
 Implements the functionality of a size object whose dimensions can be animated.
 
-[`CAnimationStoryboardEventHandler` Class](../../mfc/reference/canimationstoryboardeventhandler-class.md)\
+[`CAnimationStoryboardEventHandler` Class](canimationstoryboardeventhandler-class.md)\
 Implements a callback, which is called by the Animation API when the status of a storyboard is changed or a storyboard is updated.
 
-[`CAnimationTimerEventHandler` Class](../../mfc/reference/canimationtimereventhandler-class.md)\
+[`CAnimationTimerEventHandler` Class](canimationtimereventhandler-class.md)\
 Implements a callback, which is called by the Animation API when timing events occur.
 
-[`CAnimationValue` Class](../../mfc/reference/canimationvalue-class.md)\
+[`CAnimationValue` Class](canimationvalue-class.md)\
 Implements the functionality of animation object that has one value.
 
-[`CAnimationVariable` Class](../../mfc/reference/canimationvariable-class.md)\
+[`CAnimationVariable` Class](canimationvariable-class.md)\
 Represents an animation variable.
 
-[`CAnimationVariableChangeHandler` Class](../../mfc/reference/canimationvariablechangehandler-class.md)\
+[`CAnimationVariableChangeHandler` Class](canimationvariablechangehandler-class.md)\
 Implements a callback, which is called by the Animation API when the value of an animation variable changes.
 
-[`CAnimationVariableIntegerChangeHandler` Class](../../mfc/reference/canimationvariableintegerchangehandler-class.md)\
+[`CAnimationVariableIntegerChangeHandler` Class](canimationvariableintegerchangehandler-class.md)\
 Implements a callback, which is called by the Animation API when the value of an animation variable changes.
 
-[`CArchive` Class](../../mfc/reference/carchive-class.md)\
+[`CArchive` Class](carchive-class.md)\
 Lets you save a complex network of objects in a permanent binary form (usually disk storage) that persists after those objects are deleted.
 
-[`CArchiveException` Class](../../mfc/reference/carchiveexception-class.md)\
+[`CArchiveException` Class](carchiveexception-class.md)\
 Represents a serialization exception condition.
 
-[`CArray` Class](../../mfc/reference/carray-class.md)\
+[`CArray` Class](carray-class.md)\
 Supports arrays that resemble` C arrays, but can dynamically reduce and grow as necessary.
 
-[`CAsyncMonikerFile` Class](../../mfc/reference/casyncmonikerfile-class.md)\
+[`CAsyncMonikerFile` Class](casyncmonikerfile-class.md)\
 Provides functionality for the use of asynchronous monikers in ActiveX controls (formerly OLE controls).
 
-[`CAsyncSocket` Class](../../mfc/reference/casyncsocket-class.md)\
+[`CAsyncSocket` Class](casyncsocket-class.md)\
 Represents a Windows Socket, which is an endpoint of network communication.
 
-[`CAutoHideDockSite` Class](../../mfc/reference/cautohidedocksite-class.md)\
-Extends the [`CDockSite` Class](../../mfc/reference/cdocksite-class.md) to implement auto-hide dock panes.
+[`CAutoHideDockSite` Class](cautohidedocksite-class.md)\
+Extends the [`CDockSite` Class](cdocksite-class.md) to implement auto-hide dock panes.
 
-[`CBaseKeyFrame` Class](../../mfc/reference/cbasekeyframe-class.md)\
+[`CBaseKeyFrame` Class](cbasekeyframe-class.md)\
 Implements the basic functionality of a keyframe.
 
-[`CBasePane` Class](../../mfc/reference/cbasepane-class.md)\
+[`CBasePane` Class](cbasepane-class.md)\
 Base class for all panes.
 
-[`CBaseTabbedPane` Class](../../mfc/reference/cbasetabbedpane-class.md)\
-Extends the functionality of the [`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md) to support the creation of tabbed windows.
+[`CBaseTabbedPane` Class](cbasetabbedpane-class.md)\
+Extends the functionality of the [`CDockablePane` Class](cdockablepane-class.md) to support the creation of tabbed windows.
 
-[`CBaseTransition` Class](../../mfc/reference/cbasetransition-class.md)\
+[`CBaseTransition` Class](cbasetransition-class.md)\
 Represents a basic transition.
 
-[`CBitmap` Class](../../mfc/reference/cbitmap-class.md)\
+[`CBitmap` Class](cbitmap-class.md)\
 Encapsulates a Windows graphics device interface (GDI) bitmap and provides member functions to manipulate the bitmap.
 
-[`CBitmapButton` Class](../../mfc/reference/cbitmapbutton-class.md)\
+[`CBitmapButton` Class](cbitmapbutton-class.md)\
 Creates pushbutton controls labeled with bitmapped images instead of text.
 
-[`CBitmapRenderTarget` Class](../../mfc/reference/cbitmaprendertarget-class.md)\
+[`CBitmapRenderTarget` Class](cbitmaprendertarget-class.md)\
 A wrapper for `ID2D1BitmapRenderTarget`.
 
-[`CBrush` Class](../../mfc/reference/cbrush-class.md)\
+[`CBrush` Class](cbrush-class.md)\
 Encapsulates a Windows graphics device interface (GDI) brush.
 
-[`CButton` Class](../../mfc/reference/cbutton-class.md)\
+[`CButton` Class](cbutton-class.md)\
 Provides the functionality of Windows button controls.
 
-[`CByteArray` Class](../../mfc/reference/cbytearray-class.md)\
+[`CByteArray` Class](cbytearray-class.md)\
 Supports dynamic arrays of bytes.
 
-[`CCachedDataPathProperty` Class](../../mfc/reference/ccacheddatapathproperty-class.md)\
+[`CCachedDataPathProperty` Class](ccacheddatapathproperty-class.md)\
 Implements an OLE control property transferred asynchronously and cached in a memory file.
 
-[`CCheckListBox` Class](../../mfc/reference/cchecklistbox-class.md)\
+[`CCheckListBox` Class](cchecklistbox-class.md)\
 Provides the functionality of a Windows checklist box.
 
-[`CClientDC` Class](../../mfc/reference/cclientdc-class.md)\
+[`CClientDC` Class](cclientdc-class.md)\
 Handles the calling of the Windows functions [`GetDC`](/windows/win32/api/winuser/nf-winuser-getdc) at construction time and [`ReleaseDC`](/windows/win32/api/winuser/nf-winuser-releasedc) at destruction time.
 
-[`CCmdTarget` Class](../../mfc/reference/ccmdtarget-class.md)\
+[`CCmdTarget` Class](ccmdtarget-class.md)\
 Base class for the Microsoft Foundation Class Library message-map architecture.
 
-[`CCmdUI` Class](../../mfc/reference/ccmdui-class.md)\
+[`CCmdUI` Class](ccmdui-class.md)\
 Used only within an `ON_UPDATE_COMMAND_UI` handler in a `CCmdTarget`-derived class.
 
-[`CColorDialog` Class](../../mfc/reference/ccolordialog-class.md)\
+[`CColorDialog` Class](ccolordialog-class.md)\
 Lets you incorporate a color-selection dialog box into your application.
 
-[`CComboBox` Class](../../mfc/reference/ccombobox-class.md)\
+[`CComboBox` Class](ccombobox-class.md)\
 Provides the functionality of a Windows combo box.
 
-[`CComboBoxEx` Class](../../mfc/reference/ccomboboxex-class.md)\
+[`CComboBoxEx` Class](ccomboboxex-class.md)\
 Extends the combo box control by providing support for image lists.
 
-[`CCommandLineInfo` Class](../../mfc/reference/ccommandlineinfo-class.md)\
+[`CCommandLineInfo` Class](ccommandlineinfo-class.md)\
 Aids in parsing the command line at application startup.
 
-[`CCommonDialog` Class](../../mfc/reference/ccommondialog-class.md)\
+[`CCommonDialog` Class](ccommondialog-class.md)\
 The base class for classes that encapsulate functionality of the Windows common dialogs.
 
-[`CConnectionPoint` Class](../../mfc/reference/cconnectionpoint-class.md)\
+[`CConnectionPoint` Class](cconnectionpoint-class.md)\
 Defines a special type of interface used to communicate with other OLE objects, called a "connection point."
 
-[`CConstantTransition` Class](../../mfc/reference/cconstanttransition-class.md)\
+[`CConstantTransition` Class](cconstanttransition-class.md)\
 Encapsulates a constant transition.
 
-[`CContextMenuManager` Class](../../mfc/reference/ccontextmenumanager-class.md)\
+[`CContextMenuManager` Class](ccontextmenumanager-class.md)\
 Manages shortcut menus, also known as context menus.
 
-[`CControlBar` Class](../../mfc/reference/ccontrolbar-class.md)\
-Base class for the control-bar classes [`CStatusBar` Class](../../mfc/reference/cstatusbar-class.md), [`CToolBar` Class](../../mfc/reference/ctoolbar-class.md), [`CDialogBar` Class](../../mfc/reference/cdialogbar-class.md), [`CReBar` Class](../../mfc/reference/crebar-class.md), and [`COleResizeBar` Class](../../mfc/reference/coleresizebar-class.md).
+[`CControlBar` Class](ccontrolbar-class.md)\
+Base class for the control-bar classes [`CStatusBar` Class](cstatusbar-class.md), [`CToolBar` Class](ctoolbar-class.md), [`CDialogBar` Class](cdialogbar-class.md), [`CReBar` Class](crebar-class.md), and [`COleResizeBar` Class](coleresizebar-class.md).
 
-[`CCriticalSection` Class](../../mfc/reference/ccriticalsection-class.md)\
+[`CCriticalSection` Class](ccriticalsection-class.md)\
 Represents a "critical section", which is a synchronization object that enables one thread at a time to access a resource or section of code.
 
-[`CCtrlView` Class](../../mfc/reference/cctrlview-class.md)\
+[`CCtrlView` Class](cctrlview-class.md)\
 Adapts the document-view architecture to the common controls supported by Windows 98 and Windows NT versions 3.51 and later.
 
-[`CCubicTransition` Class](../../mfc/reference/ccubictransition-class.md)\
+[`CCubicTransition` Class](ccubictransition-class.md)\
 Encapsulates a cubic transition.
 
-[`CCustomInterpolator` Class](../../mfc/reference/ccustominterpolator-class.md)\
+[`CCustomInterpolator` Class](ccustominterpolator-class.md)\
 Implements a basic interpolator.
 
-[`CCustomTransition` Class](../../mfc/reference/ccustomtransition-class.md)\
+[`CCustomTransition` Class](ccustomtransition-class.md)\
 Implements a custom transition.
 
-[`CD2DBitmap` Class](../../mfc/reference/cd2dbitmap-class.md)\
+[`CD2DBitmap` Class](cd2dbitmap-class.md)\
 A wrapper for `ID2D1Bitmap`.
 
-[`CD2DBitmapBrush` Class](../../mfc/reference/cd2dbitmapbrush-class.md)\
+[`CD2DBitmapBrush` Class](cd2dbitmapbrush-class.md)\
 A wrapper for `ID2D1BitmapBrush`.
 
-[`CD2DBrush` Class](../../mfc/reference/cd2dbrush-class.md)\
+[`CD2DBrush` Class](cd2dbrush-class.md)\
 A wrapper for `ID2D1Brush`.
 
-[`CD2DBrushProperties` Class](../../mfc/reference/cd2dbrushproperties-class.md)\
+[`CD2DBrushProperties` Class](cd2dbrushproperties-class.md)\
 A wrapper for `D2D1_BRUSH_PROPERTIES`.
 
-[`CD2DEllipse` Class](../../mfc/reference/cd2dellipse-class.md)\
+[`CD2DEllipse` Class](cd2dellipse-class.md)\
 A wrapper for `D2D1_BRUSH_PROPERTIES`.
 
-[`CD2DGeometry` Class](../../mfc/reference/cd2dgeometry-class.md)\
+[`CD2DGeometry` Class](cd2dgeometry-class.md)\
 A wrapper for `ID2D1Geometry`.
 
-[`CD2DGeometrySink` Class](../../mfc/reference/cd2dgeometrysink-class.md)\
+[`CD2DGeometrySink` Class](cd2dgeometrysink-class.md)\
 A wrapper for `ID2D1GeometrySink`.
 
-[`CD2DGradientBrush` Class](../../mfc/reference/cd2dgradientbrush-class.md)\
+[`CD2DGradientBrush` Class](cd2dgradientbrush-class.md)\
 The base class of the `CD2DLinearGradientBrush` and the `CD2DRadialGradientBrush` classes.
 
-[`CD2DLayer` Class](../../mfc/reference/cd2dlayer-class.md)\
+[`CD2DLayer` Class](cd2dlayer-class.md)\
 A wrapper for `ID2D1Layer`.
 
-[`CD2DLinearGradientBrush` Class](../../mfc/reference/cd2dlineargradientbrush-class.md)\
+[`CD2DLinearGradientBrush` Class](cd2dlineargradientbrush-class.md)\
 A wrapper for `ID2D1LinearGradientBrush`.
 
-[`CD2DMesh` Class](../../mfc/reference/cd2dmesh-class.md)\
+[`CD2DMesh` Class](cd2dmesh-class.md)\
 A wrapper for `ID2D1Mesh`.
 
-[`CD2DPathGeometry` Class](../../mfc/reference/cd2dpathgeometry-class.md)\
+[`CD2DPathGeometry` Class](cd2dpathgeometry-class.md)\
 A wrapper for `ID2D1PathGeometry`.
 
-[`CD2DPointF` Class](../../mfc/reference/cd2dpointf-class.md)\
+[`CD2DPointF` Class](cd2dpointf-class.md)\
 A wrapper for `D2D1_POINT_2F`.
 
-[`CD2DPointU` Class](../../mfc/reference/cd2dpointu-class.md)\
+[`CD2DPointU` Class](cd2dpointu-class.md)\
 A wrapper for `D2D1_POINT_2U`.
 
-[`CD2DRadialGradientBrush` Class](../../mfc/reference/cd2dradialgradientbrush-class.md)\
+[`CD2DRadialGradientBrush` Class](cd2dradialgradientbrush-class.md)\
 A wrapper for `ID2D1RadialGradientBrush`.
 
-[`CD2DRectF` Class](../../mfc/reference/cd2drectf-class.md)\
+[`CD2DRectF` Class](cd2drectf-class.md)\
 A wrapper for `D2D1_RECT_F`.
 
-[`CD2DRectU` Class](../../mfc/reference/cd2drectu-class.md)\
+[`CD2DRectU` Class](cd2drectu-class.md)\
 A wrapper for `D2D1_RECT_U`.
 
-[`CD2DResource` Class](../../mfc/reference/cd2dresource-class.md)\
+[`CD2DResource` Class](cd2dresource-class.md)\
 An abstract class that provides an interface for creating and managing `D2D` resources such as brushes, layers, and texts.
 
-[`CD2DRoundedRect` Class](../../mfc/reference/cd2droundedrect-class.md)\
+[`CD2DRoundedRect` Class](cd2droundedrect-class.md)\
 A wrapper for `D2D1_ROUNDED_RECT`.
 
-[`CD2DSizeF` Class](../../mfc/reference/cd2dsizef-class.md)\
+[`CD2DSizeF` Class](cd2dsizef-class.md)\
 A wrapper for `D2D1_SIZE_F`.
 
-[`CD2DSizeU` Class](../../mfc/reference/cd2dsizeu-class.md)\
+[`CD2DSizeU` Class](cd2dsizeu-class.md)\
 A wrapper for `D2D1_SIZE_U`.
 
-[`CD2DSolidColorBrush` Class](../../mfc/reference/cd2dsolidcolorbrush-class.md)\
+[`CD2DSolidColorBrush` Class](cd2dsolidcolorbrush-class.md)\
 A wrapper for `ID2D1SolidColorBrush`.
 
-[`CD2DTextFormat` Class](../../mfc/reference/cd2dtextformat-class.md)\
+[`CD2DTextFormat` Class](cd2dtextformat-class.md)\
 A wrapper for `IDWriteTextFormat`.
 
-[`CD2DTextLayout` Class](../../mfc/reference/cd2dtextlayout-class.md)\
+[`CD2DTextLayout` Class](cd2dtextlayout-class.md)\
 A wrapper for `IDWriteTextLayout`.
 
-[`CDaoDatabase` Class](../../mfc/reference/cdaodatabase-class.md)\
+[`CDaoDatabase` Class](cdaodatabase-class.md)\
 Represents a connection to a database through which you can operate on the data.
 
-[`CDaoException` Class](../../mfc/reference/cdaoexception-class.md)\
+[`CDaoException` Class](cdaoexception-class.md)\
 Represents an exception condition arising from the MFC database classes based on data access objects (DAO).
 
-[`CDaoFieldExchange` Class](../../mfc/reference/cdaofieldexchange-class.md)\
+[`CDaoFieldExchange` Class](cdaofieldexchange-class.md)\
 Supports the DAO record field exchange (DFX) routines used by the DAO database classes.
 
-[`CDaoQueryDef` Class](../../mfc/reference/cdaoquerydef-class.md)\
+[`CDaoQueryDef` Class](cdaoquerydef-class.md)\
 Represents a query definition, or "querydef," usually one saved in a database.
 
-[`CDaoRecordset` Class](../../mfc/reference/cdaorecordset-class.md)\
+[`CDaoRecordset` Class](cdaorecordset-class.md)\
 Represents a set of records selected from a data source.
 
-[`CDaoRecordView` Class](../../mfc/reference/cdaorecordview-class.md)\
+[`CDaoRecordView` Class](cdaorecordview-class.md)\
 A view that displays database records in controls.
 
-[`CDaoTableDef` Class](../../mfc/reference/cdaotabledef-class.md)\
+[`CDaoTableDef` Class](cdaotabledef-class.md)\
 Represents the stored definition of a base table or an attached table.
 
-[`CDaoWorkspace` Class](../../mfc/reference/cdaoworkspace-class.md)\
+[`CDaoWorkspace` Class](cdaoworkspace-class.md)\
 Manages a named, password-protected database session from login to logoff, by a single user.
 
-[`CDatabase` Class](../../mfc/reference/cdatabase-class.md)\
+[`CDatabase` Class](cdatabase-class.md)\
 Represents a connection to a data source, through which you can operate on the data source.
 
-[`CDataExchange` Class](../../mfc/reference/cdataexchange-class.md)\
+[`CDataExchange` Class](cdataexchange-class.md)\
 Supports the dialog data exchange (DDX) and dialog data validation (DDV) routines used by the Microsoft Foundation classes.
 
-[`CDataPathProperty` Class](../../mfc/reference/cdatapathproperty-class.md)\
+[`CDataPathProperty` Class](cdatapathproperty-class.md)\
 Implements an OLE control property that can be loaded asynchronously.
 
-[`CDataRecoveryHandler` Class](../../mfc/reference/cdatarecoveryhandler-class.md)\
+[`CDataRecoveryHandler` Class](cdatarecoveryhandler-class.md)\
 Autosaves documents and restores them if an application unexpectedly exits.
 
-[`CDateTimeCtrl` Class](../../mfc/reference/cdatetimectrl-class.md)\
+[`CDateTimeCtrl` Class](cdatetimectrl-class.md)\
 Encapsulates the functionality of a date and time picker control.
 
-[`CDBException` Class](../../mfc/reference/cdbexception-class.md)\
+[`CDBException` Class](cdbexception-class.md)\
 Represents an exception condition arising from the database classes.
 
-[`CDBVariant` Class](../../mfc/reference/cdbvariant-class.md)\
+[`CDBVariant` Class](cdbvariant-class.md)\
 Represents a variant data type for the MFC ODBC classes.
 
-[`CDC` Class](../../mfc/reference/cdc-class.md)\
+[`CDC` Class](cdc-class.md)\
 Defines a class of device-context objects.
 
-[`CDCRenderTarget` Class](../../mfc/reference/cdcrendertarget-class.md)\
+[`CDCRenderTarget` Class](cdcrendertarget-class.md)\
 A wrapper for `ID2D1DCRenderTarget`.
 
-[`CDHtmlDialog` Class](../../mfc/reference/cdhtmldialog-class.md)\
+[`CDHtmlDialog` Class](cdhtmldialog-class.md)\
 Used to create dialog boxes that use HTML rather than dialog resources to implement their user interface.
 
-[`CDialog` Class](../../mfc/reference/cdialog-class.md)\
+[`CDialog` Class](cdialog-class.md)\
 Base class used for displaying dialog boxes on the screen.
 
-[`CDialogBar` Class](../../mfc/reference/cdialogbar-class.md)\
+[`CDialogBar` Class](cdialogbar-class.md)\
 Provides the functionality of a Windows modeless dialog box in a control bar.
 
-[`CDialogEx` Class](../../mfc/reference/cdialogex-class.md)\
+[`CDialogEx` Class](cdialogex-class.md)\
 Specifies the background color and background image of a dialog box.
 
-[`CDiscreteTransition` Class](../../mfc/reference/cdiscretetransition-class.md)\
+[`CDiscreteTransition` Class](cdiscretetransition-class.md)\
 Encapsulates a discrete transition.
 
-[`CDocItem` Class](../../mfc/reference/cdocitem-class.md)\
+[`CDocItem` Class](cdocitem-class.md)\
 The base class for document items, which are components of a document's data.
 
-[`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md)\
+[`CDockablePane` Class](cdockablepane-class.md)\
 Implements a pane that can either be docked in a dock site or included in a tabbed pane.
 
-[`CDockablePaneAdapter` Class](../../mfc/reference/cdockablepaneadapter-class.md)\
+[`CDockablePaneAdapter` Class](cdockablepaneadapter-class.md)\
 Provides docking support for `CWnd`-derived panes.
 
-[`CDockingManager` Class](../../mfc/reference/cdockingmanager-class.md)\
+[`CDockingManager` Class](cdockingmanager-class.md)\
 Implements the core functionality that controls docking layout in a main frame window.
 
-[`CDockingPanesRow` Class](../../mfc/reference/cdockingpanesrow-class.md)\
+[`CDockingPanesRow` Class](cdockingpanesrow-class.md)\
 Manages a list of panes that are located in the same horizontal or vertical row (column) of a dock site.
 
-[`CDockSite` Class](../../mfc/reference/cdocksite-class.md)\
-Provides functionality for arranging panes that are derived from the [`CPane` Class](../../mfc/reference/cpane-class.md) into sets of rows.
+[`CDockSite` Class](cdocksite-class.md)\
+Provides functionality for arranging panes that are derived from the [`CPane` Class](cpane-class.md) into sets of rows.
 
-[`CDockState` Class](../../mfc/reference/cdockstate-class.md)\
+[`CDockState` Class](cdockstate-class.md)\
 A serialized `CObject` class that loads, unloads, or clears the state of one or more docking control bars in persistent memory (a file).
 
-[`CDocObjectServer` Class](../../mfc/reference/cdocobjectserver-class.md)\
+[`CDocObjectServer` Class](cdocobjectserver-class.md)\
 Implements the additional OLE interfaces needed to make a normal `COleDocument` server into a full DocObject server: `IOleDocument`, `IOleDocumentView`, `IOleCommandTarget`, and `IPrint`.
 
-[`CDocObjectServerItem` Class](../../mfc/reference/cdocobjectserveritem-class.md)\
+[`CDocObjectServerItem` Class](cdocobjectserveritem-class.md)\
 Implements OLE server verbs specifically for DocObject servers.
 
-[`CDocTemplate` Class](../../mfc/reference/cdoctemplate-class.md)\
+[`CDocTemplate` Class](cdoctemplate-class.md)\
 An abstract base class that defines the basic functionality for document templates.
 
-[`CDocument` Class](../../mfc/reference/cdocument-class.md)\
+[`CDocument` Class](cdocument-class.md)\
 Provides the basic functionality for user-defined document classes.
 
-[`CDragListBox` Class](../../mfc/reference/cdraglistbox-class.md)\
+[`CDragListBox` Class](cdraglistbox-class.md)\
 In addition to providing the functionality of a Windows list box, the `CDragListBox` class lets the user move list box items, such as filenames, within the list box.
 
-[`CDrawingManager` Class](../../mfc/reference/cdrawingmanager-class.md)\
+[`CDrawingManager` Class](cdrawingmanager-class.md)\
 Implements complex drawing algorithms.
 
-[`CDumpContext` Class](../../mfc/reference/cdumpcontext-class.md)\
+[`CDumpContext` Class](cdumpcontext-class.md)\
 Supports stream-oriented diagnostic output in the form of human-readable text.
 
-[`CDWordArray` Class](../../mfc/reference/cdwordarray-class.md)\
+[`CDWordArray` Class](cdwordarray-class.md)\
 Supports arrays of 32-bit doublewords.
 
-[`CEdit` Class](../../mfc/reference/cedit-class.md)\
+[`CEdit` Class](cedit-class.md)\
 Provides the functionality of a Windows edit control.
 
-[`CEditView` Class](../../mfc/reference/ceditview-class.md)\
+[`CEditView` Class](ceditview-class.md)\
 A type of view class that provides the functionality of a Windows edit control and can be used to implement simple text-editor functionality.
 
-[`CEvent` Class](../../mfc/reference/cevent-class.md)\
+[`CEvent` Class](cevent-class.md)\
 Represents an "event", which is a synchronization object that enables one thread to notify another that an event has occurred.
 
-[`CException` Class](../../mfc/reference/cexception-class.md)\
+[`CException` Class](cexception-class.md)\
 The base class for all exceptions in the Microsoft Foundation Class Library.
 
-[`CFieldExchange` Class](../../mfc/reference/cfieldexchange-class.md)\
+[`CFieldExchange` Class](cfieldexchange-class.md)\
 Supports the record field exchange (RFX) and bulk record field exchange (Bulk RFX) routines used by the database classes.
 
-[`CFile` Class](../../mfc/reference/cfile-class.md)\
+[`CFile` Class](cfile-class.md)\
 The base class for Microsoft Foundation Class file classes.
 
-[`CFileDialog` Class](../../mfc/reference/cfiledialog-class.md)\
+[`CFileDialog` Class](cfiledialog-class.md)\
 Encapsulates the common file dialog box for Windows.
 
-[`CFileException` Class](../../mfc/reference/cfileexception-class.md)\
+[`CFileException` Class](cfileexception-class.md)\
 Represents a file-related exception condition.
 
-[`CFileFind` Class](../../mfc/reference/cfilefind-class.md)\
-Performs local file searches and is the base class for [`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md) and [`CFtpFileFind` Class](../../mfc/reference/cftpfilefind-class.md), which perform Internet file searches.
+[`CFileFind` Class](cfilefind-class.md)\
+Performs local file searches and is the base class for [`CGopherFileFind` Class](cgopherfilefind-class.md) and [`CFtpFileFind` Class](cftpfilefind-class.md), which perform Internet file searches.
 
-[`CFindReplaceDialog` Class](../../mfc/reference/cfindreplacedialog-class.md)\
+[`CFindReplaceDialog` Class](cfindreplacedialog-class.md)\
 Lets you implement standard string Find/Replace dialog boxes in your application.
 
-[`CFolderPickerDialog` Class](../../mfc/reference/cfolderpickerdialog-class.md)\
+[`CFolderPickerDialog` Class](cfolderpickerdialog-class.md)\
 Implements `CFileDialog` in the folder picker mode.
 
-[`CFont` Class](../../mfc/reference/cfont-class.md)\
+[`CFont` Class](cfont-class.md)\
 Encapsulates a Windows graphics device interface (GDI) font and provides member functions for manipulating the font.
 
-[`CFontDialog` Class](../../mfc/reference/cfontdialog-class.md)\
+[`CFontDialog` Class](cfontdialog-class.md)\
 Lets you incorporate a font-selection dialog box into your application.
 
-[`CFontHolder` Class](../../mfc/reference/cfontholder-class.md)\
+[`CFontHolder` Class](cfontholder-class.md)\
 Implements the stock Font property and encapsulates the functionality of a Windows font object and the `IFont` interface.
 
-[`CFormView` Class](../../mfc/reference/cformview-class.md)\
+[`CFormView` Class](cformview-class.md)\
 The base class used for form views.
 
-[`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md)\
+[`CFrameWnd` Class](cframewnd-class.md)\
 Provides the functionality of a Windows single document interface (SDI) overlapped or pop-up frame window, along with members for managing the window.
 
-[`CFrameWndEx` Class](../../mfc/reference/cframewndex-class.md)\
-Implements the functionality of a Windows single document interface (SDI) overlapped or popup frame window, and provides members for managing the window. It extends the [`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md) class.
+[`CFrameWndEx` Class](cframewndex-class.md)\
+Implements the functionality of a Windows single document interface (SDI) overlapped or popup frame window, and provides members for managing the window. It extends the [`CFrameWnd` Class](cframewnd-class.md) class.
 
-[`CFtpConnection` Class](../../mfc/reference/cftpconnection-class.md)\
+[`CFtpConnection` Class](cftpconnection-class.md)\
 Manages your FTP connection to an Internet server and enables direct manipulation of directories and files on that server.
 
-[`CFtpFileFind` Class](../../mfc/reference/cftpfilefind-class.md)\
+[`CFtpFileFind` Class](cftpfilefind-class.md)\
 Aids in Internet file searches of FTP servers.
 
-[`CGdiObject` Class](../../mfc/reference/cgdiobject-class.md)\
+[`CGdiObject` Class](cgdiobject-class.md)\
 Provides a base class for various kinds of Windows graphics device interface (GDI) objects such as bitmaps, regions, brushes, pens, palettes, and fonts.
 
-[`CGopherConnection` Class](../../mfc/reference/cgopherconnection-class.md)\
+[`CGopherConnection` Class](cgopherconnection-class.md)\
 Manages your connection to a gopher Internet server.
 
-[`CGopherFile` Class](../../mfc/reference/cgopherfile-class.md)\
+[`CGopherFile` Class](cgopherfile-class.md)\
 Provides the functionality to find and read files on a gopher server.
 
-[`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md)\
+[`CGopherFileFind` Class](cgopherfilefind-class.md)\
 Aids in Internet file searches of gopher servers.
 
-[`CGopherLocator` Class](../../mfc/reference/cgopherlocator-class.md)\
-Gets a gopher "locator" from a gopher server, determines the locator's type, and makes the locator available to [`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md).
+[`CGopherLocator` Class](cgopherlocator-class.md)\
+Gets a gopher "locator" from a gopher server, determines the locator's type, and makes the locator available to [`CGopherFileFind` Class](cgopherfilefind-class.md).
 
-[`CHeaderCtrl` Class](../../mfc/reference/cheaderctrl-class.md)\
+[`CHeaderCtrl` Class](cheaderctrl-class.md)\
 Provides the functionality of the Windows common header control.
 
-[`CHotKeyCtrl` Class](../../mfc/reference/chotkeyctrl-class.md)\
+[`CHotKeyCtrl` Class](chotkeyctrl-class.md)\
 Provides the functionality of the Windows common hot key control.
 
-[`CHtmlEditCtrl` Class](../../mfc/reference/chtmleditctrl-class.md)\
+[`CHtmlEditCtrl` Class](chtmleditctrl-class.md)\
 Provides the functionality of the `WebBrowser` ActiveX control in an MFC window.
 
-[`CHtmlEditCtrlBase` Class](../../mfc/reference/chtmleditctrlbase-class.md)\
+[`CHtmlEditCtrlBase` Class](chtmleditctrlbase-class.md)\
 Represents an HTML editing component.
 
-[`CHtmlEditDoc` Class](../../mfc/reference/chtmleditdoc-class.md)\
-With [`CHtmlEditView` Class](../../mfc/reference/chtmleditview-class.md), provides the functionality of the WebBrowser editing platform within the context of the MFC document-view architecture.
+[`CHtmlEditDoc` Class](chtmleditdoc-class.md)\
+With [`CHtmlEditView` Class](chtmleditview-class.md), provides the functionality of the WebBrowser editing platform within the context of the MFC document-view architecture.
 
-[`CHtmlEditView` Class](../../mfc/reference/chtmleditview-class.md)\
+[`CHtmlEditView` Class](chtmleditview-class.md)\
 Provides the functionality of the WebBrowser editing platform within the context of MFC's document/view architecture.
 
-[`CHtmlView` Class](../../mfc/reference/chtmlview-class.md)\
+[`CHtmlView` Class](chtmlview-class.md)\
 Provides the functionality of the WebBrowser control within the context of MFC's document/view architecture.
 
-[`CHttpConnection` Class](../../mfc/reference/chttpconnection-class.md)\
+[`CHttpConnection` Class](chttpconnection-class.md)\
 Manages your connection to an HTTP server.
 
-[`CHttpFile` Class](../../mfc/reference/chttpfile-class.md)\
+[`CHttpFile` Class](chttpfile-class.md)\
 Provides the functionality to request and read files on an HTTP server.
 
-[`CHwndRenderTarget` Class](../../mfc/reference/chwndrendertarget-class.md)\
+[`CHwndRenderTarget` Class](chwndrendertarget-class.md)\
 A wrapper for `ID2D1HwndRenderTarget`.
 
-[`CImageList` Class](../../mfc/reference/cimagelist-class.md)\
+[`CImageList` Class](cimagelist-class.md)\
 Provides the functionality of the Windows common image list control.
 
-[`CInstantaneousTransition` Class](../../mfc/reference/cinstantaneoustransition-class.md)\
+[`CInstantaneousTransition` Class](cinstantaneoustransition-class.md)\
 Encapsulates an instantaneous transition.
 
-[`CInternetConnection` Class](../../mfc/reference/cinternetconnection-class.md)\
+[`CInternetConnection` Class](cinternetconnection-class.md)\
 Manages your connection to an Internet server.
 
-[`CInternetException` Class](../../mfc/reference/cinternetexception-class.md)\
+[`CInternetException` Class](cinternetexception-class.md)\
 Represents an exception condition related to an Internet operation.
 
-[`CInternetFile` Class](../../mfc/reference/cinternetfile-class.md)\
+[`CInternetFile` Class](cinternetfile-class.md)\
 Enables access to files on remote systems that use Internet protocols.
 
-[`CInternetSession` Class](../../mfc/reference/cinternetsession-class.md)\
+[`CInternetSession` Class](cinternetsession-class.md)\
 Creates and initializes a single or several simultaneous Internet sessions and, if necessary, describes your connection to a proxy server.
 
-[`CInterpolatorBase` Class](../../mfc/reference/cinterpolatorbase-class.md)\
+[`CInterpolatorBase` Class](cinterpolatorbase-class.md)\
 Implements a callback, which is called by the Animation API when it has to calculate a new value of an animation variable.
 
-[`CInvalidArgException` Class](../../mfc/reference/cinvalidargexception-class.md)\
+[`CInvalidArgException` Class](cinvalidargexception-class.md)\
 This class represents an invalid argument exception condition.
 
-[`CIPAddressCtrl` Class](../../mfc/reference/cipaddressctrl-class.md)\
+[`CIPAddressCtrl` Class](cipaddressctrl-class.md)\
 Provides the functionality of the Windows common IP Address control.
 
-[`CJumpList` Class](../../mfc/reference/cjumplist-class.md)\
+[`CJumpList` Class](cjumplist-class.md)\
 The list of shortcuts revealed when you right click on an icon in the task bar.
 
-[`CKeyboardManager` Class](../../mfc/reference/ckeyboardmanager-class.md)\
+[`CKeyboardManager` Class](ckeyboardmanager-class.md)\
 Manages shortcut key tables for the main frame window and child frame windows.
 
-[`CKeyFrame` Class](../../mfc/reference/ckeyframe-class.md)\
+[`CKeyFrame` Class](ckeyframe-class.md)\
 Represents an animation keyframe.
 
-[`CLinearTransition` Class](../../mfc/reference/clineartransition-class.md)\
+[`CLinearTransition` Class](clineartransition-class.md)\
 Encapsulates a linear transition.
 
-[`CLinearTransitionFromSpeed` Class](../../mfc/reference/clineartransitionfromspeed-class.md)\
+[`CLinearTransitionFromSpeed` Class](clineartransitionfromspeed-class.md)\
 Encapsulates a linear-speed transition.
 
-[`CLinkCtrl` Class](../../mfc/reference/clinkctrl-class.md)\
+[`CLinkCtrl` Class](clinkctrl-class.md)\
 Provides the functionality of the Windows common SysLink control.
 
-[`CList` Class](../../mfc/reference/clist-class.md)\
+[`CList` Class](clist-class.md)\
 Supports ordered lists of nonunique objects accessible sequentially or by value.
 
-[`CListBox` Class](../../mfc/reference/clistbox-class.md)\
+[`CListBox` Class](clistbox-class.md)\
 Provides the functionality of a Windows list box.
 
-[`CListCtrl` Class](../../mfc/reference/clistctrl-class.md)\
+[`CListCtrl` Class](clistctrl-class.md)\
 Encapsulates the functionality of a "list view control," which displays a collection of items each consisting of an icon (from an image list) and a label.
 
-[`CListView` Class](../../mfc/reference/clistview-class.md)\
-Simplifies use of the list control and of [`CListCtrl` Class](../../mfc/reference/clistctrl-class.md), the class that encapsulates list-control functionality, with MFC's document-view architecture.
+[`CListView` Class](clistview-class.md)\
+Simplifies use of the list control and of [`CListCtrl` Class](clistctrl-class.md), the class that encapsulates list-control functionality, with MFC's document-view architecture.
 
-[`CLongBinary` Class](../../mfc/reference/clongbinary-class.md)\
+[`CLongBinary` Class](clongbinary-class.md)\
 Simplifies working with very large binary data objects (often called BLOBs, or "binary large objects") in a database.
 
-[`CMap` Class](../../mfc/reference/cmap-class.md)\
+[`CMap` Class](cmap-class.md)\
 A dictionary collection class that maps unique keys to values.
 
-[`CMapPtrToPtr` Class](../../mfc/reference/cmapptrtoptr-class.md)\
+[`CMapPtrToPtr` Class](cmapptrtoptr-class.md)\
 Supports maps of void pointers keyed by void pointers.
 
-[`CMapPtrToWord` Class](../../mfc/reference/cmapptrtoword-class.md)\
+[`CMapPtrToWord` Class](cmapptrtoword-class.md)\
 Supports maps of 16-bit words keyed by void pointers.
 
-[`CMapStringToOb` Class](../../mfc/reference/cmapstringtoob-class.md)\
+[`CMapStringToOb` Class](cmapstringtoob-class.md)\
 A dictionary collection class that maps unique `CString` objects to `CObject` pointers.
 
-[`CMapStringToPtr` Class](../../mfc/reference/cmapstringtoptr-class.md)\
+[`CMapStringToPtr` Class](cmapstringtoptr-class.md)\
 Supports maps of void pointers keyed by `CString` objects.
 
-[`CMapStringToString` Class](../../mfc/reference/cmapstringtostring-class.md)\
+[`CMapStringToString` Class](cmapstringtostring-class.md)\
 Supports maps of `CString` objects keyed by `CString` objects.
 
-[`CMapWordToOb` Class](../../mfc/reference/cmapwordtoob-class.md)\
+[`CMapWordToOb` Class](cmapwordtoob-class.md)\
 Supports maps of `CObject` pointers keyed by 16-bit words.
 
-[`CMapWordToPtr` Class](../../mfc/reference/cmapwordtoptr-class.md)\
+[`CMapWordToPtr` Class](cmapwordtoptr-class.md)\
 Supports maps of void pointers keyed by 16-bit words.
 
-[`CMDIChildWnd` Class](../../mfc/reference/cmdichildwnd-class.md)\
+[`CMDIChildWnd` Class](cmdichildwnd-class.md)\
 Provides the functionality of a Windows multiple document interface (MDI) child window, along with members for managing the window.
 
-[`CMDIChildWndEx` Class](../../mfc/reference/cmdichildwndex-class.md)\
-Provides the functionality of a Windows multiple document interface (MDI) child window. It extends the functionality of [`CMDIChildWnd` Class](../../mfc/reference/cmdichildwnd-class.md). The framework requires this class when an MDI application uses certain MFC classes.
+[`CMDIChildWndEx` Class](cmdichildwndex-class.md)\
+Provides the functionality of a Windows multiple document interface (MDI) child window. It extends the functionality of [`CMDIChildWnd` Class](cmdichildwnd-class.md). The framework requires this class when an MDI application uses certain MFC classes.
 
-[`CMDIFrameWnd` Class](../../mfc/reference/cmdiframewnd-class.md)\
+[`CMDIFrameWnd` Class](cmdiframewnd-class.md)\
 Provides the functionality of a Windows multiple document interface (MDI) frame window, along with members for managing the window.
 
-[`CMDIFrameWndEx` Class](../../mfc/reference/cmdiframewndex-class.md)\
-Extends the functionality of [`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md), a Windows Multiple Document Interface (MDI) frame window.
+[`CMDIFrameWndEx` Class](cmdiframewndex-class.md)\
+Extends the functionality of [`CFrameWnd` Class](cframewnd-class.md), a Windows Multiple Document Interface (MDI) frame window.
 
-[`CMDITabInfo` Class](../../mfc/reference/cmditabinfo-class.md)\
-Used to pass parameters to [`CMDIFrameWndEx::EnableMDITabbedGroups`](../../mfc/reference/cmdiframewndex-class.md#enablemditabbedgroups) method. Set members of this class to control the behavior of MDI tabbed groups.
+[`CMDITabInfo` Class](cmditabinfo-class.md)\
+Used to pass parameters to [`CMDIFrameWndEx::EnableMDITabbedGroups`](cmdiframewndex-class.md#enablemditabbedgroups) method. Set members of this class to control the behavior of MDI tabbed groups.
 
-[`CMemFile` Class](../../mfc/reference/cmemfile-class.md)\
-The [`CFile` Class](../../mfc/reference/cfile-class.md)-derived class that supports memory files.
+[`CMemFile` Class](cmemfile-class.md)\
+The [`CFile` Class](cfile-class.md)-derived class that supports memory files.
 
-[`CMemoryException` Class](../../mfc/reference/cmemoryexception-class.md)\
+[`CMemoryException` Class](cmemoryexception-class.md)\
 Represents an out-of-memory exception condition.
 
-[`CMenu` Class](../../mfc/reference/cmenu-class.md)\
+[`CMenu` Class](cmenu-class.md)\
 An encapsulation of the Windows `HMENU`.
 
-[`CMenuTearOffManager` Class](../../mfc/reference/cmenutearoffmanager-class.md)\
+[`CMenuTearOffManager` Class](cmenutearoffmanager-class.md)\
 Manages tear-off menus. A tear-off menu is a menu on the menu bar. The user can remove a tear-off menu from the menu bar, causing the tear-off menu to float.
 
-[`CMetaFileDC` Class](../../mfc/reference/cmetafiledc-class.md)\
+[`CMetaFileDC` Class](cmetafiledc-class.md)\
 Implements a Windows metafile, which contains a sequence of graphics device interface (GDI) commands that you can replay to create a desired image or text.
 
-[`CMFCAcceleratorKey` Class](../../mfc/reference/cmfcacceleratorkey-class.md)\
+[`CMFCAcceleratorKey` Class](cmfcacceleratorkey-class.md)\
 Helper class that implements virtual key mapping and formatting.
 
-[`CMFCAcceleratorKeyAssignCtrl` Class](../../mfc/reference/cmfcacceleratorkeyassignctrl-class.md)\
-Extends the [`CEdit` Class](../../mfc/reference/cedit-class.md) to support extra system buttons such as ALT, CONTROL, and SHIFT.
+[`CMFCAcceleratorKeyAssignCtrl` Class](cmfcacceleratorkeyassignctrl-class.md)\
+Extends the [`CEdit` Class](cedit-class.md) to support extra system buttons such as ALT, CONTROL, and SHIFT.
 
-[`CMFCAutoHideButton` Class](../../mfc/reference/cmfcautohidebutton-class.md)\
-A button that displays or hides a [`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md) that is configured to hide.
+[`CMFCAutoHideButton` Class](cmfcautohidebutton-class.md)\
+A button that displays or hides a [`CDockablePane` Class](cdockablepane-class.md) that is configured to hide.
 
-[`CMFCBaseTabCtrl` Class](../../mfc/reference/cmfcbasetabctrl-class.md)\
+[`CMFCBaseTabCtrl` Class](cmfcbasetabctrl-class.md)\
 Implements the base functionality for tabbed windows.
 
-[`CMFCButton` Class](../../mfc/reference/cmfcbutton-class.md)\
-Adds functionality to the [`CButton` Class](../../mfc/reference/cbutton-class.md) class such as aligning button text, combining button text and an image, selecting a cursor, and specifying a tool tip.
+[`CMFCButton` Class](cmfcbutton-class.md)\
+Adds functionality to the [`CButton` Class](cbutton-class.md) class such as aligning button text, combining button text and an image, selecting a cursor, and specifying a tool tip.
 
-[`CMFCCaptionBar` Class](../../mfc/reference/cmfccaptionbar-class.md)\
+[`CMFCCaptionBar` Class](cmfccaptionbar-class.md)\
 Control bar that can display three elements: a button, a text label, and a bitmap. It can only display one element of each type at a time. You can align each element to the left or right edges of the control or to the center. You can also apply a flat or 3D style to the top and bottom borders of the caption bar.
 
-[`CMFCCaptionButton` Class](../../mfc/reference/cmfccaptionbutton-class.md)\
+[`CMFCCaptionButton` Class](cmfccaptionbutton-class.md)\
 Implements a button that is displayed on the caption bar for a docking pane or a mini-frame window. Typically, the framework creates caption buttons automatically.
 
-[`CMFCColorBar` Class](../../mfc/reference/cmfccolorbar-class.md)\
+[`CMFCColorBar` Class](cmfccolorbar-class.md)\
 Represents a docking control bar that can select colors in a document or application.
 
-[`CMFCColorButton` Class](../../mfc/reference/cmfccolorbutton-class.md)\
-The `CMFCColorButton` and [`CMFCColorBar` Class](../../mfc/reference/cmfccolorbar-class.md) classes are used together to implement a color picker control.
+[`CMFCColorButton` Class](cmfccolorbutton-class.md)\
+The `CMFCColorButton` and [`CMFCColorBar` Class](cmfccolorbar-class.md) classes are used together to implement a color picker control.
 
-[`CMFCColorDialog` Class](../../mfc/reference/cmfccolordialog-class.md)\
+[`CMFCColorDialog` Class](cmfccolordialog-class.md)\
 Represents a color selection dialog box.
 
-[`CMFCColorMenuButton` Class](../../mfc/reference/cmfccolormenubutton-class.md)\
+[`CMFCColorMenuButton` Class](cmfccolormenubutton-class.md)\
 Supports a menu command or a toolbar button that starts a color picker dialog box.
 
-[`CMFCColorPickerCtrl` Class](../../mfc/reference/cmfccolorpickerctrl-class.md)\
+[`CMFCColorPickerCtrl` Class](cmfccolorpickerctrl-class.md)\
 Provides functionality for a control that is used to select colors.
 
-[`CMFCDesktopAlertDialog` Class](../../mfc/reference/cmfcdesktopalertdialog-class.md)\
-Used together with the [`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md) to display a custom dialog in a popup window.
+[`CMFCDesktopAlertDialog` Class](cmfcdesktopalertdialog-class.md)\
+Used together with the [`CMFCDesktopAlertWnd` Class](cmfcdesktopalertwnd-class.md) to display a custom dialog in a popup window.
 
-[`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md)\
+[`CMFCDesktopAlertWnd` Class](cmfcdesktopalertwnd-class.md)\
 Implements the functionality of a modeless dialog box which appears on the screen to inform the user about an event.
 
-[`CMFCDesktopAlertWndInfo` Class](../../mfc/reference/cmfcdesktopalertwndinfo-class.md)\
-Used with the [`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md). It specifies the controls that are displayed if the desktop alert window pops up.
+[`CMFCDesktopAlertWndInfo` Class](cmfcdesktopalertwndinfo-class.md)\
+Used with the [`CMFCDesktopAlertWnd` Class](cmfcdesktopalertwnd-class.md). It specifies the controls that are displayed if the desktop alert window pops up.
 
-[`CMFCDragFrameImpl` Class](../../mfc/reference/cmfcdragframeimpl-class.md)\
+[`CMFCDragFrameImpl` Class](cmfcdragframeimpl-class.md)\
 Draws the drag rectangle that appears when the user drags a pane in the standard dock mode.
 
-[`CMFCDropDownToolBar` Class](../../mfc/reference/cmfcdropdowntoolbar-class.md)\
+[`CMFCDropDownToolBar` Class](cmfcdropdowntoolbar-class.md)\
 A toolbar that appears when the user presses and holds a top-level toolbar button.
 
-[`CMFCDropDownToolbarButton` Class](../../mfc/reference/cmfcdropdowntoolbarbutton-class.md)\
-A type of toolbar button that behaves like a regular button when it is clicked. However, it opens a drop-down toolbar ([`CMFCDropDownToolBar` Class](../../mfc/reference/cmfcdropdowntoolbar-class.md) if the user presses and holds the toolbar button down.
+[`CMFCDropDownToolbarButton` Class](cmfcdropdowntoolbarbutton-class.md)\
+A type of toolbar button that behaves like a regular button when it is clicked. However, it opens a drop-down toolbar ([`CMFCDropDownToolBar` Class](cmfcdropdowntoolbar-class.md) if the user presses and holds the toolbar button down.
 
-[`CMFCDynamicLayout` Class](../../mfc/reference/cmfcdynamiclayout-class.md)\
+[`CMFCDynamicLayout` Class](cmfcdynamiclayout-class.md)\
 Specifies how controls in a window are moved and resized as the user resizes the window.
 
-[`CMFCEditBrowseCtrl` Class](../../mfc/reference/cmfceditbrowsectrl-class.md)\
+[`CMFCEditBrowseCtrl` Class](cmfceditbrowsectrl-class.md)\
 Supports the edit browse control, which is an editable text box that optionally contains a browse button. When the user clicks the browse button, the control performs a custom action or displays a standard dialog box that contains a file browser or a folder browser.
 
-[`CMFCFilterChunkValueImpl` Class](../../mfc/reference/cmfcfilterchunkvalueimpl-class.md)\
+[`CMFCFilterChunkValueImpl` Class](cmfcfilterchunkvalueimpl-class.md)\
 Simplifies both chunk and property value pair logic.
 
-[`CMFCFontComboBox` Class](../../mfc/reference/cmfcfontcombobox-class.md)\
+[`CMFCFontComboBox` Class](cmfcfontcombobox-class.md)\
 Creates a combo box control that contains a list of fonts.
 
-[`CMFCFontInfo` Class](../../mfc/reference/cmfcfontinfo-class.md)\
+[`CMFCFontInfo` Class](cmfcfontinfo-class.md)\
 Describes the name and other attributes of a font.
 
-[`CMFCHeaderCtrl` Class](../../mfc/reference/cmfcheaderctrl-class.md)\
+[`CMFCHeaderCtrl` Class](cmfcheaderctrl-class.md)\
 Supports sorting multiple columns in a header control.
 
-[`CMFCImageEditorDialog` Class](../../mfc/reference/cmfcimageeditordialog-class.md)\
+[`CMFCImageEditorDialog` Class](cmfcimageeditordialog-class.md)\
 Supports an image editor dialog box.
 
-[`CMFCKeyMapDialog` Class](../../mfc/reference/cmfckeymapdialog-class.md)\
+[`CMFCKeyMapDialog` Class](cmfckeymapdialog-class.md)\
 Supports a control that maps commands to keys on the keyboard.
 
-[`CMFCLinkCtrl` Class](../../mfc/reference/cmfclinkctrl-class.md)\
+[`CMFCLinkCtrl` Class](cmfclinkctrl-class.md)\
 Displays a button as a hyperlink and invokes the link's target when the button is clicked.
 
-[`CMFCListCtrl` Class](../../mfc/reference/cmfclistctrl-class.md)\
-Extends the functionality of [`CListCtrl` Class](../../mfc/reference/clistctrl-class.md) class by supporting the advanced header control functionality of the [`CMFCHeaderCtrl` Class](../../mfc/reference/cmfcheaderctrl-class.md).
+[`CMFCListCtrl` Class](cmfclistctrl-class.md)\
+Extends the functionality of [`CListCtrl` Class](clistctrl-class.md) class by supporting the advanced header control functionality of the [`CMFCHeaderCtrl` Class](cmfcheaderctrl-class.md).
 
-[`CMFCMaskedEdit` Class](../../mfc/reference/cmfcmaskededit-class.md)\
+[`CMFCMaskedEdit` Class](cmfcmaskededit-class.md)\
 Supports a masked edit control, which validates user input against a mask and displays the validated results according to a template.
 
-[`CMFCMenuBar` Class](../../mfc/reference/cmfcmenubar-class.md)\
+[`CMFCMenuBar` Class](cmfcmenubar-class.md)\
 A menu bar that implements docking.
 
-[`CMFCMenuButton` Class](../../mfc/reference/cmfcmenubutton-class.md)\
+[`CMFCMenuButton` Class](cmfcmenubutton-class.md)\
 A button that displays a pop-up menu and reports on the user's menu selections.
 
-[`CMFCOutlookBar` Class](../../mfc/reference/cmfcoutlookbar-class.md)\
-A tabbed pane with the visual appearance of the **Navigation Pane** in Microsoft Outlook 2000 or Outlook 2003. The `CMFCOutlookBar` object contains a [`CMFCOutlookBarTabCtrl` Class](../../mfc/reference/cmfcoutlookbartabctrl-class.md) object and a series of tabs. The tabs can be either [`CMFCOutlookBarPane` Class](../../mfc/reference/cmfcoutlookbarpane-class.md) objects or `CWnd`-derived objects. To the user, the Outlook bar appears as a series of buttons and a display area. When the user clicks a button, the corresponding control or button pane is displayed.
+[`CMFCOutlookBar` Class](cmfcoutlookbar-class.md)\
+A tabbed pane with the visual appearance of the **Navigation Pane** in Microsoft Outlook 2000 or Outlook 2003. The `CMFCOutlookBar` object contains a [`CMFCOutlookBarTabCtrl` Class](cmfcoutlookbartabctrl-class.md) object and a series of tabs. The tabs can be either [`CMFCOutlookBarPane` Class](cmfcoutlookbarpane-class.md) objects or `CWnd`-derived objects. To the user, the Outlook bar appears as a series of buttons and a display area. When the user clicks a button, the corresponding control or button pane is displayed.
 
-[`CMFCOutlookBarPane` Class](../../mfc/reference/cmfcoutlookbarpane-class.md)\
-A control derived from [`CMFCToolBar` Class](../../mfc/reference/cmfctoolbar-class.md) that can be inserted into an Outlook bar ([`CMFCOutlookBar` Class](../../mfc/reference/cmfcoutlookbar-class.md)). The Outlook bar pane contains a column of large buttons. The user can scroll up and down the list of buttons if it is larger than the pane. When the user detaches an Outlook bar pane from the Outlook bar, it can float or dock in the main frame window.
+[`CMFCOutlookBarPane` Class](cmfcoutlookbarpane-class.md)\
+A control derived from [`CMFCToolBar` Class](cmfctoolbar-class.md) that can be inserted into an Outlook bar ([`CMFCOutlookBar` Class](cmfcoutlookbar-class.md)). The Outlook bar pane contains a column of large buttons. The user can scroll up and down the list of buttons if it is larger than the pane. When the user detaches an Outlook bar pane from the Outlook bar, it can float or dock in the main frame window.
 
-[`CMFCOutlookBarTabCtrl` Class](../../mfc/reference/cmfcoutlookbartabctrl-class.md)\
+[`CMFCOutlookBarTabCtrl` Class](cmfcoutlookbartabctrl-class.md)\
 A tab control that has the visual appearance of the **Navigation Pane** in Microsoft Outlook.
 
-[`CMFCPopupMenu` Class](../../mfc/reference/cmfcpopupmenu-class.md)\
+[`CMFCPopupMenu` Class](cmfcpopupmenu-class.md)\
 Implements Windows pop-up menu functionality and extends it by adding features such as tear-off menus and tooltips.
 
-[`CMFCPopupMenuBar` Class](../../mfc/reference/cmfcpopupmenubar-class.md)\
+[`CMFCPopupMenuBar` Class](cmfcpopupmenubar-class.md)\
 A menu bar embedded into a pop-up menu.
 
-[`CMFCPreviewCtrlImpl` Class](../../mfc/reference/cmfcpreviewctrlimpl-class.md)\
+[`CMFCPreviewCtrlImpl` Class](cmfcpreviewctrlimpl-class.md)\
 Implements a window that is placed on a host window provided by the Shell for Rich Preview.
 
-[`CMFCPropertyGridColorProperty` Class](../../mfc/reference/cmfcpropertygridcolorproperty-class.md)\
+[`CMFCPropertyGridColorProperty` Class](cmfcpropertygridcolorproperty-class.md)\
 Supports a property list control item that opens a color selection dialog box.
 
-[`CMFCPropertyGridCtrl` Class](../../mfc/reference/cmfcpropertygridctrl-class.md)\
+[`CMFCPropertyGridCtrl` Class](cmfcpropertygridctrl-class.md)\
 Supports an editable property grid control that can display properties in alphabetical or hierarchical order.
 
-[`CMFCPropertyGridFileProperty` Class](../../mfc/reference/cmfcpropertygridfileproperty-class.md)\
+[`CMFCPropertyGridFileProperty` Class](cmfcpropertygridfileproperty-class.md)\
 Supports a property list control item that opens a file selection dialog box.
 
-[`CMFCPropertyGridFontProperty` Class](../../mfc/reference/cmfcpropertygridfontproperty-class.md)\
+[`CMFCPropertyGridFontProperty` Class](cmfcpropertygridfontproperty-class.md)\
 Supports a property list control item that opens a font selection dialog box.
 
-[`CMFCPropertyGridProperty` Class](../../mfc/reference/cmfcpropertygridproperty-class.md)\
+[`CMFCPropertyGridProperty` Class](cmfcpropertygridproperty-class.md)\
 Represents a list item in a property list control.
 
-[`CMFCPropertyPage` Class](../../mfc/reference/cmfcpropertypage-class.md)\
+[`CMFCPropertyPage` Class](cmfcpropertypage-class.md)\
 Supports the display of pop-up menus on a property page.
 
-[`CMFCPropertySheet` Class](../../mfc/reference/cmfcpropertysheet-class.md)\
+[`CMFCPropertySheet` Class](cmfcpropertysheet-class.md)\
 Supports a property sheet where each property page is denoted by a page tab, a toolbar button, a tree control node, or a list item.
 
-[`CMFCReBar` Class](../../mfc/reference/cmfcrebar-class.md)\
+[`CMFCReBar` Class](cmfcrebar-class.md)\
 Control bar that provides layout, persistence, and state information for rebar controls.
 
-[`CMFCRibbonApplicationButton` Class](../../mfc/reference/cmfcribbonapplicationbutton-class.md)\
+[`CMFCRibbonApplicationButton` Class](cmfcribbonapplicationbutton-class.md)\
 Implements a special button located in the top-left corner of the application window. When clicked, the button opens a menu that usually contains common **File** commands like **Open**, **Save**, and **Exit**.
 
-[`CMFCRibbonBaseElement` Class](../../mfc/reference/cmfcribbonbaseelement-class.md)\
-Base class for all elements that you can add to a [`CMFCRibbonBar` Class](../../mfc/reference/cmfcribbonbar-class.md). Examples of ribbon elements are ribbon buttons, ribbon check boxes, and ribbon combo boxes.
+[`CMFCRibbonBaseElement` Class](cmfcribbonbaseelement-class.md)\
+Base class for all elements that you can add to a [`CMFCRibbonBar` Class](cmfcribbonbar-class.md). Examples of ribbon elements are ribbon buttons, ribbon check boxes, and ribbon combo boxes.
 
-[`CMFCRibbonButton` Class](../../mfc/reference/cmfcribbonbutton-class.md)\
+[`CMFCRibbonButton` Class](cmfcribbonbutton-class.md)\
 Implements buttons that you can position on ribbon bar elements such as panels, Quick Access Toolbars, and pop-up menus.
 
-[`CMFCRibbonButtonsGroup` Class](../../mfc/reference/cmfcribbonbuttonsgroup-class.md)\
+[`CMFCRibbonButtonsGroup` Class](cmfcribbonbuttonsgroup-class.md)\
 Lets you organize a set of ribbon buttons into a group. All buttons in the group are directly adjacent to each other horizontally and enclosed in a border.
 
-[`CMFCRibbonCategory` Class](../../mfc/reference/cmfcribboncategory-class.md)\
-Implements a ribbon tab that contains a group of [`CMFCRibbonPanel` Class](../../mfc/reference/cmfcribbonpanel-class.md).
+[`CMFCRibbonCategory` Class](cmfcribboncategory-class.md)\
+Implements a ribbon tab that contains a group of [`CMFCRibbonPanel` Class](cmfcribbonpanel-class.md).
 
-[`CMFCRibbonCheckBox` Class](../../mfc/reference/cmfcribboncheckbox-class.md)\
+[`CMFCRibbonCheckBox` Class](cmfcribboncheckbox-class.md)\
 Implements a check box that you can add to a ribbon panel, Quick Access Toolbar, or popup menu.
 
-[`CMFCRibbonColorButton` Class](../../mfc/reference/cmfcribboncolorbutton-class.md)\
+[`CMFCRibbonColorButton` Class](cmfcribboncolorbutton-class.md)\
 Implements a color button that you can add to a ribbon bar. The ribbon color button displays a drop-down menu that contains one or more color palettes.
 
-[`CMFCRibbonComboBox` Class](../../mfc/reference/cmfcribboncombobox-class.md)\
+[`CMFCRibbonComboBox` Class](cmfcribboncombobox-class.md)\
 Implements a combo box control that you can add to a ribbon bar, a ribbon panel, or a ribbon popup menu.
 
-[`CMFCRibbonContextCaption` Class](../../mfc/reference/cmfcribboncontextcaption-class.md)\
+[`CMFCRibbonContextCaption` Class](cmfcribboncontextcaption-class.md)\
 Implements a colored caption that appears at the top of a ribbon category or a context category.
 
-[`CMFCRibbonEdit` Class](../../mfc/reference/cmfcribbonedit-class.md)\
+[`CMFCRibbonEdit` Class](cmfcribbonedit-class.md)\
 Implements an edit control that is positioned on a ribbon.
 
-[`CMFCRibbonFontComboBox` Class](../../mfc/reference/cmfcribbonfontcombobox-class.md)\
+[`CMFCRibbonFontComboBox` Class](cmfcribbonfontcombobox-class.md)\
 Implements a combo box that contains a list of fonts. You place the combo box on a ribbon panel.
 
-[`CMFCRibbonGallery` Class](../../mfc/reference/cmfcribbongallery-class.md)\
+[`CMFCRibbonGallery` Class](cmfcribbongallery-class.md)\
 Implements Office 2007-style ribbon galleries.
 
-[`CMFCRibbonGalleryMenuButton` Class](../../mfc/reference/cmfcribbongallerymenubutton-class.md)\
+[`CMFCRibbonGalleryMenuButton` Class](cmfcribbongallerymenubutton-class.md)\
 Implements a ribbon menu button that contains ribbon galleries.
 
-[`CMFCRibbonLabel` Class](../../mfc/reference/cmfcribbonlabel-class.md)\
+[`CMFCRibbonLabel` Class](cmfcribbonlabel-class.md)\
 Implements a non-clickable text label for a ribbon.
 
-[`CMFCRibbonLinkCtrl` Class](../../mfc/reference/cmfcribbonlinkctrl-class.md)\
+[`CMFCRibbonLinkCtrl` Class](cmfcribbonlinkctrl-class.md)\
 Implements a hyperlink that is positioned on a ribbon. The hyperlink opens a Web page when you click it.
 
-[`CMFCRibbonMainPanel` Class](../../mfc/reference/cmfcribbonmainpanel-class.md)\
-Implements a ribbon panel that displays when you click the [`CMFCRibbonApplicationButton` Class](../../mfc/reference/cmfcribbonapplicationbutton-class.md).
+[`CMFCRibbonMainPanel` Class](cmfcribbonmainpanel-class.md)\
+Implements a ribbon panel that displays when you click the [`CMFCRibbonApplicationButton` Class](cmfcribbonapplicationbutton-class.md).
 
-[`CMFCRibbonMiniToolBar` Class](../../mfc/reference/cmfcribbonminitoolbar-class.md)\
+[`CMFCRibbonMiniToolBar` Class](cmfcribbonminitoolbar-class.md)\
 Implements a contextual popup toolbar.
 
-[`CMFCRibbonPanel` Class](../../mfc/reference/cmfcribbonpanel-class.md)\
+[`CMFCRibbonPanel` Class](cmfcribbonpanel-class.md)\
 Implements a panel that contains a set of ribbon elements. When the panel is drawn, it displays as many elements as possible, given the size of the panel.
 
-[`CMFCRibbonProgressBar` Class](../../mfc/reference/cmfcribbonprogressbar-class.md)\
+[`CMFCRibbonProgressBar` Class](cmfcribbonprogressbar-class.md)\
 Implements a control that visually indicates the progress of a lengthy operation.
 
-[`CMFCRibbonSlider` Class](../../mfc/reference/cmfcribbonslider-class.md)\
+[`CMFCRibbonSlider` Class](cmfcribbonslider-class.md)\
 Implements a slider control that you can add to a ribbon bar or ribbon status bar. The ribbon slider control resembles the zoom sliders that appear in Office 2007 applications.
 
-[`CMFCRibbonStatusBar` Class](../../mfc/reference/cmfcribbonstatusbar-class.md)\
+[`CMFCRibbonStatusBar` Class](cmfcribbonstatusbar-class.md)\
 Implements a status bar control that can display ribbon elements.
 
-[`CMFCRibbonStatusBarPane` Class](../../mfc/reference/cmfcribbonstatusbarpane-class.md)\
+[`CMFCRibbonStatusBarPane` Class](cmfcribbonstatusbarpane-class.md)\
 Implements a ribbon element that you can add to a ribbon status bar.
 
-[`CMFCRibbonUndoButton` Class](../../mfc/reference/cmfcribbonundobutton-class.md)\
+[`CMFCRibbonUndoButton` Class](cmfcribbonundobutton-class.md)\
 Implements a split button, a small button with a downward pointing triangle on the rightmost part of the main button. Users can click the triangle to display a drop-down list of their most recently performed actions. Users can then select one or more actions from the drop-down list. However, if the user clicks the button, only the last (the most recently added) action on the drop-down list is undone. You should populate the list with actions as the user performs them.
 
-[`CMFCShellListCtrl` Class](../../mfc/reference/cmfcshelllistctrl-class.md)\
+[`CMFCShellListCtrl` Class](cmfcshelllistctrl-class.md)\
 Provides Windows list control functionality and expands it by including the ability to display a list of shell items.
 
-[`CMFCShellTreeCtrl` Class](../../mfc/reference/cmfcshelltreectrl-class.md)\
-Extends [`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md) functionality by displaying a hierarchy of Shell items.
+[`CMFCShellTreeCtrl` Class](cmfcshelltreectrl-class.md)\
+Extends [`CTreeCtrl` Class](ctreectrl-class.md) functionality by displaying a hierarchy of Shell items.
 
-[`CMFCSpinButtonCtrl` Class](../../mfc/reference/cmfcspinbuttonctrl-class.md)\
+[`CMFCSpinButtonCtrl` Class](cmfcspinbuttonctrl-class.md)\
 Supports a visual manager that draws a spin button control.
 
-[`CMFCStatusBar` Class](../../mfc/reference/cmfcstatusbar-class.md)\
+[`CMFCStatusBar` Class](cmfcstatusbar-class.md)\
 Implements a status bar similar to the `CStatusBar` class. However, the `CMFCStatusBar` class has features not offered by the `CStatusBar` class, such as the ability to display images, animations, and progress bars; and the ability to respond to mouse double-clicks.
 
-[`CMFCTabCtrl` Class](../../mfc/reference/cmfctabctrl-class.md)\
+[`CMFCTabCtrl` Class](cmfctabctrl-class.md)\
 Provides functionality for a tab control. The tab control displays a dockable window with flat or three-dimensional tabs at its top or bottom. The tabs can display text and an image and can change color when active.
 
-[`CMFCTabToolTipInfo Structure](../../mfc/reference/cmfctabtooltipinfo-structure.md)\
+[`CMFCTabToolTipInfo Structure](cmfctabtooltipinfo-structure.md)\
 Provides information about the MDI tab that the user is hovering over.
 
-[`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md)\
+[`CMFCTasksPane` Class](cmfctaskspane-class.md)\
 Implements a list of clickable items (tasks).
 
-[`CMFCTasksPaneTask` Class](../../mfc/reference/cmfctaskspanetask-class.md)\
-Helper class that represents tasks for the task pane control ([`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md)). The task object represents an item in the task group ([`CMFCTasksPaneTaskGroup` Class](../../mfc/reference/cmfctaskspanetaskgroup-class.md)). Each task can have a command that the framework executes when a user clicks on the task and an icon that appears to the left of the task name.
+[`CMFCTasksPaneTask` Class](cmfctaskspanetask-class.md)\
+Helper class that represents tasks for the task pane control ([`CMFCTasksPane` Class](cmfctaskspane-class.md)). The task object represents an item in the task group ([`CMFCTasksPaneTaskGroup` Class](cmfctaskspanetaskgroup-class.md)). Each task can have a command that the framework executes when a user clicks on the task and an icon that appears to the left of the task name.
 
-[`CMFCTasksPaneTaskGroup` Class](../../mfc/reference/cmfctaskspanetaskgroup-class.md)\
-Helper class used by the [`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md) control. Objects of type `CMFCTasksPaneTaskGroup` represent a *task group*. The task group is a list of items that the framework displays in a separate box that has a collapse button. The box can have an optional caption (group name). If a group is collapsed, the list of tasks is not visible.
+[`CMFCTasksPaneTaskGroup` Class](cmfctaskspanetaskgroup-class.md)\
+Helper class used by the [`CMFCTasksPane` Class](cmfctaskspane-class.md) control. Objects of type `CMFCTasksPaneTaskGroup` represent a *task group*. The task group is a list of items that the framework displays in a separate box that has a collapse button. The box can have an optional caption (group name). If a group is collapsed, the list of tasks is not visible.
 
-[`CMFCToolBar` Class](../../mfc/reference/cmfctoolbar-class.md)\
-Resembles [`CToolBar` Class](../../mfc/reference/ctoolbar-class.md), but provides additional support for user interface features. These include flat toolbars, toolbars with hot images, large icons, pager buttons, locked toolbars, rebar controls, text under images, background images, and tabbed toolbars. The `CMFCToolBar` class also contains built-in support for user customization of toolbars and menus, drag-and-drop between toolbars and menus, combo box buttons, edit box buttons, color pickers, and roll-up buttons.
+[`CMFCToolBar` Class](cmfctoolbar-class.md)\
+Resembles [`CToolBar` Class](ctoolbar-class.md), but provides additional support for user interface features. These include flat toolbars, toolbars with hot images, large icons, pager buttons, locked toolbars, rebar controls, text under images, background images, and tabbed toolbars. The `CMFCToolBar` class also contains built-in support for user customization of toolbars and menus, drag-and-drop between toolbars and menus, combo box buttons, edit box buttons, color pickers, and roll-up buttons.
 
-[`CMFCToolBarImages` Class](../../mfc/reference/cmfctoolbarimages-class.md)\
+[`CMFCToolBarImages` Class](cmfctoolbarimages-class.md)\
 Manages toolbar images loaded from application resources or from files.
 
-[`CMFCToolBarInfo` Class](../../mfc/reference/cmfctoolbarinfo-class.md)\
-Contains the resource IDs of toolbar images in various states. `CMFCToolBarInfo` is a helper class that is used as a parameter of the [`CMFCToolBar::LoadToolBarEx`](../../mfc/reference/cmfctoolbar-class.md#loadtoolbarex) method.
+[`CMFCToolBarInfo` Class](cmfctoolbarinfo-class.md)\
+Contains the resource IDs of toolbar images in various states. `CMFCToolBarInfo` is a helper class that is used as a parameter of the [`CMFCToolBar::LoadToolBarEx`](cmfctoolbar-class.md#loadtoolbarex) method.
 
-[`CMFCToolBarMenuButton` Class](../../mfc/reference/cmfctoolbarmenubutton-class.md)\
+[`CMFCToolBarMenuButton` Class](cmfctoolbarmenubutton-class.md)\
 A toolbar button that contains a pop-up menu.
 
-[`CMFCToolBarsCustomizeDialog` Class](../../mfc/reference/cmfctoolbarscustomizedialog-class.md)\
-A modeless tab dialog box ([`CPropertySheet` Class](../../mfc/reference/cpropertysheet-class.md)) that enables the user to customize the toolbars, menus, keyboard shortcuts, user-defined tools, and visual style in an application. Typically, the user accesses this dialog box by selecting **Customize** from the **Tools** menu.
+[`CMFCToolBarsCustomizeDialog` Class](cmfctoolbarscustomizedialog-class.md)\
+A modeless tab dialog box ([`CPropertySheet` Class](cpropertysheet-class.md)) that enables the user to customize the toolbars, menus, keyboard shortcuts, user-defined tools, and visual style in an application. Typically, the user accesses this dialog box by selecting **Customize** from the **Tools** menu.
 
-[`CMFCToolTipCtrl` Class](../../mfc/reference/cmfctooltipctrl-class.md)\
-An extended tooltip implementation based on the [`CToolTipCtrl` Class](../../mfc/reference/ctooltipctrl-class.md). A tooltip based on the `CMFCToolTipCtrl` class can display an icon, a label, and a description. You can customize its visual appearance by using a gradient fill, custom text and border colors, bold text, rounded corners, or a balloon style.
+[`CMFCToolTipCtrl` Class](cmfctooltipctrl-class.md)\
+An extended tooltip implementation based on the [`CToolTipCtrl` Class](ctooltipctrl-class.md). A tooltip based on the `CMFCToolTipCtrl` class can display an icon, a label, and a description. You can customize its visual appearance by using a gradient fill, custom text and border colors, bold text, rounded corners, or a balloon style.
 
-[`CMFCToolTipInfo` Class](../../mfc/reference/cmfctooltipinfo-class.md)\
+[`CMFCToolTipInfo` Class](cmfctooltipinfo-class.md)\
 Stores information about the visual appearance of tooltips.
 
-[`CMFCVisualManager` Class](../../mfc/reference/cmfcvisualmanager-class.md)\
+[`CMFCVisualManager` Class](cmfcvisualmanager-class.md)\
 Provides support for changing the appearance of your application at a global level. The `CMFCVisualManager` class works together with a class that provides instructions to draw the GUI controls of your application using a consistent style. These other classes are referred to as visual managers and they inherit from `CMFCBaseVisualManager`.
 
-[`CMFCVisualManagerOffice2003` Class](../../mfc/reference/cmfcvisualmanageroffice2003-class.md)\
+[`CMFCVisualManagerOffice2003` Class](cmfcvisualmanageroffice2003-class.md)\
 Gives an application a Microsoft Office 2003 appearance.
 
-[`CMFCVisualManagerOffice2007` Class](../../mfc/reference/cmfcvisualmanageroffice2007-class.md)\
+[`CMFCVisualManagerOffice2007` Class](cmfcvisualmanageroffice2007-class.md)\
 Gives an application a Microsoft Office 2007 appearance.
 
-[`CMFCVisualManagerVS2005` Class](../../mfc/reference/cmfcvisualmanagervs2005-class.md)\
+[`CMFCVisualManagerVS2005` Class](cmfcvisualmanagervs2005-class.md)\
 Gives an application a Microsoft Visual Studio 2005 appearance.
 
-[`CMFCVisualManagerWindows` Class](../../mfc/reference/cmfcvisualmanagerwindows-class.md)\
+[`CMFCVisualManagerWindows` Class](cmfcvisualmanagerwindows-class.md)\
 Mimics the appearance of Microsoft Windows XP or Microsoft Vista when the user selects a Windows XP or Vista theme.
 
-[`CMFCVisualManagerWindows7` Class](../../mfc/reference/cmfcvisualmanagerwindows7-class.md)\
+[`CMFCVisualManagerWindows7` Class](cmfcvisualmanagerwindows7-class.md)\
 Gives an application the appearance of a Windows 7 application.
 
-[`CMFCWindowsManagerDialog` Class](../../mfc/reference/cmfcwindowsmanagerdialog-class.md)\
+[`CMFCWindowsManagerDialog` Class](cmfcwindowsmanagerdialog-class.md)\
 Enables a user to manage MDI child windows in an MDI application.
 
-[`CMiniFrameWnd` Class](../../mfc/reference/cminiframewnd-class.md)\
+[`CMiniFrameWnd` Class](cminiframewnd-class.md)\
 Represents a half-height frame window typically seen around floating toolbars.
 
-[`CMonikerFile` Class](../../mfc/reference/cmonikerfile-class.md)\
+[`CMonikerFile` Class](cmonikerfile-class.md)\
 Represents a stream of data ([`IStream`](/windows/win32/api/objidl/nn-objidl-istream)) named by an [`IMoniker`](/windows/win32/api/objidl/nn-objidl-imoniker).
 
-[`CMonthCalCtrl` Class](../../mfc/reference/cmonthcalctrl-class.md)\
+[`CMonthCalCtrl` Class](cmonthcalctrl-class.md)\
 Encapsulates the functionality of a month calendar control.
 
-[`CMouseManager` Class](../../mfc/reference/cmousemanager-class.md)\
-Lets a user associate different commands with a particular [`CView` Class](../../mfc/reference/cview-class.md) object when the user double-clicks inside that view.
+[`CMouseManager` Class](cmousemanager-class.md)\
+Lets a user associate different commands with a particular [`CView` Class](cview-class.md) object when the user double-clicks inside that view.
 
-[`CMultiDocTemplate` Class](../../mfc/reference/cmultidoctemplate-class.md)\
+[`CMultiDocTemplate` Class](cmultidoctemplate-class.md)\
 Defines a document template that implements the multiple document interface (MDI).
 
-[`CMultiLock` Class](../../mfc/reference/cmultilock-class.md)\
+[`CMultiLock` Class](cmultilock-class.md)\
 Represents the access-control mechanism used in controlling access to resources in a multithreaded program.
 
-[`CMultiPageDHtmlDialog` Class](../../mfc/reference/cmultipagedhtmldialog-class.md)\
+[`CMultiPageDHtmlDialog` Class](cmultipagedhtmldialog-class.md)\
 A multipage dialog displays multiple HTML pages sequentially and handles the events from each page.
 
-[`CMultiPaneFrameWnd` Class](../../mfc/reference/cmultipaneframewnd-class.md)\
-Extends [`CPaneFrameWnd` Class](../../mfc/reference/cpaneframewnd-class.md). It can support multiple panes. Instead of a single embedded handle to a control bar, `CMultiPaneFrameWnd` contains a [`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md) object that enables the user to dock one `CMultiPaneFrameWnd` to another and dynamically create multiple floating, tabbed windows.
+[`CMultiPaneFrameWnd` Class](cmultipaneframewnd-class.md)\
+Extends [`CPaneFrameWnd` Class](cpaneframewnd-class.md). It can support multiple panes. Instead of a single embedded handle to a control bar, `CMultiPaneFrameWnd` contains a [`CPaneContainerManager` Class](cpanecontainermanager-class.md) object that enables the user to dock one `CMultiPaneFrameWnd` to another and dynamically create multiple floating, tabbed windows.
 
-[`CMutex` Class](../../mfc/reference/cmutex-class.md)\
+[`CMutex` Class](cmutex-class.md)\
 Represents a mutex, which is a synchronization object that allows one thread mutually exclusive access to a resource.
 
-[`CNetAddressCtrl` Class](../../mfc/reference/cnetaddressctrl-class.md)\
+[`CNetAddressCtrl` Class](cnetaddressctrl-class.md)\
 The `CNetAddressCtrl` class represents the network address control, which you can use to input and validate the format of IPv4, IPv6, and named DNS addresses.
 
-[`CNotSupportedException` Class](../../mfc/reference/cnotsupportedexception-class.md)\
+[`CNotSupportedException` Class](cnotsupportedexception-class.md)\
 Represents an exception that is the result of a request for an unsupported feature.
 
-[`CObArray` Class](../../mfc/reference/cobarray-class.md)\
+[`CObArray` Class](cobarray-class.md)\
 Supports arrays of `CObject` pointers.
 
-[`CObject` Class](../../mfc/reference/cobject-class.md)\
+[`CObject` Class](cobject-class.md)\
 The principal base class for the Microsoft Foundation Class Library.
 
-[`CObList` Class](../../mfc/reference/coblist-class.md)\
+[`CObList` Class](coblist-class.md)\
 Supports ordered lists of non-unique `CObject` pointers accessible sequentially or by pointer value.
 
-[`COccManager` Class](../../mfc/reference/coccmanager-class.md)\
+[`COccManager` Class](coccmanager-class.md)\
 Manages various custom control sites; implemented by `COleControlContainer` and `COleControlSite` objects.
 
-[`COleBusyDialog` Class](../../mfc/reference/colebusydialog-class.md)\
+[`COleBusyDialog` Class](colebusydialog-class.md)\
 Used for the OLE Server Not Responding or Server Busy dialog boxes.
 
-[`COleChangeIconDialog` Class](../../mfc/reference/colechangeicondialog-class.md)\
+[`COleChangeIconDialog` Class](colechangeicondialog-class.md)\
 Used for the OLE Change Icon dialog box.
 
-[`COleChangeSourceDialog` Class](../../mfc/reference/colechangesourcedialog-class.md)\
+[`COleChangeSourceDialog` Class](colechangesourcedialog-class.md)\
 Used for the OLE Change Source dialog box.
 
-[`COleClientItem` Class](../../mfc/reference/coleclientitem-class.md)\
+[`COleClientItem` Class](coleclientitem-class.md)\
 Defines the container interface to OLE items.
 
-[`COleCmdUI` Class](../../mfc/reference/colecmdui-class.md)\
+[`COleCmdUI` Class](colecmdui-class.md)\
 Implements a method for MFC to update the state of user-interface objects related to the `IOleCommandTarget`-driven features of your application.
 
-[`COleControl` Class](../../mfc/reference/colecontrol-class.md)\
+[`COleControl` Class](colecontrol-class.md)\
 A powerful base class for developing OLE controls.
 
-[`COleControlContainer` Class](../../mfc/reference/colecontrolcontainer-class.md)\
+[`COleControlContainer` Class](colecontrolcontainer-class.md)\
 Acts as a control container for ActiveX controls.
 
-[`COleControlModule` Class](../../mfc/reference/colecontrolmodule-class.md)\
+[`COleControlModule` Class](colecontrolmodule-class.md)\
 The base class from which you derive an OLE control module object.
 
-[`COleControlSite` Class](../../mfc/reference/colecontrolsite-class.md)\
+[`COleControlSite` Class](colecontrolsite-class.md)\
 Provides support for custom client-side control interfaces.
 
-[`COleConvertDialog` Class](../../mfc/reference/coleconvertdialog-class.md)\
+[`COleConvertDialog` Class](coleconvertdialog-class.md)\
 For more information, see the [`OLEUICONVERT`](/windows/win32/api/oledlg/ns-oledlg-oleuiconvertw) structure in the Windows SDK.
 
-[`COleCurrency` Class](../../mfc/reference/colecurrency-class.md)\
+[`COleCurrency` Class](colecurrency-class.md)\
 Encapsulates the `CURRENCY` data type of OLE automation.
 
-[`COleDataObject` Class](../../mfc/reference/coledataobject-class.md)\
+[`COleDataObject` Class](coledataobject-class.md)\
 Used in data transfers for retrieving data in various formats from the Clipboard, through drag and drop, or from an embedded OLE item.
 
-[`COleDataSource` Class](../../mfc/reference/coledatasource-class.md)\
+[`COleDataSource` Class](coledatasource-class.md)\
 Acts as a cache into which an application places the data that it will offer during data transfer operations, such as Clipboard or drag-and-drop operations.
 
-[`COleDBRecordView` Class](../../mfc/reference/coledbrecordview-class.md)\
+[`COleDBRecordView` Class](coledbrecordview-class.md)\
 A view that displays database records in controls.
 
-[`COleDialog` Class](../../mfc/reference/coledialog-class.md)\
+[`COleDialog` Class](coledialog-class.md)\
 Provides functionality common to dialog boxes for OLE.
 
-[`COleDispatchDriver` Class](../../mfc/reference/coledispatchdriver-class.md)\
+[`COleDispatchDriver` Class](coledispatchdriver-class.md)\
 Implements the client side of OLE automation.
 
-[`COleDispatchException` Class](../../mfc/reference/coledispatchexception-class.md)\
+[`COleDispatchException` Class](coledispatchexception-class.md)\
 Handles exceptions specific to the OLE `IDispatch` interface, which is a key part of OLE automation.
 
-[`COleDocObjectItem` Class](../../mfc/reference/coledocobjectitem-class.md)\
+[`COleDocObjectItem` Class](coledocobjectitem-class.md)\
 Implements Active document containment.
 
-[`COleDocument` Class](../../mfc/reference/coledocument-class.md)\
+[`COleDocument` Class](coledocument-class.md)\
 The base class for OLE documents that support visual editing.
 
-[`COleDropSource` Class](../../mfc/reference/coledropsource-class.md)\
+[`COleDropSource` Class](coledropsource-class.md)\
 Enables data to be dragged to a drop target.
 
-[`COleDropTarget` Class](../../mfc/reference/coledroptarget-class.md)\
+[`COleDropTarget` Class](coledroptarget-class.md)\
 Provides the communication mechanism between a window and the OLE libraries.
 
-[`COleException` Class](../../mfc/reference/coleexception-class.md)\
+[`COleException` Class](coleexception-class.md)\
 Represents an exception condition related to an OLE operation.
 
-[`COleInsertDialog` Class](../../mfc/reference/coleinsertdialog-class.md)\
+[`COleInsertDialog` Class](coleinsertdialog-class.md)\
 Used for the OLE Insert Object dialog box.
 
-[`COleIPFrameWnd` Class](../../mfc/reference/coleipframewnd-class.md)\
+[`COleIPFrameWnd` Class](coleipframewnd-class.md)\
 The base for your application's in-place editing window.
 
-[`COleIPFrameWndEx` Class](../../mfc/reference/coleipframewndex-class.md)\
-Implements an OLE container that supports MFC. You must derive the in-place frame window class for your application from the `COleIPFrameWndEx` class, instead of deriving it from the [`COleIPFrameWnd`](../../mfc/reference/coleipframewnd-class.md) class.
+[`COleIPFrameWndEx` Class](coleipframewndex-class.md)\
+Implements an OLE container that supports MFC. You must derive the in-place frame window class for your application from the `COleIPFrameWndEx` class, instead of deriving it from the [`COleIPFrameWnd`](coleipframewnd-class.md) class.
 
-[`COleLinkingDoc` Class](../../mfc/reference/colelinkingdoc-class.md)\
+[`COleLinkingDoc` Class](colelinkingdoc-class.md)\
 The base class for OLE container documents that support linking to the embedded items they contain.
 
-[`COleLinksDialog` Class](../../mfc/reference/colelinksdialog-class.md)\
+[`COleLinksDialog` Class](colelinksdialog-class.md)\
 Used for the OLE Edit Links dialog box.
 
-[`COleMessageFilter` Class](../../mfc/reference/colemessagefilter-class.md)\
+[`COleMessageFilter` Class](colemessagefilter-class.md)\
 Manages the concurrency required by the interaction of OLE applications.
 
-[`COleObjectFactory` Class](../../mfc/reference/coleobjectfactory-class.md)\
+[`COleObjectFactory` Class](coleobjectfactory-class.md)\
 Implements the OLE class factory, which creates OLE objects such as servers, automation objects, and documents.
 
-[`COlePasteSpecialDialog` Class](../../mfc/reference/colepastespecialdialog-class.md)\
+[`COlePasteSpecialDialog` Class](colepastespecialdialog-class.md)\
 Used for the OLE Paste Special dialog box.
 
-[`COlePropertiesDialog` Class](../../mfc/reference/colepropertiesdialog-class.md)\
+[`COlePropertiesDialog` Class](colepropertiesdialog-class.md)\
 Encapsulates the Windows common OLE Object Properties dialog box.
 
-[`COlePropertyPage` Class](../../mfc/reference/colepropertypage-class.md)\
+[`COlePropertyPage` Class](colepropertypage-class.md)\
 Used to display the properties of a custom control in a graphical interface, similar to a dialog box.
 
-[`COleResizeBar` Class](../../mfc/reference/coleresizebar-class.md)\
+[`COleResizeBar` Class](coleresizebar-class.md)\
 A type of control bar that supports resizing of in-place OLE items.
 
-[`COleSafeArray` Class](../../mfc/reference/colesafearray-class.md)\
+[`COleSafeArray` Class](colesafearray-class.md)\
 A class for working with arrays of arbitrary type and dimension.
 
-[`COleServerDoc` Class](../../mfc/reference/coleserverdoc-class.md)\
+[`COleServerDoc` Class](coleserverdoc-class.md)\
 The base class for OLE server documents.
 
-[`COleServerItem` Class](../../mfc/reference/coleserveritem-class.md)\
+[`COleServerItem` Class](coleserveritem-class.md)\
 Provides the server interface to OLE items.
 
-[`COleStreamFile` Class](../../mfc/reference/colestreamfile-class.md)\
+[`COleStreamFile` Class](colestreamfile-class.md)\
 Represents a stream of data (`IStream`) in a compound file as part of OLE Structured Storage.
 
-[`COleTemplateServer` Class](../../mfc/reference/coletemplateserver-class.md)\
+[`COleTemplateServer` Class](coletemplateserver-class.md)\
 Used for OLE visual editing servers, automation servers, and link containers (applications that support links to embeddings).
 
-[`COleUpdateDialog` Class](../../mfc/reference/coleupdatedialog-class.md)\
+[`COleUpdateDialog` Class](coleupdatedialog-class.md)\
 Used for a special case of the OLE Edit Links dialog box, which should be used when you need to update only existing linked or embedded objects in a document.
 
-[`COleVariant` Class](../../mfc/reference/colevariant-class.md)\
+[`COleVariant` Class](colevariant-class.md)\
 Encapsulates the [`VARIANT`](/windows/win32/api/oaidl/ns-oaidl-variant) data type.
 
-[`CPagerCtrl` Class](../../mfc/reference/cpagerctrl-class.md)\
+[`CPagerCtrl` Class](cpagerctrl-class.md)\
 The `CPagerCtrl` class wraps the Windows pager control, which can scroll into view a contained window that does not fit the containing window.
 
-[`CPageSetupDialog` Class](../../mfc/reference/cpagesetupdialog-class.md)\
+[`CPageSetupDialog` Class](cpagesetupdialog-class.md)\
 Encapsulates the services provided by the Windows common OLE Page Setup dialog box with additional support for setting and modifying print margins.
 
-[`CPaintDC` Class](../../mfc/reference/cpaintdc-class.md)\
-A device-context class derived from [`CDC` Class](../../mfc/reference/cdc-class.md).
+[`CPaintDC` Class](cpaintdc-class.md)\
+A device-context class derived from [`CDC` Class](cdc-class.md).
 
-[`CPalette` Class](../../mfc/reference/cpalette-class.md)\
+[`CPalette` Class](cpalette-class.md)\
 Encapsulates a Windows color palette.
 
-[`CPane` Class](../../mfc/reference/cpane-class.md)\
-Enhancement of the [`CControlBar` Class](../../mfc/reference/ccontrolbar-class.md). If you are upgrading an existing MFC project, you need to replace all occurrences of `CControlBar` with `CPane`.
+[`CPane` Class](cpane-class.md)\
+Enhancement of the [`CControlBar` Class](ccontrolbar-class.md). If you are upgrading an existing MFC project, you need to replace all occurrences of `CControlBar` with `CPane`.
 
-[`CPaneContainer` Class](../../mfc/reference/cpanecontainer-class.md)\
-Basic component of the docking model implemented by MFC. An object of this class stores pointers to two docking panes or to two instances of `CPaneContainer`. It also stores a pointer to the divider that separates the panes (or the containers). By nesting containers inside containers, the framework can build a binary tree that represents complex docking layouts. The root of the binary tree is stored in a [`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md) object.
+[`CPaneContainer` Class](cpanecontainer-class.md)\
+Basic component of the docking model implemented by MFC. An object of this class stores pointers to two docking panes or to two instances of `CPaneContainer`. It also stores a pointer to the divider that separates the panes (or the containers). By nesting containers inside containers, the framework can build a binary tree that represents complex docking layouts. The root of the binary tree is stored in a [`CPaneContainerManager` Class](cpanecontainermanager-class.md) object.
 
-[`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md)\
+[`CPaneContainerManager` Class](cpanecontainermanager-class.md)\
 Manages the storage and display of the current docking layout.
 
-[`CPaneDialog` Class](../../mfc/reference/cpanedialog-class.md)\
+[`CPaneDialog` Class](cpanedialog-class.md)\
 Supports a modeless, dockable dialog box.
 
-[`CPaneDivider` Class](../../mfc/reference/cpanedivider-class.md)\
+[`CPaneDivider` Class](cpanedivider-class.md)\
 Divides two panes, divides two groups of panes, or separates a group of panes from the client area of the main frame window.
 
-[`CPaneFrameWnd` Class](../../mfc/reference/cpaneframewnd-class.md)\
+[`CPaneFrameWnd` Class](cpaneframewnd-class.md)\
 Implements a mini-frame window that contains one pane. The pane fills the client area of the window.
 
-[`CParabolicTransitionFromAcceleration` Class](../../mfc/reference/cparabolictransitionfromacceleration-class.md)\
+[`CParabolicTransitionFromAcceleration` Class](cparabolictransitionfromacceleration-class.md)\
 Encapsulates a parabolic-acceleration transition.
 
-[`CPen` Class](../../mfc/reference/cpen-class.md)\
+[`CPen` Class](cpen-class.md)\
 Encapsulates a Windows graphics device interface (GDI) pen.
 
-[`CPictureHolder` Class](../../mfc/reference/cpictureholder-class.md)\
+[`CPictureHolder` Class](cpictureholder-class.md)\
 Implements a Picture property, which lets the user display a picture in your control.
 
 [`CPoint` Class](../../atl-mfc-shared/reference/cpoint-class.md)\
 Similar to the Windows `POINT` structure.
 
-[`CPrintDialog` Class](../../mfc/reference/cprintdialog-class.md)\
+[`CPrintDialog` Class](cprintdialog-class.md)\
 Encapsulates the services provided by the Windows common dialog box for printing.
 
-[`CPrintDialogEx` Class](../../mfc/reference/cprintdialogex-class.md)\
+[`CPrintDialogEx` Class](cprintdialogex-class.md)\
 Encapsulates the services provided by the Windows Print property sheet.
 
-[`CProgressCtrl` Class](../../mfc/reference/cprogressctrl-class.md)\
+[`CProgressCtrl` Class](cprogressctrl-class.md)\
 Provides the functionality of the Windows common progress bar control.
 
-[`CPropertyPage` Class](../../mfc/reference/cpropertypage-class.md)\
+[`CPropertyPage` Class](cpropertypage-class.md)\
 Represents individual pages of a property sheet, otherwise known as a tab dialog box.
 
-[`CPropertySheet` Class](../../mfc/reference/cpropertysheet-class.md)\
+[`CPropertySheet` Class](cpropertysheet-class.md)\
 Represents property sheets, also known as tab dialog boxes.
 
-[`CPropExchange` Class](../../mfc/reference/cpropexchange-class.md)\
+[`CPropExchange` Class](cpropexchange-class.md)\
 Supports the implementation of persistence for your OLE controls.
 
-[`CPtrArray` Class](../../mfc/reference/cptrarray-class.md)\
+[`CPtrArray` Class](cptrarray-class.md)\
 Supports arrays of void pointers.
 
-[`CPtrList` Class](../../mfc/reference/cptrlist-class.md)\
+[`CPtrList` Class](cptrlist-class.md)\
 Supports lists of void pointers.
 
-[`CReBar` Class](../../mfc/reference/crebar-class.md)\
+[`CReBar` Class](crebar-class.md)\
 A control bar that provides layout, persistence, and state information for rebar controls.
 
-[`CReBarCtrl` Class](../../mfc/reference/crebarctrl-class.md)\
+[`CReBarCtrl` Class](crebarctrl-class.md)\
 Encapsulates the functionality of a rebar control, which is a container for a child window.
 
-[`CRecentDockSiteInfo` Class](../../mfc/reference/crecentdocksiteinfo-class.md)\
-Helper class that stores recent state information for the [`CPane` Class](../../mfc/reference/cpane-class.md).
+[`CRecentDockSiteInfo` Class](crecentdocksiteinfo-class.md)\
+Helper class that stores recent state information for the [`CPane` Class](cpane-class.md).
 
-[`CRecentFileList` Class](../../mfc/reference/crecentfilelist-class.md)\
+[`CRecentFileList` Class](crecentfilelist-class.md)\
 Supports control of the most recently used (MRU) file list.
 
-[`CRecordset` Class](../../mfc/reference/crecordset-class.md)\
+[`CRecordset` Class](crecordset-class.md)\
 Represents a set of records selected from a data source.
 
-[`CRecordView` Class](../../mfc/reference/crecordview-class.md)\
+[`CRecordView` Class](crecordview-class.md)\
 A view that displays database records in controls.
 
 [`CRect` Class](../../atl-mfc-shared/reference/crect-class.md)\
 Similar to a Windows [`RECT` structure](/windows/win32/api/windef/ns-windef-rect).
 
-[`CRectTracker` Class](../../mfc/reference/crecttracker-class.md)\
+[`CRectTracker` Class](crecttracker-class.md)\
 Enables an item to be displayed, moved, and resized in different fashions.
 
-[`CRenderTarget` Class](../../mfc/reference/crendertarget-class.md)\
+[`CRenderTarget` Class](crendertarget-class.md)\
 A wrapper for `ID2D1RenderTarget`.
 
-[`CResourceException` Class](../../mfc/reference/cresourceexception-class.md)\
+[`CResourceException` Class](cresourceexception-class.md)\
 Generated when Windows cannot find or allocate a requested resource.
 
-[`CReversalTransition` Class](../../mfc/reference/creversaltransition-class.md)\
+[`CReversalTransition` Class](creversaltransition-class.md)\
 Encapsulates a reversal transition.
 
-[`CRgn` Class](../../mfc/reference/crgn-class.md)\
+[`CRgn` Class](crgn-class.md)\
 Encapsulates a Windows graphics device interface (GDI) region.
 
-[`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md)\
-With [`CRichEditView` Class](../../mfc/reference/cricheditview-class.md) and [`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
+[`CRichEditCntrItem` Class](cricheditcntritem-class.md)\
+With [`CRichEditView` Class](cricheditview-class.md) and [`CRichEditDoc` Class](cricheditdoc-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CRichEditCtrl` Class](../../mfc/reference/cricheditctrl-class.md)\
+[`CRichEditCtrl` Class](cricheditctrl-class.md)\
 Provides the functionality of the rich edit control.
 
-[`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md)\
-With [`CRichEditView` Class](../../mfc/reference/cricheditview-class.md) and [`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
+[`CRichEditDoc` Class](cricheditdoc-class.md)\
+With [`CRichEditView` Class](cricheditview-class.md) and [`CRichEditCntrItem` Class](cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CRichEditView` Class](../../mfc/reference/cricheditview-class.md)\
-With [`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md) and [`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
+[`CRichEditView` Class](cricheditview-class.md)\
+With [`CRichEditDoc` Class](cricheditdoc-class.md) and [`CRichEditCntrItem` Class](cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CScrollBar` Class](../../mfc/reference/cscrollbar-class.md)\
+[`CScrollBar` Class](cscrollbar-class.md)\
 Provides the functionality of a Windows scroll-bar control.
 
-[`CScrollView` Class](../../mfc/reference/cscrollview-class.md)\
-A [`CView` Class](../../mfc/reference/cview-class.md) with scrolling capabilities.
+[`CScrollView` Class](cscrollview-class.md)\
+A [`CView` Class](cview-class.md) with scrolling capabilities.
 
-[`CSemaphore` Class](../../mfc/reference/csemaphore-class.md)\
+[`CSemaphore` Class](csemaphore-class.md)\
 Represents a "semaphore", which is a synchronization object that allows a limited number of threads in one or more processes to access aMaintains a count of the number of threads currently accessing a specified resource.
 
-[`CSettingsStore` Class](../../mfc/reference/csettingsstore-class.md)\
+[`CSettingsStore` Class](csettingsstore-class.md)\
 Wraps Windows API functions, providing an object-oriented interface that you use to access the registry.
 
-[`CSettingsStoreSP` Class](../../mfc/reference/csettingsstoresp-class.md)\
-Helper class that you can use to create instances of the [`CSettingsStore` Class](../../mfc/reference/csettingsstore-class.md).
+[`CSettingsStoreSP` Class](csettingsstoresp-class.md)\
+Helper class that you can use to create instances of the [`CSettingsStore` Class](csettingsstore-class.md).
 
-[`CSharedFile` Class](../../mfc/reference/csharedfile-class.md)\
-The [`CMemFile` Class](../../mfc/reference/cmemfile-class.md)-derived class that supports shared memory files.
+[`CSharedFile` Class](csharedfile-class.md)\
+The [`CMemFile` Class](cmemfile-class.md)-derived class that supports shared memory files.
 
-[`CShellManager` Class](../../mfc/reference/cshellmanager-class.md)\
+[`CShellManager` Class](cshellmanager-class.md)\
 Implements several methods that enable you to work with pointers to identifier lists (PIDLs).
 
-[`CSimpleException` Class](../../mfc/reference/csimpleexception-class.md)\
+[`CSimpleException` Class](csimpleexception-class.md)\
 This class is a base class for resource-critical MFC exceptions.
 
-[`CSingleDocTemplate` Class](../../mfc/reference/csingledoctemplate-class.md)\
+[`CSingleDocTemplate` Class](csingledoctemplate-class.md)\
 Defines a document template that implements the single document interface (SDI).
 
-[`CSingleLock` Class](../../mfc/reference/csinglelock-class.md)\
+[`CSingleLock` Class](csinglelock-class.md)\
 Represents the access-control mechanism used in controlling access to a resource in a multithreaded program.
 
-[`CSinusoidalTransitionFromRange` Class](../../mfc/reference/csinusoidaltransitionfromrange-class.md)\
+[`CSinusoidalTransitionFromRange` Class](csinusoidaltransitionfromrange-class.md)\
 Encapsulates a sinusoidal-range transition that has a given range of oscillation.
 
-[`CSinusoidalTransitionFromVelocity` Class](../../mfc/reference/csinusoidaltransitionfromvelocity-class.md)\
+[`CSinusoidalTransitionFromVelocity` Class](csinusoidaltransitionfromvelocity-class.md)\
 Encapsulates a sinusoidal-velocity transition that has an amplitude that is determined by the initial velocity of the animation variable.
 
 [`CSize` Class](../../atl-mfc-shared/reference/csize-class.md)\
 Similar to the Windows [`SIZE`](/windows/win32/api/windef/ns-windef-size) structure, which implements a relative coordinate or position.
 
-[`CSliderCtrl` Class](../../mfc/reference/csliderctrl-class.md)\
+[`CSliderCtrl` Class](csliderctrl-class.md)\
 Provides the functionality of the Windows common slider control.
 
-[`CSmartDockingInfo` Class](../../mfc/reference/csmartdockinginfo-class.md)\
+[`CSmartDockingInfo` Class](csmartdockinginfo-class.md)\
 Defines the appearance of smart docking markers.
 
-[`CSmoothStopTransition` Class](../../mfc/reference/csmoothstoptransition-class.md)\
+[`CSmoothStopTransition` Class](csmoothstoptransition-class.md)\
 Encapsulates a smooth-stop transition.
 
-[`CSocket` Class](../../mfc/reference/csocket-class.md)\
+[`CSocket` Class](csocket-class.md)\
 Derives from `CAsyncSocket`, and represents a higher level of abstraction of the Windows Sockets API.
 
-[`CSocketFile` Class](../../mfc/reference/csocketfile-class.md)\
+[`CSocketFile` Class](csocketfile-class.md)\
 A `CFile` object used for sending and receiving data across a network via Windows Sockets.
 
-[`CSpinButtonCtrl` Class](../../mfc/reference/cspinbuttonctrl-class.md)\
+[`CSpinButtonCtrl` Class](cspinbuttonctrl-class.md)\
 Provides the functionality of the Windows common spin button control.
 
-[`CSplitButton` Class](../../mfc/reference/csplitbutton-class.md)\
+[`CSplitButton` Class](csplitbutton-class.md)\
 Represents a split button control. The split button control performs a default behavior when a user clicks the main part of the button, and displays a drop-down menu when a user clicks the drop-down arrow of the button.
 
-[`CSplitterWnd` Class](../../mfc/reference/csplitterwnd-class.md)\
+[`CSplitterWnd` Class](csplitterwnd-class.md)\
 Provides the functionality of a splitter window, which is a window that contains multiple panes.
 
 [`CSplitterWndEx` Class](csplitterwndex-class.md)\
 Represents a customized splitter window.
 
-[`CStatic` Class](../../mfc/reference/cstatic-class.md)\
+[`CStatic` Class](cstatic-class.md)\
 Provides the functionality of a Windows static control.
 
-[`CStatusBar` Class](../../mfc/reference/cstatusbar-class.md)\
+[`CStatusBar` Class](cstatusbar-class.md)\
 A control bar with a row of text output panes, or "indicators".
 
-[`CStatusBarCtrl` Class](../../mfc/reference/cstatusbarctrl-class.md)\
+[`CStatusBarCtrl` Class](cstatusbarctrl-class.md)\
 Provides the functionality of the Windows common status bar control.
 
-[`CStdioFile` Class](../../mfc/reference/cstdiofile-class.md)\
+[`CStdioFile` Class](cstdiofile-class.md)\
 Represents a C run-time stream file as opened by the run-time function [`fopen`, `_wfopen`](../../c-runtime-library/reference/fopen-wfopen.md).
 
-[`CStringArray` Class](../../mfc/reference/cstringarray-class.md)\
+[`CStringArray` Class](cstringarray-class.md)\
 Supports arrays of `CString` objects.
 
-[`CStringList` Class](../../mfc/reference/cstringlist-class.md)\
+[`CStringList` Class](cstringlist-class.md)\
 Supports lists of `CString` objects.
 
-[`CSyncObject` Class](../../mfc/reference/csyncobject-class.md)\
+[`CSyncObject` Class](csyncobject-class.md)\
 A pure virtual class that provides functionality common to the synchronization objects in Win32.
 
-[`CTabbedPane` Class](../../mfc/reference/ctabbedpane-class.md)\
+[`CTabbedPane` Class](ctabbedpane-class.md)\
 Implements the functionality of a pane with detachable tabs.
 
-[`CTabCtrl` Class](../../mfc/reference/ctabctrl-class.md)\
+[`CTabCtrl` Class](ctabctrl-class.md)\
 Provides the functionality of the Windows common tab control.
 
-[`CTabView` Class](../../mfc/reference/ctabview-class.md)\
-Simplifies the use of the tab control class ([`CTabView` Class](../../mfc/reference/ctabview-class.md)) in applications that use MFC's document/view architecture.
+[`CTabView` Class](ctabview-class.md)\
+Simplifies the use of the tab control class ([`CTabView` Class](ctabview-class.md)) in applications that use MFC's document/view architecture.
 
-[`CTaskDialog` Class](../../mfc/reference/ctaskdialog-class.md)\
+[`CTaskDialog` Class](ctaskdialog-class.md)\
 A pop-up dialog box that functions like a message box but can display additional information to the user. The `CTaskDialog` also includes functionality for gathering information from the user.
 
-[`CToolBar` Class](../../mfc/reference/ctoolbar-class.md)\
+[`CToolBar` Class](ctoolbar-class.md)\
 Control bars that have a row of bitmapped buttons and optional separators.
 
-[`CToolBarCtrl` Class](../../mfc/reference/ctoolbarctrl-class.md)\
+[`CToolBarCtrl` Class](ctoolbarctrl-class.md)\
 Provides the functionality of the Windows toolbar common control.
 
-[`CToolTipCtrl` Class](../../mfc/reference/ctooltipctrl-class.md)\
+[`CToolTipCtrl` Class](ctooltipctrl-class.md)\
 Encapsulates the functionality of a "tool tip control", a small pop-up window that displays a single line of text describing the purpose of a tool in an application.
 
-[`CTooltipManager` Class](../../mfc/reference/ctooltipmanager-class.md)\
+[`CTooltipManager` Class](ctooltipmanager-class.md)\
 Maintains runtime information about tooltips. The `CTooltipManager` class is instantiated one time per application.
 
-[`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md)\
+[`CTreeCtrl` Class](ctreectrl-class.md)\
 Provides the functionality of the Windows common tree view control.
 
-[`CTreeView` Class](../../mfc/reference/ctreeview-class.md)\
-Simplifies use of the tree control and of [`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md), the class that encapsulates tree-control functionality, with MFC's document-view architecture.
+[`CTreeView` Class](ctreeview-class.md)\
+Simplifies use of the tree control and of [`CTreeCtrl` Class](ctreectrl-class.md), the class that encapsulates tree-control functionality, with MFC's document-view architecture.
 
-[`CTypedPtrArray` Class](../../mfc/reference/ctypedptrarray-class.md)\
+[`CTypedPtrArray` Class](ctypedptrarray-class.md)\
 Provides a type-safe "wrapper" for objects of class `CPtrArray` or `CObArray`.
 
-[`CTypedPtrList` Class](../../mfc/reference/ctypedptrlist-class.md)\
+[`CTypedPtrList` Class](ctypedptrlist-class.md)\
 Provides a type-safe "wrapper" for objects of class `CPtrList`.
 
-[`CTypedPtrMap` Class](../../mfc/reference/ctypedptrmap-class.md)\
+[`CTypedPtrMap` Class](ctypedptrmap-class.md)\
 Provides a type-safe "wrapper" for objects of the pointer-map classes `CMapPtrToPtr`, `CMapPtrToWord`, `CMapWordToPtr`, and `CMapStringToPtr`.
 
-[`CUIntArray` Class](../../mfc/reference/cuintarray-class.md)\
+[`CUIntArray` Class](cuintarray-class.md)\
 Supports arrays of unsigned integers.
 
-[`CUserException` Class](../../mfc/reference/cuserexception-class.md)\
+[`CUserException` Class](cuserexception-class.md)\
 Thrown to stop an end-user operation.
 
-[`CUserTool` Class](../../mfc/reference/cusertool-class.md)\
-Menu item that runs an external application. The **Tools** tab of the **Customize** dialog box ([`CMFCToolBarsCustomizeDialog` Class](../../mfc/reference/cmfctoolbarscustomizedialog-class.md)) enables the user to add user tools, and to specify the name, command, arguments, and initial directory for each user tool.
+[`CUserTool` Class](cusertool-class.md)\
+Menu item that runs an external application. The **Tools** tab of the **Customize** dialog box ([`CMFCToolBarsCustomizeDialog` Class](cmfctoolbarscustomizedialog-class.md)) enables the user to add user tools, and to specify the name, command, arguments, and initial directory for each user tool.
 
-[`CUserToolsManager` Class](../../mfc/reference/cusertoolsmanager-class.md)\
-Maintains the collection of [`CUserTool` Class](../../mfc/reference/cusertool-class.md) objects in an application. A user tool is a menu item that runs an external application. The `CUserToolsManager` object enables the user or developer to add new user tools to the application. It supports the execution of the commands associated with user tools, and it also saves information about user tools in the Windows registry.
+[`CUserToolsManager` Class](cusertoolsmanager-class.md)\
+Maintains the collection of [`CUserTool` Class](cusertool-class.md) objects in an application. A user tool is a menu item that runs an external application. The `CUserToolsManager` object enables the user or developer to add new user tools to the application. It supports the execution of the commands associated with user tools, and it also saves information about user tools in the Windows registry.
 
-[`CView` Class](../../mfc/reference/cview-class.md)\
+[`CView` Class](cview-class.md)\
 Provides the basic functionality for user-defined view classes.
 
-[`CVSListBox` Class](../../mfc/reference/cvslistbox-class.md)\
+[`CVSListBox` Class](cvslistbox-class.md)\
 Supports an editable list control.
 
-[`CWaitCursor` Class](../../mfc/reference/cwaitcursor-class.md)\
+[`CWaitCursor` Class](cwaitcursor-class.md)\
 Provides a one-line way to show a wait cursor, which is usually displayed as an hourglass, while you're doing a lengthy operation.
 
-[`CWinApp` Class](../../mfc/reference/cwinapp-class.md)\
+[`CWinApp` Class](cwinapp-class.md)\
 The base class from which you derive a Windows application object.
 
-[`CWinAppEx` Class](../../mfc/reference/cwinappex-class.md)\
+[`CWinAppEx` Class](cwinappex-class.md)\
 Handles the application state, saves the state to the registry, loads the state from the registry, initializes application managers, and provides links to those same application managers.
 
-[`CWindowDC` Class](../../mfc/reference/cwindowdc-class.md)\
+[`CWindowDC` Class](cwindowdc-class.md)\
 Derived from `CDC`.
 
-[`CWinFormsControl` Class](../../mfc/reference/cwinformscontrol-class.md)\
+[`CWinFormsControl` Class](cwinformscontrol-class.md)\
 Provides the basic functionality for hosting of a Windows Forms control.
 
-[`CWinFormsDialog` Class](../../mfc/reference/cwinformsdialog-class.md)\
+[`CWinFormsDialog` Class](cwinformsdialog-class.md)\
 A wrapper for an MFC dialog class that hosts a Windows Forms user control.
 
-[`CWinFormsView` Class](../../mfc/reference/cwinformsview-class.md)\
+[`CWinFormsView` Class](cwinformsview-class.md)\
 Provides generic functionality for hosting of a Windows Forms control as an MFC view.
 
-[`CWinThread` Class](../../mfc/reference/cwinthread-class.md)\
+[`CWinThread` Class](cwinthread-class.md)\
 Represents a thread of execution within an application.
 
-[`CWnd` Class](../../mfc/reference/cwnd-class.md)\
+[`CWnd` Class](cwnd-class.md)\
 Provides the base functionality of all window classes in the Microsoft Foundation Class Library.
 
-[`CWordArray` Class](../../mfc/reference/cwordarray-class.md)\
+[`CWordArray` Class](cwordarray-class.md)\
 Supports arrays of 16-bit words.
 
 ## Related Sections
 
-[MFC Desktop Applications](../../mfc/mfc-desktop-applications.md)\
+[MFC Desktop Applications](../mfc-desktop-applications.md)\
 Contains links to topics about the classes, global functions, global variables, and macros that make up the MFC Library.

--- a/docs/mfc/reference/mfc-classes.md
+++ b/docs/mfc/reference/mfc-classes.md
@@ -620,7 +620,7 @@ Draws the drag rectangle that appears when the user drags a pane in the standard
 A toolbar that appears when the user presses and holds a top-level toolbar button.
 
 [`CMFCDropDownToolbarButton` Class](cmfcdropdowntoolbarbutton-class.md)\
-A type of toolbar button that behaves like a regular button when it is clicked. However, it opens a drop-down toolbar ([`CMFCDropDownToolBar` Class](cmfcdropdowntoolbar-class.md) if the user presses and holds the toolbar button down.
+A type of toolbar button that behaves like a regular button when it is clicked. However, it opens a drop-down toolbar ([`CMFCDropDownToolBar` Class](cmfcdropdowntoolbar-class.md)) if the user presses and holds the toolbar button down.
 
 [`CMFCDynamicLayout` Class](cmfcdynamiclayout-class.md)\
 Specifies how controls in a window are moved and resized as the user resizes the window.

--- a/docs/mfc/reference/mfc-classes.md
+++ b/docs/mfc/reference/mfc-classes.md
@@ -787,7 +787,7 @@ Implements a status bar similar to the `CStatusBar` class. However, the `CMFCSta
 [`CMFCTabCtrl` Class](cmfctabctrl-class.md)\
 Provides functionality for a tab control. The tab control displays a dockable window with flat or three-dimensional tabs at its top or bottom. The tabs can display text and an image and can change color when active.
 
-[`CMFCTabToolTipInfo Structure](cmfctabtooltipinfo-structure.md)\
+[`CMFCTabToolTipInfo` Structure](cmfctabtooltipinfo-structure.md)\
 Provides information about the MDI tab that the user is hovering over.
 
 [`CMFCTasksPane` Class](cmfctaskspane-class.md)\

--- a/docs/mfc/reference/mfc-classes.md
+++ b/docs/mfc/reference/mfc-classes.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: MFC` Classes"
-title: "MFC` Classes"
-ms.date: "11/04/2016"
+title: "MFC Classes"
+description: "Learn more about: MFC Classes"
+ms.date: 11/04/2016
 helpviewer_keywords: ["MFC, classes", "classes [MFC], MFC"]
-ms.assetid: 7b6db805-a572-43fd-9046-0fa6e3663e63
 ---
 # MFC Classes
 

--- a/docs/mfc/reference/mfc-classes.md
+++ b/docs/mfc/reference/mfc-classes.md
@@ -16,1285 +16,1285 @@ The classes in the following list are included in the Microsoft Foundation Class
 
 ## In This Section
 
-[`CAccelerateDecelerateTransition` Class](../../mfc/reference/cacceleratedeceleratetransition-class.md)<br/>
+[`CAccelerateDecelerateTransition` Class](../../mfc/reference/cacceleratedeceleratetransition-class.md)\
 Implements an accelerate-decelerate transition.
 
-[`CAnimateCtrl` Class](../../mfc/reference/canimatectrl-class.md)<br/>
+[`CAnimateCtrl` Class](../../mfc/reference/canimatectrl-class.md)\
 Provides the functionality of the Windows common animation control.
 
-[`CAnimationBaseObject` Class](../../mfc/reference/canimationbaseobject-class.md)<br/>
+[`CAnimationBaseObject` Class](../../mfc/reference/canimationbaseobject-class.md)\
 The base class for all animation objects.
 
-[`CAnimationColor` Class](../../mfc/reference/canimationcolor-class.md)<br/>
+[`CAnimationColor` Class](../../mfc/reference/canimationcolor-class.md)\
 Implements the functionality of a color whose red, green, and blue components can be animated.
 
-[`CAnimationController` Class](../../mfc/reference/canimationcontroller-class.md)<br/>
+[`CAnimationController` Class](../../mfc/reference/canimationcontroller-class.md)\
 Implements the animation controller, which provides a central interface for creating and managing animations.
 
-[`CAnimationGroup` Class](../../mfc/reference/canimationgroup-class.md)<br/>
+[`CAnimationGroup` Class](../../mfc/reference/canimationgroup-class.md)\
 Implements the animation controller, which provides a central interface for creating and managing animations.
 
-[`CAnimationManagerEventHandler` Class](../../mfc/reference/canimationmanagereventhandler-class.md)<br/>
+[`CAnimationManagerEventHandler` Class](../../mfc/reference/canimationmanagereventhandler-class.md)\
 Implements a callback, which is called by the Animation API when a status of an animation manager is changed.
 
-[`CAnimationPoint` Class](../../mfc/reference/canimationpoint-class.md)<br/>
+[`CAnimationPoint` Class](../../mfc/reference/canimationpoint-class.md)\
 Implements the functionality of a point whose coordinates can be animated.
 
-[`CAnimationRect` Class](../../mfc/reference/canimationrect-class.md)<br/>
+[`CAnimationRect` Class](../../mfc/reference/canimationrect-class.md)\
 Implements the functionality of a rectangle whose sides can be animated.
 
-[`CAnimationSize` Class](../../mfc/reference/canimationsize-class.md)<br/>
+[`CAnimationSize` Class](../../mfc/reference/canimationsize-class.md)\
 Implements the functionality of a size object whose dimensions can be animated.
 
-[`CAnimationStoryboardEventHandler` Class](../../mfc/reference/canimationstoryboardeventhandler-class.md)<br/>
+[`CAnimationStoryboardEventHandler` Class](../../mfc/reference/canimationstoryboardeventhandler-class.md)\
 Implements a callback, which is called by the Animation API when the status of a storyboard is changed or a storyboard is updated.
 
-[`CAnimationTimerEventHandler` Class](../../mfc/reference/canimationtimereventhandler-class.md)<br/>
+[`CAnimationTimerEventHandler` Class](../../mfc/reference/canimationtimereventhandler-class.md)\
 Implements a callback, which is called by the Animation API when timing events occur.
 
-[`CAnimationValue` Class](../../mfc/reference/canimationvalue-class.md)<br/>
+[`CAnimationValue` Class](../../mfc/reference/canimationvalue-class.md)\
 Implements the functionality of animation object that has one value.
 
-[`CAnimationVariable` Class](../../mfc/reference/canimationvariable-class.md)<br/>
+[`CAnimationVariable` Class](../../mfc/reference/canimationvariable-class.md)\
 Represents an animation variable.
 
-[`CAnimationVariableChangeHandler` Class](../../mfc/reference/canimationvariablechangehandler-class.md)<br/>
+[`CAnimationVariableChangeHandler` Class](../../mfc/reference/canimationvariablechangehandler-class.md)\
 Implements a callback, which is called by the Animation API when the value of an animation variable changes.
 
-[`CAnimationVariableIntegerChangeHandler` Class](../../mfc/reference/canimationvariableintegerchangehandler-class.md)<br/>
+[`CAnimationVariableIntegerChangeHandler` Class](../../mfc/reference/canimationvariableintegerchangehandler-class.md)\
 Implements a callback, which is called by the Animation API when the value of an animation variable changes.
 
-[`CArchive` Class](../../mfc/reference/carchive-class.md)<br/>
+[`CArchive` Class](../../mfc/reference/carchive-class.md)\
 Lets you save a complex network of objects in a permanent binary form (usually disk storage) that persists after those objects are deleted.
 
-[`CArchiveException` Class](../../mfc/reference/carchiveexception-class.md)<br/>
+[`CArchiveException` Class](../../mfc/reference/carchiveexception-class.md)\
 Represents a serialization exception condition.
 
-[`CArray` Class](../../mfc/reference/carray-class.md)<br/>
+[`CArray` Class](../../mfc/reference/carray-class.md)\
 Supports arrays that resemble` C arrays, but can dynamically reduce and grow as necessary.
 
-[`CAsyncMonikerFile` Class](../../mfc/reference/casyncmonikerfile-class.md)<br/>
+[`CAsyncMonikerFile` Class](../../mfc/reference/casyncmonikerfile-class.md)\
 Provides functionality for the use of asynchronous monikers in ActiveX controls (formerly OLE controls).
 
-[`CAsyncSocket` Class](../../mfc/reference/casyncsocket-class.md)<br/>
+[`CAsyncSocket` Class](../../mfc/reference/casyncsocket-class.md)\
 Represents a Windows Socket, which is an endpoint of network communication.
 
-[`CAutoHideDockSite` Class](../../mfc/reference/cautohidedocksite-class.md)<br/>
+[`CAutoHideDockSite` Class](../../mfc/reference/cautohidedocksite-class.md)\
 Extends the [`CDockSite` Class](../../mfc/reference/cdocksite-class.md) to implement auto-hide dock panes.
 
-[`CBaseKeyFrame` Class](../../mfc/reference/cbasekeyframe-class.md)<br/>
+[`CBaseKeyFrame` Class](../../mfc/reference/cbasekeyframe-class.md)\
 Implements the basic functionality of a keyframe.
 
-[`CBasePane` Class](../../mfc/reference/cbasepane-class.md)<br/>
+[`CBasePane` Class](../../mfc/reference/cbasepane-class.md)\
 Base class for all panes.
 
-[`CBaseTabbedPane` Class](../../mfc/reference/cbasetabbedpane-class.md)<br/>
+[`CBaseTabbedPane` Class](../../mfc/reference/cbasetabbedpane-class.md)\
 Extends the functionality of the [`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md) to support the creation of tabbed windows.
 
-[`CBaseTransition` Class](../../mfc/reference/cbasetransition-class.md)<br/>
+[`CBaseTransition` Class](../../mfc/reference/cbasetransition-class.md)\
 Represents a basic transition.
 
-[`CBitmap` Class](../../mfc/reference/cbitmap-class.md)<br/>
+[`CBitmap` Class](../../mfc/reference/cbitmap-class.md)\
 Encapsulates a Windows graphics device interface (GDI) bitmap and provides member functions to manipulate the bitmap.
 
-[`CBitmapButton` Class](../../mfc/reference/cbitmapbutton-class.md)<br/>
+[`CBitmapButton` Class](../../mfc/reference/cbitmapbutton-class.md)\
 Creates pushbutton controls labeled with bitmapped images instead of text.
 
-[`CBitmapRenderTarget` Class](../../mfc/reference/cbitmaprendertarget-class.md)<br/>
+[`CBitmapRenderTarget` Class](../../mfc/reference/cbitmaprendertarget-class.md)\
 A wrapper for `ID2D1BitmapRenderTarget`.
 
-[`CBrush` Class](../../mfc/reference/cbrush-class.md)<br/>
+[`CBrush` Class](../../mfc/reference/cbrush-class.md)\
 Encapsulates a Windows graphics device interface (GDI) brush.
 
-[`CButton` Class](../../mfc/reference/cbutton-class.md)<br/>
+[`CButton` Class](../../mfc/reference/cbutton-class.md)\
 Provides the functionality of Windows button controls.
 
-[`CByteArray` Class](../../mfc/reference/cbytearray-class.md)<br/>
+[`CByteArray` Class](../../mfc/reference/cbytearray-class.md)\
 Supports dynamic arrays of bytes.
 
-[`CCachedDataPathProperty` Class](../../mfc/reference/ccacheddatapathproperty-class.md)<br/>
+[`CCachedDataPathProperty` Class](../../mfc/reference/ccacheddatapathproperty-class.md)\
 Implements an OLE control property transferred asynchronously and cached in a memory file.
 
-[`CCheckListBox` Class](../../mfc/reference/cchecklistbox-class.md)<br/>
+[`CCheckListBox` Class](../../mfc/reference/cchecklistbox-class.md)\
 Provides the functionality of a Windows checklist box.
 
-[`CClientDC` Class](../../mfc/reference/cclientdc-class.md)<br/>
+[`CClientDC` Class](../../mfc/reference/cclientdc-class.md)\
 Handles the calling of the Windows functions [`GetDC`](/windows/win32/api/winuser/nf-winuser-getdc) at construction time and [`ReleaseDC`](/windows/win32/api/winuser/nf-winuser-releasedc) at destruction time.
 
-[`CCmdTarget` Class](../../mfc/reference/ccmdtarget-class.md)<br/>
+[`CCmdTarget` Class](../../mfc/reference/ccmdtarget-class.md)\
 Base class for the Microsoft Foundation Class Library message-map architecture.
 
-[`CCmdUI` Class](../../mfc/reference/ccmdui-class.md)<br/>
+[`CCmdUI` Class](../../mfc/reference/ccmdui-class.md)\
 Used only within an `ON_UPDATE_COMMAND_UI` handler in a `CCmdTarget`-derived class.
 
-[`CColorDialog` Class](../../mfc/reference/ccolordialog-class.md)<br/>
+[`CColorDialog` Class](../../mfc/reference/ccolordialog-class.md)\
 Lets you incorporate a color-selection dialog box into your application.
 
-[`CComboBox` Class](../../mfc/reference/ccombobox-class.md)<br/>
+[`CComboBox` Class](../../mfc/reference/ccombobox-class.md)\
 Provides the functionality of a Windows combo box.
 
-[`CComboBoxEx` Class](../../mfc/reference/ccomboboxex-class.md)<br/>
+[`CComboBoxEx` Class](../../mfc/reference/ccomboboxex-class.md)\
 Extends the combo box control by providing support for image lists.
 
-[`CCommandLineInfo` Class](../../mfc/reference/ccommandlineinfo-class.md)<br/>
+[`CCommandLineInfo` Class](../../mfc/reference/ccommandlineinfo-class.md)\
 Aids in parsing the command line at application startup.
 
-[`CCommonDialog` Class](../../mfc/reference/ccommondialog-class.md)<br/>
+[`CCommonDialog` Class](../../mfc/reference/ccommondialog-class.md)\
 The base class for classes that encapsulate functionality of the Windows common dialogs.
 
-[`CConnectionPoint` Class](../../mfc/reference/cconnectionpoint-class.md)<br/>
+[`CConnectionPoint` Class](../../mfc/reference/cconnectionpoint-class.md)\
 Defines a special type of interface used to communicate with other OLE objects, called a "connection point."
 
-[`CConstantTransition` Class](../../mfc/reference/cconstanttransition-class.md)<br/>
+[`CConstantTransition` Class](../../mfc/reference/cconstanttransition-class.md)\
 Encapsulates a constant transition.
 
-[`CContextMenuManager` Class](../../mfc/reference/ccontextmenumanager-class.md)<br/>
+[`CContextMenuManager` Class](../../mfc/reference/ccontextmenumanager-class.md)\
 Manages shortcut menus, also known as context menus.
 
-[`CControlBar` Class](../../mfc/reference/ccontrolbar-class.md)<br/>
+[`CControlBar` Class](../../mfc/reference/ccontrolbar-class.md)\
 Base class for the control-bar classes [`CStatusBar` Class](../../mfc/reference/cstatusbar-class.md), [`CToolBar` Class](../../mfc/reference/ctoolbar-class.md), [`CDialogBar` Class](../../mfc/reference/cdialogbar-class.md), [`CReBar` Class](../../mfc/reference/crebar-class.md), and [`COleResizeBar` Class](../../mfc/reference/coleresizebar-class.md).
 
-[`CCriticalSection` Class](../../mfc/reference/ccriticalsection-class.md)<br/>
+[`CCriticalSection` Class](../../mfc/reference/ccriticalsection-class.md)\
 Represents a "critical section", which is a synchronization object that enables one thread at a time to access a resource or section of code.
 
-[`CCtrlView` Class](../../mfc/reference/cctrlview-class.md)<br/>
+[`CCtrlView` Class](../../mfc/reference/cctrlview-class.md)\
 Adapts the document-view architecture to the common controls supported by Windows 98 and Windows NT versions 3.51 and later.
 
-[`CCubicTransition` Class](../../mfc/reference/ccubictransition-class.md)<br/>
+[`CCubicTransition` Class](../../mfc/reference/ccubictransition-class.md)\
 Encapsulates a cubic transition.
 
-[`CCustomInterpolator` Class](../../mfc/reference/ccustominterpolator-class.md)<br/>
+[`CCustomInterpolator` Class](../../mfc/reference/ccustominterpolator-class.md)\
 Implements a basic interpolator.
 
-[`CCustomTransition` Class](../../mfc/reference/ccustomtransition-class.md)<br/>
+[`CCustomTransition` Class](../../mfc/reference/ccustomtransition-class.md)\
 Implements a custom transition.
 
-[`CD2DBitmap` Class](../../mfc/reference/cd2dbitmap-class.md)<br/>
+[`CD2DBitmap` Class](../../mfc/reference/cd2dbitmap-class.md)\
 A wrapper for `ID2D1Bitmap`.
 
-[`CD2DBitmapBrush` Class](../../mfc/reference/cd2dbitmapbrush-class.md)<br/>
+[`CD2DBitmapBrush` Class](../../mfc/reference/cd2dbitmapbrush-class.md)\
 A wrapper for `ID2D1BitmapBrush`.
 
-[`CD2DBrush` Class](../../mfc/reference/cd2dbrush-class.md)<br/>
+[`CD2DBrush` Class](../../mfc/reference/cd2dbrush-class.md)\
 A wrapper for `ID2D1Brush`.
 
-[`CD2DBrushProperties` Class](../../mfc/reference/cd2dbrushproperties-class.md)<br/>
+[`CD2DBrushProperties` Class](../../mfc/reference/cd2dbrushproperties-class.md)\
 A wrapper for `D2D1_BRUSH_PROPERTIES`.
 
-[`CD2DEllipse` Class](../../mfc/reference/cd2dellipse-class.md)<br/>
+[`CD2DEllipse` Class](../../mfc/reference/cd2dellipse-class.md)\
 A wrapper for `D2D1_BRUSH_PROPERTIES`.
 
-[`CD2DGeometry` Class](../../mfc/reference/cd2dgeometry-class.md)<br/>
+[`CD2DGeometry` Class](../../mfc/reference/cd2dgeometry-class.md)\
 A wrapper for `ID2D1Geometry`.
 
-[`CD2DGeometrySink` Class](../../mfc/reference/cd2dgeometrysink-class.md)<br/>
+[`CD2DGeometrySink` Class](../../mfc/reference/cd2dgeometrysink-class.md)\
 A wrapper for `ID2D1GeometrySink`.
 
-[`CD2DGradientBrush` Class](../../mfc/reference/cd2dgradientbrush-class.md)<br/>
+[`CD2DGradientBrush` Class](../../mfc/reference/cd2dgradientbrush-class.md)\
 The base class of the `CD2DLinearGradientBrush` and the `CD2DRadialGradientBrush` classes.
 
-[`CD2DLayer` Class](../../mfc/reference/cd2dlayer-class.md)<br/>
+[`CD2DLayer` Class](../../mfc/reference/cd2dlayer-class.md)\
 A wrapper for `ID2D1Layer`.
 
-[`CD2DLinearGradientBrush` Class](../../mfc/reference/cd2dlineargradientbrush-class.md)<br/>
+[`CD2DLinearGradientBrush` Class](../../mfc/reference/cd2dlineargradientbrush-class.md)\
 A wrapper for `ID2D1LinearGradientBrush`.
 
-[`CD2DMesh` Class](../../mfc/reference/cd2dmesh-class.md)<br/>
+[`CD2DMesh` Class](../../mfc/reference/cd2dmesh-class.md)\
 A wrapper for `ID2D1Mesh`.
 
-[`CD2DPathGeometry` Class](../../mfc/reference/cd2dpathgeometry-class.md)<br/>
+[`CD2DPathGeometry` Class](../../mfc/reference/cd2dpathgeometry-class.md)\
 A wrapper for `ID2D1PathGeometry`.
 
-[`CD2DPointF` Class](../../mfc/reference/cd2dpointf-class.md)<br/>
+[`CD2DPointF` Class](../../mfc/reference/cd2dpointf-class.md)\
 A wrapper for `D2D1_POINT_2F`.
 
-[`CD2DPointU` Class](../../mfc/reference/cd2dpointu-class.md)<br/>
+[`CD2DPointU` Class](../../mfc/reference/cd2dpointu-class.md)\
 A wrapper for `D2D1_POINT_2U`.
 
-[`CD2DRadialGradientBrush` Class](../../mfc/reference/cd2dradialgradientbrush-class.md)<br/>
+[`CD2DRadialGradientBrush` Class](../../mfc/reference/cd2dradialgradientbrush-class.md)\
 A wrapper for `ID2D1RadialGradientBrush`.
 
-[`CD2DRectF` Class](../../mfc/reference/cd2drectf-class.md)<br/>
+[`CD2DRectF` Class](../../mfc/reference/cd2drectf-class.md)\
 A wrapper for `D2D1_RECT_F`.
 
-[`CD2DRectU` Class](../../mfc/reference/cd2drectu-class.md)<br/>
+[`CD2DRectU` Class](../../mfc/reference/cd2drectu-class.md)\
 A wrapper for `D2D1_RECT_U`.
 
-[`CD2DResource` Class](../../mfc/reference/cd2dresource-class.md)<br/>
+[`CD2DResource` Class](../../mfc/reference/cd2dresource-class.md)\
 An abstract class that provides an interface for creating and managing `D2D` resources such as brushes, layers, and texts.
 
-[`CD2DRoundedRect` Class](../../mfc/reference/cd2droundedrect-class.md)<br/>
+[`CD2DRoundedRect` Class](../../mfc/reference/cd2droundedrect-class.md)\
 A wrapper for `D2D1_ROUNDED_RECT`.
 
-[`CD2DSizeF` Class](../../mfc/reference/cd2dsizef-class.md)<br/>
+[`CD2DSizeF` Class](../../mfc/reference/cd2dsizef-class.md)\
 A wrapper for `D2D1_SIZE_F`.
 
-[`CD2DSizeU` Class](../../mfc/reference/cd2dsizeu-class.md)<br/>
+[`CD2DSizeU` Class](../../mfc/reference/cd2dsizeu-class.md)\
 A wrapper for `D2D1_SIZE_U`.
 
-[`CD2DSolidColorBrush` Class](../../mfc/reference/cd2dsolidcolorbrush-class.md)<br/>
+[`CD2DSolidColorBrush` Class](../../mfc/reference/cd2dsolidcolorbrush-class.md)\
 A wrapper for `ID2D1SolidColorBrush`.
 
-[`CD2DTextFormat` Class](../../mfc/reference/cd2dtextformat-class.md)<br/>
+[`CD2DTextFormat` Class](../../mfc/reference/cd2dtextformat-class.md)\
 A wrapper for `IDWriteTextFormat`.
 
-[`CD2DTextLayout` Class](../../mfc/reference/cd2dtextlayout-class.md)<br/>
+[`CD2DTextLayout` Class](../../mfc/reference/cd2dtextlayout-class.md)\
 A wrapper for `IDWriteTextLayout`.
 
-[`CDaoDatabase` Class](../../mfc/reference/cdaodatabase-class.md)<br/>
+[`CDaoDatabase` Class](../../mfc/reference/cdaodatabase-class.md)\
 Represents a connection to a database through which you can operate on the data.
 
-[`CDaoException` Class](../../mfc/reference/cdaoexception-class.md)<br/>
+[`CDaoException` Class](../../mfc/reference/cdaoexception-class.md)\
 Represents an exception condition arising from the MFC database classes based on data access objects (DAO).
 
-[`CDaoFieldExchange` Class](../../mfc/reference/cdaofieldexchange-class.md)<br/>
+[`CDaoFieldExchange` Class](../../mfc/reference/cdaofieldexchange-class.md)\
 Supports the DAO record field exchange (DFX) routines used by the DAO database classes.
 
-[`CDaoQueryDef` Class](../../mfc/reference/cdaoquerydef-class.md)<br/>
+[`CDaoQueryDef` Class](../../mfc/reference/cdaoquerydef-class.md)\
 Represents a query definition, or "querydef," usually one saved in a database.
 
-[`CDaoRecordset` Class](../../mfc/reference/cdaorecordset-class.md)<br/>
+[`CDaoRecordset` Class](../../mfc/reference/cdaorecordset-class.md)\
 Represents a set of records selected from a data source.
 
-[`CDaoRecordView` Class](../../mfc/reference/cdaorecordview-class.md)<br/>
+[`CDaoRecordView` Class](../../mfc/reference/cdaorecordview-class.md)\
 A view that displays database records in controls.
 
-[`CDaoTableDef` Class](../../mfc/reference/cdaotabledef-class.md)<br/>
+[`CDaoTableDef` Class](../../mfc/reference/cdaotabledef-class.md)\
 Represents the stored definition of a base table or an attached table.
 
-[`CDaoWorkspace` Class](../../mfc/reference/cdaoworkspace-class.md)<br/>
+[`CDaoWorkspace` Class](../../mfc/reference/cdaoworkspace-class.md)\
 Manages a named, password-protected database session from login to logoff, by a single user.
 
-[`CDatabase` Class](../../mfc/reference/cdatabase-class.md)<br/>
+[`CDatabase` Class](../../mfc/reference/cdatabase-class.md)\
 Represents a connection to a data source, through which you can operate on the data source.
 
-[`CDataExchange` Class](../../mfc/reference/cdataexchange-class.md)<br/>
+[`CDataExchange` Class](../../mfc/reference/cdataexchange-class.md)\
 Supports the dialog data exchange (DDX) and dialog data validation (DDV) routines used by the Microsoft Foundation classes.
 
-[`CDataPathProperty` Class](../../mfc/reference/cdatapathproperty-class.md)<br/>
+[`CDataPathProperty` Class](../../mfc/reference/cdatapathproperty-class.md)\
 Implements an OLE control property that can be loaded asynchronously.
 
-[`CDataRecoveryHandler` Class](../../mfc/reference/cdatarecoveryhandler-class.md)<br/>
+[`CDataRecoveryHandler` Class](../../mfc/reference/cdatarecoveryhandler-class.md)\
 Autosaves documents and restores them if an application unexpectedly exits.
 
-[`CDateTimeCtrl` Class](../../mfc/reference/cdatetimectrl-class.md)<br/>
+[`CDateTimeCtrl` Class](../../mfc/reference/cdatetimectrl-class.md)\
 Encapsulates the functionality of a date and time picker control.
 
-[`CDBException` Class](../../mfc/reference/cdbexception-class.md)<br/>
+[`CDBException` Class](../../mfc/reference/cdbexception-class.md)\
 Represents an exception condition arising from the database classes.
 
-[`CDBVariant` Class](../../mfc/reference/cdbvariant-class.md)<br/>
+[`CDBVariant` Class](../../mfc/reference/cdbvariant-class.md)\
 Represents a variant data type for the MFC ODBC classes.
 
-[`CDC` Class](../../mfc/reference/cdc-class.md)<br/>
+[`CDC` Class](../../mfc/reference/cdc-class.md)\
 Defines a class of device-context objects.
 
-[`CDCRenderTarget` Class](../../mfc/reference/cdcrendertarget-class.md)<br/>
+[`CDCRenderTarget` Class](../../mfc/reference/cdcrendertarget-class.md)\
 A wrapper for `ID2D1DCRenderTarget`.
 
-[`CDHtmlDialog` Class](../../mfc/reference/cdhtmldialog-class.md)<br/>
+[`CDHtmlDialog` Class](../../mfc/reference/cdhtmldialog-class.md)\
 Used to create dialog boxes that use HTML rather than dialog resources to implement their user interface.
 
-[`CDialog` Class](../../mfc/reference/cdialog-class.md)<br/>
+[`CDialog` Class](../../mfc/reference/cdialog-class.md)\
 Base class used for displaying dialog boxes on the screen.
 
-[`CDialogBar` Class](../../mfc/reference/cdialogbar-class.md)<br/>
+[`CDialogBar` Class](../../mfc/reference/cdialogbar-class.md)\
 Provides the functionality of a Windows modeless dialog box in a control bar.
 
-[`CDialogEx` Class](../../mfc/reference/cdialogex-class.md)<br/>
+[`CDialogEx` Class](../../mfc/reference/cdialogex-class.md)\
 Specifies the background color and background image of a dialog box.
 
-[`CDiscreteTransition` Class](../../mfc/reference/cdiscretetransition-class.md)<br/>
+[`CDiscreteTransition` Class](../../mfc/reference/cdiscretetransition-class.md)\
 Encapsulates a discrete transition.
 
-[`CDocItem` Class](../../mfc/reference/cdocitem-class.md)<br/>
+[`CDocItem` Class](../../mfc/reference/cdocitem-class.md)\
 The base class for document items, which are components of a document's data.
 
-[`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md)<br/>
+[`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md)\
 Implements a pane that can either be docked in a dock site or included in a tabbed pane.
 
-[`CDockablePaneAdapter` Class](../../mfc/reference/cdockablepaneadapter-class.md)<br/>
+[`CDockablePaneAdapter` Class](../../mfc/reference/cdockablepaneadapter-class.md)\
 Provides docking support for `CWnd`-derived panes.
 
-[`CDockingManager` Class](../../mfc/reference/cdockingmanager-class.md)<br/>
+[`CDockingManager` Class](../../mfc/reference/cdockingmanager-class.md)\
 Implements the core functionality that controls docking layout in a main frame window.
 
-[`CDockingPanesRow` Class](../../mfc/reference/cdockingpanesrow-class.md)<br/>
+[`CDockingPanesRow` Class](../../mfc/reference/cdockingpanesrow-class.md)\
 Manages a list of panes that are located in the same horizontal or vertical row (column) of a dock site.
 
-[`CDockSite` Class](../../mfc/reference/cdocksite-class.md)<br/>
+[`CDockSite` Class](../../mfc/reference/cdocksite-class.md)\
 Provides functionality for arranging panes that are derived from the [`CPane` Class](../../mfc/reference/cpane-class.md) into sets of rows.
 
-[`CDockState` Class](../../mfc/reference/cdockstate-class.md)<br/>
+[`CDockState` Class](../../mfc/reference/cdockstate-class.md)\
 A serialized `CObject` class that loads, unloads, or clears the state of one or more docking control bars in persistent memory (a file).
 
-[`CDocObjectServer` Class](../../mfc/reference/cdocobjectserver-class.md)<br/>
+[`CDocObjectServer` Class](../../mfc/reference/cdocobjectserver-class.md)\
 Implements the additional OLE interfaces needed to make a normal `COleDocument` server into a full DocObject server: `IOleDocument`, `IOleDocumentView`, `IOleCommandTarget`, and `IPrint`.
 
-[`CDocObjectServerItem` Class](../../mfc/reference/cdocobjectserveritem-class.md)<br/>
+[`CDocObjectServerItem` Class](../../mfc/reference/cdocobjectserveritem-class.md)\
 Implements OLE server verbs specifically for DocObject servers.
 
-[`CDocTemplate` Class](../../mfc/reference/cdoctemplate-class.md)<br/>
+[`CDocTemplate` Class](../../mfc/reference/cdoctemplate-class.md)\
 An abstract base class that defines the basic functionality for document templates.
 
-[`CDocument` Class](../../mfc/reference/cdocument-class.md)<br/>
+[`CDocument` Class](../../mfc/reference/cdocument-class.md)\
 Provides the basic functionality for user-defined document classes.
 
-[`CDragListBox` Class](../../mfc/reference/cdraglistbox-class.md)<br/>
+[`CDragListBox` Class](../../mfc/reference/cdraglistbox-class.md)\
 In addition to providing the functionality of a Windows list box, the `CDragListBox` class lets the user move list box items, such as filenames, within the list box.
 
-[`CDrawingManager` Class](../../mfc/reference/cdrawingmanager-class.md)<br/>
+[`CDrawingManager` Class](../../mfc/reference/cdrawingmanager-class.md)\
 Implements complex drawing algorithms.
 
-[`CDumpContext` Class](../../mfc/reference/cdumpcontext-class.md)<br/>
+[`CDumpContext` Class](../../mfc/reference/cdumpcontext-class.md)\
 Supports stream-oriented diagnostic output in the form of human-readable text.
 
-[`CDWordArray` Class](../../mfc/reference/cdwordarray-class.md)<br/>
+[`CDWordArray` Class](../../mfc/reference/cdwordarray-class.md)\
 Supports arrays of 32-bit doublewords.
 
-[`CEdit` Class](../../mfc/reference/cedit-class.md)<br/>
+[`CEdit` Class](../../mfc/reference/cedit-class.md)\
 Provides the functionality of a Windows edit control.
 
-[`CEditView` Class](../../mfc/reference/ceditview-class.md)<br/>
+[`CEditView` Class](../../mfc/reference/ceditview-class.md)\
 A type of view class that provides the functionality of a Windows edit control and can be used to implement simple text-editor functionality.
 
-[`CEvent` Class](../../mfc/reference/cevent-class.md)<br/>
+[`CEvent` Class](../../mfc/reference/cevent-class.md)\
 Represents an "event", which is a synchronization object that enables one thread to notify another that an event has occurred.
 
-[`CException` Class](../../mfc/reference/cexception-class.md)<br/>
+[`CException` Class](../../mfc/reference/cexception-class.md)\
 The base class for all exceptions in the Microsoft Foundation Class Library.
 
-[`CFieldExchange` Class](../../mfc/reference/cfieldexchange-class.md)<br/>
+[`CFieldExchange` Class](../../mfc/reference/cfieldexchange-class.md)\
 Supports the record field exchange (RFX) and bulk record field exchange (Bulk RFX) routines used by the database classes.
 
-[`CFile` Class](../../mfc/reference/cfile-class.md)<br/>
+[`CFile` Class](../../mfc/reference/cfile-class.md)\
 The base class for Microsoft Foundation Class file classes.
 
-[`CFileDialog` Class](../../mfc/reference/cfiledialog-class.md)<br/>
+[`CFileDialog` Class](../../mfc/reference/cfiledialog-class.md)\
 Encapsulates the common file dialog box for Windows.
 
-[`CFileException` Class](../../mfc/reference/cfileexception-class.md)<br/>
+[`CFileException` Class](../../mfc/reference/cfileexception-class.md)\
 Represents a file-related exception condition.
 
-[`CFileFind` Class](../../mfc/reference/cfilefind-class.md)<br/>
+[`CFileFind` Class](../../mfc/reference/cfilefind-class.md)\
 Performs local file searches and is the base class for [`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md) and [`CFtpFileFind` Class](../../mfc/reference/cftpfilefind-class.md), which perform Internet file searches.
 
-[`CFindReplaceDialog` Class](../../mfc/reference/cfindreplacedialog-class.md)<br/>
+[`CFindReplaceDialog` Class](../../mfc/reference/cfindreplacedialog-class.md)\
 Lets you implement standard string Find/Replace dialog boxes in your application.
 
-[`CFolderPickerDialog` Class](../../mfc/reference/cfolderpickerdialog-class.md)<br/>
+[`CFolderPickerDialog` Class](../../mfc/reference/cfolderpickerdialog-class.md)\
 Implements `CFileDialog` in the folder picker mode.
 
-[`CFont` Class](../../mfc/reference/cfont-class.md)<br/>
+[`CFont` Class](../../mfc/reference/cfont-class.md)\
 Encapsulates a Windows graphics device interface (GDI) font and provides member functions for manipulating the font.
 
-[`CFontDialog` Class](../../mfc/reference/cfontdialog-class.md)<br/>
+[`CFontDialog` Class](../../mfc/reference/cfontdialog-class.md)\
 Lets you incorporate a font-selection dialog box into your application.
 
-[`CFontHolder` Class](../../mfc/reference/cfontholder-class.md)<br/>
+[`CFontHolder` Class](../../mfc/reference/cfontholder-class.md)\
 Implements the stock Font property and encapsulates the functionality of a Windows font object and the `IFont` interface.
 
-[`CFormView` Class](../../mfc/reference/cformview-class.md)<br/>
+[`CFormView` Class](../../mfc/reference/cformview-class.md)\
 The base class used for form views.
 
-[`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md)<br/>
+[`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md)\
 Provides the functionality of a Windows single document interface (SDI) overlapped or pop-up frame window, along with members for managing the window.
 
-[`CFrameWndEx` Class](../../mfc/reference/cframewndex-class.md)<br/>
+[`CFrameWndEx` Class](../../mfc/reference/cframewndex-class.md)\
 Implements the functionality of a Windows single document interface (SDI) overlapped or popup frame window, and provides members for managing the window. It extends the [`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md) class.
 
-[`CFtpConnection` Class](../../mfc/reference/cftpconnection-class.md)<br/>
+[`CFtpConnection` Class](../../mfc/reference/cftpconnection-class.md)\
 Manages your FTP connection to an Internet server and enables direct manipulation of directories and files on that server.
 
-[`CFtpFileFind` Class](../../mfc/reference/cftpfilefind-class.md)<br/>
+[`CFtpFileFind` Class](../../mfc/reference/cftpfilefind-class.md)\
 Aids in Internet file searches of FTP servers.
 
-[`CGdiObject` Class](../../mfc/reference/cgdiobject-class.md)<br/>
+[`CGdiObject` Class](../../mfc/reference/cgdiobject-class.md)\
 Provides a base class for various kinds of Windows graphics device interface (GDI) objects such as bitmaps, regions, brushes, pens, palettes, and fonts.
 
-[`CGopherConnection` Class](../../mfc/reference/cgopherconnection-class.md)<br/>
+[`CGopherConnection` Class](../../mfc/reference/cgopherconnection-class.md)\
 Manages your connection to a gopher Internet server.
 
-[`CGopherFile` Class](../../mfc/reference/cgopherfile-class.md)<br/>
+[`CGopherFile` Class](../../mfc/reference/cgopherfile-class.md)\
 Provides the functionality to find and read files on a gopher server.
 
-[`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md)<br/>
+[`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md)\
 Aids in Internet file searches of gopher servers.
 
-[`CGopherLocator` Class](../../mfc/reference/cgopherlocator-class.md)<br/>
+[`CGopherLocator` Class](../../mfc/reference/cgopherlocator-class.md)\
 Gets a gopher "locator" from a gopher server, determines the locator's type, and makes the locator available to [`CGopherFileFind` Class](../../mfc/reference/cgopherfilefind-class.md).
 
-[`CHeaderCtrl` Class](../../mfc/reference/cheaderctrl-class.md)<br/>
+[`CHeaderCtrl` Class](../../mfc/reference/cheaderctrl-class.md)\
 Provides the functionality of the Windows common header control.
 
-[`CHotKeyCtrl` Class](../../mfc/reference/chotkeyctrl-class.md)<br/>
+[`CHotKeyCtrl` Class](../../mfc/reference/chotkeyctrl-class.md)\
 Provides the functionality of the Windows common hot key control.
 
-[`CHtmlEditCtrl` Class](../../mfc/reference/chtmleditctrl-class.md)<br/>
+[`CHtmlEditCtrl` Class](../../mfc/reference/chtmleditctrl-class.md)\
 Provides the functionality of the `WebBrowser` ActiveX control in an MFC window.
 
-[`CHtmlEditCtrlBase` Class](../../mfc/reference/chtmleditctrlbase-class.md)<br/>
+[`CHtmlEditCtrlBase` Class](../../mfc/reference/chtmleditctrlbase-class.md)\
 Represents an HTML editing component.
 
-[`CHtmlEditDoc` Class](../../mfc/reference/chtmleditdoc-class.md)<br/>
+[`CHtmlEditDoc` Class](../../mfc/reference/chtmleditdoc-class.md)\
 With [`CHtmlEditView` Class](../../mfc/reference/chtmleditview-class.md), provides the functionality of the WebBrowser editing platform within the context of the MFC document-view architecture.
 
-[`CHtmlEditView` Class](../../mfc/reference/chtmleditview-class.md)<br/>
+[`CHtmlEditView` Class](../../mfc/reference/chtmleditview-class.md)\
 Provides the functionality of the WebBrowser editing platform within the context of MFC's document/view architecture.
 
-[`CHtmlView` Class](../../mfc/reference/chtmlview-class.md)<br/>
+[`CHtmlView` Class](../../mfc/reference/chtmlview-class.md)\
 Provides the functionality of the WebBrowser control within the context of MFC's document/view architecture.
 
-[`CHttpConnection` Class](../../mfc/reference/chttpconnection-class.md)<br/>
+[`CHttpConnection` Class](../../mfc/reference/chttpconnection-class.md)\
 Manages your connection to an HTTP server.
 
-[`CHttpFile` Class](../../mfc/reference/chttpfile-class.md)<br/>
+[`CHttpFile` Class](../../mfc/reference/chttpfile-class.md)\
 Provides the functionality to request and read files on an HTTP server.
 
-[`CHwndRenderTarget` Class](../../mfc/reference/chwndrendertarget-class.md)<br/>
+[`CHwndRenderTarget` Class](../../mfc/reference/chwndrendertarget-class.md)\
 A wrapper for `ID2D1HwndRenderTarget`.
 
-[`CImageList` Class](../../mfc/reference/cimagelist-class.md)<br/>
+[`CImageList` Class](../../mfc/reference/cimagelist-class.md)\
 Provides the functionality of the Windows common image list control.
 
-[`CInstantaneousTransition` Class](../../mfc/reference/cinstantaneoustransition-class.md)<br/>
+[`CInstantaneousTransition` Class](../../mfc/reference/cinstantaneoustransition-class.md)\
 Encapsulates an instantaneous transition.
 
-[`CInternetConnection` Class](../../mfc/reference/cinternetconnection-class.md)<br/>
+[`CInternetConnection` Class](../../mfc/reference/cinternetconnection-class.md)\
 Manages your connection to an Internet server.
 
-[`CInternetException` Class](../../mfc/reference/cinternetexception-class.md)<br/>
+[`CInternetException` Class](../../mfc/reference/cinternetexception-class.md)\
 Represents an exception condition related to an Internet operation.
 
-[`CInternetFile` Class](../../mfc/reference/cinternetfile-class.md)<br/>
+[`CInternetFile` Class](../../mfc/reference/cinternetfile-class.md)\
 Enables access to files on remote systems that use Internet protocols.
 
-[`CInternetSession` Class](../../mfc/reference/cinternetsession-class.md)<br/>
+[`CInternetSession` Class](../../mfc/reference/cinternetsession-class.md)\
 Creates and initializes a single or several simultaneous Internet sessions and, if necessary, describes your connection to a proxy server.
 
-[`CInterpolatorBase` Class](../../mfc/reference/cinterpolatorbase-class.md)<br/>
+[`CInterpolatorBase` Class](../../mfc/reference/cinterpolatorbase-class.md)\
 Implements a callback, which is called by the Animation API when it has to calculate a new value of an animation variable.
 
-[`CInvalidArgException` Class](../../mfc/reference/cinvalidargexception-class.md)<br/>
+[`CInvalidArgException` Class](../../mfc/reference/cinvalidargexception-class.md)\
 This class represents an invalid argument exception condition.
 
-[`CIPAddressCtrl` Class](../../mfc/reference/cipaddressctrl-class.md)<br/>
+[`CIPAddressCtrl` Class](../../mfc/reference/cipaddressctrl-class.md)\
 Provides the functionality of the Windows common IP Address control.
 
-[`CJumpList` Class](../../mfc/reference/cjumplist-class.md)<br/>
+[`CJumpList` Class](../../mfc/reference/cjumplist-class.md)\
 The list of shortcuts revealed when you right click on an icon in the task bar.
 
-[`CKeyboardManager` Class](../../mfc/reference/ckeyboardmanager-class.md)<br/>
+[`CKeyboardManager` Class](../../mfc/reference/ckeyboardmanager-class.md)\
 Manages shortcut key tables for the main frame window and child frame windows.
 
-[`CKeyFrame` Class](../../mfc/reference/ckeyframe-class.md)<br/>
+[`CKeyFrame` Class](../../mfc/reference/ckeyframe-class.md)\
 Represents an animation keyframe.
 
-[`CLinearTransition` Class](../../mfc/reference/clineartransition-class.md)<br/>
+[`CLinearTransition` Class](../../mfc/reference/clineartransition-class.md)\
 Encapsulates a linear transition.
 
-[`CLinearTransitionFromSpeed` Class](../../mfc/reference/clineartransitionfromspeed-class.md)<br/>
+[`CLinearTransitionFromSpeed` Class](../../mfc/reference/clineartransitionfromspeed-class.md)\
 Encapsulates a linear-speed transition.
 
-[`CLinkCtrl` Class](../../mfc/reference/clinkctrl-class.md)<br/>
+[`CLinkCtrl` Class](../../mfc/reference/clinkctrl-class.md)\
 Provides the functionality of the Windows common SysLink control.
 
-[`CList` Class](../../mfc/reference/clist-class.md)<br/>
+[`CList` Class](../../mfc/reference/clist-class.md)\
 Supports ordered lists of nonunique objects accessible sequentially or by value.
 
-[`CListBox` Class](../../mfc/reference/clistbox-class.md)<br/>
+[`CListBox` Class](../../mfc/reference/clistbox-class.md)\
 Provides the functionality of a Windows list box.
 
-[`CListCtrl` Class](../../mfc/reference/clistctrl-class.md)<br/>
+[`CListCtrl` Class](../../mfc/reference/clistctrl-class.md)\
 Encapsulates the functionality of a "list view control," which displays a collection of items each consisting of an icon (from an image list) and a label.
 
-[`CListView` Class](../../mfc/reference/clistview-class.md)<br/>
+[`CListView` Class](../../mfc/reference/clistview-class.md)\
 Simplifies use of the list control and of [`CListCtrl` Class](../../mfc/reference/clistctrl-class.md), the class that encapsulates list-control functionality, with MFC's document-view architecture.
 
-[`CLongBinary` Class](../../mfc/reference/clongbinary-class.md)<br/>
+[`CLongBinary` Class](../../mfc/reference/clongbinary-class.md)\
 Simplifies working with very large binary data objects (often called BLOBs, or "binary large objects") in a database.
 
-[`CMap` Class](../../mfc/reference/cmap-class.md)<br/>
+[`CMap` Class](../../mfc/reference/cmap-class.md)\
 A dictionary collection class that maps unique keys to values.
 
-[`CMapPtrToPtr` Class](../../mfc/reference/cmapptrtoptr-class.md)<br/>
+[`CMapPtrToPtr` Class](../../mfc/reference/cmapptrtoptr-class.md)\
 Supports maps of void pointers keyed by void pointers.
 
-[`CMapPtrToWord` Class](../../mfc/reference/cmapptrtoword-class.md)<br/>
+[`CMapPtrToWord` Class](../../mfc/reference/cmapptrtoword-class.md)\
 Supports maps of 16-bit words keyed by void pointers.
 
-[`CMapStringToOb` Class](../../mfc/reference/cmapstringtoob-class.md)<br/>
+[`CMapStringToOb` Class](../../mfc/reference/cmapstringtoob-class.md)\
 A dictionary collection class that maps unique `CString` objects to `CObject` pointers.
 
-[`CMapStringToPtr` Class](../../mfc/reference/cmapstringtoptr-class.md)<br/>
+[`CMapStringToPtr` Class](../../mfc/reference/cmapstringtoptr-class.md)\
 Supports maps of void pointers keyed by `CString` objects.
 
-[`CMapStringToString` Class](../../mfc/reference/cmapstringtostring-class.md)<br/>
+[`CMapStringToString` Class](../../mfc/reference/cmapstringtostring-class.md)\
 Supports maps of `CString` objects keyed by `CString` objects.
 
-[`CMapWordToOb` Class](../../mfc/reference/cmapwordtoob-class.md)<br/>
+[`CMapWordToOb` Class](../../mfc/reference/cmapwordtoob-class.md)\
 Supports maps of `CObject` pointers keyed by 16-bit words.
 
-[`CMapWordToPtr` Class](../../mfc/reference/cmapwordtoptr-class.md)<br/>
+[`CMapWordToPtr` Class](../../mfc/reference/cmapwordtoptr-class.md)\
 Supports maps of void pointers keyed by 16-bit words.
 
-[`CMDIChildWnd` Class](../../mfc/reference/cmdichildwnd-class.md)<br/>
+[`CMDIChildWnd` Class](../../mfc/reference/cmdichildwnd-class.md)\
 Provides the functionality of a Windows multiple document interface (MDI) child window, along with members for managing the window.
 
-[`CMDIChildWndEx` Class](../../mfc/reference/cmdichildwndex-class.md)<br/>
+[`CMDIChildWndEx` Class](../../mfc/reference/cmdichildwndex-class.md)\
 Provides the functionality of a Windows multiple document interface (MDI) child window. It extends the functionality of [`CMDIChildWnd` Class](../../mfc/reference/cmdichildwnd-class.md). The framework requires this class when an MDI application uses certain MFC classes.
 
-[`CMDIFrameWnd` Class](../../mfc/reference/cmdiframewnd-class.md)<br/>
+[`CMDIFrameWnd` Class](../../mfc/reference/cmdiframewnd-class.md)\
 Provides the functionality of a Windows multiple document interface (MDI) frame window, along with members for managing the window.
 
-[`CMDIFrameWndEx` Class](../../mfc/reference/cmdiframewndex-class.md)<br/>
+[`CMDIFrameWndEx` Class](../../mfc/reference/cmdiframewndex-class.md)\
 Extends the functionality of [`CFrameWnd` Class](../../mfc/reference/cframewnd-class.md), a Windows Multiple Document Interface (MDI) frame window.
 
-[`CMDITabInfo` Class](../../mfc/reference/cmditabinfo-class.md)<br/>
+[`CMDITabInfo` Class](../../mfc/reference/cmditabinfo-class.md)\
 Used to pass parameters to [`CMDIFrameWndEx::EnableMDITabbedGroups`](../../mfc/reference/cmdiframewndex-class.md#enablemditabbedgroups) method. Set members of this class to control the behavior of MDI tabbed groups.
 
-[`CMemFile` Class](../../mfc/reference/cmemfile-class.md)<br/>
+[`CMemFile` Class](../../mfc/reference/cmemfile-class.md)\
 The [`CFile` Class](../../mfc/reference/cfile-class.md)-derived class that supports memory files.
 
-[`CMemoryException` Class](../../mfc/reference/cmemoryexception-class.md)<br/>
+[`CMemoryException` Class](../../mfc/reference/cmemoryexception-class.md)\
 Represents an out-of-memory exception condition.
 
-[`CMenu` Class](../../mfc/reference/cmenu-class.md)<br/>
+[`CMenu` Class](../../mfc/reference/cmenu-class.md)\
 An encapsulation of the Windows `HMENU`.
 
-[`CMenuTearOffManager` Class](../../mfc/reference/cmenutearoffmanager-class.md)<br/>
+[`CMenuTearOffManager` Class](../../mfc/reference/cmenutearoffmanager-class.md)\
 Manages tear-off menus. A tear-off menu is a menu on the menu bar. The user can remove a tear-off menu from the menu bar, causing the tear-off menu to float.
 
-[`CMetaFileDC` Class](../../mfc/reference/cmetafiledc-class.md)<br/>
+[`CMetaFileDC` Class](../../mfc/reference/cmetafiledc-class.md)\
 Implements a Windows metafile, which contains a sequence of graphics device interface (GDI) commands that you can replay to create a desired image or text.
 
-[`CMFCAcceleratorKey` Class](../../mfc/reference/cmfcacceleratorkey-class.md)<br/>
+[`CMFCAcceleratorKey` Class](../../mfc/reference/cmfcacceleratorkey-class.md)\
 Helper class that implements virtual key mapping and formatting.
 
-[`CMFCAcceleratorKeyAssignCtrl` Class](../../mfc/reference/cmfcacceleratorkeyassignctrl-class.md)<br/>
+[`CMFCAcceleratorKeyAssignCtrl` Class](../../mfc/reference/cmfcacceleratorkeyassignctrl-class.md)\
 Extends the [`CEdit` Class](../../mfc/reference/cedit-class.md) to support extra system buttons such as ALT, CONTROL, and SHIFT.
 
-[`CMFCAutoHideButton` Class](../../mfc/reference/cmfcautohidebutton-class.md)<br/>
+[`CMFCAutoHideButton` Class](../../mfc/reference/cmfcautohidebutton-class.md)\
 A button that displays or hides a [`CDockablePane` Class](../../mfc/reference/cdockablepane-class.md) that is configured to hide.
 
-[`CMFCBaseTabCtrl` Class](../../mfc/reference/cmfcbasetabctrl-class.md)<br/>
+[`CMFCBaseTabCtrl` Class](../../mfc/reference/cmfcbasetabctrl-class.md)\
 Implements the base functionality for tabbed windows.
 
-[`CMFCButton` Class](../../mfc/reference/cmfcbutton-class.md)<br/>
+[`CMFCButton` Class](../../mfc/reference/cmfcbutton-class.md)\
 Adds functionality to the [`CButton` Class](../../mfc/reference/cbutton-class.md) class such as aligning button text, combining button text and an image, selecting a cursor, and specifying a tool tip.
 
-[`CMFCCaptionBar` Class](../../mfc/reference/cmfccaptionbar-class.md)<br/>
+[`CMFCCaptionBar` Class](../../mfc/reference/cmfccaptionbar-class.md)\
 Control bar that can display three elements: a button, a text label, and a bitmap. It can only display one element of each type at a time. You can align each element to the left or right edges of the control or to the center. You can also apply a flat or 3D style to the top and bottom borders of the caption bar.
 
-[`CMFCCaptionButton` Class](../../mfc/reference/cmfccaptionbutton-class.md)<br/>
+[`CMFCCaptionButton` Class](../../mfc/reference/cmfccaptionbutton-class.md)\
 Implements a button that is displayed on the caption bar for a docking pane or a mini-frame window. Typically, the framework creates caption buttons automatically.
 
-[`CMFCColorBar` Class](../../mfc/reference/cmfccolorbar-class.md)<br/>
+[`CMFCColorBar` Class](../../mfc/reference/cmfccolorbar-class.md)\
 Represents a docking control bar that can select colors in a document or application.
 
-[`CMFCColorButton` Class](../../mfc/reference/cmfccolorbutton-class.md)<br/>
+[`CMFCColorButton` Class](../../mfc/reference/cmfccolorbutton-class.md)\
 The `CMFCColorButton` and [`CMFCColorBar` Class](../../mfc/reference/cmfccolorbar-class.md) classes are used together to implement a color picker control.
 
-[`CMFCColorDialog` Class](../../mfc/reference/cmfccolordialog-class.md)<br/>
+[`CMFCColorDialog` Class](../../mfc/reference/cmfccolordialog-class.md)\
 Represents a color selection dialog box.
 
-[`CMFCColorMenuButton` Class](../../mfc/reference/cmfccolormenubutton-class.md)<br/>
+[`CMFCColorMenuButton` Class](../../mfc/reference/cmfccolormenubutton-class.md)\
 Supports a menu command or a toolbar button that starts a color picker dialog box.
 
-[`CMFCColorPickerCtrl` Class](../../mfc/reference/cmfccolorpickerctrl-class.md)<br/>
+[`CMFCColorPickerCtrl` Class](../../mfc/reference/cmfccolorpickerctrl-class.md)\
 Provides functionality for a control that is used to select colors.
 
-[`CMFCDesktopAlertDialog` Class](../../mfc/reference/cmfcdesktopalertdialog-class.md)<br/>
+[`CMFCDesktopAlertDialog` Class](../../mfc/reference/cmfcdesktopalertdialog-class.md)\
 Used together with the [`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md) to display a custom dialog in a popup window.
 
-[`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md)<br/>
+[`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md)\
 Implements the functionality of a modeless dialog box which appears on the screen to inform the user about an event.
 
-[`CMFCDesktopAlertWndInfo` Class](../../mfc/reference/cmfcdesktopalertwndinfo-class.md)<br/>
+[`CMFCDesktopAlertWndInfo` Class](../../mfc/reference/cmfcdesktopalertwndinfo-class.md)\
 Used with the [`CMFCDesktopAlertWnd` Class](../../mfc/reference/cmfcdesktopalertwnd-class.md). It specifies the controls that are displayed if the desktop alert window pops up.
 
-[`CMFCDragFrameImpl` Class](../../mfc/reference/cmfcdragframeimpl-class.md)<br/>
+[`CMFCDragFrameImpl` Class](../../mfc/reference/cmfcdragframeimpl-class.md)\
 Draws the drag rectangle that appears when the user drags a pane in the standard dock mode.
 
-[`CMFCDropDownToolBar` Class](../../mfc/reference/cmfcdropdowntoolbar-class.md)<br/>
+[`CMFCDropDownToolBar` Class](../../mfc/reference/cmfcdropdowntoolbar-class.md)\
 A toolbar that appears when the user presses and holds a top-level toolbar button.
 
-[`CMFCDropDownToolbarButton` Class](../../mfc/reference/cmfcdropdowntoolbarbutton-class.md)<br/>
+[`CMFCDropDownToolbarButton` Class](../../mfc/reference/cmfcdropdowntoolbarbutton-class.md)\
 A type of toolbar button that behaves like a regular button when it is clicked. However, it opens a drop-down toolbar ([`CMFCDropDownToolBar` Class](../../mfc/reference/cmfcdropdowntoolbar-class.md) if the user presses and holds the toolbar button down.
 
-[`CMFCDynamicLayout` Class](../../mfc/reference/cmfcdynamiclayout-class.md)<br/>
+[`CMFCDynamicLayout` Class](../../mfc/reference/cmfcdynamiclayout-class.md)\
 Specifies how controls in a window are moved and resized as the user resizes the window.
 
-[`CMFCEditBrowseCtrl` Class](../../mfc/reference/cmfceditbrowsectrl-class.md)<br/>
+[`CMFCEditBrowseCtrl` Class](../../mfc/reference/cmfceditbrowsectrl-class.md)\
 Supports the edit browse control, which is an editable text box that optionally contains a browse button. When the user clicks the browse button, the control performs a custom action or displays a standard dialog box that contains a file browser or a folder browser.
 
-[`CMFCFilterChunkValueImpl` Class](../../mfc/reference/cmfcfilterchunkvalueimpl-class.md)<br/>
+[`CMFCFilterChunkValueImpl` Class](../../mfc/reference/cmfcfilterchunkvalueimpl-class.md)\
 Simplifies both chunk and property value pair logic.
 
-[`CMFCFontComboBox` Class](../../mfc/reference/cmfcfontcombobox-class.md)<br/>
+[`CMFCFontComboBox` Class](../../mfc/reference/cmfcfontcombobox-class.md)\
 Creates a combo box control that contains a list of fonts.
 
-[`CMFCFontInfo` Class](../../mfc/reference/cmfcfontinfo-class.md)<br/>
+[`CMFCFontInfo` Class](../../mfc/reference/cmfcfontinfo-class.md)\
 Describes the name and other attributes of a font.
 
-[`CMFCHeaderCtrl` Class](../../mfc/reference/cmfcheaderctrl-class.md)<br/>
+[`CMFCHeaderCtrl` Class](../../mfc/reference/cmfcheaderctrl-class.md)\
 Supports sorting multiple columns in a header control.
 
-[`CMFCImageEditorDialog` Class](../../mfc/reference/cmfcimageeditordialog-class.md)<br/>
+[`CMFCImageEditorDialog` Class](../../mfc/reference/cmfcimageeditordialog-class.md)\
 Supports an image editor dialog box.
 
-[`CMFCKeyMapDialog` Class](../../mfc/reference/cmfckeymapdialog-class.md)<br/>
+[`CMFCKeyMapDialog` Class](../../mfc/reference/cmfckeymapdialog-class.md)\
 Supports a control that maps commands to keys on the keyboard.
 
-[`CMFCLinkCtrl` Class](../../mfc/reference/cmfclinkctrl-class.md)<br/>
+[`CMFCLinkCtrl` Class](../../mfc/reference/cmfclinkctrl-class.md)\
 Displays a button as a hyperlink and invokes the link's target when the button is clicked.
 
-[`CMFCListCtrl` Class](../../mfc/reference/cmfclistctrl-class.md)<br/>
+[`CMFCListCtrl` Class](../../mfc/reference/cmfclistctrl-class.md)\
 Extends the functionality of [`CListCtrl` Class](../../mfc/reference/clistctrl-class.md) class by supporting the advanced header control functionality of the [`CMFCHeaderCtrl` Class](../../mfc/reference/cmfcheaderctrl-class.md).
 
-[`CMFCMaskedEdit` Class](../../mfc/reference/cmfcmaskededit-class.md)<br/>
+[`CMFCMaskedEdit` Class](../../mfc/reference/cmfcmaskededit-class.md)\
 Supports a masked edit control, which validates user input against a mask and displays the validated results according to a template.
 
-[`CMFCMenuBar` Class](../../mfc/reference/cmfcmenubar-class.md)<br/>
+[`CMFCMenuBar` Class](../../mfc/reference/cmfcmenubar-class.md)\
 A menu bar that implements docking.
 
-[`CMFCMenuButton` Class](../../mfc/reference/cmfcmenubutton-class.md)<br/>
+[`CMFCMenuButton` Class](../../mfc/reference/cmfcmenubutton-class.md)\
 A button that displays a pop-up menu and reports on the user's menu selections.
 
-[`CMFCOutlookBar` Class](../../mfc/reference/cmfcoutlookbar-class.md)<br/>
+[`CMFCOutlookBar` Class](../../mfc/reference/cmfcoutlookbar-class.md)\
 A tabbed pane with the visual appearance of the **Navigation Pane** in Microsoft Outlook 2000 or Outlook 2003. The `CMFCOutlookBar` object contains a [`CMFCOutlookBarTabCtrl` Class](../../mfc/reference/cmfcoutlookbartabctrl-class.md) object and a series of tabs. The tabs can be either [`CMFCOutlookBarPane` Class](../../mfc/reference/cmfcoutlookbarpane-class.md) objects or `CWnd`-derived objects. To the user, the Outlook bar appears as a series of buttons and a display area. When the user clicks a button, the corresponding control or button pane is displayed.
 
-[`CMFCOutlookBarPane` Class](../../mfc/reference/cmfcoutlookbarpane-class.md)<br/>
+[`CMFCOutlookBarPane` Class](../../mfc/reference/cmfcoutlookbarpane-class.md)\
 A control derived from [`CMFCToolBar` Class](../../mfc/reference/cmfctoolbar-class.md) that can be inserted into an Outlook bar ([`CMFCOutlookBar` Class](../../mfc/reference/cmfcoutlookbar-class.md)). The Outlook bar pane contains a column of large buttons. The user can scroll up and down the list of buttons if it is larger than the pane. When the user detaches an Outlook bar pane from the Outlook bar, it can float or dock in the main frame window.
 
-[`CMFCOutlookBarTabCtrl` Class](../../mfc/reference/cmfcoutlookbartabctrl-class.md)<br/>
+[`CMFCOutlookBarTabCtrl` Class](../../mfc/reference/cmfcoutlookbartabctrl-class.md)\
 A tab control that has the visual appearance of the **Navigation Pane** in Microsoft Outlook.
 
-[`CMFCPopupMenu` Class](../../mfc/reference/cmfcpopupmenu-class.md)<br/>
+[`CMFCPopupMenu` Class](../../mfc/reference/cmfcpopupmenu-class.md)\
 Implements Windows pop-up menu functionality and extends it by adding features such as tear-off menus and tooltips.
 
-[`CMFCPopupMenuBar` Class](../../mfc/reference/cmfcpopupmenubar-class.md)<br/>
+[`CMFCPopupMenuBar` Class](../../mfc/reference/cmfcpopupmenubar-class.md)\
 A menu bar embedded into a pop-up menu.
 
-[`CMFCPreviewCtrlImpl` Class](../../mfc/reference/cmfcpreviewctrlimpl-class.md)<br/>
+[`CMFCPreviewCtrlImpl` Class](../../mfc/reference/cmfcpreviewctrlimpl-class.md)\
 Implements a window that is placed on a host window provided by the Shell for Rich Preview.
 
-[`CMFCPropertyGridColorProperty` Class](../../mfc/reference/cmfcpropertygridcolorproperty-class.md)<br/>
+[`CMFCPropertyGridColorProperty` Class](../../mfc/reference/cmfcpropertygridcolorproperty-class.md)\
 Supports a property list control item that opens a color selection dialog box.
 
-[`CMFCPropertyGridCtrl` Class](../../mfc/reference/cmfcpropertygridctrl-class.md)<br/>
+[`CMFCPropertyGridCtrl` Class](../../mfc/reference/cmfcpropertygridctrl-class.md)\
 Supports an editable property grid control that can display properties in alphabetical or hierarchical order.
 
-[`CMFCPropertyGridFileProperty` Class](../../mfc/reference/cmfcpropertygridfileproperty-class.md)<br/>
+[`CMFCPropertyGridFileProperty` Class](../../mfc/reference/cmfcpropertygridfileproperty-class.md)\
 Supports a property list control item that opens a file selection dialog box.
 
-[`CMFCPropertyGridFontProperty` Class](../../mfc/reference/cmfcpropertygridfontproperty-class.md)<br/>
+[`CMFCPropertyGridFontProperty` Class](../../mfc/reference/cmfcpropertygridfontproperty-class.md)\
 Supports a property list control item that opens a font selection dialog box.
 
-[`CMFCPropertyGridProperty` Class](../../mfc/reference/cmfcpropertygridproperty-class.md)<br/>
+[`CMFCPropertyGridProperty` Class](../../mfc/reference/cmfcpropertygridproperty-class.md)\
 Represents a list item in a property list control.
 
-[`CMFCPropertyPage` Class](../../mfc/reference/cmfcpropertypage-class.md)<br/>
+[`CMFCPropertyPage` Class](../../mfc/reference/cmfcpropertypage-class.md)\
 Supports the display of pop-up menus on a property page.
 
-[`CMFCPropertySheet` Class](../../mfc/reference/cmfcpropertysheet-class.md)<br/>
+[`CMFCPropertySheet` Class](../../mfc/reference/cmfcpropertysheet-class.md)\
 Supports a property sheet where each property page is denoted by a page tab, a toolbar button, a tree control node, or a list item.
 
-[`CMFCReBar` Class](../../mfc/reference/cmfcrebar-class.md)<br/>
+[`CMFCReBar` Class](../../mfc/reference/cmfcrebar-class.md)\
 Control bar that provides layout, persistence, and state information for rebar controls.
 
-[`CMFCRibbonApplicationButton` Class](../../mfc/reference/cmfcribbonapplicationbutton-class.md)<br/>
+[`CMFCRibbonApplicationButton` Class](../../mfc/reference/cmfcribbonapplicationbutton-class.md)\
 Implements a special button located in the top-left corner of the application window. When clicked, the button opens a menu that usually contains common **File** commands like **Open**, **Save**, and **Exit**.
 
-[`CMFCRibbonBaseElement` Class](../../mfc/reference/cmfcribbonbaseelement-class.md)<br/>
+[`CMFCRibbonBaseElement` Class](../../mfc/reference/cmfcribbonbaseelement-class.md)\
 Base class for all elements that you can add to a [`CMFCRibbonBar` Class](../../mfc/reference/cmfcribbonbar-class.md). Examples of ribbon elements are ribbon buttons, ribbon check boxes, and ribbon combo boxes.
 
-[`CMFCRibbonButton` Class](../../mfc/reference/cmfcribbonbutton-class.md)<br/>
+[`CMFCRibbonButton` Class](../../mfc/reference/cmfcribbonbutton-class.md)\
 Implements buttons that you can position on ribbon bar elements such as panels, Quick Access Toolbars, and pop-up menus.
 
-[`CMFCRibbonButtonsGroup` Class](../../mfc/reference/cmfcribbonbuttonsgroup-class.md)<br/>
+[`CMFCRibbonButtonsGroup` Class](../../mfc/reference/cmfcribbonbuttonsgroup-class.md)\
 Lets you organize a set of ribbon buttons into a group. All buttons in the group are directly adjacent to each other horizontally and enclosed in a border.
 
-[`CMFCRibbonCategory` Class](../../mfc/reference/cmfcribboncategory-class.md)<br/>
+[`CMFCRibbonCategory` Class](../../mfc/reference/cmfcribboncategory-class.md)\
 Implements a ribbon tab that contains a group of [`CMFCRibbonPanel` Class](../../mfc/reference/cmfcribbonpanel-class.md).
 
-[`CMFCRibbonCheckBox` Class](../../mfc/reference/cmfcribboncheckbox-class.md)<br/>
+[`CMFCRibbonCheckBox` Class](../../mfc/reference/cmfcribboncheckbox-class.md)\
 Implements a check box that you can add to a ribbon panel, Quick Access Toolbar, or popup menu.
 
-[`CMFCRibbonColorButton` Class](../../mfc/reference/cmfcribboncolorbutton-class.md)<br/>
+[`CMFCRibbonColorButton` Class](../../mfc/reference/cmfcribboncolorbutton-class.md)\
 Implements a color button that you can add to a ribbon bar. The ribbon color button displays a drop-down menu that contains one or more color palettes.
 
-[`CMFCRibbonComboBox` Class](../../mfc/reference/cmfcribboncombobox-class.md)<br/>
+[`CMFCRibbonComboBox` Class](../../mfc/reference/cmfcribboncombobox-class.md)\
 Implements a combo box control that you can add to a ribbon bar, a ribbon panel, or a ribbon popup menu.
 
-[`CMFCRibbonContextCaption` Class](../../mfc/reference/cmfcribboncontextcaption-class.md)<br/>
+[`CMFCRibbonContextCaption` Class](../../mfc/reference/cmfcribboncontextcaption-class.md)\
 Implements a colored caption that appears at the top of a ribbon category or a context category.
 
-[`CMFCRibbonEdit` Class](../../mfc/reference/cmfcribbonedit-class.md)<br/>
+[`CMFCRibbonEdit` Class](../../mfc/reference/cmfcribbonedit-class.md)\
 Implements an edit control that is positioned on a ribbon.
 
-[`CMFCRibbonFontComboBox` Class](../../mfc/reference/cmfcribbonfontcombobox-class.md)<br/>
+[`CMFCRibbonFontComboBox` Class](../../mfc/reference/cmfcribbonfontcombobox-class.md)\
 Implements a combo box that contains a list of fonts. You place the combo box on a ribbon panel.
 
-[`CMFCRibbonGallery` Class](../../mfc/reference/cmfcribbongallery-class.md)<br/>
+[`CMFCRibbonGallery` Class](../../mfc/reference/cmfcribbongallery-class.md)\
 Implements Office 2007-style ribbon galleries.
 
-[`CMFCRibbonGalleryMenuButton` Class](../../mfc/reference/cmfcribbongallerymenubutton-class.md)<br/>
+[`CMFCRibbonGalleryMenuButton` Class](../../mfc/reference/cmfcribbongallerymenubutton-class.md)\
 Implements a ribbon menu button that contains ribbon galleries.
 
-[`CMFCRibbonLabel` Class](../../mfc/reference/cmfcribbonlabel-class.md)<br/>
+[`CMFCRibbonLabel` Class](../../mfc/reference/cmfcribbonlabel-class.md)\
 Implements a non-clickable text label for a ribbon.
 
-[`CMFCRibbonLinkCtrl` Class](../../mfc/reference/cmfcribbonlinkctrl-class.md)<br/>
+[`CMFCRibbonLinkCtrl` Class](../../mfc/reference/cmfcribbonlinkctrl-class.md)\
 Implements a hyperlink that is positioned on a ribbon. The hyperlink opens a Web page when you click it.
 
-[`CMFCRibbonMainPanel` Class](../../mfc/reference/cmfcribbonmainpanel-class.md)<br/>
+[`CMFCRibbonMainPanel` Class](../../mfc/reference/cmfcribbonmainpanel-class.md)\
 Implements a ribbon panel that displays when you click the [`CMFCRibbonApplicationButton` Class](../../mfc/reference/cmfcribbonapplicationbutton-class.md).
 
-[`CMFCRibbonMiniToolBar` Class](../../mfc/reference/cmfcribbonminitoolbar-class.md)<br/>
+[`CMFCRibbonMiniToolBar` Class](../../mfc/reference/cmfcribbonminitoolbar-class.md)\
 Implements a contextual popup toolbar.
 
-[`CMFCRibbonPanel` Class](../../mfc/reference/cmfcribbonpanel-class.md)<br/>
+[`CMFCRibbonPanel` Class](../../mfc/reference/cmfcribbonpanel-class.md)\
 Implements a panel that contains a set of ribbon elements. When the panel is drawn, it displays as many elements as possible, given the size of the panel.
 
-[`CMFCRibbonProgressBar` Class](../../mfc/reference/cmfcribbonprogressbar-class.md)<br/>
+[`CMFCRibbonProgressBar` Class](../../mfc/reference/cmfcribbonprogressbar-class.md)\
 Implements a control that visually indicates the progress of a lengthy operation.
 
-[`CMFCRibbonSlider` Class](../../mfc/reference/cmfcribbonslider-class.md)<br/>
+[`CMFCRibbonSlider` Class](../../mfc/reference/cmfcribbonslider-class.md)\
 Implements a slider control that you can add to a ribbon bar or ribbon status bar. The ribbon slider control resembles the zoom sliders that appear in Office 2007 applications.
 
-[`CMFCRibbonStatusBar` Class](../../mfc/reference/cmfcribbonstatusbar-class.md)<br/>
+[`CMFCRibbonStatusBar` Class](../../mfc/reference/cmfcribbonstatusbar-class.md)\
 Implements a status bar control that can display ribbon elements.
 
-[`CMFCRibbonStatusBarPane` Class](../../mfc/reference/cmfcribbonstatusbarpane-class.md)<br/>
+[`CMFCRibbonStatusBarPane` Class](../../mfc/reference/cmfcribbonstatusbarpane-class.md)\
 Implements a ribbon element that you can add to a ribbon status bar.
 
-[`CMFCRibbonUndoButton` Class](../../mfc/reference/cmfcribbonundobutton-class.md)<br/>
+[`CMFCRibbonUndoButton` Class](../../mfc/reference/cmfcribbonundobutton-class.md)\
 Implements a split button, a small button with a downward pointing triangle on the rightmost part of the main button. Users can click the triangle to display a drop-down list of their most recently performed actions. Users can then select one or more actions from the drop-down list. However, if the user clicks the button, only the last (the most recently added) action on the drop-down list is undone. You should populate the list with actions as the user performs them.
 
-[`CMFCShellListCtrl` Class](../../mfc/reference/cmfcshelllistctrl-class.md)<br/>
+[`CMFCShellListCtrl` Class](../../mfc/reference/cmfcshelllistctrl-class.md)\
 Provides Windows list control functionality and expands it by including the ability to display a list of shell items.
 
-[`CMFCShellTreeCtrl` Class](../../mfc/reference/cmfcshelltreectrl-class.md)<br/>
+[`CMFCShellTreeCtrl` Class](../../mfc/reference/cmfcshelltreectrl-class.md)\
 Extends [`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md) functionality by displaying a hierarchy of Shell items.
 
-[`CMFCSpinButtonCtrl` Class](../../mfc/reference/cmfcspinbuttonctrl-class.md)<br/>
+[`CMFCSpinButtonCtrl` Class](../../mfc/reference/cmfcspinbuttonctrl-class.md)\
 Supports a visual manager that draws a spin button control.
 
-[`CMFCStatusBar` Class](../../mfc/reference/cmfcstatusbar-class.md)<br/>
+[`CMFCStatusBar` Class](../../mfc/reference/cmfcstatusbar-class.md)\
 Implements a status bar similar to the `CStatusBar` class. However, the `CMFCStatusBar` class has features not offered by the `CStatusBar` class, such as the ability to display images, animations, and progress bars; and the ability to respond to mouse double-clicks.
 
-[`CMFCTabCtrl` Class](../../mfc/reference/cmfctabctrl-class.md)<br/>
+[`CMFCTabCtrl` Class](../../mfc/reference/cmfctabctrl-class.md)\
 Provides functionality for a tab control. The tab control displays a dockable window with flat or three-dimensional tabs at its top or bottom. The tabs can display text and an image and can change color when active.
 
-[`CMFCTabToolTipInfo Structure](../../mfc/reference/cmfctabtooltipinfo-structure.md)<br/>
+[`CMFCTabToolTipInfo Structure](../../mfc/reference/cmfctabtooltipinfo-structure.md)\
 Provides information about the MDI tab that the user is hovering over.
 
-[`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md)<br/>
+[`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md)\
 Implements a list of clickable items (tasks).
 
-[`CMFCTasksPaneTask` Class](../../mfc/reference/cmfctaskspanetask-class.md)<br/>
+[`CMFCTasksPaneTask` Class](../../mfc/reference/cmfctaskspanetask-class.md)\
 Helper class that represents tasks for the task pane control ([`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md)). The task object represents an item in the task group ([`CMFCTasksPaneTaskGroup` Class](../../mfc/reference/cmfctaskspanetaskgroup-class.md)). Each task can have a command that the framework executes when a user clicks on the task and an icon that appears to the left of the task name.
 
-[`CMFCTasksPaneTaskGroup` Class](../../mfc/reference/cmfctaskspanetaskgroup-class.md)<br/>
+[`CMFCTasksPaneTaskGroup` Class](../../mfc/reference/cmfctaskspanetaskgroup-class.md)\
 Helper class used by the [`CMFCTasksPane` Class](../../mfc/reference/cmfctaskspane-class.md) control. Objects of type `CMFCTasksPaneTaskGroup` represent a *task group*. The task group is a list of items that the framework displays in a separate box that has a collapse button. The box can have an optional caption (group name). If a group is collapsed, the list of tasks is not visible.
 
-[`CMFCToolBar` Class](../../mfc/reference/cmfctoolbar-class.md)<br/>
+[`CMFCToolBar` Class](../../mfc/reference/cmfctoolbar-class.md)\
 Resembles [`CToolBar` Class](../../mfc/reference/ctoolbar-class.md), but provides additional support for user interface features. These include flat toolbars, toolbars with hot images, large icons, pager buttons, locked toolbars, rebar controls, text under images, background images, and tabbed toolbars. The `CMFCToolBar` class also contains built-in support for user customization of toolbars and menus, drag-and-drop between toolbars and menus, combo box buttons, edit box buttons, color pickers, and roll-up buttons.
 
-[`CMFCToolBarImages` Class](../../mfc/reference/cmfctoolbarimages-class.md)<br/>
+[`CMFCToolBarImages` Class](../../mfc/reference/cmfctoolbarimages-class.md)\
 Manages toolbar images loaded from application resources or from files.
 
-[`CMFCToolBarInfo` Class](../../mfc/reference/cmfctoolbarinfo-class.md)<br/>
+[`CMFCToolBarInfo` Class](../../mfc/reference/cmfctoolbarinfo-class.md)\
 Contains the resource IDs of toolbar images in various states. `CMFCToolBarInfo` is a helper class that is used as a parameter of the [`CMFCToolBar::LoadToolBarEx`](../../mfc/reference/cmfctoolbar-class.md#loadtoolbarex) method.
 
-[`CMFCToolBarMenuButton` Class](../../mfc/reference/cmfctoolbarmenubutton-class.md)<br/>
+[`CMFCToolBarMenuButton` Class](../../mfc/reference/cmfctoolbarmenubutton-class.md)\
 A toolbar button that contains a pop-up menu.
 
-[`CMFCToolBarsCustomizeDialog` Class](../../mfc/reference/cmfctoolbarscustomizedialog-class.md)<br/>
+[`CMFCToolBarsCustomizeDialog` Class](../../mfc/reference/cmfctoolbarscustomizedialog-class.md)\
 A modeless tab dialog box ([`CPropertySheet` Class](../../mfc/reference/cpropertysheet-class.md)) that enables the user to customize the toolbars, menus, keyboard shortcuts, user-defined tools, and visual style in an application. Typically, the user accesses this dialog box by selecting **Customize** from the **Tools** menu.
 
-[`CMFCToolTipCtrl` Class](../../mfc/reference/cmfctooltipctrl-class.md)<br/>
+[`CMFCToolTipCtrl` Class](../../mfc/reference/cmfctooltipctrl-class.md)\
 An extended tooltip implementation based on the [`CToolTipCtrl` Class](../../mfc/reference/ctooltipctrl-class.md). A tooltip based on the `CMFCToolTipCtrl` class can display an icon, a label, and a description. You can customize its visual appearance by using a gradient fill, custom text and border colors, bold text, rounded corners, or a balloon style.
 
-[`CMFCToolTipInfo` Class](../../mfc/reference/cmfctooltipinfo-class.md)<br/>
+[`CMFCToolTipInfo` Class](../../mfc/reference/cmfctooltipinfo-class.md)\
 Stores information about the visual appearance of tooltips.
 
-[`CMFCVisualManager` Class](../../mfc/reference/cmfcvisualmanager-class.md)<br/>
+[`CMFCVisualManager` Class](../../mfc/reference/cmfcvisualmanager-class.md)\
 Provides support for changing the appearance of your application at a global level. The `CMFCVisualManager` class works together with a class that provides instructions to draw the GUI controls of your application using a consistent style. These other classes are referred to as visual managers and they inherit from `CMFCBaseVisualManager`.
 
-[`CMFCVisualManagerOffice2003` Class](../../mfc/reference/cmfcvisualmanageroffice2003-class.md)<br/>
+[`CMFCVisualManagerOffice2003` Class](../../mfc/reference/cmfcvisualmanageroffice2003-class.md)\
 Gives an application a Microsoft Office 2003 appearance.
 
-[`CMFCVisualManagerOffice2007` Class](../../mfc/reference/cmfcvisualmanageroffice2007-class.md)<br/>
+[`CMFCVisualManagerOffice2007` Class](../../mfc/reference/cmfcvisualmanageroffice2007-class.md)\
 Gives an application a Microsoft Office 2007 appearance.
 
-[`CMFCVisualManagerVS2005` Class](../../mfc/reference/cmfcvisualmanagervs2005-class.md)<br/>
+[`CMFCVisualManagerVS2005` Class](../../mfc/reference/cmfcvisualmanagervs2005-class.md)\
 Gives an application a Microsoft Visual Studio 2005 appearance.
 
-[`CMFCVisualManagerWindows` Class](../../mfc/reference/cmfcvisualmanagerwindows-class.md)<br/>
+[`CMFCVisualManagerWindows` Class](../../mfc/reference/cmfcvisualmanagerwindows-class.md)\
 Mimics the appearance of Microsoft Windows XP or Microsoft Vista when the user selects a Windows XP or Vista theme.
 
-[`CMFCVisualManagerWindows7` Class](../../mfc/reference/cmfcvisualmanagerwindows7-class.md)<br/>
+[`CMFCVisualManagerWindows7` Class](../../mfc/reference/cmfcvisualmanagerwindows7-class.md)\
 Gives an application the appearance of a Windows 7 application.
 
-[`CMFCWindowsManagerDialog` Class](../../mfc/reference/cmfcwindowsmanagerdialog-class.md)<br/>
+[`CMFCWindowsManagerDialog` Class](../../mfc/reference/cmfcwindowsmanagerdialog-class.md)\
 Enables a user to manage MDI child windows in an MDI application.
 
-[`CMiniFrameWnd` Class](../../mfc/reference/cminiframewnd-class.md)<br/>
+[`CMiniFrameWnd` Class](../../mfc/reference/cminiframewnd-class.md)\
 Represents a half-height frame window typically seen around floating toolbars.
 
-[`CMonikerFile` Class](../../mfc/reference/cmonikerfile-class.md)<br/>
+[`CMonikerFile` Class](../../mfc/reference/cmonikerfile-class.md)\
 Represents a stream of data ([`IStream`](/windows/win32/api/objidl/nn-objidl-istream)) named by an [`IMoniker`](/windows/win32/api/objidl/nn-objidl-imoniker).
 
-[`CMonthCalCtrl` Class](../../mfc/reference/cmonthcalctrl-class.md)<br/>
+[`CMonthCalCtrl` Class](../../mfc/reference/cmonthcalctrl-class.md)\
 Encapsulates the functionality of a month calendar control.
 
-[`CMouseManager` Class](../../mfc/reference/cmousemanager-class.md)<br/>
+[`CMouseManager` Class](../../mfc/reference/cmousemanager-class.md)\
 Lets a user associate different commands with a particular [`CView` Class](../../mfc/reference/cview-class.md) object when the user double-clicks inside that view.
 
-[`CMultiDocTemplate` Class](../../mfc/reference/cmultidoctemplate-class.md)<br/>
+[`CMultiDocTemplate` Class](../../mfc/reference/cmultidoctemplate-class.md)\
 Defines a document template that implements the multiple document interface (MDI).
 
-[`CMultiLock` Class](../../mfc/reference/cmultilock-class.md)<br/>
+[`CMultiLock` Class](../../mfc/reference/cmultilock-class.md)\
 Represents the access-control mechanism used in controlling access to resources in a multithreaded program.
 
-[`CMultiPageDHtmlDialog` Class](../../mfc/reference/cmultipagedhtmldialog-class.md)<br/>
+[`CMultiPageDHtmlDialog` Class](../../mfc/reference/cmultipagedhtmldialog-class.md)\
 A multipage dialog displays multiple HTML pages sequentially and handles the events from each page.
 
-[`CMultiPaneFrameWnd` Class](../../mfc/reference/cmultipaneframewnd-class.md)<br/>
+[`CMultiPaneFrameWnd` Class](../../mfc/reference/cmultipaneframewnd-class.md)\
 Extends [`CPaneFrameWnd` Class](../../mfc/reference/cpaneframewnd-class.md). It can support multiple panes. Instead of a single embedded handle to a control bar, `CMultiPaneFrameWnd` contains a [`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md) object that enables the user to dock one `CMultiPaneFrameWnd` to another and dynamically create multiple floating, tabbed windows.
 
-[`CMutex` Class](../../mfc/reference/cmutex-class.md)<br/>
+[`CMutex` Class](../../mfc/reference/cmutex-class.md)\
 Represents a mutex, which is a synchronization object that allows one thread mutually exclusive access to a resource.
 
-[`CNetAddressCtrl` Class](../../mfc/reference/cnetaddressctrl-class.md)<br/>
+[`CNetAddressCtrl` Class](../../mfc/reference/cnetaddressctrl-class.md)\
 The `CNetAddressCtrl` class represents the network address control, which you can use to input and validate the format of IPv4, IPv6, and named DNS addresses.
 
-[`CNotSupportedException` Class](../../mfc/reference/cnotsupportedexception-class.md)<br/>
+[`CNotSupportedException` Class](../../mfc/reference/cnotsupportedexception-class.md)\
 Represents an exception that is the result of a request for an unsupported feature.
 
-[`CObArray` Class](../../mfc/reference/cobarray-class.md)<br/>
+[`CObArray` Class](../../mfc/reference/cobarray-class.md)\
 Supports arrays of `CObject` pointers.
 
-[`CObject` Class](../../mfc/reference/cobject-class.md)<br/>
+[`CObject` Class](../../mfc/reference/cobject-class.md)\
 The principal base class for the Microsoft Foundation Class Library.
 
-[`CObList` Class](../../mfc/reference/coblist-class.md)<br/>
+[`CObList` Class](../../mfc/reference/coblist-class.md)\
 Supports ordered lists of non-unique `CObject` pointers accessible sequentially or by pointer value.
 
-[`COccManager` Class](../../mfc/reference/coccmanager-class.md)<br/>
+[`COccManager` Class](../../mfc/reference/coccmanager-class.md)\
 Manages various custom control sites; implemented by `COleControlContainer` and `COleControlSite` objects.
 
-[`COleBusyDialog` Class](../../mfc/reference/colebusydialog-class.md)<br/>
+[`COleBusyDialog` Class](../../mfc/reference/colebusydialog-class.md)\
 Used for the OLE Server Not Responding or Server Busy dialog boxes.
 
-[`COleChangeIconDialog` Class](../../mfc/reference/colechangeicondialog-class.md)<br/>
+[`COleChangeIconDialog` Class](../../mfc/reference/colechangeicondialog-class.md)\
 Used for the OLE Change Icon dialog box.
 
-[`COleChangeSourceDialog` Class](../../mfc/reference/colechangesourcedialog-class.md)<br/>
+[`COleChangeSourceDialog` Class](../../mfc/reference/colechangesourcedialog-class.md)\
 Used for the OLE Change Source dialog box.
 
-[`COleClientItem` Class](../../mfc/reference/coleclientitem-class.md)<br/>
+[`COleClientItem` Class](../../mfc/reference/coleclientitem-class.md)\
 Defines the container interface to OLE items.
 
-[`COleCmdUI` Class](../../mfc/reference/colecmdui-class.md)<br/>
+[`COleCmdUI` Class](../../mfc/reference/colecmdui-class.md)\
 Implements a method for MFC to update the state of user-interface objects related to the `IOleCommandTarget`-driven features of your application.
 
-[`COleControl` Class](../../mfc/reference/colecontrol-class.md)<br/>
+[`COleControl` Class](../../mfc/reference/colecontrol-class.md)\
 A powerful base class for developing OLE controls.
 
-[`COleControlContainer` Class](../../mfc/reference/colecontrolcontainer-class.md)<br/>
+[`COleControlContainer` Class](../../mfc/reference/colecontrolcontainer-class.md)\
 Acts as a control container for ActiveX controls.
 
-[`COleControlModule` Class](../../mfc/reference/colecontrolmodule-class.md)<br/>
+[`COleControlModule` Class](../../mfc/reference/colecontrolmodule-class.md)\
 The base class from which you derive an OLE control module object.
 
-[`COleControlSite` Class](../../mfc/reference/colecontrolsite-class.md)<br/>
+[`COleControlSite` Class](../../mfc/reference/colecontrolsite-class.md)\
 Provides support for custom client-side control interfaces.
 
-[`COleConvertDialog` Class](../../mfc/reference/coleconvertdialog-class.md)<br/>
+[`COleConvertDialog` Class](../../mfc/reference/coleconvertdialog-class.md)\
 For more information, see the [`OLEUICONVERT`](/windows/win32/api/oledlg/ns-oledlg-oleuiconvertw) structure in the Windows SDK.
 
-[`COleCurrency` Class](../../mfc/reference/colecurrency-class.md)<br/>
+[`COleCurrency` Class](../../mfc/reference/colecurrency-class.md)\
 Encapsulates the `CURRENCY` data type of OLE automation.
 
-[`COleDataObject` Class](../../mfc/reference/coledataobject-class.md)<br/>
+[`COleDataObject` Class](../../mfc/reference/coledataobject-class.md)\
 Used in data transfers for retrieving data in various formats from the Clipboard, through drag and drop, or from an embedded OLE item.
 
-[`COleDataSource` Class](../../mfc/reference/coledatasource-class.md)<br/>
+[`COleDataSource` Class](../../mfc/reference/coledatasource-class.md)\
 Acts as a cache into which an application places the data that it will offer during data transfer operations, such as Clipboard or drag-and-drop operations.
 
-[`COleDBRecordView` Class](../../mfc/reference/coledbrecordview-class.md)<br/>
+[`COleDBRecordView` Class](../../mfc/reference/coledbrecordview-class.md)\
 A view that displays database records in controls.
 
-[`COleDialog` Class](../../mfc/reference/coledialog-class.md)<br/>
+[`COleDialog` Class](../../mfc/reference/coledialog-class.md)\
 Provides functionality common to dialog boxes for OLE.
 
-[`COleDispatchDriver` Class](../../mfc/reference/coledispatchdriver-class.md)<br/>
+[`COleDispatchDriver` Class](../../mfc/reference/coledispatchdriver-class.md)\
 Implements the client side of OLE automation.
 
-[`COleDispatchException` Class](../../mfc/reference/coledispatchexception-class.md)<br/>
+[`COleDispatchException` Class](../../mfc/reference/coledispatchexception-class.md)\
 Handles exceptions specific to the OLE `IDispatch` interface, which is a key part of OLE automation.
 
-[`COleDocObjectItem` Class](../../mfc/reference/coledocobjectitem-class.md)<br/>
+[`COleDocObjectItem` Class](../../mfc/reference/coledocobjectitem-class.md)\
 Implements Active document containment.
 
-[`COleDocument` Class](../../mfc/reference/coledocument-class.md)<br/>
+[`COleDocument` Class](../../mfc/reference/coledocument-class.md)\
 The base class for OLE documents that support visual editing.
 
-[`COleDropSource` Class](../../mfc/reference/coledropsource-class.md)<br/>
+[`COleDropSource` Class](../../mfc/reference/coledropsource-class.md)\
 Enables data to be dragged to a drop target.
 
-[`COleDropTarget` Class](../../mfc/reference/coledroptarget-class.md)<br/>
+[`COleDropTarget` Class](../../mfc/reference/coledroptarget-class.md)\
 Provides the communication mechanism between a window and the OLE libraries.
 
-[`COleException` Class](../../mfc/reference/coleexception-class.md)<br/>
+[`COleException` Class](../../mfc/reference/coleexception-class.md)\
 Represents an exception condition related to an OLE operation.
 
-[`COleInsertDialog` Class](../../mfc/reference/coleinsertdialog-class.md)<br/>
+[`COleInsertDialog` Class](../../mfc/reference/coleinsertdialog-class.md)\
 Used for the OLE Insert Object dialog box.
 
-[`COleIPFrameWnd` Class](../../mfc/reference/coleipframewnd-class.md)<br/>
+[`COleIPFrameWnd` Class](../../mfc/reference/coleipframewnd-class.md)\
 The base for your application's in-place editing window.
 
-[`COleIPFrameWndEx` Class](../../mfc/reference/coleipframewndex-class.md)<br/>
+[`COleIPFrameWndEx` Class](../../mfc/reference/coleipframewndex-class.md)\
 Implements an OLE container that supports MFC. You must derive the in-place frame window class for your application from the `COleIPFrameWndEx` class, instead of deriving it from the [`COleIPFrameWnd`](../../mfc/reference/coleipframewnd-class.md) class.
 
-[`COleLinkingDoc` Class](../../mfc/reference/colelinkingdoc-class.md)<br/>
+[`COleLinkingDoc` Class](../../mfc/reference/colelinkingdoc-class.md)\
 The base class for OLE container documents that support linking to the embedded items they contain.
 
-[`COleLinksDialog` Class](../../mfc/reference/colelinksdialog-class.md)<br/>
+[`COleLinksDialog` Class](../../mfc/reference/colelinksdialog-class.md)\
 Used for the OLE Edit Links dialog box.
 
-[`COleMessageFilter` Class](../../mfc/reference/colemessagefilter-class.md)<br/>
+[`COleMessageFilter` Class](../../mfc/reference/colemessagefilter-class.md)\
 Manages the concurrency required by the interaction of OLE applications.
 
-[`COleObjectFactory` Class](../../mfc/reference/coleobjectfactory-class.md)<br/>
+[`COleObjectFactory` Class](../../mfc/reference/coleobjectfactory-class.md)\
 Implements the OLE class factory, which creates OLE objects such as servers, automation objects, and documents.
 
-[`COlePasteSpecialDialog` Class](../../mfc/reference/colepastespecialdialog-class.md)<br/>
+[`COlePasteSpecialDialog` Class](../../mfc/reference/colepastespecialdialog-class.md)\
 Used for the OLE Paste Special dialog box.
 
-[`COlePropertiesDialog` Class](../../mfc/reference/colepropertiesdialog-class.md)<br/>
+[`COlePropertiesDialog` Class](../../mfc/reference/colepropertiesdialog-class.md)\
 Encapsulates the Windows common OLE Object Properties dialog box.
 
-[`COlePropertyPage` Class](../../mfc/reference/colepropertypage-class.md)<br/>
+[`COlePropertyPage` Class](../../mfc/reference/colepropertypage-class.md)\
 Used to display the properties of a custom control in a graphical interface, similar to a dialog box.
 
-[`COleResizeBar` Class](../../mfc/reference/coleresizebar-class.md)<br/>
+[`COleResizeBar` Class](../../mfc/reference/coleresizebar-class.md)\
 A type of control bar that supports resizing of in-place OLE items.
 
-[`COleSafeArray` Class](../../mfc/reference/colesafearray-class.md)<br/>
+[`COleSafeArray` Class](../../mfc/reference/colesafearray-class.md)\
 A class for working with arrays of arbitrary type and dimension.
 
-[`COleServerDoc` Class](../../mfc/reference/coleserverdoc-class.md)<br/>
+[`COleServerDoc` Class](../../mfc/reference/coleserverdoc-class.md)\
 The base class for OLE server documents.
 
-[`COleServerItem` Class](../../mfc/reference/coleserveritem-class.md)<br/>
+[`COleServerItem` Class](../../mfc/reference/coleserveritem-class.md)\
 Provides the server interface to OLE items.
 
-[`COleStreamFile` Class](../../mfc/reference/colestreamfile-class.md)<br/>
+[`COleStreamFile` Class](../../mfc/reference/colestreamfile-class.md)\
 Represents a stream of data (`IStream`) in a compound file as part of OLE Structured Storage.
 
-[`COleTemplateServer` Class](../../mfc/reference/coletemplateserver-class.md)<br/>
+[`COleTemplateServer` Class](../../mfc/reference/coletemplateserver-class.md)\
 Used for OLE visual editing servers, automation servers, and link containers (applications that support links to embeddings).
 
-[`COleUpdateDialog` Class](../../mfc/reference/coleupdatedialog-class.md)<br/>
+[`COleUpdateDialog` Class](../../mfc/reference/coleupdatedialog-class.md)\
 Used for a special case of the OLE Edit Links dialog box, which should be used when you need to update only existing linked or embedded objects in a document.
 
-[`COleVariant` Class](../../mfc/reference/colevariant-class.md)<br/>
+[`COleVariant` Class](../../mfc/reference/colevariant-class.md)\
 Encapsulates the [`VARIANT`](/windows/win32/api/oaidl/ns-oaidl-variant) data type.
 
-[`CPagerCtrl` Class](../../mfc/reference/cpagerctrl-class.md)<br/>
+[`CPagerCtrl` Class](../../mfc/reference/cpagerctrl-class.md)\
 The `CPagerCtrl` class wraps the Windows pager control, which can scroll into view a contained window that does not fit the containing window.
 
-[`CPageSetupDialog` Class](../../mfc/reference/cpagesetupdialog-class.md)<br/>
+[`CPageSetupDialog` Class](../../mfc/reference/cpagesetupdialog-class.md)\
 Encapsulates the services provided by the Windows common OLE Page Setup dialog box with additional support for setting and modifying print margins.
 
-[`CPaintDC` Class](../../mfc/reference/cpaintdc-class.md)<br/>
+[`CPaintDC` Class](../../mfc/reference/cpaintdc-class.md)\
 A device-context class derived from [`CDC` Class](../../mfc/reference/cdc-class.md).
 
-[`CPalette` Class](../../mfc/reference/cpalette-class.md)<br/>
+[`CPalette` Class](../../mfc/reference/cpalette-class.md)\
 Encapsulates a Windows color palette.
 
-[`CPane` Class](../../mfc/reference/cpane-class.md)<br/>
+[`CPane` Class](../../mfc/reference/cpane-class.md)\
 Enhancement of the [`CControlBar` Class](../../mfc/reference/ccontrolbar-class.md). If you are upgrading an existing MFC project, you need to replace all occurrences of `CControlBar` with `CPane`.
 
-[`CPaneContainer` Class](../../mfc/reference/cpanecontainer-class.md)<br/>
+[`CPaneContainer` Class](../../mfc/reference/cpanecontainer-class.md)\
 Basic component of the docking model implemented by MFC. An object of this class stores pointers to two docking panes or to two instances of `CPaneContainer`. It also stores a pointer to the divider that separates the panes (or the containers). By nesting containers inside containers, the framework can build a binary tree that represents complex docking layouts. The root of the binary tree is stored in a [`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md) object.
 
-[`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md)<br/>
+[`CPaneContainerManager` Class](../../mfc/reference/cpanecontainermanager-class.md)\
 Manages the storage and display of the current docking layout.
 
-[`CPaneDialog` Class](../../mfc/reference/cpanedialog-class.md)<br/>
+[`CPaneDialog` Class](../../mfc/reference/cpanedialog-class.md)\
 Supports a modeless, dockable dialog box.
 
-[`CPaneDivider` Class](../../mfc/reference/cpanedivider-class.md)<br/>
+[`CPaneDivider` Class](../../mfc/reference/cpanedivider-class.md)\
 Divides two panes, divides two groups of panes, or separates a group of panes from the client area of the main frame window.
 
-[`CPaneFrameWnd` Class](../../mfc/reference/cpaneframewnd-class.md)<br/>
+[`CPaneFrameWnd` Class](../../mfc/reference/cpaneframewnd-class.md)\
 Implements a mini-frame window that contains one pane. The pane fills the client area of the window.
 
-[`CParabolicTransitionFromAcceleration` Class](../../mfc/reference/cparabolictransitionfromacceleration-class.md)<br/>
+[`CParabolicTransitionFromAcceleration` Class](../../mfc/reference/cparabolictransitionfromacceleration-class.md)\
 Encapsulates a parabolic-acceleration transition.
 
-[`CPen` Class](../../mfc/reference/cpen-class.md)<br/>
+[`CPen` Class](../../mfc/reference/cpen-class.md)\
 Encapsulates a Windows graphics device interface (GDI) pen.
 
-[`CPictureHolder` Class](../../mfc/reference/cpictureholder-class.md)<br/>
+[`CPictureHolder` Class](../../mfc/reference/cpictureholder-class.md)\
 Implements a Picture property, which lets the user display a picture in your control.
 
-[`CPoint` Class](../../atl-mfc-shared/reference/cpoint-class.md)<br/>
+[`CPoint` Class](../../atl-mfc-shared/reference/cpoint-class.md)\
 Similar to the Windows `POINT` structure.
 
-[`CPrintDialog` Class](../../mfc/reference/cprintdialog-class.md)<br/>
+[`CPrintDialog` Class](../../mfc/reference/cprintdialog-class.md)\
 Encapsulates the services provided by the Windows common dialog box for printing.
 
-[`CPrintDialogEx` Class](../../mfc/reference/cprintdialogex-class.md)<br/>
+[`CPrintDialogEx` Class](../../mfc/reference/cprintdialogex-class.md)\
 Encapsulates the services provided by the Windows Print property sheet.
 
-[`CProgressCtrl` Class](../../mfc/reference/cprogressctrl-class.md)<br/>
+[`CProgressCtrl` Class](../../mfc/reference/cprogressctrl-class.md)\
 Provides the functionality of the Windows common progress bar control.
 
-[`CPropertyPage` Class](../../mfc/reference/cpropertypage-class.md)<br/>
+[`CPropertyPage` Class](../../mfc/reference/cpropertypage-class.md)\
 Represents individual pages of a property sheet, otherwise known as a tab dialog box.
 
-[`CPropertySheet` Class](../../mfc/reference/cpropertysheet-class.md)<br/>
+[`CPropertySheet` Class](../../mfc/reference/cpropertysheet-class.md)\
 Represents property sheets, also known as tab dialog boxes.
 
-[`CPropExchange` Class](../../mfc/reference/cpropexchange-class.md)<br/>
+[`CPropExchange` Class](../../mfc/reference/cpropexchange-class.md)\
 Supports the implementation of persistence for your OLE controls.
 
-[`CPtrArray` Class](../../mfc/reference/cptrarray-class.md)<br/>
+[`CPtrArray` Class](../../mfc/reference/cptrarray-class.md)\
 Supports arrays of void pointers.
 
-[`CPtrList` Class](../../mfc/reference/cptrlist-class.md)<br/>
+[`CPtrList` Class](../../mfc/reference/cptrlist-class.md)\
 Supports lists of void pointers.
 
-[`CReBar` Class](../../mfc/reference/crebar-class.md)<br/>
+[`CReBar` Class](../../mfc/reference/crebar-class.md)\
 A control bar that provides layout, persistence, and state information for rebar controls.
 
-[`CReBarCtrl` Class](../../mfc/reference/crebarctrl-class.md)<br/>
+[`CReBarCtrl` Class](../../mfc/reference/crebarctrl-class.md)\
 Encapsulates the functionality of a rebar control, which is a container for a child window.
 
-[`CRecentDockSiteInfo` Class](../../mfc/reference/crecentdocksiteinfo-class.md)<br/>
+[`CRecentDockSiteInfo` Class](../../mfc/reference/crecentdocksiteinfo-class.md)\
 Helper class that stores recent state information for the [`CPane` Class](../../mfc/reference/cpane-class.md).
 
-[`CRecentFileList` Class](../../mfc/reference/crecentfilelist-class.md)<br/>
+[`CRecentFileList` Class](../../mfc/reference/crecentfilelist-class.md)\
 Supports control of the most recently used (MRU) file list.
 
-[`CRecordset` Class](../../mfc/reference/crecordset-class.md)<br/>
+[`CRecordset` Class](../../mfc/reference/crecordset-class.md)\
 Represents a set of records selected from a data source.
 
-[`CRecordView` Class](../../mfc/reference/crecordview-class.md)<br/>
+[`CRecordView` Class](../../mfc/reference/crecordview-class.md)\
 A view that displays database records in controls.
 
-[`CRect` Class](../../atl-mfc-shared/reference/crect-class.md)<br/>
+[`CRect` Class](../../atl-mfc-shared/reference/crect-class.md)\
 Similar to a Windows [`RECT` structure](/windows/win32/api/windef/ns-windef-rect).
 
-[`CRectTracker` Class](../../mfc/reference/crecttracker-class.md)<br/>
+[`CRectTracker` Class](../../mfc/reference/crecttracker-class.md)\
 Enables an item to be displayed, moved, and resized in different fashions.
 
-[`CRenderTarget` Class](../../mfc/reference/crendertarget-class.md)<br/>
+[`CRenderTarget` Class](../../mfc/reference/crendertarget-class.md)\
 A wrapper for `ID2D1RenderTarget`.
 
-[`CResourceException` Class](../../mfc/reference/cresourceexception-class.md)<br/>
+[`CResourceException` Class](../../mfc/reference/cresourceexception-class.md)\
 Generated when Windows cannot find or allocate a requested resource.
 
-[`CReversalTransition` Class](../../mfc/reference/creversaltransition-class.md)<br/>
+[`CReversalTransition` Class](../../mfc/reference/creversaltransition-class.md)\
 Encapsulates a reversal transition.
 
-[`CRgn` Class](../../mfc/reference/crgn-class.md)<br/>
+[`CRgn` Class](../../mfc/reference/crgn-class.md)\
 Encapsulates a Windows graphics device interface (GDI) region.
 
-[`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md)<br/>
+[`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md)\
 With [`CRichEditView` Class](../../mfc/reference/cricheditview-class.md) and [`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CRichEditCtrl` Class](../../mfc/reference/cricheditctrl-class.md)<br/>
+[`CRichEditCtrl` Class](../../mfc/reference/cricheditctrl-class.md)\
 Provides the functionality of the rich edit control.
 
-[`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md)<br/>
+[`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md)\
 With [`CRichEditView` Class](../../mfc/reference/cricheditview-class.md) and [`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CRichEditView` Class](../../mfc/reference/cricheditview-class.md)<br/>
+[`CRichEditView` Class](../../mfc/reference/cricheditview-class.md)\
 With [`CRichEditDoc` Class](../../mfc/reference/cricheditdoc-class.md) and [`CRichEditCntrItem` Class](../../mfc/reference/cricheditcntritem-class.md), provides the functionality of the rich edit control within the context of MFC's document view architecture.
 
-[`CScrollBar` Class](../../mfc/reference/cscrollbar-class.md)<br/>
+[`CScrollBar` Class](../../mfc/reference/cscrollbar-class.md)\
 Provides the functionality of a Windows scroll-bar control.
 
-[`CScrollView` Class](../../mfc/reference/cscrollview-class.md)<br/>
+[`CScrollView` Class](../../mfc/reference/cscrollview-class.md)\
 A [`CView` Class](../../mfc/reference/cview-class.md) with scrolling capabilities.
 
-[`CSemaphore` Class](../../mfc/reference/csemaphore-class.md)<br/>
+[`CSemaphore` Class](../../mfc/reference/csemaphore-class.md)\
 Represents a "semaphore", which is a synchronization object that allows a limited number of threads in one or more processes to access aMaintains a count of the number of threads currently accessing a specified resource.
 
-[`CSettingsStore` Class](../../mfc/reference/csettingsstore-class.md)<br/>
+[`CSettingsStore` Class](../../mfc/reference/csettingsstore-class.md)\
 Wraps Windows API functions, providing an object-oriented interface that you use to access the registry.
 
-[`CSettingsStoreSP` Class](../../mfc/reference/csettingsstoresp-class.md)<br/>
+[`CSettingsStoreSP` Class](../../mfc/reference/csettingsstoresp-class.md)\
 Helper class that you can use to create instances of the [`CSettingsStore` Class](../../mfc/reference/csettingsstore-class.md).
 
-[`CSharedFile` Class](../../mfc/reference/csharedfile-class.md)<br/>
+[`CSharedFile` Class](../../mfc/reference/csharedfile-class.md)\
 The [`CMemFile` Class](../../mfc/reference/cmemfile-class.md)-derived class that supports shared memory files.
 
-[`CShellManager` Class](../../mfc/reference/cshellmanager-class.md)<br/>
+[`CShellManager` Class](../../mfc/reference/cshellmanager-class.md)\
 Implements several methods that enable you to work with pointers to identifier lists (PIDLs).
 
-[`CSimpleException` Class](../../mfc/reference/csimpleexception-class.md)<br/>
+[`CSimpleException` Class](../../mfc/reference/csimpleexception-class.md)\
 This class is a base class for resource-critical MFC exceptions.
 
-[`CSingleDocTemplate` Class](../../mfc/reference/csingledoctemplate-class.md)<br/>
+[`CSingleDocTemplate` Class](../../mfc/reference/csingledoctemplate-class.md)\
 Defines a document template that implements the single document interface (SDI).
 
-[`CSingleLock` Class](../../mfc/reference/csinglelock-class.md)<br/>
+[`CSingleLock` Class](../../mfc/reference/csinglelock-class.md)\
 Represents the access-control mechanism used in controlling access to a resource in a multithreaded program.
 
-[`CSinusoidalTransitionFromRange` Class](../../mfc/reference/csinusoidaltransitionfromrange-class.md)<br/>
+[`CSinusoidalTransitionFromRange` Class](../../mfc/reference/csinusoidaltransitionfromrange-class.md)\
 Encapsulates a sinusoidal-range transition that has a given range of oscillation.
 
-[`CSinusoidalTransitionFromVelocity` Class](../../mfc/reference/csinusoidaltransitionfromvelocity-class.md)<br/>
+[`CSinusoidalTransitionFromVelocity` Class](../../mfc/reference/csinusoidaltransitionfromvelocity-class.md)\
 Encapsulates a sinusoidal-velocity transition that has an amplitude that is determined by the initial velocity of the animation variable.
 
-[`CSize` Class](../../atl-mfc-shared/reference/csize-class.md)<br/>
+[`CSize` Class](../../atl-mfc-shared/reference/csize-class.md)\
 Similar to the Windows [`SIZE`](/windows/win32/api/windef/ns-windef-size) structure, which implements a relative coordinate or position.
 
-[`CSliderCtrl` Class](../../mfc/reference/csliderctrl-class.md)<br/>
+[`CSliderCtrl` Class](../../mfc/reference/csliderctrl-class.md)\
 Provides the functionality of the Windows common slider control.
 
-[`CSmartDockingInfo` Class](../../mfc/reference/csmartdockinginfo-class.md)<br/>
+[`CSmartDockingInfo` Class](../../mfc/reference/csmartdockinginfo-class.md)\
 Defines the appearance of smart docking markers.
 
-[`CSmoothStopTransition` Class](../../mfc/reference/csmoothstoptransition-class.md)<br/>
+[`CSmoothStopTransition` Class](../../mfc/reference/csmoothstoptransition-class.md)\
 Encapsulates a smooth-stop transition.
 
-[`CSocket` Class](../../mfc/reference/csocket-class.md)<br/>
+[`CSocket` Class](../../mfc/reference/csocket-class.md)\
 Derives from `CAsyncSocket`, and represents a higher level of abstraction of the Windows Sockets API.
 
-[`CSocketFile` Class](../../mfc/reference/csocketfile-class.md)<br/>
+[`CSocketFile` Class](../../mfc/reference/csocketfile-class.md)\
 A `CFile` object used for sending and receiving data across a network via Windows Sockets.
 
-[`CSpinButtonCtrl` Class](../../mfc/reference/cspinbuttonctrl-class.md)<br/>
+[`CSpinButtonCtrl` Class](../../mfc/reference/cspinbuttonctrl-class.md)\
 Provides the functionality of the Windows common spin button control.
 
-[`CSplitButton` Class](../../mfc/reference/csplitbutton-class.md)<br/>
+[`CSplitButton` Class](../../mfc/reference/csplitbutton-class.md)\
 Represents a split button control. The split button control performs a default behavior when a user clicks the main part of the button, and displays a drop-down menu when a user clicks the drop-down arrow of the button.
 
-[`CSplitterWnd` Class](../../mfc/reference/csplitterwnd-class.md)<br/>
+[`CSplitterWnd` Class](../../mfc/reference/csplitterwnd-class.md)\
 Provides the functionality of a splitter window, which is a window that contains multiple panes.
 
-[`CSplitterWndEx` Class](csplitterwndex-class.md)<br/>
+[`CSplitterWndEx` Class](csplitterwndex-class.md)\
 Represents a customized splitter window.
 
-[`CStatic` Class](../../mfc/reference/cstatic-class.md)<br/>
+[`CStatic` Class](../../mfc/reference/cstatic-class.md)\
 Provides the functionality of a Windows static control.
 
-[`CStatusBar` Class](../../mfc/reference/cstatusbar-class.md)<br/>
+[`CStatusBar` Class](../../mfc/reference/cstatusbar-class.md)\
 A control bar with a row of text output panes, or "indicators".
 
-[`CStatusBarCtrl` Class](../../mfc/reference/cstatusbarctrl-class.md)<br/>
+[`CStatusBarCtrl` Class](../../mfc/reference/cstatusbarctrl-class.md)\
 Provides the functionality of the Windows common status bar control.
 
-[`CStdioFile` Class](../../mfc/reference/cstdiofile-class.md)<br/>
+[`CStdioFile` Class](../../mfc/reference/cstdiofile-class.md)\
 Represents a C run-time stream file as opened by the run-time function [`fopen`, `_wfopen`](../../c-runtime-library/reference/fopen-wfopen.md).
 
-[`CStringArray` Class](../../mfc/reference/cstringarray-class.md)<br/>
+[`CStringArray` Class](../../mfc/reference/cstringarray-class.md)\
 Supports arrays of `CString` objects.
 
-[`CStringList` Class](../../mfc/reference/cstringlist-class.md)<br/>
+[`CStringList` Class](../../mfc/reference/cstringlist-class.md)\
 Supports lists of `CString` objects.
 
-[`CSyncObject` Class](../../mfc/reference/csyncobject-class.md)<br/>
+[`CSyncObject` Class](../../mfc/reference/csyncobject-class.md)\
 A pure virtual class that provides functionality common to the synchronization objects in Win32.
 
-[`CTabbedPane` Class](../../mfc/reference/ctabbedpane-class.md)<br/>
+[`CTabbedPane` Class](../../mfc/reference/ctabbedpane-class.md)\
 Implements the functionality of a pane with detachable tabs.
 
-[`CTabCtrl` Class](../../mfc/reference/ctabctrl-class.md)<br/>
+[`CTabCtrl` Class](../../mfc/reference/ctabctrl-class.md)\
 Provides the functionality of the Windows common tab control.
 
-[`CTabView` Class](../../mfc/reference/ctabview-class.md)<br/>
+[`CTabView` Class](../../mfc/reference/ctabview-class.md)\
 Simplifies the use of the tab control class ([`CTabView` Class](../../mfc/reference/ctabview-class.md)) in applications that use MFC's document/view architecture.
 
-[`CTaskDialog` Class](../../mfc/reference/ctaskdialog-class.md)<br/>
+[`CTaskDialog` Class](../../mfc/reference/ctaskdialog-class.md)\
 A pop-up dialog box that functions like a message box but can display additional information to the user. The `CTaskDialog` also includes functionality for gathering information from the user.
 
-[`CToolBar` Class](../../mfc/reference/ctoolbar-class.md)<br/>
+[`CToolBar` Class](../../mfc/reference/ctoolbar-class.md)\
 Control bars that have a row of bitmapped buttons and optional separators.
 
-[`CToolBarCtrl` Class](../../mfc/reference/ctoolbarctrl-class.md)<br/>
+[`CToolBarCtrl` Class](../../mfc/reference/ctoolbarctrl-class.md)\
 Provides the functionality of the Windows toolbar common control.
 
-[`CToolTipCtrl` Class](../../mfc/reference/ctooltipctrl-class.md)<br/>
+[`CToolTipCtrl` Class](../../mfc/reference/ctooltipctrl-class.md)\
 Encapsulates the functionality of a "tool tip control", a small pop-up window that displays a single line of text describing the purpose of a tool in an application.
 
-[`CTooltipManager` Class](../../mfc/reference/ctooltipmanager-class.md)<br/>
+[`CTooltipManager` Class](../../mfc/reference/ctooltipmanager-class.md)\
 Maintains runtime information about tooltips. The `CTooltipManager` class is instantiated one time per application.
 
-[`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md)<br/>
+[`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md)\
 Provides the functionality of the Windows common tree view control.
 
-[`CTreeView` Class](../../mfc/reference/ctreeview-class.md)<br/>
+[`CTreeView` Class](../../mfc/reference/ctreeview-class.md)\
 Simplifies use of the tree control and of [`CTreeCtrl` Class](../../mfc/reference/ctreectrl-class.md), the class that encapsulates tree-control functionality, with MFC's document-view architecture.
 
-[`CTypedPtrArray` Class](../../mfc/reference/ctypedptrarray-class.md)<br/>
+[`CTypedPtrArray` Class](../../mfc/reference/ctypedptrarray-class.md)\
 Provides a type-safe "wrapper" for objects of class `CPtrArray` or `CObArray`.
 
-[`CTypedPtrList` Class](../../mfc/reference/ctypedptrlist-class.md)<br/>
+[`CTypedPtrList` Class](../../mfc/reference/ctypedptrlist-class.md)\
 Provides a type-safe "wrapper" for objects of class `CPtrList`.
 
-[`CTypedPtrMap` Class](../../mfc/reference/ctypedptrmap-class.md)<br/>
+[`CTypedPtrMap` Class](../../mfc/reference/ctypedptrmap-class.md)\
 Provides a type-safe "wrapper" for objects of the pointer-map classes `CMapPtrToPtr`, `CMapPtrToWord`, `CMapWordToPtr`, and `CMapStringToPtr`.
 
-[`CUIntArray` Class](../../mfc/reference/cuintarray-class.md)<br/>
+[`CUIntArray` Class](../../mfc/reference/cuintarray-class.md)\
 Supports arrays of unsigned integers.
 
-[`CUserException` Class](../../mfc/reference/cuserexception-class.md)<br/>
+[`CUserException` Class](../../mfc/reference/cuserexception-class.md)\
 Thrown to stop an end-user operation.
 
-[`CUserTool` Class](../../mfc/reference/cusertool-class.md)<br/>
+[`CUserTool` Class](../../mfc/reference/cusertool-class.md)\
 Menu item that runs an external application. The **Tools** tab of the **Customize** dialog box ([`CMFCToolBarsCustomizeDialog` Class](../../mfc/reference/cmfctoolbarscustomizedialog-class.md)) enables the user to add user tools, and to specify the name, command, arguments, and initial directory for each user tool.
 
-[`CUserToolsManager` Class](../../mfc/reference/cusertoolsmanager-class.md)<br/>
+[`CUserToolsManager` Class](../../mfc/reference/cusertoolsmanager-class.md)\
 Maintains the collection of [`CUserTool` Class](../../mfc/reference/cusertool-class.md) objects in an application. A user tool is a menu item that runs an external application. The `CUserToolsManager` object enables the user or developer to add new user tools to the application. It supports the execution of the commands associated with user tools, and it also saves information about user tools in the Windows registry.
 
-[`CView` Class](../../mfc/reference/cview-class.md)<br/>
+[`CView` Class](../../mfc/reference/cview-class.md)\
 Provides the basic functionality for user-defined view classes.
 
-[`CVSListBox` Class](../../mfc/reference/cvslistbox-class.md)<br/>
+[`CVSListBox` Class](../../mfc/reference/cvslistbox-class.md)\
 Supports an editable list control.
 
-[`CWaitCursor` Class](../../mfc/reference/cwaitcursor-class.md)<br/>
+[`CWaitCursor` Class](../../mfc/reference/cwaitcursor-class.md)\
 Provides a one-line way to show a wait cursor, which is usually displayed as an hourglass, while you're doing a lengthy operation.
 
-[`CWinApp` Class](../../mfc/reference/cwinapp-class.md)<br/>
+[`CWinApp` Class](../../mfc/reference/cwinapp-class.md)\
 The base class from which you derive a Windows application object.
 
-[`CWinAppEx` Class](../../mfc/reference/cwinappex-class.md)<br/>
+[`CWinAppEx` Class](../../mfc/reference/cwinappex-class.md)\
 Handles the application state, saves the state to the registry, loads the state from the registry, initializes application managers, and provides links to those same application managers.
 
-[`CWindowDC` Class](../../mfc/reference/cwindowdc-class.md)<br/>
+[`CWindowDC` Class](../../mfc/reference/cwindowdc-class.md)\
 Derived from `CDC`.
 
-[`CWinFormsControl` Class](../../mfc/reference/cwinformscontrol-class.md)<br/>
+[`CWinFormsControl` Class](../../mfc/reference/cwinformscontrol-class.md)\
 Provides the basic functionality for hosting of a Windows Forms control.
 
-[`CWinFormsDialog` Class](../../mfc/reference/cwinformsdialog-class.md)<br/>
+[`CWinFormsDialog` Class](../../mfc/reference/cwinformsdialog-class.md)\
 A wrapper for an MFC dialog class that hosts a Windows Forms user control.
 
-[`CWinFormsView` Class](../../mfc/reference/cwinformsview-class.md)<br/>
+[`CWinFormsView` Class](../../mfc/reference/cwinformsview-class.md)\
 Provides generic functionality for hosting of a Windows Forms control as an MFC view.
 
-[`CWinThread` Class](../../mfc/reference/cwinthread-class.md)<br/>
+[`CWinThread` Class](../../mfc/reference/cwinthread-class.md)\
 Represents a thread of execution within an application.
 
-[`CWnd` Class](../../mfc/reference/cwnd-class.md)<br/>
+[`CWnd` Class](../../mfc/reference/cwnd-class.md)\
 Provides the base functionality of all window classes in the Microsoft Foundation Class Library.
 
-[`CWordArray` Class](../../mfc/reference/cwordarray-class.md)<br/>
+[`CWordArray` Class](../../mfc/reference/cwordarray-class.md)\
 Supports arrays of 16-bit words.
 
 ## Related Sections
 
-[MFC Desktop Applications](../../mfc/mfc-desktop-applications.md)<br/>
+[MFC Desktop Applications](../../mfc/mfc-desktop-applications.md)\
 Contains links to topics about the classes, global functions, global variables, and macros that make up the MFC Library.


### PR DESCRIPTION
- Remove stray backtick in "MFC Classes" title and some metadata cleanups
- Replace `br` elements with escapes (replace all `<br/>` with `\`)
- Simplify relative links (replace all `../../mfc/reference/` with nothing, then replace all `../../mfc/` with `../`)
- Fix unmatched backtick for `CMFCTabToolTipInfo` structure link
- Fix unmatched parenthesis for `CMFCDropDownToolBar` class link

Best reviewed one commit at a time.