### PR TITLE
Add links to "C++ standard library header files" topic

### DIFF
--- a/docs/standard-library/cpp-standard-library-header-files.md
+++ b/docs/standard-library/cpp-standard-library-header-files.md
@@ -1,9 +1,8 @@
 ---
 title: "C++ standard library header files"
 description: "C++ standard library header files, categorized"
-ms.date: "08/31/2020"
+ms.date: 08/31/2020
 helpviewer_keywords: ["header files, C++ Standard Library", "C++ Standard Library, header files"]
-ms.assetid: e7bf497a-0f63-48d0-9b54-cb0eef4073c4
 ---
 # C++ standard library header files
 


### PR DESCRIPTION
Add links, elide redundant `./` link prefix, and update metadata.