### PR TITLE
Remove rogue space within backticked terms

### DIFF
--- a/docs/c-runtime-library/find-memory-leaks-using-the-crt-library.md
+++ b/docs/c-runtime-library/find-memory-leaks-using-the-crt-library.md
@@ -241,7 +241,7 @@ _CrtMemCheckpoint( &s1 );
 
 The `_CrtMemCheckpoint` function fills in the structure with a snapshot of the current memory state.
 
-To output the contents of a `_CrtMemState` structure, pass the structure to the `_ CrtMemDumpStatistics` function:
+To output the contents of a `_CrtMemState` structure, pass the structure to the `_CrtMemDumpStatistics` function:
 
 ```cpp
 _CrtMemDumpStatistics( &s1 );

--- a/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
+++ b/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
@@ -63,10 +63,10 @@ By default, this function's global state is scoped to the application. To change
 
 | Routine | Required header |
 |---|---|
-| **`islower`** | \<ctype.h> |
-| **`iswlower`** | \<ctype.h> or \<wchar.h> |
-| **`_islower_l`** | \<ctype.h> |
-| **`_swlower_l`** | \<ctype.h> or \<wchar.h> |
+| **`islower`** | `<ctype.h>` |
+| **`iswlower`** | `<ctype.h>` or `<wchar.h>` |
+| **`_islower_l`** | `<ctype.h>` |
+| **`_swlower_l`** | `<ctype.h>` or `<wchar.h>` |
 
 For more compatibility information, see [Compatibility](../compatibility.md).
 

--- a/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
+++ b/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: islower, iswlower, _islower_l, _iswlower_l"
 title: "islower, iswlower, _islower_l, _iswlower_l"
-ms.date: "4/2/2020"
+description: "Learn more about: islower, iswlower, _islower_l, _iswlower_l"
+ms.date: 4/2/2020
 api_name: ["iswlower", "_islower_l", "islower", "_iswlower_l", "_o_islower", "_o_iswlower"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-string-l1-1-0.dll", "ntoskrnl.exe"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_istlower", "islower", "_ismbclower_l", "_liswlower_l", "_istlower_l", "_iswlower_l", "_islower _l", "_islower_l", "iswlower"]
 helpviewer_keywords: ["_islower _l function", "_ismbclower_l function", "islower function", "_iswlower_l function", "_liswlower_l function", "_istlower_l function", "istlower function", "_istlower function", "iswlower function", "_islower_l function"]
-ms.assetid: fcc3b70a-2b47-45fd-944d-e5c1942e6457
 ---
 # `islower`, `iswlower`, `_islower_l`, `_iswlower_l`
 

--- a/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
+++ b/docs/c-runtime-library/reference/islower-iswlower-islower-l-iswlower-l.md
@@ -54,7 +54,7 @@ The behavior of **`islower`** and **`_islower_l`** is undefined if *`c`* isn't E
 | TCHAR.H routine | `_UNICODE` and `_MBCS` not defined | `_MBCS` defined | `_UNICODE` defined |
 |---|---|---|---|
 | `_istlower` | **`islower`** | [`_ismbclower`](ismbclower-ismbclower-l-ismbcupper-ismbcupper-l.md) | **`iswlower`** |
-| **`_istlower_l`** | `_islower _l` | [`_ismbclower_l`](ismbclower-ismbclower-l-ismbcupper-ismbcupper-l.md) | **`_liswlower_l`** |
+| **`_istlower_l`** | `_islower_l` | [`_ismbclower_l`](ismbclower-ismbclower-l-ismbcupper-ismbcupper-l.md) | **`_liswlower_l`** |
 
 ## Remarks
 

--- a/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
+++ b/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
@@ -95,8 +95,8 @@ By default, this function's global state is scoped to the application. To change
 
 | Routine | Required header |
 |---|---|
-| **`_mbsnbset_s`** | \<mbstring.h> |
-| **`_mbsnbset_s_l`** | \<mbstring.h> |
+| **`_mbsnbset_s`** | `<mbstring.h>` |
+| **`_mbsnbset_s_l`** | `<mbstring.h>` |
 
 For more compatibility information, see [Compatibility](../compatibility.md).
 

--- a/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
+++ b/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
@@ -90,7 +90,7 @@ By default, this function's global state is scoped to the application. To change
 | Tchar.h routine | `_UNICODE` and `_MBCS` not defined | `_MBCS` defined | `_UNICODE` defined |
 |---|---|---|---|
 | `_tcsnset_s` | `_strnset_s` | **`_mbsnbset_s`** | `_wcsnset_s` |
-| `_tcsnset_s_l` | `_strnset_s _l` | **`_mbsnbset_s_l`** | `_wcsnset_s_l` |
+| `_tcsnset_s_l` | `_strnset_s_l` | **`_mbsnbset_s_l`** | `_wcsnset_s_l` |
 
 ## Requirements
 

--- a/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
+++ b/docs/c-runtime-library/reference/mbsnbset-s-mbsnbset-s-l.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _mbsnbset_s, _mbsnbset_s_l"
 title: "_mbsnbset_s, _mbsnbset_s_l"
-ms.date: "4/2/2020"
+description: "Learn more about: _mbsnbset_s, _mbsnbset_s_l"
+ms.date: 4/2/2020
 api_name: ["_mbsnbset_s_l", "_mbsnbset_s", "_o__mbsnbset_s", "_o__mbsnbset_s_l"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-multibyte-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["mbsnbset_s", "_mbsnbset_s_l", "_mbsnbset_s", "mbsnbset_s_l"]
 helpviewer_keywords: ["tcsnset_s function", "mbsnbset_s function", "mbsnbset_s_l function", "_mbsnbset_s_l function", "_tcsnset_s_l function", "_mbsnbset_s function", "_tcsnset_s function", "tcsnset_s_l function"]
-ms.assetid: 811f92c9-cc31-4bbd-8017-2d1bfc6fb96f
 ---
 # `_mbsnbset_s`, `_mbsnbset_s_l`
 


### PR DESCRIPTION
Remove rogue space within backticked terms, add backticks, and update metadata.