### PR TITLE
Fix alloc/dealloc pair mistake in `alloc-dealloc-mismatch` ASan error reference

### DIFF
--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -10,9 +10,9 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 > Address Sanitizer Error: Mismatch between allocation and deallocation APIs
 
 Enables runtime detection of mismatched memory operations that may lead to undefined behavior, such as:
-- `malloc` must be paired with `free`, not `delete`.
-- `new` must be paired with `delete`, not `free`.
-- `new[]` must be paired with `delete[]`, not `delete`.
+- `malloc` must be paired with `free`, not `delete` or `delete[]`.
+- `new` must be paired with `delete`, not `free` or `delete[]`.
+- `new[]` must be paired with `delete[]`, not `delete` or `free`.
 
 The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -19,6 +19,7 @@ The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by defau
 ## Example
 
 ```cpp
+// example1.cpp
 // Demonstrate alloc-dealloc-mismatch error
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,7 +44,7 @@ int main(int argc, char* argv[])
 }
 ```
 
-Run the following commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts) to run the example:
+In a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts), run the following commands to see an exampe of `alloc_dealloc_mismatch`:
 
 ```cmd
 cl example1.cpp /fsanitize=address /Zi
@@ -53,7 +54,7 @@ devenv /debugexe example1.exe 2
 
 ### Output
 
-:::image type="content" source="media/alloc-dealloc-mismatch-example-1.png" alt-text="Screenshot of debugger displaying alloc-dealloc-mismatch error in example 1.":::
+:::image type="content" source="media/alloc-dealloc-mismatch-example-1.png" alt-text="Screenshot of debugger displaying alloc-dealloc-mismatch error in example 1." lightbox="media/media/alloc-dealloc-mismatch-example-1.png":::
 
 ## See also
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -14,7 +14,7 @@ Enables runtime detection of mismatched memory operations that may lead to undef
 - `new` must be paired with `delete`, not `free` or `delete[]`.
 - `new[]` must be paired with `delete[]`, not `delete` or `free`.
 
-The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.
+In Windows, `alloc-dealloc-mismatch` error detection is off by default. To enable it, set the environment variable `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running your program.
 
 ## Example
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 
 Enables runtime detection of mismatched memory operations that may lead to undefined behavior, such as:
 - `malloc` must be paired with `free`, not `delete`.
-- `new` must paired with `delete`, not `free`
+- `new` must be paired with `delete`, not `free`.
 - `new[]` must be paired with `delete[]`, not `delete`.
 
 The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -54,7 +54,7 @@ devenv /debugexe example1.exe 2
 
 ### Output
 
-:::image type="content" source="media/alloc-dealloc-mismatch-example-1.png" alt-text="Screenshot of debugger displaying alloc-dealloc-mismatch error in example 1." lightbox="media/media/alloc-dealloc-mismatch-example-1.png":::
+:::image type="content" source="media/alloc-dealloc-mismatch-example-1.png" alt-text="Screenshot of debugger displaying alloc-dealloc-mismatch error in example 1." lightbox="media/alloc-dealloc-mismatch-example-1.png":::
 
 ## See also
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -1,7 +1,7 @@
 ---
 title: "Error: alloc-dealloc-mismatch"
-description: "Source examples and live debug screenshots for alloc-dealloc-mismatch errors."
-ms.date: 03/02/2021
+description: "Learn about the alloc-dealloc-mismatch Address Sanitizer error."
+ms.date: 05/28/2025
 f1_keywords: ["alloc-dealloc-mismatch"]
 helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error alloc-dealloc-mismatch"]
 ---
@@ -9,12 +9,16 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 
 > Address Sanitizer Error: Mismatch between allocation and deallocation APIs
 
-The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program. This environment variable is checked at runtime to report errors on `malloc`/`free`, `new`/`delete`, and `new[]`/`delete[]`.
+Enables runtime detection of mismatched memory operations that may lead to undefined behavior, such as:
+•	`malloc` paired with `delete` (use `free` to release memory allocated with `malloc`)
+•	`new` paired with `free` (use `delete` to release memory allocated with `new`)
+•	`new` paired with `delete[]`, (use `delete[]` only when releasing an array allocated with `new` ) and so on.
+
+The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.
 
 ## Example
 
 ```cpp
-// example1.cpp
 // alloc-dealloc-mismatch error
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +44,7 @@ int main(int argc, char* argv[]) {
 }
 ```
 
