### PR TITLE
Fix wrong remarks for `forward_list::emplace_front` and add backticks

### DIFF
--- a/docs/standard-library/forward-list-class.md
+++ b/docs/standard-library/forward-list-class.md
@@ -350,7 +350,7 @@ The element added to the beginning of the forward list.
 
 ### Remarks
 
-This member function inserts an element with the constructor arguments `_ val` at the end of the controlled sequence.
+This member function inserts an element with the constructor arguments `val` at the beginning of the controlled sequence.
 
 If an exception is thrown, the container is left unaltered and the exception is rethrown.
 

--- a/docs/standard-library/forward-list-class.md
+++ b/docs/standard-library/forward-list-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::forward_list", "std::forward_list::allocator_type", 
 ms.custom: devdivchpfy22
 ---
 
-# forward_list Class
+# `forward_list` Class
 
 Describes an object that controls a varying-length sequence of elements. The sequence is stored as a singly-linked list of nodes, each containing a member of type `Type`.
 
@@ -21,22 +21,22 @@ class forward_list
 
 ### Parameters
 
-Type*\
-The element data type to be stored in the forward_list.
+*`Type`*\
+The element data type to be stored in the `forward_list`.
 
-*Allocator*\
-The stored allocator object that encapsulates details about the  forward_list allocation and deallocation of memory. This parameter is optional. The default value is allocator<`Type`>.
+*`Allocator`*\
+The stored allocator object that encapsulates details about the `forward_list` allocation and deallocation of memory. This parameter is optional. The default value is allocator<`Type`>.
 
 ## Remarks
 
