### PR TITLE
Correct backticks wrongly including surrounding space

### DIFF
--- a/docs/build/reference/idlout-name-midl-output-files.md
+++ b/docs/build/reference/idlout-name-midl-output-files.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /IDLOUT (Name MIDL Output Files)"
 title: "/IDLOUT (Name MIDL Output Files)"
+description: "Learn more about: /IDLOUT (Name MIDL Output Files)"
 ms.date: 03/27/2025
 f1_keywords: ["/idlout", "VC.Project.VCLinkerTool.MergedIDLBaseFileName"]
 helpviewer_keywords: ["MIDL, output file names", ".idl files, path", "MIDL", "/IDLOUT linker option", "IDL files, path", "-IDLOUT linker option", "IDLOUT linker option"]

--- a/docs/build/reference/idlout-name-midl-output-files.md
+++ b/docs/build/reference/idlout-name-midl-output-files.md
@@ -21,7 +21,7 @@ Specifies the name of the `.idl` file created by the MIDL compiler. No file exte
 
 ## Remarks
 
-The `/IDLOUT` option specifies the name and extension of the `.idl `file.
+The `/IDLOUT` option specifies the name and extension of the `.idl` file.
 
 The MIDL compiler is called by the MSVC linker when linking projects that have the [`module`](../../windows/attributes/module-cpp.md) attribute.
 

--- a/docs/build/reference/pdb-use-program-database.md
+++ b/docs/build/reference/pdb-use-program-database.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /PDB (Use Program Database)"
 title: "/PDB (Use Program Database)"
+description: "Learn more about: /PDB (Use Program Database)"
 ms.date: 03/24/2025
 f1_keywords: ["/pdb", "VC.Project.VCLinkerTool.ProgramDatabaseFile"]
 helpviewer_keywords: ["-PDB linker option", "/PDB linker option", "PDB linker option", "PDB files, creating", ".pdb files, creating"]

--- a/docs/build/reference/pdb-use-program-database.md
+++ b/docs/build/reference/pdb-use-program-database.md
@@ -22,7 +22,7 @@ A user-specified name for the program database (PDB) that the linker creates. It
 
 By default, when [`/DEBUG`](debug-generate-debug-info.md) is specified, the linker creates a program database (PDB) which holds debugging information. The default file name for the PDB has the base name of the program and the extension .pdb.
 
-Use `/PDB:`*`filename`* to specify the name of the PDB file. If `/DEBUG `is not specified, the `/PDB` option is ignored.
+Use `/PDB:`*`filename`* to specify the name of the PDB file. If `/DEBUG` is not specified, the `/PDB` option is ignored.
 
 A PDB file can be up to 2GB in size.
 

--- a/docs/build/reference/winmdfile-specify-winmd-file.md
+++ b/docs/build/reference/winmdfile-specify-winmd-file.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /WINMDFILE (Specify winmd File)"
 title: "/WINMDFILE (Specify winmd File)"
+description: "Learn more about: /WINMDFILE (Specify winmd File)"
 ms.date: 03/27/2025
 f1_keywords: ["VC.Project.VCLinkerTool.GenerateWindowsMetadataFile"]
 ---
@@ -31,6 +31,6 @@ Use the value that is specified in `filename` to override the default `.winmd` f
 
 ## See also
 
-[`/WINMD `(Generate Windows Metadata)](winmd-generate-windows-metadata.md)\
+[`/WINMD` (Generate Windows Metadata)](winmd-generate-windows-metadata.md)\
 [MSVC linker reference](linking.md)\
 [MSVC Linker Options](linker-options.md)

--- a/docs/build/understanding-manifest-generation-for-c-cpp-programs.md
+++ b/docs/build/understanding-manifest-generation-for-c-cpp-programs.md
@@ -181,7 +181,7 @@ clean :
 #^^^^^^^^^^^^^^^^^^^^^^^^^ Change #4. (Add full path if necessary.)
 ```
 
-The makefiles now include two files that do the real work,*` makefile.inc`* and *`makefile.target.inc`*.
+The makefiles now include two files that do the real work, *`makefile.inc`* and *`makefile.target.inc`*.
 
 Create *`makefile.inc`* and copy the following content into it:
 

--- a/docs/build/understanding-manifest-generation-for-c-cpp-programs.md
+++ b/docs/build/understanding-manifest-generation-for-c-cpp-programs.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Understanding manifest generation for C/C++ programs"
 title: "Understanding manifest generation for C/C++ programs"
+description: "Learn more about: Understanding manifest generation for C/C++ programs"
 ms.date: 06/10/2022
 helpviewer_keywords: ["manifests [C++]"]
-ms.assetid: a1f24221-5b09-4824-be48-92eae5644b53
 ---
 # Understanding manifest generation for C/C++ programs
 

--- a/docs/standard-library/clock-time-conversion-struct.md
+++ b/docs/standard-library/clock-time-conversion-struct.md
@@ -101,7 +101,7 @@ The `time_point` to convert.
 
 1-3\) Identity conversions. No conversion. Returns `t` without any changes.\
 4\) Returns `utc_clock::to_sys(t)`.\
-5\) Returns` utc_clock::from_sys(t)`.
+5\) Returns `utc_clock::from_sys(t)`.
 
 ### Deduction guides
 


### PR DESCRIPTION
Correct backticks wrongly including surrounding space and clean up some metadata.