### PR TITLE
Add missing escapes and clean up a few topics

### DIFF
--- a/docs/build/reference/msbuild-reference-cpp.md
+++ b/docs/build/reference/msbuild-reference-cpp.md
@@ -12,25 +12,25 @@ If for some reason you wish to use MSBuild directly from the command line, see [
 
 ## In this section
 
-[MSBuild internals for C++ projects](msbuild-visual-cpp-overview.md)<br/>
+[MSBuild internals for C++ projects](msbuild-visual-cpp-overview.md)\
 Information about how properties and targets are stored and consumed.
 
-[Common macros for build commands and properties](common-macros-for-build-commands-and-properties.md)<br/>
+[Common macros for build commands and properties](common-macros-for-build-commands-and-properties.md)\
 Describes macros (compile-time constants) that can be used to define properties such as paths and product versions.
 
-[File types created for C++ projects](file-types-created-for-visual-cpp-projects.md)<br/>
+[File types created for C++ projects](file-types-created-for-visual-cpp-projects.md)\
 Describes the various kinds of files that Visual Studio creates for different project types.
 
-[Visual Studio C++ project templates](visual-cpp-project-types.md)<br>
+[Visual Studio C++ project templates](visual-cpp-project-types.md)\
 Describes the MSBuild-based project types that are available for C++.
 
-[C++ new item templates](using-visual-cpp-add-new-item-templates.md)<br>
+[C++ new item templates](using-visual-cpp-add-new-item-templates.md)\
 Describes source files and other items you can add to a Visual Studio project.
 
 [Precompiled header files](../creating-precompiled-header-files.md)\
 How to use precompiled header files and how to create your own custom precompiled code to speed up build times.
 
-[Visual Studio project property reference](property-pages-visual-cpp.md)<br/>
+[Visual Studio project property reference](property-pages-visual-cpp.md)\
 Reference documentation for project properties that are set in the Visual Studio IDE.
 
 ## See also

--- a/docs/build/reference/msbuild-reference-cpp.md
+++ b/docs/build/reference/msbuild-reference-cpp.md
@@ -27,7 +27,7 @@ Describes the MSBuild-based project types that are available for C++.
 [C++ new item templates](using-visual-cpp-add-new-item-templates.md)<br>
 Describes source files and other items you can add to a Visual Studio project.
 
-[Precompiled header files](../creating-precompiled-header-files.md)
+[Precompiled header files](../creating-precompiled-header-files.md)\
 How to use precompiled header files and how to create your own custom precompiled code to speed up build times.
 
 [Visual Studio project property reference](property-pages-visual-cpp.md)<br/>

--- a/docs/build/reference/msbuild-reference-cpp.md
+++ b/docs/build/reference/msbuild-reference-cpp.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: MSBuild reference for C++ projects"
 title: "MSBuild reference for C++ projects in Visual Studio"
-ms.date: "12/08/2018"
+description: "Learn more about: MSBuild reference for C++ projects"
+ms.date: 12/08/2018
 helpviewer_keywords: ["MSBuild reference [C++]"]
 ---
 # MSBuild reference for C++ projects

--- a/docs/cpp/c-cpp-language-and-standard-libraries.md
+++ b/docs/cpp/c-cpp-language-and-standard-libraries.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: C/C++ language and standard libraries reference"
 title: "C/C++ language and standard libraries reference"
+description: "Learn more about: C/C++ language and standard libraries reference"
 ms.date: 09/11/2024
 ms.topic: "overview"
 ms.custom: intro-overview

--- a/docs/cpp/c-cpp-language-and-standard-libraries.md
+++ b/docs/cpp/c-cpp-language-and-standard-libraries.md
@@ -16,7 +16,7 @@ You'll also find documentation for the C runtime library, the C++ standard libra
 [C language](../c-language/c-language-reference.md)\
 Reference content for the Microsoft implementation of the C language.
 
-[C++ language](../cpp/cpp-language-reference.md)\
+[C++ language](cpp-language-reference.md)\
 Reference content for the Microsoft implementation of the C++ language.
 
 [C/C++ preprocessor](../preprocessor/c-cpp-preprocessor-reference.md)\

--- a/docs/cpp/c-cpp-language-and-standard-libraries.md
+++ b/docs/cpp/c-cpp-language-and-standard-libraries.md
@@ -66,7 +66,7 @@ A header-only C++20 library for using polymorphism in C++ without inheritance. F
 [SafeInt library](../safeint/safeint-library.md)\
 A portable library that can be used with MSVC, GCC, or Clang to help prevent integer overflows.
 
-[Data Access Libraries](../data/data-access-in-cpp.md)
+[Data Access Libraries](../data/data-access-in-cpp.md)\
 Libraries to support data access using ATL or MFC, and legacy services such as OLE DB and ODBC.
 
 ## Related articles

--- a/docs/security/security-best-practices-for-cpp.md
+++ b/docs/security/security-best-practices-for-cpp.md
@@ -86,5 +86,5 @@ For information about how to indentify and mitigate against speculative executio
 ## See also
 
 <xref:System.Security>\
-[Security](/dotnet/standard/security/index)\
+[Security in .NET](/dotnet/standard/security/index)\
 [How User Account Control (UAC) Affects Your Application](how-user-account-control-uac-affects-your-application.md)

--- a/docs/security/security-best-practices-for-cpp.md
+++ b/docs/security/security-best-practices-for-cpp.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Security Best Practices for C++"
 title: "Security Best Practices for C++"
-ms.date: "05/08/2018"
+description: "Learn more about: Security Best Practices for C++"
+ms.date: 05/08/2018
 f1_keywords: ["securitybestpracticesVC"]
 helpviewer_keywords: ["Visual C++, security", "security [C++]", "security [C++], best practices"]
-ms.assetid: 86acaccf-cdb4-4517-bd58-553618e3ec42
 ---
 # Security Best Practices for C++
 

--- a/docs/security/security-best-practices-for-cpp.md
+++ b/docs/security/security-best-practices-for-cpp.md
@@ -14,22 +14,22 @@ This article contains information about security tools and practices. Using them
 
 These security features are built into the Microsoft C++ compiler and linker:
 
-[`/guard` (Enable Control Flow Guard)](../build/reference/guard-enable-control-flow-guard.md)<br/>
+[`/guard` (Enable Control Flow Guard)](../build/reference/guard-enable-control-flow-guard.md)\
 Causes the compiler to analyze control flow for indirect call targets at compile time, and then to insert code to verify the targets at runtime.
 
-[`/GS` (Buffer Security Check)](../build/reference/gs-buffer-security-check.md)<br/>
+[`/GS` (Buffer Security Check)](../build/reference/gs-buffer-security-check.md)\
 Instructs the compiler to insert overrun detection code into functions that are at risk of being exploited. When an overrun is detected, execution is stopped. By default, this option is on.
 
-[`/SAFESEH` (Image has Safe Exception Handlers)](../build/reference/safeseh-image-has-safe-exception-handlers.md)<br/>
+[`/SAFESEH` (Image has Safe Exception Handlers)](../build/reference/safeseh-image-has-safe-exception-handlers.md)\
 Instructs the linker to include in the output image a table that contains the address of each exception handler. At run time, the operating system uses this table to make sure that only legitimate exception handlers are executed. This helps prevent the execution of exception handlers that are introduced by a malicious attack at run time. By default, this option is off.
 
 [`/NXCOMPAT`](../build/reference/nxcompat.md), [`/NXCOMPAT` (Compatible with Data Execution Prevention)](../build/reference/nxcompat-compatible-with-data-execution-prevention.md)\
 These compiler and linker options enable Data Execution Prevention (DEP) compatibility. DEP guards the CPU against the execution of non-code pages.
 
-[`/analyze` (Code Analysis)](../build/reference/analyze-code-analysis.md)<br/>
+[`/analyze` (Code Analysis)](../build/reference/analyze-code-analysis.md)\
 This compiler option activates code analysis that reports potential security issues such as buffer overrun, un-initialized memory, null pointer dereferencing, and memory leaks. By default, this option is off. For more information, see [Code Analysis for C/C++ Overview](../code-quality/code-analysis-for-c-cpp-overview.md).
 
-[`/DYNAMICBASE` (Use address space layout randomization)](../build/reference/dynamicbase-use-address-space-layout-randomization.md)<br/>
+[`/DYNAMICBASE` (Use address space layout randomization)](../build/reference/dynamicbase-use-address-space-layout-randomization.md)\
 This linker option enables the building of an executable image that can be loaded at different locations in memory at the beginning of execution. This option also makes the stack location in memory much less predictable.
 
 ## Security-Enhanced CRT
@@ -86,6 +86,6 @@ For information about how to indentify and mitigate against speculative executio
 
 ## See also
 
-<xref:System.Security> <br/>
-[Security](/dotnet/standard/security/index)<br/>
+<xref:System.Security>\
+[Security](/dotnet/standard/security/index)\
 [How User Account Control (UAC) Affects Your Application](how-user-account-control-uac-affects-your-application.md)

--- a/docs/security/security-best-practices-for-cpp.md
+++ b/docs/security/security-best-practices-for-cpp.md
@@ -23,7 +23,7 @@ Instructs the compiler to insert overrun detection code into functions that are 
 [`/SAFESEH` (Image has Safe Exception Handlers)](../build/reference/safeseh-image-has-safe-exception-handlers.md)<br/>
 Instructs the linker to include in the output image a table that contains the address of each exception handler. At run time, the operating system uses this table to make sure that only legitimate exception handlers are executed. This helps prevent the execution of exception handlers that are introduced by a malicious attack at run time. By default, this option is off.
 
-[`/NXCOMPAT`](../build/reference/nxcompat.md), [`/NXCOMPAT` (Compatible with Data Execution Prevention)](../build/reference/nxcompat-compatible-with-data-execution-prevention.md)
+[`/NXCOMPAT`](../build/reference/nxcompat.md), [`/NXCOMPAT` (Compatible with Data Execution Prevention)](../build/reference/nxcompat-compatible-with-data-execution-prevention.md)\
 These compiler and linker options enable Data Execution Prevention (DEP) compatibility. DEP guards the CPU against the execution of non-code pages.
 
 [`/analyze` (Code Analysis)](../build/reference/analyze-code-analysis.md)<br/>


### PR DESCRIPTION
Add a couple of missing escapes between the link and description, as well as a bunch of cleanups.