### PR TITLE
Expand C2601 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2601.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2601.md
@@ -17,7 +17,7 @@ Or, there may be an extra/missing brace before the location of the C2601 error.
 
 ## Examples
 
-## Define function within a function
+### Define function within a function
 
 [Lambda Expressions](../../cpp/lambda-expressions-in-cpp.md) may be used to emulate the behavior of local functions:
 
@@ -37,7 +37,7 @@ int main()
 }
 ```
 
-## Missing closing brace
+### Missing closing brace
 
 If a preceding function is missing a closing brace, the subsequent function is taken to be a local function:
 


### PR DESCRIPTION
- Add "Remarks", "Examples", and other headings to keep things organized
- Add blockquotes for error message
- Tweak error remarks
- Replace the faulty old example (unused variable `i` and contrived `funcname` logic)
- Provide a possible solution of using lambda expressions
- Add a short example on the missing brace scenario
- Update metadata