### PR TITLE
Add missing code blocks and fix syntax in some standard library references

### DIFF
--- a/docs/standard-library/basic-ostream-class.md
+++ b/docs/standard-library/basic-ostream-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: basic_ostream Class"
 title: "basic_ostream Class"
-ms.date: "03/27/2019"
+description: "Learn more about: basic_ostream Class"
+ms.date: 03/27/2019
 f1_keywords: ["ostream/std::basic_ostream", "ostream/std::basic_ostream::flush", "ostream/std::basic_ostream::put", "ostream/std::basic_ostream::seekp", "ostream/std::basic_ostream::sentry", "ostream/std::basic_ostream::swap", "ostream/std::basic_ostream::tellp", "ostream/std::basic_ostream::write"]
 helpviewer_keywords: ["std::basic_ostream [C++]", "std::basic_ostream [C++], flush", "std::basic_ostream [C++], put", "std::basic_ostream [C++], seekp", "std::basic_ostream [C++], sentry", "std::basic_ostream [C++], swap", "std::basic_ostream [C++], tellp", "std::basic_ostream [C++], write"]
-ms.assetid: 5baadc65-b662-4fab-8c9f-94457c58cda1
 ---
 # basic_ostream Class
 

--- a/docs/standard-library/basic-ostream-class.md
+++ b/docs/standard-library/basic-ostream-class.md
@@ -449,12 +449,14 @@ int main()
 
 The nested class describes an object whose declaration structures the formatted output functions and the unformatted output functions.
 
+```cpp
 class sentry {
    public:
    explicit sentry(basic_ostream\<Elem, Tr>& _Ostr);
    operator bool() const;
    ~sentry();
    };
+```
 
 ### Remarks
 

--- a/docs/standard-library/basic-ostream-class.md
+++ b/docs/standard-library/basic-ostream-class.md
@@ -450,12 +450,13 @@ int main()
 The nested class describes an object whose declaration structures the formatted output functions and the unformatted output functions.
 
 ```cpp
-class sentry {
-   public:
-   explicit sentry(basic_ostream\<Elem, Tr>& _Ostr);
-   operator bool() const;
-   ~sentry();
-   };
+class sentry
+{
+public:
+    explicit sentry(basic_ostream<Elem, Tr>& _Ostr);
+    operator bool() const;
+    ~sentry();
+};
 ```
 
 ### Remarks

--- a/docs/standard-library/bernoulli-distribution-class.md
+++ b/docs/standard-library/bernoulli-distribution-class.md
@@ -14,30 +14,30 @@ Generates a Bernoulli distribution.
 
 ```cpp
 class bernoulli_distribution
-   {
+{
 public:
-   // types
-   typedef bool result_type;
-   struct param_type;
+    // types
+    typedef bool result_type;
+    struct param_type;
 
-   // constructors and reset functions
-   explicit bernoulli_distribution(double p = 0.5);
-   explicit bernoulli_distribution(const param_type& parm);
-   void reset();
+    // constructors and reset functions
+    explicit bernoulli_distribution(double p = 0.5);
+    explicit bernoulli_distribution(const param_type& parm);
+    void reset();
 
-   // generating functions
-   template <class URNG>
-   result_type operator()(URNG& gen);
-   template <class URNG>
-   result_type operator()(URNG& gen, const param_type& parm);
+    // generating functions
+    template <class URNG>
+    result_type operator()(URNG& gen);
+    template <class URNG>
+    result_type operator()(URNG& gen, const param_type& parm);
 
-   // property functions
-   double p() const;
-   param_type param() const;
-   void param(const param_type& parm);
-   result_type min() const;
-   result_type max() const;
-   };
+    // property functions
+    double p() const;
+    param_type param() const;
+    void param(const param_type& parm);
+    result_type min() const;
+    result_type max() const;
+};
 ```
 
 ### Parameters

--- a/docs/standard-library/bernoulli-distribution-class.md
+++ b/docs/standard-library/bernoulli-distribution-class.md
@@ -161,6 +161,7 @@ The second constructor constructs an object whose stored parameters are initiali
 
 Contains the parameters of the distribution.
 
+```cpp
 struct param_type {
    typedef bernoulli_distribution distribution_type;
    param_type(double p = 0.5);
@@ -169,6 +170,7 @@ struct param_type {
    bool operator==(const param_type& right) const;
    bool operator!=(const param_type& right) const;
    };
+```
 
 ### Parameters
 

--- a/docs/standard-library/bernoulli-distribution-class.md
+++ b/docs/standard-library/bernoulli-distribution-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: bernoulli_distribution Class"
 title: "bernoulli_distribution Class"
-ms.date: "11/04/2016"
+description: "Learn more about: bernoulli_distribution Class"
+ms.date: 11/04/2016
 f1_keywords: ["random/std::bernoulli_distribution", "random/std::bernoulli_distribution::reset", "random/std::bernoulli_distribution::p", "random/std::bernoulli_distribution::param", "random/std::bernoulli_distribution::min", "random/std::bernoulli_distribution::max", "random/std::bernoulli_distribution::operator()", "random/std::bernoulli_distribution::param_type", "random/std::bernoulli_distribution::param_type::p", "random/std::bernoulli_distribution::param_type::operator==", "random/std::bernoulli_distribution::param_type::operator!="]
 helpviewer_keywords: ["std::bernoulli_distribution [C++]", "std::bernoulli_distribution [C++], reset", "std::bernoulli_distribution [C++], p", "std::bernoulli_distribution [C++], param", "std::bernoulli_distribution [C++], min", "std::bernoulli_distribution [C++], max", "std::bernoulli_distribution [C++], param_type", "std::bernoulli_distribution [C++], param_type"]
