### PR TITLE
Clean up `<limits>` enums reference

### DIFF
--- a/docs/standard-library/limits-enums.md
+++ b/docs/standard-library/limits-enums.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <limits> enums"
 title: "<limits> enums"
-ms.date: "11/04/2016"
+description: "Learn more about: <limits> enums"
+ms.date: 11/04/2016
 f1_keywords: ["limits/std::float_denorm_style", "limits/std::float_round_style"]
-ms.assetid: c86680a2-ba97-4ed9-8c20-a448857d7dc5
 ---
 # `<limits>` enums
 


### PR DESCRIPTION
Bunch of cleanups for `<limits>` enums reference.