-A `forward_list` object allocates and frees storage for the sequence it controls through a stored object of class *Allocator* that is based on [allocator Class](../standard-library/allocator-class.md) (commonly known as `std::allocator)`. For more information, see [Allocators](../standard-library/allocators.md). An allocator object must have the same external interface as an object of type `allocator`.
+A `forward_list` object allocates and frees storage for the sequence it controls through a stored object of class *`Allocator`* that is based on [`allocator` Class](../standard-library/allocator-class.md) (commonly known as `std::allocator`). For more information, see [Allocators](../standard-library/allocators.md). An allocator object must have the same external interface as an object of type `allocator`.
 
 > [!NOTE]
 > The stored allocator object is not copied when the container object is assigned.
 
 Iterators, pointers and references might become invalid when elements of their controlled sequence are erased through `forward_list`. Insertions and splices performed on the controlled sequence through `forward_list` don't invalidate iterators.
 
-Additions to the controlled sequence might occur by calls to [forward_list::insert_after](#insert_after), which is the only member function that calls the constructor `Type(const  T&)`. `forward_list` might also call move constructors. If such an expression throws an exception, the container object inserts no new elements and rethrows the exception. Thus, an object of type `forward_list` is left in a known state when such exceptions occur.
+Additions to the controlled sequence might occur by calls to [`forward_list::insert_after`](#insert_after), which is the only member function that calls the constructor `Type(const  T&)`. `forward_list` might also call move constructors. If such an expression throws an exception, the container object inserts no new elements and rethrows the exception. Thus, an object of type `forward_list` is left in a known state when such exceptions occur.
 
 ## Members
 
@@ -44,62 +44,62 @@ Additions to the controlled sequence might occur by calls to [forward_list::inse
 
 |Name|Description|
 |-|-|
-|[forward_list](#forward_list)|Constructs an object of type `forward_list`.|
+|[`forward_list`](#forward_list)|Constructs an object of type `forward_list`.|
 
 ### Typedefs
 
 |Name|Description|
 |-|-|
-|[allocator_type](#allocator_type)|A type that represents the allocator class for a forward list object.|
-|[const_iterator](#const_iterator)|A type that provides a constant iterator for the forward list.|
-|[const_pointer](#const_pointer)|A type that provides a pointer to a **`const`** element in a forward list.|
-|[const_reference](#const_reference)|A type that provides a constant reference to an element in the forward list.|
-|[difference_type](#difference_type)|A signed integer type that can be used to represent the number of elements of a forward list in a range between elements pointed to by iterators.|
-|[iterator](#iterator)|A type that provides an iterator for the forward list.|
-|[pointer](#pointer)|A type that provides a pointer to an element in the forward list.|
-|[reference](#reference)|A type that provides a reference to an element in the forward list.|
-|[size_type](#size_type)|A type that represents the unsigned distance between two elements.|
-|[value_type](#value_type)|A type that represents the type of element stored in a forward list.|
+|[`allocator_type`](#allocator_type)|A type that represents the allocator class for a forward list object.|
+|[`const_iterator`](#const_iterator)|A type that provides a constant iterator for the forward list.|
+|[`const_pointer`](#const_pointer)|A type that provides a pointer to a **`const`** element in a forward list.|
+|[`const_reference`](#const_reference)|A type that provides a constant reference to an element in the forward list.|
+|[`difference_type`](#difference_type)|A signed integer type that can be used to represent the number of elements of a forward list in a range between elements pointed to by iterators.|
+|[`iterator`](#iterator)|A type that provides an iterator for the forward list.|
+|[`pointer`](#pointer)|A type that provides a pointer to an element in the forward list.|
+|[`reference`](#reference)|A type that provides a reference to an element in the forward list.|
+|[`size_type`](#size_type)|A type that represents the unsigned distance between two elements.|
+|[`value_type`](#value_type)|A type that represents the type of element stored in a forward list.|
 
 ### Functions
 
 |Name|Description|
 |-|-|
-|[assign](#assign)|Erases elements from a forward list and copies a new set of elements to a target forward list.|
-|[before_begin](#before_begin)|Returns an iterator addressing the position before the first element in a forward list.|
-|[begin](#begin)|Returns an iterator addressing the first element in a forward list.|
-|[cbefore_begin](#cbefore_begin)|Returns a const iterator addressing the position before the first element in a forward list.|
-|[cbegin](#cbegin)|Returns a const iterator addressing the first element in a forward list.|
-|[cend](#cend)|Returns a const iterator that addresses the location succeeding the last element in a forward list.|
-|[clear](#clear)|Erases all the elements of a forward list.|
-|[emplace_after](#emplace_after)|Move constructs a new element after a specified position.|
-|[emplace_front](#emplace_front)|Adds an element constructed in place to the beginning of the list.|
-|[empty](#empty)|Tests whether a forward list is empty.|
-|[end](#end)|Returns an iterator that addresses the location succeeding the last element in a forward list.|
-|[erase_after](#erase_after)|Removes elements from the forward list after a specified position.|
-|[front](#front)|Returns a reference to the first element in a forward list.|
-|[get_allocator](#get_allocator)|Returns a copy of the allocator object used to construct a forward list.|
-|[insert_after](#insert_after)|Adds elements to the forward list after a specified position.|
-|[max_size](#max_size)|Returns the maximum length of a forward list.|
-|[merge](#merge)|Removes the elements from the argument list, inserts them into the target forward list, and orders the new, combined set of elements in ascending order or in some other specified order.|
-|[pop_front](#pop_front)|Deletes the element at the beginning of a forward list.|
-|[push_front](#push_front)|Adds an element to the beginning of a forward list.|
-|[remove](#remove)|Erases elements in a forward list that matches a specified value.|
-|[remove_if](#remove_if)|Erases elements from a forward list for which a specified predicate is satisfied.|
-|[resize](#resize)|Specifies a new size for a forward list.|
-|[reverse](#reverse)|Reverses the order in which the elements occur in a forward list.|
-|[sort](#sort)|Arranges the elements in ascending order or with an order specified by a predicate.|
-|[splice_after](#splice_after)|Restitches links between nodes.|
-|[swap](#swap)|Exchanges the elements of two forward lists.|
-|[unique](#unique)|Removes adjacent elements that pass a specified test.|
+|[`assign`](#assign)|Erases elements from a forward list and copies a new set of elements to a target forward list.|
+|[`before_begin`](#before_begin)|Returns an iterator addressing the position before the first element in a forward list.|
+|[`begin`](#begin)|Returns an iterator addressing the first element in a forward list.|
+|[`cbefore_begin`](#cbefore_begin)|Returns a const iterator addressing the position before the first element in a forward list.|
+|[`cbegin`](#cbegin)|Returns a const iterator addressing the first element in a forward list.|
+|[`cend`](#cend)|Returns a const iterator that addresses the location succeeding the last element in a forward list.|
+|[`clear`](#clear)|Erases all the elements of a forward list.|
+|[`emplace_after`](#emplace_after)|Move constructs a new element after a specified position.|
+|[`emplace_front`](#emplace_front)|Adds an element constructed in place to the beginning of the list.|
+|[`empty`](#empty)|Tests whether a forward list is empty.|
+|[`end`](#end)|Returns an iterator that addresses the location succeeding the last element in a forward list.|
+|[`erase_after`](#erase_after)|Removes elements from the forward list after a specified position.|
+|[`front`](#front)|Returns a reference to the first element in a forward list.|
+|[`get_allocator`](#get_allocator)|Returns a copy of the allocator object used to construct a forward list.|
+|[`insert_after`](#insert_after)|Adds elements to the forward list after a specified position.|
+|[`max_size`](#max_size)|Returns the maximum length of a forward list.|
+|[`merge`](#merge)|Removes the elements from the argument list, inserts them into the target forward list, and orders the new, combined set of elements in ascending order or in some other specified order.|
+|[`pop_front`](#pop_front)|Deletes the element at the beginning of a forward list.|
+|[`push_front`](#push_front)|Adds an element to the beginning of a forward list.|
+|[`remove`](#remove)|Erases elements in a forward list that matches a specified value.|
+|[`remove_if`](#remove_if)|Erases elements from a forward list for which a specified predicate is satisfied.|
+|[`resize`](#resize)|Specifies a new size for a forward list.|
+|[`reverse`](#reverse)|Reverses the order in which the elements occur in a forward list.|
+|[`sort`](#sort)|Arranges the elements in ascending order or with an order specified by a predicate.|
+|[`splice_after`](#splice_after)|Restitches links between nodes.|
+|[`swap`](#swap)|Exchanges the elements of two forward lists.|
+|[`unique`](#unique)|Removes adjacent elements that pass a specified test.|
 
 ### Operators
 
 |Name|Description|
 |-|-|
-|[operator=](#op_eq)|Replaces the elements of the forward list with a copy of another forward list.|
+|[`operator=`](#op_eq)|Replaces the elements of the forward list with a copy of another forward list.|
 
-## <a name="allocator_type"></a> allocator_type
+## <a name="allocator_type"></a> `allocator_type`
 
 A type that represents the allocator class for a forward list object.
 
@@ -109,9 +109,9 @@ typedef Allocator allocator_type;
 
 ### Remarks
 
-`allocator_type` is a synonym for the template parameter Allocator.
+`allocator_type` is a synonym for the template parameter `Allocator`.
 
-## <a name="assign"></a> assign
+## <a name="assign"></a> `assign`
 
 Erases elements from a forward list and copies a new set of elements to a target forward list.
 
@@ -129,33 +129,33 @@ void assign(InputIterator First, InputIterator Last);
 
 ### Parameters
 
-*first*\
+*`first`*\
 The beginning of the replacement range.
 
-*last*\
+*`last`*\
 The end of the replacement range.
 
-*count*\
+*`count`*\
 The number of elements to assign.
 
-*val*\
+*`val`*\
 The value to assign each element.
 
-*Type*\
+*`Type`*\
 The type of the value.
 
-*IList*\
-The initializer_list to copy.
+*`IList`*\
+The `initializer_list` to copy.
 
 ### Remarks
 
-If the forward_list is an integer type, the first member function behaves the same as `assign((size_type)First, (Type)Last)`. Otherwise, the first member function replaces the sequence controlled by **`*this`** with the sequence [ `First, Last)`, which must not overlap the initial controlled sequence.
+If the `forward_list` is an integer type, the first member function behaves the same as `assign((size_type)First, (Type)Last)`. Otherwise, the first member function replaces the sequence controlled by **`*this`** with the sequence [ `First, Last)`, which must not overlap the initial controlled sequence.
 
 The second member function replaces the sequence controlled by **`*this`** with a repetition of `Count` elements of value `Val`.
 
-The third member function copies the elements of the initializer_list into the forward_list.
+The third member function copies the elements of the `initializer_list` into the `forward_list`.
 
-## <a name="before_begin"></a> before_begin
+## <a name="before_begin"></a> `before_begin`
 
 Returns an iterator addressing the position before the first element in a forward list.
 
@@ -170,7 +170,7 @@ A forward iterator that points just before the first element of the sequence (or
 
 ### Remarks
 
-## <a name="begin"></a> begin
+## <a name="begin"></a> `begin`
 
 Returns an iterator addressing the first element in a forward list.
 
@@ -185,7 +185,7 @@ A forward iterator that points at the first element of the sequence (or just bey
 
 ### Remarks
 
-## <a name="cbefore_begin"></a> cbefore_begin
+## <a name="cbefore_begin"></a> `cbefore_begin`
 
 Returns a const iterator addressing the position before the first element in a forward list.
 
@@ -199,7 +199,7 @@ A forward iterator that points just before the first element of the sequence (or
 
 ### Remarks
 
-## <a name="cbegin"></a> cbegin
+## <a name="cbegin"></a> `cbegin`
 
 Returns a **`const`** iterator that addresses the first element in the range.
 
@@ -215,7 +215,7 @@ A **`const`** forward-access iterator that points at the first element of the ra
 
 With the return value of `cbegin`, the elements in the range can't be modified.
 
-You can use this member function in place of the `begin()` member function to guarantee that the return value is `const_iterator`. Typically, it's used with the [auto](../cpp/auto-cpp.md) type deduction keyword, as shown in the following example. In the example, consider `Container` to be a modifiable (non- **`const`**) container of any kind that supports `begin()` and `cbegin()`.
+You can use this member function in place of the `begin()` member function to guarantee that the return value is `const_iterator`. Typically, it's used with the [`auto`](../cpp/auto-cpp.md) type deduction keyword, as shown in the following example. In the example, consider `Container` to be a modifiable (non- **`const`**) container of any kind that supports `begin()` and `cbegin()`.
 
 ```cpp
 auto i1 = Container.begin();
@@ -224,7 +224,7 @@ auto i2 = Container.cbegin();
 // i2 is Container<T>::const_iterator
 ```
 
-## <a name="cend"></a> cend
+## <a name="cend"></a> `cend`
 
 Returns a **`const`** iterator that addresses the location just beyond the last element in a range.
 
@@ -240,7 +240,7 @@ A forward-access iterator that points just beyond the end of the range.
 
 `cend` is used to test whether an iterator has passed the end of its range.
 
-You can use this member function in place of the `end()` member function to guarantee that the return value is `const_iterator`. Typically, it's used with the [auto](../cpp/auto-cpp.md) type deduction keyword, as shown in the following example. In the example, consider `Container` to be a modifiable (non- **`const`**) container of any kind that supports `end()` and `cend()`.
+You can use this member function in place of the `end()` member function to guarantee that the return value is `const_iterator`. Typically, it's used with the [`auto`](../cpp/auto-cpp.md) type deduction keyword, as shown in the following example. In the example, consider `Container` to be a modifiable (non- **`const`**) container of any kind that supports `end()` and `cend()`.
 
 ```cpp
 auto i1 = Container.end();
@@ -252,7 +252,7 @@ auto i2 = Container.cend();
 
 The value returned by `cend` shouldn't be dereferenced.
 
-## <a name="clear"></a> clear
+## <a name="clear"></a> `clear`
 
 Erases all the elements of a forward list.
 
@@ -264,7 +264,7 @@ void clear();
 
 This member function calls `erase_after(before_begin(), end())`.
 
-## <a name="const_iterator"></a> const_iterator
+## <a name="const_iterator"></a> `const_iterator`
 
 A type that provides a constant iterator for the forward list.
 
@@ -276,7 +276,7 @@ typedef implementation-defined const_iterator;
 
 `const_iterator` describes an object that can serve as a constant forward iterator for the controlled sequence. It's described here as a synonym for an implementation-defined type.
 
-## <a name="const_pointer"></a> const_pointer
+## <a name="const_pointer"></a> `const_pointer`
 
 A type that provides a pointer to a **`const`** element in a forward list.
 
@@ -287,7 +287,7 @@ typedef typename Allocator::const_pointer
 
 ### Remarks
 
-## <a name="const_reference"></a> const_reference
+## <a name="const_reference"></a> `const_reference`
 
 A type that provides a constant reference to an element in the forward list.
 
@@ -297,7 +297,7 @@ typedef typename Allocator::const_reference const_reference;
 
 ### Remarks
 
-## <a name="difference_type"></a> difference_type
+## <a name="difference_type"></a> `difference_type`
 
 A signed integer type that can be used to represent the number of elements of a forward list in a range between elements pointed to by iterators.
 
@@ -309,7 +309,7 @@ typedef typename Allocator::difference_type difference_type;
 
 `difference_type` describes an object that can represent the difference between the addresses of any two elements in the controlled sequence.
 
-## <a name="emplace_after"></a> emplace_after
+## <a name="emplace_after"></a> `emplace_after`
 
 Move constructs a new element after a specified position.
 
@@ -320,10 +320,10 @@ iterator emplace_after(const_iterator Where, Type&& val);
 
 ### Parameters
 
-*Where*\
+*`Where`*\
 The position in the target forward list where the new element is constructed.
 
-*val*\
+*`val`*\
 The constructor argument.
 
 ### Return Value
@@ -332,9 +332,9 @@ An iterator that designates the newly inserted element.
 
 ### Remarks
 
-This member function inserts an element with the constructor arguments *val* just after the element pointed to by *Where* in the controlled sequence. Its behavior is otherwise the same as [forward_list::insert_after](#insert_after).
+This member function inserts an element with the constructor arguments *`val`* just after the element pointed to by *`Where`* in the controlled sequence. Its behavior is otherwise the same as [`forward_list::insert_after`](#insert_after).
 
-## <a name="emplace_front"></a> emplace_front
+## <a name="emplace_front"></a> `emplace_front`
 
 Adds an element constructed in place to the beginning of the list.
 
@@ -345,7 +345,7 @@ template <class Type>
 
 ### Parameters
 
-*val*\
+*`val`*\
 The element added to the beginning of the forward list.
 
 ### Remarks
@@ -354,7 +354,7 @@ This member function inserts an element with the constructor arguments `val` at 
 
 If an exception is thrown, the container is left unaltered and the exception is rethrown.
 
-## <a name="empty"></a> empty
+## <a name="empty"></a> `empty`
 
 Tests whether a forward list is empty.
 
@@ -366,7 +366,7 @@ bool empty() const;
 
 **`true`** if the forward list is empty; otherwise, **`false`**.
 
-## <a name="end"></a> end
+## <a name="end"></a> `end`
 
 Returns an iterator that addresses the location succeeding the last element in a forward list.
 
@@ -379,7 +379,7 @@ iterator end();
 
 A forward iterator that points just beyond the end of the sequence.
 
-## <a name="erase_after"></a> erase_after
+## <a name="erase_after"></a> `erase_after`
 
 Removes elements from the forward list after a specified position.
 
@@ -390,22 +390,22 @@ iterator erase_after(const_iterator first, const_iterator last);
 
 ### Parameters
 
-*Where*\
+*`Where`*\
 The position in the target forward list where the element is erased.
 
-*first*\
+*`first`*\
 The beginning of the range to erase.
 
-*last*\
+*`last`*\
 The end of the range to erase.
 
 ### Return Value
 
-An iterator that designates the first element remaining beyond any elements removed, or [forward_list::end](#end) if no such element exists.
+An iterator that designates the first element remaining beyond any elements removed, or [`forward_list::end`](#end) if no such element exists.
 
 ### Remarks
 
-The first member function removes the element of the controlled sequence just after *Where*.
+The first member function removes the element of the controlled sequence just after *`Where`*.
 
 The second member function removes the elements of the controlled sequence in the range `( first,  last)` (neither end point is included).
 
@@ -413,7 +413,7 @@ Erasing `N` elements causes `N` destructor calls. [Reallocation](../standard-lib
 
 The member functions never throw an exception.
 
-## <a name="forward_list"></a> forward_list
+## <a name="forward_list"></a> `forward_list`
 
 Constructs an object of type `forward_list`.
 
@@ -436,36 +436,36 @@ forward_list(InputIterator First, InputIterator Last, const Allocator& Al);
 
 ### Parameters
 
-*Al*\
+*`Al`*\
 The allocator class to use with this object.
 
-*Count*\
+*`Count`*\
 The number of elements in the list constructed.
 
-*Val*\
+*`Val`*\
 The value of the elements in the list constructed.
 
-*Right*\
+*`Right`*\
 The list of which the constructed list is to be a copy.
 
-*First*\
+*`First`*\
 The position of the first element in the range of elements to be copied.
 
-*Last*\
+*`Last`*\
 The position of the first element beyond the range of elements to be copied.
 
-*IList*\
-The initializer_list to copy.
+*`IList`*\
+The `initializer_list` to copy.
 
 ### Remarks
 
-All constructors store an [allocator](../standard-library/allocator-class.md) and initialize the controlled sequence. The allocator object is the argument *Al*, if present. For the copy constructor, it's `right.get_allocator()`. Otherwise, it's `Allocator()`.
+All constructors store an [`allocator`](../standard-library/allocator-class.md) and initialize the controlled sequence. The allocator object is the argument *`Al`*, if present. For the copy constructor, it's `right.get_allocator()`. Otherwise, it's `Allocator()`.
 
 The first two constructors specify an empty initial controlled sequence.
 
-The third constructor specifies a repetition of *Count* elements of value `Type()`.
+The third constructor specifies a repetition of *`Count`* elements of value `Type()`.
 
-The fourth and fifth constructors specify a repetition of *Count* elements of value *Val*.
+The fourth and fifth constructors specify a repetition of *`Count`* elements of value *`Val`*.
 
 The sixth constructor specifies a copy of the sequence controlled by *Right*. If `InputIterator` is an integer type, the next two constructors specify a repetition of `(size_type)First` elements of value `(Type)Last`. Otherwise, the next two constructors specify the sequence `[First, Last)`.
 
@@ -473,7 +473,7 @@ The ninth and tenth constructors are the same as the sixth, but with an [rvalue]
 
 The last constructor specifies the initial controlled sequence with an object of class `initializer_list<Type>`.
 
-## <a name="front"></a> front
+## <a name="front"></a> `front`
 
 Returns a reference to the first element in a forward list.
 
@@ -486,7 +486,7 @@ const_reference front() const;
 
 A reference to the first element of the controlled sequence, which must be non-empty.
 
-## <a name="get_allocator"></a> get_allocator
+## <a name="get_allocator"></a> `get_allocator`
 
 Returns a copy of the allocator object used to construct a forward list.
 
@@ -496,9 +496,9 @@ allocator_type get_allocator() const;
 
 ### Return Value
 
-The stored [allocator](../standard-library/allocator-class.md) object.
+The stored [`allocator`](../standard-library/allocator-class.md) object.
 
-## <a name="insert_after"></a> insert_after
+## <a name="insert_after"></a> `insert_after`
 
 Adds elements to the forward list after a specified position.
 
@@ -513,23 +513,23 @@ template <class InputIterator>
 
 ### Parameters
 
-*Where*\
+*`Where`*\
 The position in the target forward list where the first element is inserted.
 
-*Count*\
+*`Count`*\
 The number of elements to insert.
 
-*First*\
+*`First`*\
 The beginning of the insertion range.
 
-*Last*\
+*`Last`*\
 The end of the insertion range.
 
-*Val*\
+*`Val`*\
 The element added to the forward list.
 
-*IList*\
-The initializer_list to insert.
+*`IList`*\
+The `initializer_list` to insert.
 
 ### Return Value
 
@@ -537,11 +537,11 @@ An iterator that designates the newly inserted element (first and last member fu
 
 ### Remarks
 
-Each of the member functions inserts—just after the element pointed to by *Where* in the controlled sequence—a sequence that' specified by the remaining operands.
+Each of the member functions inserts—just after the element pointed to by *`Where`* in the controlled sequence—a sequence that' specified by the remaining operands.
 
-The first member function inserts an element that has value *Val* and returns an iterator that designates the newly inserted element.
+The first member function inserts an element that has value *`Val`* and returns an iterator that designates the newly inserted element.
 
-The second member function inserts a repetition of *Count* elements of value *Val*.
+The second member function inserts a repetition of *`Count`* elements of value *`Val`*.
 
 If `InputIterator` is an integer type, the third member function behaves the same as `insert(it, (size_type)First, (Type)Last)`. Otherwise, it inserts the sequence `[First, Last)`, which must not overlap the initial controlled sequence.
 
@@ -553,7 +553,7 @@ Inserting `N` elements causes `N` constructor calls. [Reallocation](../standard-
 
 If an exception is thrown during the insertion of one or more elements, the container is left unaltered and the exception is rethrown.
 
-## <a name="iterator"></a> iterator
+## <a name="iterator"></a> `iterator`
 
 A type that provides an iterator for the forward list.
 
@@ -565,7 +565,7 @@ typedef implementation-defined iterator;
 
 `iterator` describes an object that can serve as a forward iterator for the controlled sequence. It's described here as a synonym for an implementation-defined type.
 
-## <a name="max_size"></a> max_size
+## <a name="max_size"></a> `max_size`
 
 Returns the maximum length of a forward list.
 
@@ -579,7 +579,7 @@ The length of the longest sequence that the object can control.
 
 ### Remarks
 
-## <a name="merge"></a> merge
+## <a name="merge"></a> `merge`
 
 Combines two sorted sequences into a single sorted sequence in linear time. Removes the elements from the argument list, and inserts them into this `forward_list`. The two lists should be sorted by the same compare function object before the call to `merge`. The combined list will be sorted by that compare function object.
 
@@ -591,10 +591,10 @@ template <class Predicate>
 
 ### Parameters
 
-*right*\
+*`right`*\
 The forward list to merge from.
 
-*comp*\
+*`comp`*\
 The compare function object that is used to sort elements.
 
 ### Remarks
@@ -607,7 +607,7 @@ No pairs of elements in the original controlled sequence are reversed in the res
 
 An exception occurs only if `comp` throws an exception. In that case, the controlled sequence is left in unspecified order and the exception is rethrown.
 
-## <a name="op_eq"></a> operator=
+## <a name="op_eq"></a> `operator=`
 
 Replaces the elements of the forward list with a copy of another forward list.
 
@@ -619,21 +619,21 @@ forward_list& operator=(forward_list&& right);
 
 ### Parameters
 
-*right*\
+*`right`*\
 The forward list being copied into the forward list.
 
-*IList*\
+*`IList`*\
 A brace-enclosed initializer list, which behaves just like a sequence of elements of type `Type`.
 
 ### Remarks
 
-The first member operator replaces the controlled sequence with a copy of the sequence controlled by *right*.
+The first member operator replaces the controlled sequence with a copy of the sequence controlled by *`right`*.
 
 The second member operator replaces the controlled sequence from an object of class `initializer_list<Type>`.
 
 The third member operator is the same as the first, but with an [rvalue](../cpp/rvalue-reference-declarator-amp-amp.md) reference.
 
-## <a name="pointer"></a> pointer
+## <a name="pointer"></a> `pointer`
 
 A type that provides a pointer to an element in the forward list.
 
@@ -641,7 +641,7 @@ A type that provides a pointer to an element in the forward list.
 typedef typename Allocator::pointer pointer;
 ```
 
-## <a name="pop_front"></a> pop_front
+## <a name="pop_front"></a> `pop_front`
 
 Deletes the element at the beginning of a forward list.
 
@@ -655,7 +655,7 @@ The first element of the forward list must be non-empty.
 
 The member function never throws an exception.
 
-## <a name="push_front"></a> push_front
+## <a name="push_front"></a> `push_front`
 
 Adds an element to the beginning of a forward list.
 
@@ -666,14 +666,14 @@ void push_front(Type&& val);
 
 ### Parameters
 
-*val*\
+*`val`*\
 The element added to the beginning of the forward list.
 
 ### Remarks
 
 If an exception is thrown, the container is left unaltered and the exception is rethrown.
 
-## <a name="reference"></a> reference
+## <a name="reference"></a> `reference`
 
 A type that provides a reference to an element in the forward list.
 
@@ -681,7 +681,7 @@ A type that provides a reference to an element in the forward list.
 typedef typename Allocator::reference reference;
 ```
 
-## <a name="remove"></a> remove
+## <a name="remove"></a> `remove`
 
 Erases elements in a forward list that matches a specified value.
 
@@ -691,7 +691,7 @@ void remove(const Type& val);
 
 ### Parameters
 
-*val*\
+*`val`*\
 The value which, if held by an element, will result in that element's removal from the list.
 
 ### Remarks
@@ -700,7 +700,7 @@ The member function removes from the controlled sequence all elements, designate
 
 The member function never throws an exception.
 
-## <a name="remove_if"></a> remove_if
+## <a name="remove_if"></a> `remove_if`
 
 Erases elements from a forward list for which a specified predicate is satisfied.
 
@@ -711,16 +711,16 @@ template <class Predicate>
 
 ### Parameters
 
-*pred*\
+*`pred`*\
 The unary predicate which, if satisfied by an element, results in the deletion of that element from the list.
 
 ### Remarks
 
 The member function removes from the controlled sequence all elements, designated by the iterator `P`, for which `pred(*P)` is true.
 
-An exception occurs only if *pred* throws an exception. In that case, the controlled sequence is left in an unspecified state and the exception is rethrown.
+An exception occurs only if *`pred`* throws an exception. In that case, the controlled sequence is left in an unspecified state and the exception is rethrown.
 
-## <a name="resize"></a> resize
+## <a name="resize"></a> `resize`
 
 Specifies a new size for a forward list.
 
@@ -731,17 +731,17 @@ void resize(size_type _Newsize, const Type& val);
 
 ### Parameters
 
-*_Newsize*\
+*`_Newsize`*\
 The number of elements in the resized forward list.
 
-*val*\
+*`val`*\
 The value to use for padding.
 
 ### Remarks
 
-The member functions both ensure that the number of elements in the list henceforth is *_Newsize*. If it must make the controlled sequence longer, the first member function appends elements with value `Type()`, while the second member function appends elements with value *val*. To make the controlled sequence shorter, both member functions effectively call `erase_after(begin() + _Newsize - 1, end())`.
+The member functions both ensure that the number of elements in the list henceforth is *`_Newsize`*. If it must make the controlled sequence longer, the first member function appends elements with value `Type()`, while the second member function appends elements with value *`val`*. To make the controlled sequence shorter, both member functions effectively call `erase_after(begin() + _Newsize - 1, end())`.
 
-## <a name="reverse"></a> reverse
+## <a name="reverse"></a> `reverse`
 
 Reverses the order in which the elements occur in a forward list.
 
@@ -749,7 +749,7 @@ Reverses the order in which the elements occur in a forward list.
 void reverse();
 ```
 
-## <a name="size_type"></a> size_type
+## <a name="size_type"></a> `size_type`
 
 A type that represents the unsigned distance between two elements.
 
@@ -761,7 +761,7 @@ typedef typename Allocator::size_type size_type;
 
 The unsigned integer type describes an object that can represent the length of any controlled sequence.
 
-## <a name="sort"></a> sort
+## <a name="sort"></a> `sort`
 
 Arranges the elements in ascending order or with an order specified by a predicate.
 
@@ -773,7 +773,7 @@ void sort(Predicate pred);
 
 ### Parameters
 
-*pred*\
+*`pred`*\
 The ordering predicate.
 
 ### Remarks
@@ -782,11 +782,11 @@ Both member functions order the elements in the controlled sequence by a predica
 
 For the iterators `Pi` and `Pj` designating elements at positions `i` and `j`, the first member function imposes the order `!(*Pj < *Pi)` whenever `i < j`. (The elements are sorted in `ascending` order.) The member template function imposes the order `! pred(*Pj, *Pi)` whenever `i < j`. No ordered pairs of elements in the original controlled sequence are reversed in the resulting controlled sequence. (The sort is stable.)
 
-An exception occurs only if *pred* throws an exception. In that case, the controlled sequence is left in unspecified order and the exception is rethrown.
+An exception occurs only if *`pred`* throws an exception. In that case, the controlled sequence is left in unspecified order and the exception is rethrown.
 
-## <a name="splice_after"></a> splice_after
+## <a name="splice_after"></a> `splice_after`
 
-Removes elements from a source forward_list and inserts them into a destination forward_list.
+Removes elements from a source `forward_list` and inserts them into a destination `forward_list`.
 
 ```cpp
 // insert the entire source forward_list
@@ -813,30 +813,30 @@ void splice_after(
 
 ### Parameters
 
-*Where*\
-The position in the destination forward_list after which to insert.
+*`Where`*\
+The position in the destination `forward_list` after which to insert.
 
-*Source*\
-The source forward_list that is to be inserted into the destination forward_list.
+*`Source`*\
+The source `forward_list` that is to be inserted into the destination `forward_list`.
 
-*Iter*\
-The element to be inserted from the source forward_list.
+*`Iter`*\
+The element to be inserted from the source `forward_list`.
 
-*First*\
-The first element in the range to be inserted from source forward_list.
+*`First`*\
+The first element in the range to be inserted from source `forward_list`.
 
-*Last*\
-The first position beyond the range to be inserted from the source forward_list.
+*`Last`*\
+The first position beyond the range to be inserted from the source `forward_list`.
 
 ### Remarks
 
-The first pair of member functions inserts the sequence controlled by *Source* just after the element in the controlled sequence pointed to by *Where*. It also removes all elements from *Source*. (`&Source` must not equal **`this`**.)
+The first pair of member functions inserts the sequence controlled by *`Source`* just after the element in the controlled sequence pointed to by *`Where`*. It also removes all elements from *`Source`*. (`&Source` must not equal **`this`**.)
 
-The second pair of member functions removes the element just after *Iter* in the sequence controlled by *Source* and inserts it just after the element in the controlled sequence pointed to by *Where*. (If `Where == Iter || Where == ++Iter`, no change occurs.)
+The second pair of member functions removes the element just after *`Iter`* in the sequence controlled by *`Source`* and inserts it just after the element in the controlled sequence pointed to by *`Where`*. (If `Where == Iter || Where == ++Iter`, no change occurs.)
 
-The third pair of member functions (ranged splice) inserts the subrange designated by `(First, Last)` from the sequence controlled by *Source* just after the element in the controlled sequence pointed to by *Where*. It also removes the original subrange from the sequence controlled by *Source*. (If `&Source == this`, the range `(First, Last)` must not include the element pointed to by *Where*.)
+The third pair of member functions (ranged splice) inserts the subrange designated by `(First, Last)` from the sequence controlled by *`Source`* just after the element in the controlled sequence pointed to by *`Where`*. It also removes the original subrange from the sequence controlled by *`Source`*. (If `&Source == this`, the range `(First, Last)` must not include the element pointed to by *`Where`*.)
 
-If the ranged splice inserts `N` elements, and `&Source != this`, an object of class [iterator](#iterator) is incremented `N` times.
+If the ranged splice inserts `N` elements, and `&Source != this`, an object of class [`iterator`](#iterator) is incremented `N` times.
 
 No iterators, pointers, or references that designate spliced elements become invalid.
 
@@ -913,7 +913,7 @@ int main()
 Beginning state of lists:c1 = (10) (11)c2 = (20) (21) (22)c3 = (30) (31)c4 = (40) (41) (42) (43)After splicing c1 into c2:c1 =c2 = (20) (21) (10) (11) (22)After splicing the first element of c3 into c2:c3 = (30)c2 = (20) (21) (31) (10) (11) (22)After splicing a range of c4 into c2:c4 = (40) (41)c2 = (20) (21) (42) (43) (31) (10) (11) (22)
 ```
 
-## <a name="swap"></a> swap
+## <a name="swap"></a> `swap`
 
 Exchanges the elements of two forward lists.
 
@@ -923,14 +923,14 @@ void swap(forward_list& right);
 
 ### Parameters
 
-*right*\
+*`right`*\
 The forward list providing the elements to be exchanged.
 
 ### Remarks
 
-The member function swaps the controlled sequences between **`*this`** and *right*. If `get_allocator() ==  right.get_allocator()`, it does so in constant time, it throws no exceptions, and it invalidates no references, pointers, or iterators that designate elements in the two controlled sequences. Otherwise, it performs element assignments and constructor calls proportional to the number of elements in the two controlled sequences.
+The member function swaps the controlled sequences between **`*this`** and *`right`*. If `get_allocator() ==  right.get_allocator()`, it does so in constant time, it throws no exceptions, and it invalidates no references, pointers, or iterators that designate elements in the two controlled sequences. Otherwise, it performs element assignments and constructor calls proportional to the number of elements in the two controlled sequences.
 
-## <a name="unique"></a> unique
+## <a name="unique"></a> `unique`
 
 Eliminates all but the first element from every consecutive group of equal elements.
 
@@ -942,7 +942,7 @@ void unique(BinaryPredicate comp);
 
 ### Parameters
 
-*comp*\
+*`comp`*\
 The binary predicate used to compare successive elements.
 
 ### Remarks
@@ -955,7 +955,7 @@ For a controlled sequence of length `N` (> 0), the predicate `comp(*Pi, *Pj)` is
 
 An exception occurs only if `comp` throws an exception. In that case, the controlled sequence is left in an unspecified state and the exception is rethrown.
 
-## <a name="value_type"></a> value_type
+## <a name="value_type"></a> `value_type`
 
 A type that represents the type of element stored in a forward list.
 


### PR DESCRIPTION
Details of the remark fix can be found in the review comment.