### PR TITLE
Remove empty lines at start and end of code block

### DIFF
--- a/docs/code-quality/c6393.md
+++ b/docs/code-quality/c6393.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Warning C6393"
 title: Warning C6393
+description: "Learn more about: Warning C6393"
 ms.date: 11/29/2023
 f1_keywords: ["C6393", "LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP", "__WARNING_LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP"]
 helpviewer_keywords: ["C6393"]

--- a/docs/code-quality/c6393.md
+++ b/docs/code-quality/c6393.md
@@ -26,7 +26,6 @@ Code analysis name: `LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP`
 The following code creates a lookup table for the day of the year, assuming 365 days per year. However, this doesn't work if the year is a leap year:
 
 ```cpp
- 
 #include <vector> 
   
 void foo(int year) 

--- a/docs/code-quality/c6393.md
+++ b/docs/code-quality/c6393.md
@@ -26,25 +26,25 @@ Code analysis name: `LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP`
 The following code creates a lookup table for the day of the year, assuming 365 days per year. However, this doesn't work if the year is a leap year:
 
 ```cpp
-#include <vector> 
-  
-void foo(int year) 
-{ 
-    const std::vector<int> items(365);  // C6393 
-    // Initialize items and use it... 
+#include <vector>
+
+void foo(int year)
+{
+    const std::vector<int> items(365);   // C6393
+    // Initialize items and use it...
 }
 ```
 
 To fix the problem, adjust the size of the lookup table as the table is created according to the result of appropriate leap year check:
 
 ```cpp
-#include <vector> 
-  
-void foo(int year) 
-{ 
-    bool isLeapYear = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0); 
-    const std::vector<int> items(isLeapYear ? 366 : 365); 
-    // Initialize items and use it... 
+#include <vector>
+
+void foo(int year)
+{
+    bool isLeapYear = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    const std::vector<int> items(isLeapYear ? 366 : 365);
+    // Initialize items and use it...
 }
 ```
 

--- a/docs/cpp/functions-cpp.md
+++ b/docs/cpp/functions-cpp.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Functions (C++)"
 title: "Functions (C++)"
-ms.date: "11/19/2018"
+description: "Learn more about: Functions (C++)"
+ms.date: 11/19/2018
 helpviewer_keywords: ["defaults, arguments", "function definitions", "function definitions, about function definitions", "default arguments", "declarators, functions"]
 ---
 # Functions (C++)

--- a/docs/cpp/functions-cpp.md
+++ b/docs/cpp/functions-cpp.md
@@ -77,7 +77,6 @@ Optional parts of a function declaration are:
     ```cpp
     //Declare printf with C linkage.
     extern "C" int printf( const char *fmt, ... );
-
     ```
 
    For more information, see [Translation units and linkage](../cpp/program-and-linkage-cpp.md).

--- a/docs/porting/visual-cpp-what-s-new-2003-through-2015.md
+++ b/docs/porting/visual-cpp-what-s-new-2003-through-2015.md
@@ -226,7 +226,6 @@ Although these differences can affect your source code or other build artifacts,
    ```cpp
     error C3688: invalid literal suffix '_x'; literal operator or literal operator template 'operator ""_x' not found
     note: Did you forget a space between the string literal and the prefix of the following string literal?
-
    ```
 
    To fix this problem, add a space between the string literal and the macro.


### PR DESCRIPTION
- Remove empty lines at start and end of code block
- Remove bunch of trailing spaces in C6393 warning examples
- Update metadata