### PR TITLE
Add metadata to all includes

### DIFF
--- a/docs/error-messages/includes/error-boilerplate.md
+++ b/docs/error-messages/includes/error-boilerplate.md
@@ -1,3 +1,7 @@
+---
+ms.date: 02/28/2025
+ms.topic: include
+---
 > [!IMPORTANT]
 > The Visual Studio compilers and build tools can report many kinds of errors and warnings. After an error or warning is found, the build tools may make assumptions about code intent and attempt to continue, so that more issues can be reported at the same time. If the tools make the wrong assumption, later errors or warnings may not apply to your project. When you correct issues in your project, always start with the first error or warning that's reported, and rebuild often. One fix may resolve multiple subsequent errors.
 

--- a/docs/mfc/includes/note_settings_general_md.md
+++ b/docs/mfc/includes/note_settings_general_md.md
@@ -1,2 +1,6 @@
+---
+ms.date: 03/27/2020
+ms.topic: include
+---
 > [!NOTE]
 > Your computer might show different names or locations for some of the Visual Studio user interface elements in the following instructions. The Visual Studio edition that you have and the settings that you use determine these elements. For more information, see [Personalizing the  IDE](/visualstudio/ide/personalizing-the-visual-studio-ide).

--- a/docs/overview/includes/note_security_samplecode_md.md
+++ b/docs/overview/includes/note_security_samplecode_md.md
@@ -1,2 +1,6 @@
+---
+ms.date: 03/29/2019
+ms.topic: include
+---
 > [!IMPORTANT]
 > This sample code is intended to illustrate a concept, and it shows only the code that is relevant to that concept. It may not meet the security requirements for a specific environment, and it should not be used exactly as shown. We recommend that you add security and error-handling code to make your projects more secure and robust. Microsoft provides this sample code "AS IS" with no warranties.


### PR DESCRIPTION
Includes in other Microsoft Docs repositories have the metadata and [`docs/get-started/includes/git-source-control.md`](https://github.com/MicrosoftDocs/cpp-docs/blob/e7390ecd4d0f783fc7008ce34f7c5b262d490a1c/docs/get-started/includes/git-source-control.md?plain=1) already has it, so we know there are no issues. The `ms.date` value is just the date of the latest commit for the respective includes, as shown on GitHub.