### PR TITLE
Add missing `scoped_lock` to `toc.yml`

### DIFF
--- a/docs/standard-library/toc.yml
+++ b/docs/standard-library/toc.yml
@@ -797,6 +797,8 @@ items:
           href: recursive-mutex-class.md
         - name: recursive_timed_mutex class
           href: recursive-timed-mutex-class.md
+        - name: scoped_lock class
+          href: scoped-lock-class.md
         - name: timed_mutex class
           href: timed-mutex-class.md
         - name: try_to_lock_t struct


### PR DESCRIPTION
`scoped_lock` is missing from the `toc.yml` even though the `<mutex>` header index page has it.