### PR TITLE
Improve "C++ Language Reference" index page

### DIFF
--- a/docs/cpp/cpp-language-reference.md
+++ b/docs/cpp/cpp-language-reference.md
@@ -14,79 +14,79 @@ For an overview of Modern C++ programming practices, see [Welcome Back to C++](w
 
 See the following tables to quickly find a keyword or operator:
 
-- [C++ Keywords](../cpp/keywords-cpp.md)
+- [C++ Keywords](keywords-cpp.md)
 
-- [C++ Operators](../cpp/cpp-built-in-operators-precedence-and-associativity.md)
+- [C++ Operators](cpp-built-in-operators-precedence-and-associativity.md)
 
 ## In This Section
 
-[Lexical Conventions](../cpp/lexical-conventions.md)\
+[Lexical Conventions](lexical-conventions.md)\
 Fundamental lexical elements of a C++ program: tokens, comments, operators, keywords, punctuators, literals. Also, file translation, operator precedence/associativity.
 
-[Basic Concepts](../cpp/basic-concepts-cpp.md)\
+[Basic Concepts](basic-concepts-cpp.md)\
 Scope, linkage, program startup and termination, storage classes, and types.
 
 [Built-in types](fundamental-types-cpp.md)\
 The fundamental types that are built into the C++ compiler and their value ranges.
 
-[Standard Conversions](../cpp/standard-conversions.md)\
+[Standard Conversions](standard-conversions.md)\
 Type conversions between built-in types. Also, arithmetic conversions and conversions among pointer, reference, and pointer-to-member types.
 
 [Declarations and definitions](declarations-and-definitions-cpp.md)\
 Declaring and defining variables, types and functions.
 
-[Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
+[Operators, Precedence and Associativity](cpp-built-in-operators-precedence-and-associativity.md)\
 The operators in C++.
 
-[Expressions](../cpp/expressions-cpp.md)\
+[Expressions](expressions-cpp.md)\
 Types of expressions, semantics of expressions, reference topics on operators, casting and casting operators, run-time type information.
 
-[Lambda Expressions](../cpp/lambda-expressions-in-cpp.md)\
+[Lambda Expressions](lambda-expressions-in-cpp.md)\
 A programming technique that implicitly defines a function object class and constructs a function object of that class type.
 
-[Statements](../cpp/statements-cpp.md)\
+[Statements](statements-cpp.md)\
 Expression, null, compound, selection, iteration, jump, and declaration statements.
 
-[Classes and structs](../cpp/classes-and-structs-cpp.md)\
+[Classes and structs](classes-and-structs-cpp.md)\
 Introduction to classes, structures, and unions. Also, member functions, special member functions, data members, bit fields, **`this`** pointer, nested classes.
 
 [Unions](unions.md)\
 User-defined types in which all members share the same memory location.
 
-[Derived Classes](../cpp/inheritance-cpp.md)\
+[Derived Classes](inheritance-cpp.md)\
 Single and multiple inheritance, **`virtual`** functions, multiple base classes, **abstract** classes, scope rules. Also, the **`__super`** and **`__interface`** keywords.
 
-[Member-Access Control](../cpp/member-access-control-cpp.md)\
+[Member-Access Control](member-access-control-cpp.md)\
 Controlling access to class members: **`public`**, **`private`**, and **`protected`** keywords. Friend functions and classes.
 
 [Overloading](operator-overloading.md)\
 Overloaded operators, rules for operator overloading.
 
-[Exception Handling](../cpp/exception-handling-in-visual-cpp.md)\
+[Exception Handling](exception-handling-in-visual-cpp.md)\
 C++ exception handling, structured exception handling (SEH), keywords used in writing exception handling statements.
 
-[Assertion and User-Supplied Messages](../cpp/assertion-and-user-supplied-messages-cpp.md)\
+[Assertion and User-Supplied Messages](assertion-and-user-supplied-messages-cpp.md)\
 `#error` directive, the **`static_assert`** keyword, the `assert` macro.
 
-[Templates](../cpp/templates-cpp.md)\
+[Templates](templates-cpp.md)\
 Template specifications, function templates, class templates, **`typename`** keyword, templates vs. macros, templates and smart pointers.
 
-[Event Handling](../cpp/event-handling.md)\
+[Event Handling](event-handling.md)\
 Declaring events and event handlers.
 
-[Microsoft-Specific Modifiers](../cpp/microsoft-specific-modifiers.md)\
+[Microsoft-Specific Modifiers](microsoft-specific-modifiers.md)\
 Modifiers specific to Microsoft C++. Memory addressing, calling conventions, **`naked`** functions, extended storage-class attributes (**`__declspec`**), **`__w64`**.
 
 [Inline Assembler](../assembler/inline/inline-assembler.md)\
 Using assembly language and C++ in **`__asm`** blocks.
 
-[Compiler COM Support](../cpp/compiler-com-support.md)\
+[Compiler COM Support](compiler-com-support.md)\
 A reference to Microsoft-specific classes and global functions used to support COM types.
 
-[Microsoft Extensions](../cpp/microsoft-extensions.md)\
+[Microsoft Extensions](microsoft-extensions.md)\
 Microsoft extensions to C++.
 
-[Nonstandard Behavior](../cpp/nonstandard-behavior.md)\
+[Nonstandard Behavior](nonstandard-behavior.md)\
 Information about nonstandard behavior of the Microsoft C++ compiler.
 
 [Welcome Back to C++](welcome-back-to-cpp-modern-cpp.md)\

--- a/docs/cpp/cpp-language-reference.md
+++ b/docs/cpp/cpp-language-reference.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: C++ Language Reference"
 title: "C++ Language Reference"
+description: "Learn more about: C++ Language Reference"
 ms.custom: "index-page"
-ms.date: "12/10/2019"
+ms.date: 12/10/2019
 helpviewer_keywords: ["C++, language reference"]
-ms.assetid: 4be9cacb-c862-4391-894a-3a118c9c93ce
 ---
 # C++ Language Reference
 
@@ -15,7 +14,6 @@ For an overview of Modern C++ programming practices, see [Welcome Back to C++](w
 See the following tables to quickly find a keyword or operator:
 
 - [C++ Keywords](keywords-cpp.md)
-
 - [C++ Operators](cpp-built-in-operators-precedence-and-associativity.md)
 
 ## In This Section

--- a/docs/cpp/cpp-language-reference.md
+++ b/docs/cpp/cpp-language-reference.md
@@ -26,13 +26,13 @@ Fundamental lexical elements of a C++ program: tokens, comments, operators, keyw
 [Basic Concepts](../cpp/basic-concepts-cpp.md)\
 Scope, linkage, program startup and termination, storage classes, and types.
 
-[Built-in types](fundamental-types-cpp.md)
+[Built-in types](fundamental-types-cpp.md)\
 The fundamental types that are built into the C++ compiler and their value ranges.
 
 [Standard Conversions](../cpp/standard-conversions.md)\
 Type conversions between built-in types. Also, arithmetic conversions and conversions among pointer, reference, and pointer-to-member types.
 
-[Declarations and definitions](declarations-and-definitions-cpp.md)
+[Declarations and definitions](declarations-and-definitions-cpp.md)\
 Declaring and defining variables, types and functions.
 
 [Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\

--- a/docs/cpp/cpp-language-reference.md
+++ b/docs/cpp/cpp-language-reference.md
@@ -20,90 +20,90 @@ See the following tables to quickly find a keyword or operator:
 
 ## In This Section
 
-[Lexical Conventions](../cpp/lexical-conventions.md)<br/>
+[Lexical Conventions](../cpp/lexical-conventions.md)\
 Fundamental lexical elements of a C++ program: tokens, comments, operators, keywords, punctuators, literals. Also, file translation, operator precedence/associativity.
 
-[Basic Concepts](../cpp/basic-concepts-cpp.md)<br/>
+[Basic Concepts](../cpp/basic-concepts-cpp.md)\
 Scope, linkage, program startup and termination, storage classes, and types.
 
 [Built-in types](fundamental-types-cpp.md)
 The fundamental types that are built into the C++ compiler and their value ranges.
 
-[Standard Conversions](../cpp/standard-conversions.md)<br/>
+[Standard Conversions](../cpp/standard-conversions.md)\
 Type conversions between built-in types. Also, arithmetic conversions and conversions among pointer, reference, and pointer-to-member types.
 
 [Declarations and definitions](declarations-and-definitions-cpp.md)
 Declaring and defining variables, types and functions.
 
-[Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)<br/>
+[Operators, Precedence and Associativity](../cpp/cpp-built-in-operators-precedence-and-associativity.md)\
 The operators in C++.
 
-[Expressions](../cpp/expressions-cpp.md)<br/>
+[Expressions](../cpp/expressions-cpp.md)\
 Types of expressions, semantics of expressions, reference topics on operators, casting and casting operators, run-time type information.
 
-[Lambda Expressions](../cpp/lambda-expressions-in-cpp.md)<br/>
+[Lambda Expressions](../cpp/lambda-expressions-in-cpp.md)\
 A programming technique that implicitly defines a function object class and constructs a function object of that class type.
 
-[Statements](../cpp/statements-cpp.md)<br/>
+[Statements](../cpp/statements-cpp.md)\
 Expression, null, compound, selection, iteration, jump, and declaration statements.
 
-[Classes and structs](../cpp/classes-and-structs-cpp.md)<br/>
+[Classes and structs](../cpp/classes-and-structs-cpp.md)\
 Introduction to classes, structures, and unions. Also, member functions, special member functions, data members, bit fields, **`this`** pointer, nested classes.
 
-[Unions](unions.md)<br/>
+[Unions](unions.md)\
 User-defined types in which all members share the same memory location.
 
-[Derived Classes](../cpp/inheritance-cpp.md)<br/>
+[Derived Classes](../cpp/inheritance-cpp.md)\
 Single and multiple inheritance, **`virtual`** functions, multiple base classes, **abstract** classes, scope rules. Also, the **`__super`** and **`__interface`** keywords.
 
-[Member-Access Control](../cpp/member-access-control-cpp.md)<br/>
+[Member-Access Control](../cpp/member-access-control-cpp.md)\
 Controlling access to class members: **`public`**, **`private`**, and **`protected`** keywords. Friend functions and classes.
 
-[Overloading](operator-overloading.md)<br/>
+[Overloading](operator-overloading.md)\
 Overloaded operators, rules for operator overloading.
 
-[Exception Handling](../cpp/exception-handling-in-visual-cpp.md)<br/>
+[Exception Handling](../cpp/exception-handling-in-visual-cpp.md)\
 C++ exception handling, structured exception handling (SEH), keywords used in writing exception handling statements.
 
-[Assertion and User-Supplied Messages](../cpp/assertion-and-user-supplied-messages-cpp.md)<br/>
+[Assertion and User-Supplied Messages](../cpp/assertion-and-user-supplied-messages-cpp.md)\
 `#error` directive, the **`static_assert`** keyword, the `assert` macro.
 
-[Templates](../cpp/templates-cpp.md)<br/>
+[Templates](../cpp/templates-cpp.md)\
 Template specifications, function templates, class templates, **`typename`** keyword, templates vs. macros, templates and smart pointers.
 
-[Event Handling](../cpp/event-handling.md)<br/>
+[Event Handling](../cpp/event-handling.md)\
 Declaring events and event handlers.
 
-[Microsoft-Specific Modifiers](../cpp/microsoft-specific-modifiers.md)<br/>
+[Microsoft-Specific Modifiers](../cpp/microsoft-specific-modifiers.md)\
 Modifiers specific to Microsoft C++. Memory addressing, calling conventions, **`naked`** functions, extended storage-class attributes (**`__declspec`**), **`__w64`**.
 
-[Inline Assembler](../assembler/inline/inline-assembler.md)<br/>
+[Inline Assembler](../assembler/inline/inline-assembler.md)\
 Using assembly language and C++ in **`__asm`** blocks.
 
-[Compiler COM Support](../cpp/compiler-com-support.md)<br/>
+[Compiler COM Support](../cpp/compiler-com-support.md)\
 A reference to Microsoft-specific classes and global functions used to support COM types.
 
-[Microsoft Extensions](../cpp/microsoft-extensions.md)<br/>
+[Microsoft Extensions](../cpp/microsoft-extensions.md)\
 Microsoft extensions to C++.
 
-[Nonstandard Behavior](../cpp/nonstandard-behavior.md)<br/>
+[Nonstandard Behavior](../cpp/nonstandard-behavior.md)\
 Information about nonstandard behavior of the Microsoft C++ compiler.
 
-[Welcome Back to C++](welcome-back-to-cpp-modern-cpp.md)<br/>
+[Welcome Back to C++](welcome-back-to-cpp-modern-cpp.md)\
 An overview of modern C++ programming practices for writing safe, correct and efficient programs.
 
 ## Related Sections
 
-[Component Extensions for Runtime Platforms](../extensions/component-extensions-for-runtime-platforms.md)<br/>
+[Component Extensions for Runtime Platforms](../extensions/component-extensions-for-runtime-platforms.md)\
 Reference material on using the Microsoft C++ compiler to target .NET.
 
-[C/C++ Building Reference](../build/reference/c-cpp-building-reference.md)<br/>
+[C/C++ Building Reference](../build/reference/c-cpp-building-reference.md)\
 Compiler options, linker options, and other build tools.
 
-[C/C++ Preprocessor Reference](../preprocessor/c-cpp-preprocessor-reference.md)<br/>
+[C/C++ Preprocessor Reference](../preprocessor/c-cpp-preprocessor-reference.md)\
 Reference material on pragmas, preprocessor directives, predefined macros, and the preprocessor.
 
-[Visual C++ Libraries](../standard-library/cpp-standard-library-reference.md)<br/>
+[Visual C++ Libraries](../standard-library/cpp-standard-library-reference.md)\
 A list of links to the reference start pages for the various Microsoft C++ libraries.
 
 ## See also


### PR DESCRIPTION
Perform various cleanups (simplify relative links and replace `br` elements) and fix inconsistency with topic description being on the same line or next line:

![image](https://github.com/user-attachments/assets/5ed04963-1db0-4b65-9d00-9ce6ac4c0279)


