### PR TITLE
Add missing escapes for superscript definitions

### DIFF
--- a/docs/build/reference/compiler-options-listed-alphabetically.md
+++ b/docs/build/reference/compiler-options-listed-alphabetically.md
@@ -261,7 +261,7 @@ This table contains an alphabetical list of compiler options. For a list of comp
 | [`/Zs`](zs-syntax-check-only.md) | Checks syntax only. |
 | [`/ZW`](zw-windows-runtime-compilation.md) | Produces an output file to run on the Windows Runtime. |
 
-<sup>17.10</sup> This option is available starting in Visual Studio 2022 version 17.10.
+<sup>17.10</sup> This option is available starting in Visual Studio 2022 version 17.10.\
 <sup>17.14</sup> This option is available starting in Visual Studio 2022 version 17.14.
 
 ## See also

--- a/docs/build/reference/compiler-options-listed-by-category.md
+++ b/docs/build/reference/compiler-options-listed-by-category.md
@@ -329,7 +329,7 @@ Experimental options may only be supported by certain versions of the compiler. 
 | [`/Ze`](za-ze-disable-language-extensions.md) | Deprecated. Enables language extensions. |
 | [`/Zg`](zg-generate-function-prototypes.md) | Removed in Visual Studio 2015. Generates function prototypes. |
 
-<sup>17.10</sup> This option is available starting in Visual Studio 2022 version 17.10.
+<sup>17.10</sup> This option is available starting in Visual Studio 2022 version 17.10.\
 <sup>17.14</sup> This option is available starting in Visual Studio 2022 version 17.14.
 
 ## See also


### PR DESCRIPTION
Add missing escapes to prevent multiple superscript definitions from being on the same line:

![image](https://github.com/user-attachments/assets/6170fcd9-d0e3-4116-b963-9720a1e614c5)
