### PR TITLE
Remove duplicate `IOleInPlaceObjectWindowless` in `COleControlSite` reference

### DIFF
--- a/docs/mfc/reference/colecontrolsite-class.md
+++ b/docs/mfc/reference/colecontrolsite-class.md
@@ -721,7 +721,7 @@ LPOLEOBJECT m_pObject;
 
 ## <a name="m_pwindowlessobject"></a> COleControlSite::m_pWindowlessObject
 
-Contains the `IOleInPlaceObjectWindowless`[IOleInPlaceObjectWindowless](/windows/win32/api/ocidl/nn-ocidl-ioleinplaceobjectwindowless) interface of the control.
+Contains the [`IOleInPlaceObjectWindowless`](/windows/win32/api/ocidl/nn-ocidl-ioleinplaceobjectwindowless) interface of the control.
 
 ```
 IOleInPlaceObjectWindowless* m_pWindowlessObject;


### PR DESCRIPTION
Remove duplicate `IOleInPlaceObjectWindowless` text.