### PR TITLE
Remove backslash in backticked terms

### DIFF
--- a/docs/mfc/reference/cwinapp-class.md
+++ b/docs/mfc/reference/cwinapp-class.md
@@ -961,7 +961,7 @@ HCURSOR LoadOEMCursor(UINT nIDCursor) const;
 ### Parameters
 
 *nIDCursor*<br/>
-An **OCR_** manifest constant identifier that specifies a predefined Windows cursor. You must have `#define OEMRESOURCE` before `#include \<afxwin.h>` to gain access to the **OCR_** constants in WINDOWS.H.
+An **OCR_** manifest constant identifier that specifies a predefined Windows cursor. You must have `#define OEMRESOURCE` before `#include <afxwin.h>` to gain access to the **OCR_** constants in WINDOWS.H.
 
 ### Return Value
 
@@ -988,7 +988,7 @@ HICON LoadOEMIcon(UINT nIDIcon) const;
 ### Parameters
 
 *nIDIcon*<br/>
-An **OIC_** manifest constant identifier that specifies a predefined Windows icon. You must have `#define OEMRESOURCE` before `#include \<afxwin.h>` to access the **OIC_** constants in WINDOWS.H.
+An **OIC_** manifest constant identifier that specifies a predefined Windows icon. You must have `#define OEMRESOURCE` before `#include <afxwin.h>` to access the **OIC_** constants in WINDOWS.H.
 
 ### Return Value
 

--- a/docs/parallel/amp/graphics-cpp-amp.md
+++ b/docs/parallel/amp/graphics-cpp-amp.md
@@ -139,7 +139,7 @@ There are limits on the size of each dimension of the `texture` object, as shown
 
 ### Reading from Texture Objects
 
