### PR TITLE
Improve C2574 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
@@ -10,7 +10,11 @@ ms.assetid: 3e1c5c18-ee8b-4dbb-bfc0-d3b8991af71b
 
 > '*function*': cannot be declared static
 
+## Remarks
+
 Neither destructors nor constructors can be declared **`static`**.
+
+## Example
 
 The following sample generates C2574:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
@@ -8,7 +8,7 @@ ms.assetid: 3e1c5c18-ee8b-4dbb-bfc0-d3b8991af71b
 ---
 # Compiler Error C2574
 
-'destructor' : cannot be declared static
+> '*function*': cannot be declared static
 
 Neither destructors nor constructors can be declared **`static`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2574"
 title: "Compiler Error C2574"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2574"
+ms.date: 06/04/2025
 f1_keywords: ["C2574"]
 helpviewer_keywords: ["C2574"]
-ms.assetid: 3e1c5c18-ee8b-4dbb-bfc0-d3b8991af71b
 ---
 # Compiler Error C2574
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
@@ -16,14 +16,16 @@ Neither destructors nor constructors can be declared **`static`**.
 
 ## Example
 
-The following sample generates C2574:
+The following example generates C2574:
 
 ```cpp
 // C2574.cpp
 // compile with: /c
-class A {
-   virtual static ~A();   // C2574
-   //  try the following line instead
-   // virtual ~A();
+struct S
+{
+    static S() {}   // C2574
+
+    // Try the following line instead:
+    // S() {}
 };
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2574.md
@@ -12,7 +12,7 @@ ms.assetid: 3e1c5c18-ee8b-4dbb-bfc0-d3b8991af71b
 
 ## Remarks
 
-Neither destructors nor constructors can be declared **`static`**.
+Neither [constructors](../../cpp/constructors-cpp.md) nor [destructors](../../cpp/destructors-cpp.md) can be declared **`static`**.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
@@ -89,7 +89,7 @@ The articles in this section of the documentation explain a subset of the error 
 |[Compiler error C2571](compiler-error-C2571.md)|'*identifier*': virtual function cannot be in union '*union*'|
 |[Compiler error C2572](compiler-error-C2572.md)|'*function*': redefinition of default argument: parameter *number*|
 |[Compiler error C2573](compiler-error-C2573.md)|'*class*': cannot delete pointers to objects of this type; the class has no non-placement overload for 'operator delete'. Use ::delete, or add 'operator delete(void*)' to the class|
-|[Compiler error C2574](compiler-error-C2574.md)|'*destructor*': cannot be declared static|
+|[Compiler error C2574](compiler-error-C2574.md)|'*function*': cannot be declared static|
 |[Compiler error C2575](compiler-error-C2575.md)|'*identifier*': only member functions and bases can be virtual|
 |Compiler error C2576|'*identifier*': cannot introduce a new virtual method as 'public'. Consider making the method non-virtual, or change the accessibility to 'internal' or 'protected private'|
 |[Compiler error C2577](compiler-error-C2577.md)|'*identifier*': a destructor/finalizer cannot have a return type|

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler errors C2500 Through C2599"
 title: "Compiler errors C2500 Through C2599"
-ms.date: "04/21/2019"
+description: "Learn more about: Compiler errors C2500 Through C2599"
+ms.date: 04/21/2019
 f1_keywords: ["C2501", "C2508", "C2515", "C2519", "C2520", "C2522", "C2525", "C2527", "C2536", "C2538", "C2539", "C2546", "C2547", "C2559", "C2560", "C2564", "C2565", "C2576", "C2578", "C2580", "C2590", "C2591", "C2595", "C2596"]
 helpviewer_keywords: ["C2501", "C2508", "C2515", "C2519", "C2520", "C2522", "C2525", "C2527", "C2536", "C2538", "C2539", "C2546", "C2547", "C2559", "C2560", "C2564", "C2565", "C2576", "C2578", "C2580", "C2590", "C2591", "C2595", "C2596"]
 ---


### PR DESCRIPTION
- Improve the error message to account for both constructors and destructors
- Add "Remarks" and "Example" headings to keep things clean
- Tweak remarks (constructor before destructor seems more canonical) and add links
- Overhaul example
  - Use struct instead, to avoid needing `public:` and prevent issues with defining the members as `private`
  - Remove orthogonal `virtual` to keep the example more focused
  - Define instead of just declaring the constructor to prevent `VCR001` warning
- Update metadata