### PR TITLE
Update C2433 reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2433.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2433.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2433"
 title: "Compiler Error C2433"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2433"
+ms.date: 05/25/2025
 f1_keywords: ["C2433"]
 helpviewer_keywords: ["C2433"]
-ms.assetid: 7079fedd-6059-4125-82ef-ebe275f1f9d1
 ---
 # Compiler Error C2433
 


### PR DESCRIPTION
Replace old example that no longer emits C2433 (it now emits the newer C7524).