### PR TITLE
Elide line tabulation (U+000B) in "Microsoft C/C++ change history 2003 - 2015"

### DIFF
--- a/docs/porting/visual-cpp-change-history-2003-2015.md
+++ b/docs/porting/visual-cpp-change-history-2003-2015.md
@@ -1650,10 +1650,10 @@ Although these differences can affect your source code or other build artifacts,
 
     //b.cpp
     // compile with cl.exe /nologo /LD /EHsc /Osx b.cpp
-    #pragma comment(lib, "A")
+    #pragma comment(lib, "A")
     class __declspec(dllimport) A
     {
-    public: A();
+    public: A();
             A(const A&);
             virtual ~A();
     private:
@@ -1667,7 +1667,7 @@ Although these differences can affect your source code or other build artifacts,
 
     //c.cpp
     #pragma comment(lib, "A")
-    #pragma comment(lib, "B")
+    #pragma comment(lib, "B")
     class __declspec(dllimport) A
     {
     public:


### PR DESCRIPTION
Elide line tabulation (U+000B) that renders as such:

![image](https://github.com/user-attachments/assets/c42bbbc9-3d8f-4f7f-be67-9c68996a23f0)
