### PR TITLE
Fix copy-paste error in save_preg description

### DIFF
--- a/docs/build/arm64-exception-handling.md
+++ b/docs/build/arm64-exception-handling.md
@@ -311,7 +311,7 @@ The unwind codes are encoded according to the table below. All unwind codes are 
 | `save_any_dreg` | 11100111'0pxrrrrr'01oooooo: save register(s)<ul><li>`p`: 0/1 => single `D(#r)` vs pair `D(#r)` + `D(#r+1)`</li><li>`x`: 0/1 => positive vs negative pre-indexed stack offset</li><li>`o`: offset = `o` * 16, if x=1 or p=1, else `o` * 8</li></ul>(Windows >= 11 required) |
 | `save_any_qreg` | 11100111'0pxrrrrr'10oooooo: save register(s)<ul><li>`p`: 0/1 => single `Q(#r)` vs pair `Q(#r)` + `Q(#r+1)`</li><li>`x`: 0/1 => positive vs negative pre-indexed stack offset</li><li>`o`: offset = `o` * 16</li></ul>(Windows >= 11 required) |
 | `save_zreg` | 11100111'0oo0rrrr'11oooooo: save reg `Z(#r+8)` at `[sp + #o * VL]`, (`Z8` through `Z23`)
-| `save_preg` | 11100111'0oo1rrrr'11oooooo: save reg `P(#r+8)` at `[sp + #o * (VL / 8)]`, (`P4` through `P15`; `r` values `[0, 3]` are reserved)
+| `save_preg` | 11100111'0oo1rrrr'11oooooo: save reg `P(#r)` at `[sp + #o * (VL / 8)]`, (`P4` through `P15`; `r` values `[0, 3]` are reserved)
 |  | 11100111'1yyyyyyy': reserved |
 |  | 11101xxx: reserved for custom stack cases below only generated for asm routines |
 |  | 11101000: Custom stack for `MSFT_OP_TRAP_FRAME` |


### PR DESCRIPTION
save reg P(**#r+8**) at [sp + #o * (VL / 8)], (P4 through P15; r values [0, 3] are reserved)

should be 

save reg P(**#r**) at [sp + #o * (VL / 8)], (P4 through P15; r values [0, 3] are reserved)

Once you read the description in parenthesis, the contradiction becomes evident.