-You can read from a `texture` object by using [texture::operator\[\]](reference/texture-class.md#operator_at), [texture::operator() Operator](reference/texture-class.md#operator_call), or [texture::get Method](reference/texture-class.md#get). The two operators return a value, not a reference. Therefore, you cannot write to a `texture` object by using `texture::operator\[\]`.
+You can read from a `texture` object by using [texture::operator\[\]](reference/texture-class.md#operator_at), [texture::operator() Operator](reference/texture-class.md#operator_call), or [texture::get Method](reference/texture-class.md#get). The two operators return a value, not a reference. Therefore, you cannot write to a `texture` object by using `texture::operator[]`.
 
 ```cpp
 void readTexture() {

--- a/docs/parallel/amp/graphics-cpp-amp.md
+++ b/docs/parallel/amp/graphics-cpp-amp.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Graphics (C++ AMP)"
 title: "Graphics (C++ AMP)"
-ms.date: "11/04/2016"
+description: "Learn more about: Graphics (C++ AMP)"
+ms.date: 11/04/2016
 ---
 # Graphics (C++ AMP)
 

--- a/docs/standard-library/basic-istream-class.md
+++ b/docs/standard-library/basic-istream-class.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: basic_istream Class"
 title: "basic_istream Class"
+description: "Learn more about: basic_istream Class"
 ms.date: 06/10/2022
 f1_keywords: ["istream/std::basic_istream", "istream/std::basic_istream::gcount", "istream/std::basic_istream::get", "istream/std::basic_istream::getline", "istream/std::basic_istream::", "istream/std::basic_istream::peek", "istream/std::basic_istream::putback", "istream/std::basic_istream::read", "istream/std::basic_istream::readsome", "istream/std::basic_istream::seekg", "istream/std::basic_istream::sentry", "istream/std::basic_istream::swap", "istream/std::basic_istream::sync", "istream/std::basic_istream::tellg", "istream/std::basic_istream::unget"]
 helpviewer_keywords: ["std::basic_istream [C++]", "std::basic_istream [C++], gcount", "std::basic_istream [C++], get", "std::basic_istream [C++], getline", "std::basic_istream [C++], OVERWRITE", "std::basic_istream [C++], peek", "std::basic_istream [C++], putback", "std::basic_istream [C++], read", "std::basic_istream [C++], readsome", "std::basic_istream [C++], seekg", "std::basic_istream [C++], sentry", "std::basic_istream [C++], swap", "std::basic_istream [C++], sync", "std::basic_istream [C++], tellg", "std::basic_istream [C++], unget"]

--- a/docs/standard-library/basic-istream-class.md
+++ b/docs/standard-library/basic-istream-class.md
@@ -410,7 +410,7 @@ Type 'abcdef': abcdef
 def
 ```
 
-## <a name="op_gt_gt"></a> `basic\_istream::operator>>`
+## <a name="op_gt_gt"></a> `basic_istream::operator>>`
 
 Calls a function on the input stream or reads formatted data from the input stream.
 
@@ -451,7 +451,7 @@ The stream (`*this`).
 
 ### Remarks
 
-The `<istream>` header also defines several global extraction operators. For more information, see [`operator>> (\<istream>)`](../standard-library/istream-operators.md#op_gt_gt).
+The `<istream>` header also defines several global extraction operators. For more information, see [`operator>> (<istream>)`](../standard-library/istream-operators.md#op_gt_gt).
 
 The first member function ensures that an expression of the form `istr >> ws` calls `ws(istr)`, and then returns `*this`. For more information, see [`ws`](../standard-library/istream-functions.md#ws).
 

--- a/docs/standard-library/ctype-char-class.md
+++ b/docs/standard-library/ctype-char-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: ctype<char> Class"
 title: "ctype<char> Class"
-ms.date: "11/04/2016"
+description: "Learn more about: ctype<char> Class"
+ms.date: 11/04/2016
 f1_keywords: ["ctype<char>", "locale/std::ctype<char>"]
 helpviewer_keywords: ["ctype<char> class"]
-ms.assetid: ee30acb4-a743-405e-b3d4-13602092da84
 ---
 # `ctype<char>` Class
 

--- a/docs/standard-library/ctype-char-class.md
+++ b/docs/standard-library/ctype-char-class.md
@@ -8,7 +8,7 @@ ms.assetid: ee30acb4-a743-405e-b3d4-13602092da84
 ---
 # `ctype<char>` Class
 
-The class is an explicit specialization of class template `ctype\<CharType>` to type **`char`**, describing an object that can serve as a locale facet to characterize various properties of a character of type **`char`**.
+The class is an explicit specialization of class template `ctype<CharType>` to type **`char`**, describing an object that can serve as a locale facet to characterize various properties of a character of type **`char`**.
 
 ## Syntax
 

--- a/docs/standard-library/hash-map-class.md
+++ b/docs/standard-library/hash-map-class.md
@@ -1526,7 +1526,7 @@ The position just beyond the last element to be copied from a `hash_map`.
 
 The first `insert` member function returns a pair whose `bool` component returns `true` if an insertion was made and `false` if the `hash_map` already contained an element whose key had an equivalent value in the ordering, and whose iterator component returns the address where a new element was inserted or where the element was already located.
 
-To access the iterator component of a pair `pr` returned by this member function, use `pr.first`, and to dereference it, use `(pr.first)`. To access the **`bool`** component of a pair `pr` returned by this member function, use `pr.second`, and to dereference it, use `\(pr.second)`.
+To access the iterator component of a pair `pr` returned by this member function, use `pr.first`, and to dereference it, use `(pr.first)`. To access the **`bool`** component of a pair `pr` returned by this member function, use `pr.second`, and to dereference it, use `(pr.second)`.
 
 The second `insert` member function, the hint version, returns an iterator that points to the position where the new element was inserted into the `hash_map`.
 

--- a/docs/standard-library/regex.md
+++ b/docs/standard-library/regex.md
@@ -81,7 +81,7 @@ To modify the details of the grammar of regular expressions, write a class that 
 |[`operator==`](../standard-library/regex-operators.md#op_eq_eq)|Comparison of various objects, equal.|
 |[`operator!=`](../standard-library/regex-operators.md#op_neq)|Comparison of various objects, not equal.|
 |[`operator<`](../standard-library/regex-operators.md#op_lt)|Comparison of various objects, less than.|
-|[`operator\<=`](../standard-library/regex-operators.md#op_gt_eq)|Comparison of various objects, less than or equal.|
+|[`operator<=`](../standard-library/regex-operators.md#op_gt_eq)|Comparison of various objects, less than or equal.|
 |[`operator>`](../standard-library/regex-operators.md#op_gt)|Comparison of various objects, greater than.|
 |[`operator>=`](../standard-library/regex-operators.md#op_gt_eq)|Comparison of various objects, greater than or equal.|
 |[`operator<<`](../standard-library/regex-operators.md#op_lt_lt)|Inserts a `sub_match` in a stream.|

--- a/docs/standard-library/scoped-allocator-adaptor-class.md
+++ b/docs/standard-library/scoped-allocator-adaptor-class.md
@@ -67,7 +67,7 @@ Three types are defined for the sake of exposition:
 
 |Name|Description|
 |----------|-----------------|
-|[scoped_allocator_adaptor::rebind Struct](#rebind_struct)|Defines the type `Outer::rebind\<Other>::other` as a synonym for `scoped_allocator_adaptor\<Other, Inner...>`.|
+|[scoped_allocator_adaptor::rebind Struct](#rebind_struct)|Defines the type `Outer::rebind<Other>::other` as a synonym for `scoped_allocator_adaptor<Other, Inner...>`.|
 
 ### Methods
 
@@ -277,7 +277,7 @@ A reference to the stored object of type `outer_allocator_type`.
 
 ## <a name="rebind_struct"></a> scoped_allocator_adaptor::rebind Struct
 
-Defines the type `Outer::rebind\<Other>::other` as a synonym for `scoped_allocator_adaptor\<Other, Inner...>`.
+Defines the type `Outer::rebind<Other>::other` as a synonym for `scoped_allocator_adaptor<Other, Inner...>`.
 
 struct rebind{
    typedef Other_traits::rebind\<Other>

--- a/docs/standard-library/string-view.md
+++ b/docs/standard-library/string-view.md
@@ -1,7 +1,7 @@
 ---
 title: "<string_view>"
 description: "Overview of `basic_string_view`, which refers to a constant contiguous sequence of char-like objects."
-ms.date: "9/4/2020"
+ms.date: 9/4/2020
 helpviewer_keywords: ["string_view header"]
 ---
 # `<string_view>`

--- a/docs/standard-library/string-view.md
+++ b/docs/standard-library/string-view.md
@@ -37,7 +37,7 @@ The `<string_view>` operators can compare `string_view` objects to objects of an
 |[`operator==`](../standard-library/string-view-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
 |[`operator<`](../standard-library/string-view-operators.md#op_lt)|Tests if the object on the left side of the operator is less than to the object on the right side.|
 |[`operator<=`](../standard-library/string-view-operators.md#op_lt_eq)|Tests if the object on the left side of the operator is less than or equal to the object on the right side.|
-|[`operator<\<`](../standard-library/string-view-operators.md#op_lt_lt)|A template function that inserts a `string_view` into an output stream.|
+|[`operator<<`](../standard-library/string-view-operators.md#op_lt_lt)|A template function that inserts a `string_view` into an output stream.|
 |[`operator>`](../standard-library/string-view-operators.md#op_gt)|Tests if the object on the left side of the operator is greater than to the object on the right side.|
 |[`operator>=`](../standard-library/string-view-operators.md#op_gt_eq)|Tests if the object on the left side of the operator is greater than or equal to the object on the right side.|
 


### PR DESCRIPTION
Remove backslash in backticked terms that render verbatim:

![image](https://github.com/user-attachments/assets/481b1a20-b891-47c9-8fb3-5a9aa8d512f7)