### PR TITLE
Replace `&gt` character reference in metadata

### DIFF
--- a/docs/standard-library/forward-list-operators.md
+++ b/docs/standard-library/forward-list-operators.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <forward_list> operators"
 title: "<forward_list> operators"
-ms.date: "11/04/2016"
+description: "Learn more about: <forward_list> operators"
+ms.date: 11/04/2016
 f1_keywords: ["forward_list/std::operator!=", "forward_list/std::operator==", "forward_list/std::operator>", "forward_list/std::operator>=;", "forward_list/std::operator<", "forward_list/std::operator<="]
-ms.assetid: 57492e09-3836-4dbc-9ae5-78ecf506c190
 helpviewer_keywords: ["std::operator!= (forward_list)", "std::operator== (forward_list)", "std::operator> (forward_list)", "std::operator>=; (forward_list)", "std::operator< (forward_list)", "std::operator<= (forward_list)"]
 ---
 # `<forward_list>` operators

--- a/docs/standard-library/forward-list-operators.md
+++ b/docs/standard-library/forward-list-operators.md
@@ -2,9 +2,9 @@
 description: "Learn more about: <forward_list> operators"
 title: "<forward_list> operators"
 ms.date: "11/04/2016"
-f1_keywords: ["forward_list/std::operator!=", "forward_list/std::operator==", "forward_list/std::operator>", "forward_list/std::operator&gt=;", "forward_list/std::operator<", "forward_list/std::operator<="]
+f1_keywords: ["forward_list/std::operator!=", "forward_list/std::operator==", "forward_list/std::operator>", "forward_list/std::operator>=;", "forward_list/std::operator<", "forward_list/std::operator<="]
 ms.assetid: 57492e09-3836-4dbc-9ae5-78ecf506c190
-helpviewer_keywords: ["std::operator!= (forward_list)", "std::operator== (forward_list)", "std::operator> (forward_list)", "std::operator&gt=; (forward_list)", "std::operator< (forward_list)", "std::operator<= (forward_list)"]
+helpviewer_keywords: ["std::operator!= (forward_list)", "std::operator== (forward_list)", "std::operator> (forward_list)", "std::operator>=; (forward_list)", "std::operator< (forward_list)", "std::operator<= (forward_list)"]
 ---
 # `<forward_list>` operators
 

--- a/docs/standard-library/optional-operators.md
+++ b/docs/standard-library/optional-operators.md
@@ -2,7 +2,7 @@
 description: "Learn more about: <optional> operators"
 title: "<optional> operators"
 ms.date: "11/04/2016"
-f1_keywords: ["optional/std::operator!=", "optional/std::operator==", "optional/std::operator>", "optional/std::operator&gt=;", "optional/std::operator<", "optional/std::operator<="]
+f1_keywords: ["optional/std::operator!=", "optional/std::operator==", "optional/std::operator>", "optional/std::operator>=;", "optional/std::operator<", "optional/std::operator<="]
 ms.assetid: 57492e09-3836-4dbc-9ae5-78ecf506c190
 helpviewer_keywords: ["std::operator!= (optional)", "std::operator== (optional)", "std::operator> (optional)", "std::operator>= (optional)", "std::operator< (optional)", "std::`operator<=` (optional)"]
 ---

--- a/docs/standard-library/optional-operators.md
+++ b/docs/standard-library/optional-operators.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <optional> operators"
 title: "<optional> operators"
-ms.date: "11/04/2016"
+description: "Learn more about: <optional> operators"
+ms.date: 11/04/2016
 f1_keywords: ["optional/std::operator!=", "optional/std::operator==", "optional/std::operator>", "optional/std::operator>=;", "optional/std::operator<", "optional/std::operator<="]
-ms.assetid: 57492e09-3836-4dbc-9ae5-78ecf506c190
 helpviewer_keywords: ["std::operator!= (optional)", "std::operator== (optional)", "std::operator> (optional)", "std::operator>= (optional)", "std::operator< (optional)", "std::`operator<=` (optional)"]
 ---
 # `<optional>` operators


### PR DESCRIPTION
Replace 3 instances of `&gt` with `>` in metadata with the usual cleanups.

(Best reviewed one commit at a time as the combined diff rendered on GitHub is not that clear)