### PR TITLE
Tweak C4789 warning reference

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
@@ -19,9 +19,7 @@ ms.assetid: 5800c301-5afb-4af0-85c1-ceb54d775234
 The warning occurs if the copy uses the intrinsic form of one of these CRT functions:
 
 - [`strcpy`](../../c-runtime-library/reference/strcpy-wcscpy-mbscpy.md)
-
 - [`memset`](../../c-runtime-library/reference/memset-wmemset.md)
-
 - [`memcpy`](../../c-runtime-library/reference/memcpy-wmemcpy.md), [`wmemcpy`](../../c-runtime-library/reference/memcpy-wmemcpy.md)
 
 The warning also appears when you cast a parameter to a larger data type, and then make a copy assignment from an lvalue reference.
@@ -41,7 +39,7 @@ The [`/sdl` (Enable Additional Security Checks)](../../build/reference/sdl-enabl
 
 ## Examples
 
-The following sample generates C4789.
+The following sample generates C4789:
 
 ```cpp
 // C4789.cpp
@@ -63,7 +61,7 @@ int main()
 }
 ```
 
-The following sample also generates C4789.
+The following sample also generates C4789:
 
 ```cpp
 // C4789b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (Level 1) C4789"
 title: "Compiler Warning (Level 1) C4789"
+description: "Learn more about: Compiler Warning (Level 1) C4789"
 ms.date: 08/30/2022
 f1_keywords: ["C4789"]
 helpviewer_keywords: ["C4789"]
-ms.assetid: 5800c301-5afb-4af0-85c1-ceb54d775234
 ---
 # Compiler Warning (Level 1) C4789
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
@@ -31,7 +31,7 @@ Visual C++ might generate this warning for a code path that never executes. You 
 ```cpp
 #pragma warning( push )
 #pragma warning( disable : 4789 )
-// unused code that generates compiler warning C4789`
+// unused code that generates compiler warning C4789
 #pragma warning( pop )
 ```
 


### PR DESCRIPTION
Remove stray backtick, compact unordered list, use colons, and update metadata.