### PR TITLE
Resolve misplaced leading backtick in link text

### DIFF
--- a/docs/build/reference/linker-property-pages.md
+++ b/docs/build/reference/linker-property-pages.md
@@ -252,7 +252,7 @@ Specifies total heap allocation size in virtual memory. Default is 1 MB.    ([`/
 
 ### Heap Commit Size
 
-Specifies total heap allocation size in physical memory. Default is 4 KB.    (`[/HEAP:reserve,commit`](heap-set-heap-size.md))
+Specifies total heap allocation size in physical memory. Default is 4 KB.    ([`/HEAP:reserve,commit`](heap-set-heap-size.md))
 
 ### Stack Reserve Size
 
@@ -373,7 +373,7 @@ Partially sign the Windows Metadata. Use [`/WINMDDELAYSIGN`](winmddelaysign-part
 
 ### Entry Point
 
-The `[/ENTRY`](entry-entry-point-symbol.md) option specifies an entry point function as the starting address for an *`.exe`* file or DLL.
+The [`/ENTRY`](entry-entry-point-symbol.md) option specifies an entry point function as the starting address for an *`.exe`* file or DLL.
 
 ### No Entry Point
 

--- a/docs/build/reference/linker-property-pages.md
+++ b/docs/build/reference/linker-property-pages.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Property Pages"
 title: "Linker Property Pages"
+description: "Learn more about: Linker Property Pages"
 ms.date: 09/07/2022
 ms.topic: "article"
 f1_keywords: ["VC.Project.VCLinkerTool.IgnoreImportLibrary", "VC.Project.VCLinkerTool.RegisterOutput", "VC.Project.VCLinkerTool.PerUserRedirection", "VC.Project.VCLinkerTool.LinkLibraryDependencies", "VC.Project.VCLinkerTool.UseLibraryDependencyInputs"]
-ms.assetid: 7e7671e5-a35a-4e67-9bdb-661d75c4d11e
 ---
 # Linker Property Pages
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2653"
 title: "Compiler Error C2653"
-ms.date: "11/30/2017"
+description: "Learn more about: Compiler Error C2653"
+ms.date: 11/30/2017
 f1_keywords: ["C2653"]
 helpviewer_keywords: ["C2653"]
-ms.assetid: 3f49e731-affd-43a0-a8d0-181db7650bc3
 ---
 # Compiler Error C2653
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
@@ -14,7 +14,7 @@ The language syntax requires a class, structure, union, or namespace name here.
 
 This error can occur when you use a name that has not been declared as a class, structure, union, or namespace in front of a scope operator. To fix this issue, declare the name or include the header that declares the name before it is used.
 
-C2653 is also possible if you try to define a *compound namespace*, a namespace that contains one or more scope-nested namespace names. Compound namespace definitions are not allowed in C++ prior to C++17. Compound namespaces are supported starting in Visual Studio 2015 Update 3 when you specify the [`/std:c++latest`](../../build/reference/std-specify-language-standard-version.md) compiler option. Starting in Visual Studio 2017 version 15.5, the compiler supports compound namespace definitions when the `[/std:c++17`](../../build/reference/std-specify-language-standard-version.md) or later option is specified.
+C2653 is also possible if you try to define a *compound namespace*, a namespace that contains one or more scope-nested namespace names. Compound namespace definitions are not allowed in C++ prior to C++17. Compound namespaces are supported starting in Visual Studio 2015 Update 3 when you specify the [`/std:c++latest`](../../build/reference/std-specify-language-standard-version.md) compiler option. Starting in Visual Studio 2017 version 15.5, the compiler supports compound namespace definitions when the [`/std:c++17`](../../build/reference/std-specify-language-standard-version.md) or later option is specified.
 
 ## Examples
 


### PR DESCRIPTION
Resolve misplaced leading backtick in link text that breaks the entire link:

![image](https://github.com/user-attachments/assets/aec707cf-e40b-4553-bd4e-bf37821fba9f)
![image](https://github.com/user-attachments/assets/9f6e3c39-88ba-4702-84b9-f28716dd29e6)
![image](https://github.com/user-attachments/assets/1dcb8b48-dc52-46d0-bb41-ea457063763e)