-ms.assetid: 586bcde1-95ca-411a-bf17-4aaf19482f34
 ---
 # bernoulli_distribution Class
 

--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <condition_variable> enums"
 title: "<condition_variable> enums"
-ms.date: "11/04/2016"
+description: "Learn more about: <condition_variable> enums"
+ms.date: 11/04/2016
 f1_keywords: ["condition_variable/std::cv_status"]
-ms.assetid: f261ad79-e25b-4afa-9f8a-909ce697e0d8
 ---
 # `<condition_variable>` enums
 

--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -12,8 +12,9 @@ ms.assetid: f261ad79-e25b-4afa-9f8a-909ce697e0d8
 Supplies symbolic names for the return values of the methods of class template [condition_variable](../standard-library/condition-variable-class.md).
 
 ```cpp
-class cv_status {
-   no_timeout
-   timeout
+enum class cv_status
+{
+    no_timeout,
+    timeout
 };
 ```

--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -11,7 +11,9 @@ ms.assetid: f261ad79-e25b-4afa-9f8a-909ce697e0d8
 
 Supplies symbolic names for the return values of the methods of class template [condition_variable](../standard-library/condition-variable-class.md).
 
+```cpp
 class cv_status {
    no_timeout
    timeout
 };
+```

--- a/docs/standard-library/negative-binomial-distribution-class.md
+++ b/docs/standard-library/negative-binomial-distribution-class.md
@@ -224,6 +224,7 @@ The second constructor constructs an object whose stored parameters are initiali
 
 Stores the parameters of the distribution.
 
+```cpp
 struct param_type {
    typedef negative_binomial_distribution`<`result_type> distribution_type;
    param_type(result_type k = 1, double p = 0.5);
@@ -233,6 +234,7 @@ struct param_type {
    bool operator==(const param_type& right) const;
    bool operator!=(const param_type& right) const;
    };
+```
 
 ### Parameters
 

--- a/docs/standard-library/negative-binomial-distribution-class.md
+++ b/docs/standard-library/negative-binomial-distribution-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: negative_binomial_distribution Class"
 title: "negative_binomial_distribution Class"
-ms.date: "11/04/2016"
+description: "Learn more about: negative_binomial_distribution Class"
+ms.date: 11/04/2016
 f1_keywords: ["random/std::negative_binomial_distribution", "random/std::negative_binomial_distribution::reset", "random/std::negative_binomial_distribution::k", "random/std::negative_binomial_distribution::p", "random/std::negative_binomial_distribution::param", "random/std::negative_binomial_distribution::min", "random/std::negative_binomial_distribution::max", "random/std::negative_binomial_distribution::operator()", "random/std::negative_binomial_distribution::param_type", "random/std::negative_binomial_distribution::param_type::k", "random/std::negative_binomial_distribution::param_type::p", "random/std::negative_binomial_distribution::param_type::operator==", "random/std::negative_binomial_distribution::param_type::operator!="]
 helpviewer_keywords: ["std::negative_binomial_distribution [C++]", "std::negative_binomial_distribution [C++], reset", "std::negative_binomial_distribution [C++], k", "std::negative_binomial_distribution [C++], p", "std::negative_binomial_distribution [C++], param", "std::negative_binomial_distribution [C++], min", "std::negative_binomial_distribution [C++], max", "std::negative_binomial_distribution [C++], param_type", "std::negative_binomial_distribution [C++], param_type"]
-ms.assetid: 7f5f0967-7fdd-4578-99d4-88f292b4fe9c
 ---
 # negative_binomial_distribution Class
 

--- a/docs/standard-library/negative-binomial-distribution-class.md
+++ b/docs/standard-library/negative-binomial-distribution-class.md
@@ -225,15 +225,16 @@ The second constructor constructs an object whose stored parameters are initiali
 Stores the parameters of the distribution.
 
 ```cpp
-struct param_type {
-   typedef negative_binomial_distribution`<`result_type> distribution_type;
-   param_type(result_type k = 1, double p = 0.5);
-   result_type k() const;
-   double p() const;
+struct param_type
+{
+    typedef negative_binomial_distribution<result_type> distribution_type;
+    param_type(result_type k = 1, double p = 0.5);
+    result_type k() const;
+    double p() const;
 
-   bool operator==(const param_type& right) const;
-   bool operator!=(const param_type& right) const;
-   };
+    bool operator==(const param_type& right) const;
+    bool operator!=(const param_type& right) const;
+};
 ```
 
 ### Parameters


### PR DESCRIPTION
- Add missing code blocks
- Fix syntax by removing stray characters (backticks and escapes), adding missing comma, and changing wrong `class` to `enum class`
- Format syntax
- Update metadata