### PR TITLE
Fix misplaced forward slash in backtick enclosed flags

### DIFF
--- a/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
+++ b/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
@@ -30,7 +30,7 @@ A key file might contain only the public key.
 
 Other linker options that affect assembly generation are:
 
-- [/`ASSEMBLYDEBUG`](assemblydebug-add-debuggableattribute.md)
+- [`/ASSEMBLYDEBUG`](assemblydebug-add-debuggableattribute.md)
 - [`/ASSEMBLYLINKRESOURCE`](assemblylinkresource-link-to-dotnet-framework-resource.md)
 - [`/ASSEMBLYMODULE`](assemblymodule-add-a-msil-module-to-the-assembly.md)
 - [`/ASSEMBLYRESOURCE`](assemblyresource-embed-a-managed-resource.md)

--- a/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
+++ b/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
@@ -20,7 +20,7 @@ File that contains the key. Place the string in double quotation marks (" ") if 
 
 The linker inserts the public key into the assembly manifest and then signs the final assembly with the private key. To generate a key file, type [`sn -k`](/dotnet/framework/tools/sn-exe-strong-name-tool) *filename* at the command line. A signed assembly is said to have a strong name.
 
-If you compile with [`/LN`](ln-create-msil-module.md), the name of the key file is held in the module and incorporated into the assembly that is created when you compile an assembly that includes an explicit reference to the module, via [`#using`](../../preprocessor/hash-using-directive-cpp.md), or when linking with `[/ASSEMBLYMODULE`](assemblymodule-add-a-msil-module-to-the-assembly.md).
+If you compile with [`/LN`](ln-create-msil-module.md), the name of the key file is held in the module and incorporated into the assembly that is created when you compile an assembly that includes an explicit reference to the module, via [`#using`](../../preprocessor/hash-using-directive-cpp.md), or when linking with [`/ASSEMBLYMODULE`](assemblymodule-add-a-msil-module-to-the-assembly.md).
 
 You can also pass your encryption information to the linker with [`/KEYCONTAINER`](keycontainer-specify-a-key-container-to-sign-an-assembly.md). Use [`/DELAYSIGN`](delaysign-partially-sign-an-assembly.md) if you want a partially signed assembly. For more information on signing an assembly, see [Strong Name Assemblies (Assembly Signing) (C++/CLI)](../../dotnet/strong-name-assemblies-assembly-signing-cpp-cli.md) and [Creating and Using Strong-Named Assemblies](/dotnet/framework/app-domains/create-and-use-strong-named-assemblies).
 

--- a/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
+++ b/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
@@ -5,7 +5,7 @@ ms.date: 03/24/2025
 f1_keywords: ["/keyfile", "VC.Project.VCLinkerTool.KeyFile"]
 helpviewer_keywords: ["/KEYFILE linker option", "-KEYFILE linker option", "KEYFILE linker option"]
 ---
-# /KEYFILE (Specify Key or Key Pair to Sign an Assembly)
+# `/KEYFILE` (Specify Key or Key Pair to Sign an Assembly)
 
 ```
 /KEYFILE:filename

--- a/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
+++ b/docs/build/reference/keyfile-specify-key-or-key-pair-to-sign-an-assembly.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /KEYFILE (Specify Key or Key Pair to Sign an Assembly)"
 title: "/KEYFILE (Specify Key or Key Pair to Sign an Assembly)"
+description: "Learn more about: /KEYFILE (Specify Key or Key Pair to Sign an Assembly)"
 ms.date: 03/24/2025
 f1_keywords: ["/keyfile", "VC.Project.VCLinkerTool.KeyFile"]
 helpviewer_keywords: ["/KEYFILE linker option", "-KEYFILE linker option", "KEYFILE linker option"]

--- a/docs/build/reference/qspectre.md
+++ b/docs/build/reference/qspectre.md
@@ -38,7 +38,7 @@ If your code operates on data that crosses a trust boundary, then we recommend y
 
 The **`/Qspectre`** option is available starting in Visual Studio 2017 version 15.5.5, and in all updates to Microsoft C/C++ compilers (MSVC) made on or after January 23, 2018. Use the Visual Studio Installer to update the compiler, and to install the Spectre-mitigated libraries as individual components. The **`/Qspectre`** option is also available in Visual Studio 2015 Update 3 through a patch. For more information, see [KB 4338871](https://support.microsoft.com/help/4338871).
 
-All versions of Visual Studio 2017 version 15.5, and all Previews of Visual Studio 2017 version 15.6. include an undocumented option, **/`d2guardspecload`**. It's equivalent to the initial behavior of **`/Qspectre`**. You can use **`/d2guardspecload`** to apply the same mitigations to your code in these versions of the compiler. We recommend you update your build to use **`/Qspectre`** in compilers that support the option. The **`/Qspectre`** option may also support new mitigations in later versions of the compiler.
+All versions of Visual Studio 2017 version 15.5, and all Previews of Visual Studio 2017 version 15.6. include an undocumented option, **`/d2guardspecload`**. It's equivalent to the initial behavior of **`/Qspectre`**. You can use **`/d2guardspecload`** to apply the same mitigations to your code in these versions of the compiler. We recommend you update your build to use **`/Qspectre`** in compilers that support the option. The **`/Qspectre`** option may also support new mitigations in later versions of the compiler.
 
 ### Effect
 

--- a/docs/build/reference/qspectre.md
+++ b/docs/build/reference/qspectre.md
@@ -5,7 +5,7 @@ ms.date: 07/02/2021
 f1_keywords: ["VC.Project.VCCLCompilerTool.SpectreMitigation"]
 helpviewer_keywords: ["/Qspectre"]
 ---
-# /Qspectre
+# `/Qspectre`
 
 Specifies compiler generation of instructions to mitigate certain Spectre variant 1 security vulnerabilities.
 

--- a/docs/build/reference/qspectre.md
+++ b/docs/build/reference/qspectre.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /Qspectre"
 title: "/Qspectre"
+description: "Learn more about: /Qspectre"
 ms.date: 07/02/2021
 f1_keywords: ["VC.Project.VCCLCompilerTool.SpectreMitigation"]
 helpviewer_keywords: ["/Qspectre"]

--- a/docs/build/reference/zc-ternary.md
+++ b/docs/build/reference/zc-ternary.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: `/Zc:ternary` (Enforce conditional operator rules)"
 title: "/Zc:ternary (Enforce conditional operator rules)"
-ms.date: "09/12/2019"
+description: "Learn more about: `/Zc:ternary` (Enforce conditional operator rules)"
+ms.date: 09/12/2019
 f1_keywords: ["/Zc:ternary"]
 helpviewer_keywords: ["/Zc:ternary", "Zc:ternary", "-Zc:ternary"]
 ---

--- a/docs/build/reference/zc-ternary.md
+++ b/docs/build/reference/zc-ternary.md
@@ -23,7 +23,7 @@ The **`/Zc:ternary`** option is off by default in Visual Studio 2017. Use **`/Zc
 
 ### Examples
 
-This sample shows how a class that provides both non-explicit initialization from a type, and conversion to a type, can lead to ambiguous conversions. This code is accepted by the compiler by default, but rejected when **/`Zc:ternary`** or **`/permissive-`** is specified.
+This sample shows how a class that provides both non-explicit initialization from a type, and conversion to a type, can lead to ambiguous conversions. This code is accepted by the compiler by default, but rejected when **`/Zc:ternary`** or **`/permissive-`** is specified.
 
 ```cpp
 // zcternary1.cpp


### PR DESCRIPTION
Fix misplaced forward slash in backtick enclosed flags and some other updates.