### PR TITLE
Clean up `<condition_variable>` enums reference

### DIFF
--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -10,7 +10,7 @@ The `<condition_variable>` header provides the following enums:
 
 ## <a name="cv_status"></a> `cv_status`
 
-Supplies symbolic names for the return values of the methods of class template [`condition_variable`](../standard-library/condition-variable-class.md).
+Supplies symbolic names for the return values of the methods of class template [`condition_variable`](condition-variable-class.md).
 
 ```cpp
 enum class cv_status

--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -6,6 +6,8 @@ f1_keywords: ["condition_variable/std::cv_status"]
 ---
 # `<condition_variable>` enums
 
+The `<condition_variable>` header provides the following enums:
+
 ## <a name="cv_status"></a> cv_status
 
 Supplies symbolic names for the return values of the methods of class template [condition_variable](../standard-library/condition-variable-class.md).

--- a/docs/standard-library/condition-variable-enums.md
+++ b/docs/standard-library/condition-variable-enums.md
@@ -8,9 +8,9 @@ f1_keywords: ["condition_variable/std::cv_status"]
 
 The `<condition_variable>` header provides the following enums:
 
-## <a name="cv_status"></a> cv_status
+## <a name="cv_status"></a> `cv_status`
 
-Supplies symbolic names for the return values of the methods of class template [condition_variable](../standard-library/condition-variable-class.md).
+Supplies symbolic names for the return values of the methods of class template [`condition_variable`](../standard-library/condition-variable-class.md).
 
 ```cpp
 enum class cv_status


### PR DESCRIPTION
Add leading sentence, backticks, and clean up a redundant relative link.