### PR TITLE
Resolve rogue ConcRT reference syntax

### DIFF
--- a/docs/parallel/concrt/reference/concurrent-priority-queue-class.md
+++ b/docs/parallel/concrt/reference/concurrent-priority-queue-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: concurrent_priority_queue Class"
 title: "concurrent_priority_queue Class"
-ms.date: "11/04/2016"
+description: "Learn more about: concurrent_priority_queue Class"
+ms.date: 11/04/2016
 f1_keywords: ["concurrent_priority_queue", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::concurrent_priority_queue", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::clear", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::empty", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::get_allocator", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::push", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::size", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::swap", "CONCURRENT_PRIORITY_QUEUE/concurrency::concurrent_priority_queue::try_pop"]
 helpviewer_keywords: ["concurrent_priority_queue class"]
-ms.assetid: 3e740381-0f4e-41fc-8b66-ad0bb55f17a3
 ---
 # concurrent_priority_queue Class
 

--- a/docs/parallel/concrt/reference/concurrent-priority-queue-class.md
+++ b/docs/parallel/concrt/reference/concurrent-priority-queue-class.md
@@ -14,10 +14,9 @@ The `concurrent_priority_queue` class is a container that allows multiple thread
 
 ```cpp
 template <typename T,
-    typename _Compare= std::less<T>,
-    typename _Ax = std::allocator<T>
->,
-    typename _Ax = std::allocator<T>> class concurrent_priority_queue;
+    typename _Compare = std::less<T>,
+    typename _Ax = std::allocator<T>>
+class concurrent_priority_queue;
 ```
 
 ### Parameters

--- a/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
@@ -1,7 +1,7 @@
 ---
 title: "concurrent_unordered_map Class"
 description: "Learn more about: concurrent_unordered_map Class"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["concurrent_unordered_map", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::concurrent_unordered_map", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::at", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::hash_function", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::insert", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::key_eq", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::swap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_map::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_map class"]
 ---

--- a/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-map-class.md
@@ -16,18 +16,8 @@ template <typename K,
     typename _Element_type,
     typename _Hasher = std::hash<K>,
     typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<std::pair<const K,
-    _Element_type>>
->,
-typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<std::pair<const K,
-    _Element_type>>> class concurrent_unordered_map : public details::_Concurrent_hash<details::_Concurrent_unordered_map_traits<K,
-    _Element_type,
-details::_Hash_compare<K,
-    _Hasher,
-key_equality>,
-    _Allocator_type,
-false>>;
+    typename _Allocator_type = std::allocator<std::pair<const K, _Element_type>>>
+class concurrent_unordered_map : public details::_Concurrent_hash<details::_Concurrent_unordered_map_traits<K, _Element_type, details::_Hash_compare<K, _Hasher, key_equality>, _Allocator_type, false>>;
 ```
 
 ### Parameters

--- a/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
@@ -16,18 +16,8 @@ template <typename K,
     typename _Element_type,
     typename _Hasher = std::hash<K>,
     typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<std::pair<const K,
-    _Element_type>>
->,
-typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<std::pair<const K,
-    _Element_type>>> class concurrent_unordered_multimap : public details::_Concurrent_hash<details::_Concurrent_unordered_map_traits<K,
-    _Element_type,
-details::_Hash_compare<K,
-    _Hasher,
-key_equality>,
-    _Allocator_type,
-true>>;
+    typename _Allocator_type = std::allocator<std::pair<const K, _Element_type>>>
+class concurrent_unordered_multimap : public details::_Concurrent_hash<details::_Concurrent_unordered_map_traits<K, _Element_type, details::_Hash_compare<K, _Hasher, key_equality>, _Allocator_type, true>>;
 ```
 
 ### Parameters

--- a/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multimap-class.md
@@ -1,7 +1,7 @@
 ---
 title: "concurrent_unordered_multimap Class"
 description: "Learn more about: concurrent_unordered_multimap Class"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::concurrent_unordered_multimap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::hash_function", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::insert", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::key_eq", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::swap", "CONCURRENT_UNORDERED_MAP/concurrency::concurrent_unordered_multimap::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_multimap class"]
 ---

--- a/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
@@ -15,15 +15,8 @@ The `concurrent_unordered_multiset` class is an concurrency-safe container that 
 template <typename K,
     typename _Hasher = std::hash<K>,
     typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<K>
->,
-    typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<K>> class concurrent_unordered_multiset : public details::_Concurrent_hash<details::_Concurrent_unordered_set_traits<K,
-    details::_Hash_compare<K,
-_Hasher,
-    key_equality>,
-_Allocator_type,
-    true>>;
+    typename _Allocator_type = std::allocator<K>>
+class concurrent_unordered_multiset : public details::_Concurrent_hash<details::_Concurrent_unordered_set_traits<K, details::_Hash_compare<K, _Hasher, key_equality>, _Allocator_type, true>>;
 ```
 
 ### Parameters

--- a/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-multiset-class.md
@@ -1,7 +1,7 @@
 ---
 title: "concurrent_unordered_multiset Class"
 description: "Learn more about: concurrent_unordered_multiset Class"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::concurrent_unordered_multiset", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::hash_function", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::insert", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::key_eq", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::swap", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_multiset::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_multiset class"]
 ---

--- a/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
@@ -1,7 +1,7 @@
 ---
 title: "concurrent_unordered_set Class"
 description: "Learn more about: concurrent_unordered_set Class"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::concurrent_unordered_set", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::hash_function", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::insert", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::key_eq", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::swap", "CONCURRENT_UNORDERED_SET/concurrency::concurrent_unordered_set::unsafe_erase"]
 helpviewer_keywords: ["concurrent_unordered_set class"]
 ---

--- a/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
+++ b/docs/parallel/concrt/reference/concurrent-unordered-set-class.md
@@ -15,15 +15,8 @@ The `concurrent_unordered_set` class is an concurrency-safe container that contr
 template <typename K,
     typename _Hasher = std::hash<K>,
     typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<K>
->,
-    typename key_equality = std::equal_to<K>,
-    typename _Allocator_type = std::allocator<K>> class concurrent_unordered_set : public details::_Concurrent_hash<details::_Concurrent_unordered_set_traits<K,
-    details::_Hash_compare<K,
-_Hasher,
-    key_equality>,
-_Allocator_type,
-    false>>;
+    typename _Allocator_type = std::allocator<K>>
+class concurrent_unordered_set : public details::_Concurrent_hash<details::_Concurrent_unordered_set_traits<K, details::_Hash_compare<K, _Hasher, key_equality>, _Allocator_type, false>>;
 ```
 
 ### Parameters


### PR DESCRIPTION
Remove all the duplicated template parameters and fix up the weird formatting.