### PR TITLE
Add backticks for code analysis names

### DIFF
--- a/docs/code-quality/c28112.md
+++ b/docs/code-quality/c28112.md
@@ -16,7 +16,7 @@ A variable that is accessed by using the Interlocked executive support routines,
 
 `InterlockedXxx` functions are intended to provide atomic operations, but are only atomic with respect to other `InterlockedXxx` functions. Although certain ordinary assignments, accesses, and comparisons to variables that are used by the Interlocked\* routines can be safely accessed by using a different function, the risk is great enough to justify examining each instance.
 
-Code analysis name: INTERLOCKED_ACCESS
+Code analysis name: `INTERLOCKED_ACCESS`
 
 ## Example
 

--- a/docs/code-quality/c28112.md
+++ b/docs/code-quality/c28112.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28112"
 title: Warning C28112
+description: "Learn more about: Warning C28112"
 ms.date: 08/25/2022
 f1_keywords: ["C28112", "INTERLOCKED_ACCESS", "__WARNING_INTERLOCKED_ACCESS"]
 helpviewer_keywords: ["C28112"]
-ms.assetid: 2720a5dc-84e9-4f78-a8c7-a320c9f9216b
 ---
 # Warning C28112
 

--- a/docs/code-quality/c28159.md
+++ b/docs/code-quality/c28159.md
@@ -15,7 +15,7 @@ This warning occurs when you use a function that is semantically equivalent to a
 
 C28159 is a general warning message; the annotation `__drv_preferredFunction` was used (possibly with a conditional `__drv_when`() annotation) to flag a bad coding practice.
 
-Code analysis name: USE_OTHER_FUNCTION
+Code analysis name: `USE_OTHER_FUNCTION`
 
 ## Example
 

--- a/docs/code-quality/c28160.md
+++ b/docs/code-quality/c28160.md
@@ -16,4 +16,4 @@ This warning is reported when a `__drv_error` annotation has been encountered.
 
 This annotation is used to flag coding practices that should be fixed, and can be used with a `__drv_when` annotation to indicate specific combinations of parameters.
 
-Code analysis name: ERROR
+Code analysis name: `ERROR`

--- a/docs/code-quality/c28160.md
+++ b/docs/code-quality/c28160.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28160"
 title: Warning C28160
+description: "Learn more about: Warning C28160"
 ms.date: 09/08/2022
 f1_keywords: ["C28160", "ERROR", "__WARNING_ERROR"]
 helpviewer_keywords: ["C28160"]
-ms.assetid: cab15f6b-909c-4cc8-81a0-c24ac7c91c7c
 ---
 # Warning C28160
 


### PR DESCRIPTION
Virtually all code analysis names are already backticked, this PR adds it to the remaining few.