### PR TITLE
Update C2583 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -12,7 +12,7 @@ ms.assetid: b1c952dc-872c-47e4-9fc8-4dd72bcee6f9
 
 ## Remarks
 
-A constructor or destructor can't be declared **`const`** or **`volatile`**.
+A [constructor](../../cpp/constructors-cpp.md) or [destructor](../../cpp/destructors-cpp.md) can't be declared **`const`** or **`volatile`**.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2583"
 title: "Compiler Error C2583"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2583"
+ms.date: 06/06/2025
 f1_keywords: ["C2583"]
 helpviewer_keywords: ["C2583"]
-ms.assetid: b1c952dc-872c-47e4-9fc8-4dd72bcee6f9
 ---
 # Compiler Error C2583
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -12,7 +12,7 @@ ms.assetid: b1c952dc-872c-47e4-9fc8-4dd72bcee6f9
 
 ## Remarks
 
-A constructor or destructor is declared **`const`** or **`volatile`**. This is not allowed.
+A constructor or destructor can't be declared **`const`** or **`volatile`**.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -8,7 +8,7 @@ ms.assetid: b1c952dc-872c-47e4-9fc8-4dd72bcee6f9
 ---
 # Compiler Error C2583
 
-'identifier' : 'const/volatile' 'this' pointer is illegal for constructors/destructors
+> '*identifier*': '*const/volatile*' 'this' pointer is illegal for constructors/destructors
 
 A constructor or destructor is declared **`const`** or **`volatile`**. This is not allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -16,17 +16,16 @@ A [constructor](../../cpp/constructors-cpp.md) or [destructor](../../cpp/destruc
 
 ## Example
 
-The following sample generates C2583:
+The following example generates C2583:
 
 ```cpp
 // C2583.cpp
 // compile with: /c
-class A {
-public:
-   int i;
-   A() const;   // C2583
+struct S
+{
+    S() const {}   // C2583
 
-   // try the following line instead
-   // A();
+    // Try the following line instead:
+    // S() {}
 };
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2583.md
@@ -10,7 +10,11 @@ ms.assetid: b1c952dc-872c-47e4-9fc8-4dd72bcee6f9
 
 > '*identifier*': '*const/volatile*' 'this' pointer is illegal for constructors/destructors
 
+## Remarks
+
 A constructor or destructor is declared **`const`** or **`volatile`**. This is not allowed.
+
+## Example
 
 The following sample generates C2583:
 

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
@@ -98,7 +98,7 @@ The articles in this section of the documentation explain a subset of the error 
 |Compiler error C2580|'*identifier*': multiple versions of a defaulted special member functions are not allowed|
 |[Compiler error C2581](compiler-error-C2581.md)|'*type*': static 'operator =' function is illegal|
 |[Compiler error C2582](compiler-error-C2582.md)|'operator *operator*' function is unavailable in '*type*'|
-|[Compiler error C2583](compiler-error-C2583.md)|'*identifier*': 'const/volatile' 'this' pointer is illegal for constructors/destructors|
+|[Compiler error C2583](compiler-error-C2583.md)|'*identifier*': '*const/volatile*' 'this' pointer is illegal for constructors/destructors|
 |[Compiler error C2584](compiler-error-C2584.md)|'*class*': direct base '*base_class2*' is inaccessible; already a base of '*base_class1*'|
 |[Compiler error C2585](compiler-error-C2585.md)|explicit conversion to '*type*' is ambiguous|
 |[Compiler error C2586](compiler-error-C2586.md)|incorrect user-defined conversion syntax: illegal indirections|


### PR DESCRIPTION
- Add blockquotes and italics to error message
- Reword and add links to remarks
- Add headings to keep things clean
- Simplify (remove nonintegral `int i`) and improve example
- Update metadata