### PR TITLE
Add `helpviewer_keywords` to `CXXXX[X]` reference pages

### DIFF
--- a/docs/code-quality/c28310.md
+++ b/docs/code-quality/c28310.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28310"
 title: Warning C28310
+description: "Learn more about: Warning C28310"
 ms.date: 11/04/2016
 f1_keywords: ["C28310"]
 helpviewer_keywords: ["C28310"]
-ms.assetid: 51054ca8-01b6-454b-9853-f05f1c817b18
 ---
 # Warning C28310
 

--- a/docs/code-quality/c28310.md
+++ b/docs/code-quality/c28310.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C28310"
 title: Warning C28310
 ms.date: 11/04/2016
 f1_keywords: ["C28310"]
+helpviewer_keywords: ["C28310"]
 ms.assetid: 51054ca8-01b6-454b-9853-f05f1c817b18
 ---
 # Warning C28310

--- a/docs/code-quality/c28311.md
+++ b/docs/code-quality/c28311.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28311"
 title: Warning C28311
+description: "Learn more about: Warning C28311"
 ms.date: 11/04/2016
 f1_keywords: ["C28311"]
 helpviewer_keywords: ["C28311"]
-ms.assetid: 2c76e07a-4418-40ef-8a77-c62774bc3677
 ---
 # Warning C28311
 

--- a/docs/code-quality/c28311.md
+++ b/docs/code-quality/c28311.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C28311"
 title: Warning C28311
 ms.date: 11/04/2016
 f1_keywords: ["C28311"]
+helpviewer_keywords: ["C28311"]
 ms.assetid: 2c76e07a-4418-40ef-8a77-c62774bc3677
 ---
 # Warning C28311

--- a/docs/code-quality/c28312.md
+++ b/docs/code-quality/c28312.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C28312"
 title: Warning C28312
 ms.date: 11/04/2016
 f1_keywords: ["C28312"]
+helpviewer_keywords: ["C28312"]
 ms.assetid: 19828546-33c9-4373-b7df-2a362ca12637
 ---
 # Warning C28312

--- a/docs/code-quality/c28312.md
+++ b/docs/code-quality/c28312.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28312"
 title: Warning C28312
+description: "Learn more about: Warning C28312"
 ms.date: 11/04/2016
 f1_keywords: ["C28312"]
 helpviewer_keywords: ["C28312"]
-ms.assetid: 19828546-33c9-4373-b7df-2a362ca12637
 ---
 # Warning C28312
 

--- a/docs/code-quality/c6102.md
+++ b/docs/code-quality/c6102.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6102"
 title: Warning C6102
+description: "Learn more about: Warning C6102"
 ms.date: 11/04/2016
 f1_keywords: ["C6102"]
 helpviewer_keywords: ["C6102"]
-ms.assetid: cfd49a8c-df46-48de-8dcb-02ecf2450034
 ---
 # Warning C6102
 

--- a/docs/code-quality/c6102.md
+++ b/docs/code-quality/c6102.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6102"
 title: Warning C6102
 ms.date: 11/04/2016
 f1_keywords: ["C6102"]
+helpviewer_keywords: ["C6102"]
 ms.assetid: cfd49a8c-df46-48de-8dcb-02ecf2450034
 ---
 # Warning C6102

--- a/docs/code-quality/c6103.md
+++ b/docs/code-quality/c6103.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6103"
 title: Warning C6103
+description: "Learn more about: Warning C6103"
 ms.date: 11/04/2016
 f1_keywords: ["C6103"]
 helpviewer_keywords: ["C6103"]
-ms.assetid: 22d1ab35-31a3-4ba9-8ef4-7a64bce66621
 ---
 # Warning C6103
 

--- a/docs/code-quality/c6103.md
+++ b/docs/code-quality/c6103.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6103"
 title: Warning C6103
 ms.date: 11/04/2016
 f1_keywords: ["C6103"]
+helpviewer_keywords: ["C6103"]
 ms.assetid: 22d1ab35-31a3-4ba9-8ef4-7a64bce66621
 ---
 # Warning C6103

--- a/docs/code-quality/c6411.md
+++ b/docs/code-quality/c6411.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6411"
 title: Warning C6411
+description: "Learn more about: Warning C6411"
 ms.date: 11/04/2016
 f1_keywords: ["C6411", "POTENTIAL_READ_OVERRUN"]
 helpviewer_keywords: ["C6411"]
-ms.assetid: 6bbc1734-eec4-4ad6-9908-4ed2a5f025db
 ---
 # Warning C6411
 

--- a/docs/code-quality/c6411.md
+++ b/docs/code-quality/c6411.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6411"
 title: Warning C6411
 ms.date: 11/04/2016
 f1_keywords: ["C6411", "POTENTIAL_READ_OVERRUN"]
+helpviewer_keywords: ["C6411"]
 ms.assetid: 6bbc1734-eec4-4ad6-9908-4ed2a5f025db
 ---
 # Warning C6411

