### PR TITLE
Resolve invalid brace in `helpviewer_keywords` metadata

### DIFF
--- a/docs/dotnet/reflection-cpp-cli.md
+++ b/docs/dotnet/reflection-cpp-cli.md
@@ -2,7 +2,7 @@
 description: "Learn more about: Reflection (C++/CLI)"
 title: "Reflection (C++/CLI)"
 ms.date: "11/04/2016"
-helpviewer_keywords: ["typeid keyword [C++]", "reflection [C++}, about reflection", "metadata, reflection", "GetType method", ".NET Framework [C++], reflection", "data types [C++], reflection", "reflection [C++}", "plug-ins [C++]", "reflection [C++}, plug-ins", "assemblies [C++], enumerating data types in", "public types [C++]", "reflection [C++], external assemblies", "assemblies [C++]", "data types [C++], enumerating", "public members [C++]"]
+helpviewer_keywords: ["typeid keyword [C++]", "reflection [C++], about reflection", "metadata, reflection", "GetType method", ".NET Framework [C++], reflection", "data types [C++], reflection", "reflection [C++]", "plug-ins [C++]", "reflection [C++], plug-ins", "assemblies [C++], enumerating data types in", "public types [C++]", "reflection [C++], external assemblies", "assemblies [C++]", "data types [C++], enumerating", "public members [C++]"]
 ms.assetid: 46b6ff4a-e441-4022-8892-78e69422f230
 ---
 # Reflection (C++/CLI)

--- a/docs/dotnet/reflection-cpp-cli.md
+++ b/docs/dotnet/reflection-cpp-cli.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Reflection (C++/CLI)"
 title: "Reflection (C++/CLI)"
-ms.date: "11/04/2016"
+description: "Learn more about: Reflection (C++/CLI)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["typeid keyword [C++]", "reflection [C++], about reflection", "metadata, reflection", "GetType method", ".NET Framework [C++], reflection", "data types [C++], reflection", "reflection [C++]", "plug-ins [C++]", "reflection [C++], plug-ins", "assemblies [C++], enumerating data types in", "public types [C++]", "reflection [C++], external assemblies", "assemblies [C++]", "data types [C++], enumerating", "public members [C++]"]
-ms.assetid: 46b6ff4a-e441-4022-8892-78e69422f230
 ---
 # Reflection (C++/CLI)
 

--- a/docs/extensions/generic-interfaces-visual-cpp.md
+++ b/docs/extensions/generic-interfaces-visual-cpp.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Generic Interfaces (C++/CLI)"
 title: "Generic Interfaces (C++/CLI)"
-ms.date: "10/12/2018"
+description: "Learn more about: Generic Interfaces (C++/CLI)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["generic interfaces", "interfaces, generic [C++]"]
-ms.assetid: f3da788a-ba83-4db7-9dcf-9b95a8fb9d1a
 ---
 # Generic Interfaces (C++/CLI)
 

--- a/docs/extensions/generic-interfaces-visual-cpp.md
+++ b/docs/extensions/generic-interfaces-visual-cpp.md
@@ -3,7 +3,7 @@ description: "Learn more about: Generic Interfaces (C++/CLI)"
 title: "Generic Interfaces (C++/CLI)"
 ms.date: "10/12/2018"
 ms.topic: "reference"
-helpviewer_keywords: ["generic interfaces", "interfaces, generic [C++}"]
+helpviewer_keywords: ["generic interfaces", "interfaces, generic [C++]"]
 ms.assetid: f3da788a-ba83-4db7-9dcf-9b95a8fb9d1a
 ---
 # Generic Interfaces (C++/CLI)

--- a/docs/mfc/activation-verbs.md
+++ b/docs/mfc/activation-verbs.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Activation: Verbs"
 title: "Activation: Verbs"
-ms.date: "11/04/2016"
+description: "Learn more about: Activation: Verbs"
+ms.date: 11/04/2016
 helpviewer_keywords: ["verbs [MFC]", "OLE [MFC], activation", "edit verb [MFC]", "activation [MFC], verbs", "OLE [MFC], editing", "Primary verb [MFC]", "OLE activation [MFC]"]
-ms.assetid: eb56ff23-1de8-43ad-abeb-dc7346ba7b70
 ---
 # Activation: Verbs
 

--- a/docs/mfc/activation-verbs.md
+++ b/docs/mfc/activation-verbs.md
@@ -2,7 +2,7 @@
 description: "Learn more about: Activation: Verbs"
 title: "Activation: Verbs"
 ms.date: "11/04/2016"
-helpviewer_keywords: ["verbs [MFC]", "OLE [MFC], activation", "edit verb [MFC]", "activation [MFC], verbs", "OLE [MFC], editing", "Primary verb [MFC]", "OLE activation {MFC]"]
+helpviewer_keywords: ["verbs [MFC]", "OLE [MFC], activation", "edit verb [MFC]", "activation [MFC], verbs", "OLE [MFC], editing", "Primary verb [MFC]", "OLE activation [MFC]"]
 ms.assetid: eb56ff23-1de8-43ad-abeb-dc7346ba7b70
 ---
 # Activation: Verbs


### PR DESCRIPTION
It seems that a brace (both open and close) does not belong in `helpviewer_keywords` metadata, hence this PR addresses all such occurrence in this repo.