### PR TITLE
Fix duplicate `operator[]` entry in `CSimpleStringT` reference

### DIFF
--- a/docs/atl-mfc-shared/reference/csimplestringt-class.md
+++ b/docs/atl-mfc-shared/reference/csimplestringt-class.md
@@ -716,28 +716,6 @@ CSimpleString s(_T("abc"), pMgr);
 ASSERT(s[1] == _T('b'));
 ```
 
-## <a name="operator_at"></a> `CSimpleStringT::operator []`
-
-Call this function to access a single character of the character array.
-
-### Syntax
-
-```cpp
-XCHAR operator[](int iChar) const;
-```
-
-### Parameters
-
-*`iChar`*<br/>
-Zero-based index of a character in the string.
-
-### Remarks
-
-The overloaded subscript (**`[]`**) operator returns a single character specified by the zero-based index in *`iChar`*. This operator is a convenient substitute for the [`GetAt`](#getat) member function.
-
-> [!NOTE]
-> You can use the subscript (**`[]`**) operator to get the value of a character in a `CSimpleStringT`, but you cannot use it to change the value of a character in a `CSimpleStringT`.
-
 ## <a name="operator_add_eq"></a> `CSimpleStringT::operator +=`
 
 Joins a new string or character to the end of an existing string.


### PR DESCRIPTION
Discovered via the duplicate `operator_at` anchor value. There does not seem to be another overload of `operator[]`, hence the extra entry is removed. Both entries are slightly different, but the first one is kept since it has the example. The diff between the first and second entry:

````diff
- ## <a name="operator_at"></a> `CSimpleStringT::operator[]`
+ ## <a name="operator_at"></a> `CSimpleStringT::operator []`

  Call this function to access a single character of the character array.

  ### Syntax

  ```cpp
  XCHAR operator[](int iChar) const;
  ```

- #### Parameters
+ ### Parameters

  *`iChar`*<br/>
  Zero-based index of a character in the string.

  ### Remarks

  The overloaded subscript (**`[]`**) operator returns a single character specified by the zero-based index in *`iChar`*. This operator is a convenient substitute for the [`GetAt`](#getat) member function.

  > [!NOTE]
  > You can use the subscript (**`[]`**) operator to get the value of a character in a `CSimpleStringT`, but you cannot use it to change the value of a character in a `CSimpleStringT`.
-
- ### Example
-
- The following example demonstrates the use of `CSimpleStringT::operator []`.
-
- ```cpp
- CSimpleString s(_T("abc"), pMgr);
- ASSERT(s[1] == _T('b'));
- ```
````