--- a/docs/code-quality/c6412.md
+++ b/docs/code-quality/c6412.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6412"
 title: Warning C6412
 ms.date: 11/04/2016
 f1_keywords: ["C6412", "POTENTIAL_WRITE_OVERRUN"]
+helpviewer_keywords: ["C6412"]
 ms.assetid: 6498f045-1bdc-4428-9d95-d9498de207bb
 ---
 # Warning C6412

--- a/docs/code-quality/c6412.md
+++ b/docs/code-quality/c6412.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6412"
 title: Warning C6412
+description: "Learn more about: Warning C6412"
 ms.date: 11/04/2016
 f1_keywords: ["C6412", "POTENTIAL_WRITE_OVERRUN"]
 helpviewer_keywords: ["C6412"]
-ms.assetid: 6498f045-1bdc-4428-9d95-d9498de207bb
 ---
 # Warning C6412
 

--- a/docs/code-quality/c6993.md
+++ b/docs/code-quality/c6993.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Warning C6993"
 title: Warning C6993
+description: "Learn more about: Warning C6993"
 ms.date: 2/25/2025
 f1_keywords: ["C6993"]
 helpviewer_keywords: ["C6993"]

--- a/docs/code-quality/c6993.md
+++ b/docs/code-quality/c6993.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6993"
 title: Warning C6993
 ms.date: 2/25/2025
 f1_keywords: ["C6993"]
+helpviewer_keywords: ["C6993"]
 ---
 # Warning C6993
 

--- a/docs/code-quality/c6995.md
+++ b/docs/code-quality/c6995.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6995"
 title: Warning C6995
 ms.date: 11/04/2016
 f1_keywords: ["C6995"]
+helpviewer_keywords: ["C6995"]
 ms.assetid: 1e82e3ad-99fe-4a35-87d5-359c74b9658e
 ---
 # Warning C6995

--- a/docs/code-quality/c6995.md
+++ b/docs/code-quality/c6995.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6995"
 title: Warning C6995
+description: "Learn more about: Warning C6995"
 ms.date: 11/04/2016
 f1_keywords: ["C6995"]
 helpviewer_keywords: ["C6995"]
-ms.assetid: 1e82e3ad-99fe-4a35-87d5-359c74b9658e
 ---
 # Warning C6995
 

--- a/docs/code-quality/c6997.md
+++ b/docs/code-quality/c6997.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6997"
 title: Warning C6997
+description: "Learn more about: Warning C6997"
 ms.date: 11/04/2016
 f1_keywords: ["C6997", "IGNORED_ANNOTATIONS"]
 helpviewer_keywords: ["C6997"]
-ms.assetid: 48fd86a3-d57b-4ecb-979a-5d3a4186482e
 ---
 # Warning C6997
 

--- a/docs/code-quality/c6997.md
+++ b/docs/code-quality/c6997.md
@@ -3,6 +3,7 @@ description: "Learn more about: Warning C6997"
 title: Warning C6997
 ms.date: 11/04/2016
 f1_keywords: ["C6997", "IGNORED_ANNOTATIONS"]
+helpviewer_keywords: ["C6997"]
 ms.assetid: 48fd86a3-d57b-4ecb-979a-5d3a4186482e
 ---
 # Warning C6997

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2134.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2134.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2134"
 title: "Compiler Error C2134"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2134"
+ms.date: 11/04/2016
 f1_keywords: ["C2134"]
 helpviewer_keywords: ["C2134"]
-ms.assetid: d45cb3e8-0be4-4bd6-8be9-5f8d2384363f
 ---
 # Compiler Error C2134
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2134.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2134.md
@@ -3,6 +3,7 @@ description: "Learn more about: Compiler Error C2134"
 title: "Compiler Error C2134"
 ms.date: "11/04/2016"
 f1_keywords: ["C2134"]
+helpviewer_keywords: ["C2134"]
 ms.assetid: d45cb3e8-0be4-4bd6-8be9-5f8d2384363f
 ---
 # Compiler Error C2134

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
@@ -3,6 +3,7 @@ description: "Learn more about: Compiler Error C2397"
 title: "Compiler Error C2397"
 ms.date: "11/04/2016"
 f1_keywords: ["C2397"]
+helpviewer_keywords: ["C2397"]
 ms.assetid: b418cf5a-d50d-4a6c-98a7-994ae35046d1
 ---
 # Compiler Error C2397

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2397.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2397"
 title: "Compiler Error C2397"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2397"
+ms.date: 11/04/2016
 f1_keywords: ["C2397"]
 helpviewer_keywords: ["C2397"]
-ms.assetid: b418cf5a-d50d-4a6c-98a7-994ae35046d1
 ---
 # Compiler Error C2397
 


### PR DESCRIPTION
Add `helpviewer_keywords` to `CXXXX[X]` reference pages that do not have them.