-To build and test this example, run these commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
+To try this example, run the following commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
 
 ```cmd
 cl example1.cpp /fsanitize=address /Zi

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -54,11 +54,11 @@ devenv /debugexe example1.exe 2
 
 ## See also
 
-[AddressSanitizer overview](./asan.md)\
-[AddressSanitizer known issues](./asan-known-issues.md)\
-[AddressSanitizer build and language reference](./asan-building.md)\
-[AddressSanitizer runtime reference](./asan-runtime.md)\
-[AddressSanitizer shadow bytes](./asan-shadow-bytes.md)\
-[AddressSanitizer cloud or distributed testing](./asan-offline-crash-dumps.md)\
-[AddressSanitizer debugger integration](./asan-debugger-integration.md)\
-[AddressSanitizer error examples](./asan-error-examples.md)
+[AddressSanitizer overview](asan.md)\
+[AddressSanitizer known issues](asan-known-issues.md)\
+[AddressSanitizer build and language reference](asan-building.md)\
+[AddressSanitizer runtime reference](asan-runtime.md)\
+[AddressSanitizer shadow bytes](asan-shadow-bytes.md)\
+[AddressSanitizer cloud or distributed testing](asan-offline-crash-dumps.md)\
+[AddressSanitizer debugger integration](asan-debugger-integration.md)\
+[AddressSanitizer error examples](asan-error-examples.md)

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -10,9 +10,9 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 > Address Sanitizer Error: Mismatch between allocation and deallocation APIs
 
 Enables runtime detection of mismatched memory operations that may lead to undefined behavior, such as:
-• `malloc` must be paired with `free`, not `delete`.
-• `new` must paired with `delete`, not `free`
-• `new[]` must be paired with `delete[]`, not `delete`.
+- `malloc` must be paired with `free`, not `delete`.
+- `new` must paired with `delete`, not `free`
+- `new[]` must be paired with `delete[]`, not `delete`.
 
 The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -19,32 +19,31 @@ The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by defau
 ## Example
 
 ```cpp
-// alloc-dealloc-mismatch error
+// Demonstrate alloc-dealloc-mismatch error
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(int argc, char* argv[]) {
-
+int main(int argc, char* argv[])
+{
     if (argc != 2) return -1;
 
-    switch (atoi(argv[1])) {
-
-    case 1:
-        delete[](new int[10]);
-        break;
-    case 2:
-        delete (new int[10]);      // Boom!
-        break;
-    default:
-        printf("arguments: 1: no error 2: runtime error\n");
-        return -1;
+    switch (atoi(argv[1]))
+    {
+        case 1:
+            delete[](new int[10]);
+            break;
+        case 2:
+            delete (new int[10]);      // Boom!
+            break;
+        default:
+            printf("arguments: 1: no error 2: runtime error\n");
+            return -1;
     }
-
     return 0;
 }
 ```
 
-To try this example, run the following commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts):
+Run the following commands in a Visual Studio 2019 version 16.9 or later [developer command prompt](../build/building-on-the-command-line.md#developer_command_prompt_shortcuts) to run the example:
 
 ```cmd
 cl example1.cpp /fsanitize=address /Zi
@@ -52,7 +51,7 @@ set ASAN_OPTIONS=alloc_dealloc_mismatch=1
 devenv /debugexe example1.exe 2
 ```
 
-### Resulting error
+### Output
 
 :::image type="content" source="media/alloc-dealloc-mismatch-example-1.png" alt-text="Screenshot of debugger displaying alloc-dealloc-mismatch error in example 1.":::
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -10,9 +10,9 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 > Address Sanitizer Error: Mismatch between allocation and deallocation APIs
 
 Enables runtime detection of mismatched memory operations that may lead to undefined behavior, such as:
-•	`malloc` paired with `delete` (use `free` to release memory allocated with `malloc`)
-•	`new` paired with `free` (use `delete` to release memory allocated with `new`)
-•	`new` paired with `delete[]`, (use `delete[]` only when releasing an array allocated with `new` ) and so on.
+• `malloc` must be paired with `free`, not `delete`.
+• `new` must paired with `delete`, not `free`
+• `new[]` must be paired with `delete[]`, not `delete`.
 
 The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program.
 

--- a/docs/sanitizers/error-alloc-dealloc-mismatch.md
+++ b/docs/sanitizers/error-alloc-dealloc-mismatch.md
@@ -9,7 +9,7 @@ helpviewer_keywords: ["alloc-dealloc-mismatch error", "AddressSanitizer error al
 
 > Address Sanitizer Error: Mismatch between allocation and deallocation APIs
 
-The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program. This environment variable is checked at runtime to report errors on `malloc`/`delete`, `new`/`free`, and `new`/`delete[]`.
+The `alloc`/`dealloc` mismatch functionality in AddressSanitizer is off by default for Windows. To enable it, run `set ASAN_OPTIONS=alloc_dealloc_mismatch=1` before running the program. This environment variable is checked at runtime to report errors on `malloc`/`free`, `new`/`delete`, and `new[]`/`delete[]`.
 
 ## Example
 


### PR DESCRIPTION
- `malloc` should be paired with `free` instead of `delete`
- `new` should be paired with `delete` instead of `free`
- `delete[]` should be paired with `new[]` instead of `new`