### PR TITLE
Remove redundant semicolons after `if`, `for`, `while`, and `switch` constructs

### DIFF
--- a/docs/atl-mfc-shared/codesnippet/CPP/cstringt-class_39.cpp
+++ b/docs/atl-mfc-shared/codesnippet/CPP/cstringt-class_39.cpp
@@ -8,4 +8,4 @@
    {
       _tprintf_s(_T("Resulting token: %s\n"), resToken);
       resToken = str.Tokenize(_T("% #"), curPos);
-   };   
+   }

--- a/docs/cpp/switch-statement-cpp.md
+++ b/docs/cpp/switch-statement-cpp.md
@@ -117,7 +117,7 @@ int main()
         break;
     case status::bad:
         throw BadGadget();
-    };
+    }
 ```
 
 An inner block of a **`switch`** statement can contain definitions with initializers as long as they're *reachable*, that is, not bypassed by all possible execution paths. Names introduced using these declarations have local scope. For example:

--- a/docs/cpp/switch-statement-cpp.md
+++ b/docs/cpp/switch-statement-cpp.md
@@ -1,11 +1,10 @@
 ---
 title: "switch statement (C++)"
 description: "Reference to the Standard C++ switch statement in Microsoft Visual Studio C++."
-ms.date: "04/25/2020"
+ms.date: 04/25/2020
 f1_keywords: ["default_cpp", "switch_cpp", "case_cpp"]
 helpviewer_keywords: ["switch keyword [C++]", "case keyword [C++], in switch statements", "default keyword [C++]"]
 no-loc: [switch, case, default, break, while, opt]
-ms.assetid: 6c3f3ed3-5593-463c-8f4b-b33742b455c6
 ---
 # `switch` statement (C++)
 

--- a/docs/cpp/try-except-statement.md
+++ b/docs/cpp/try-except-statement.md
@@ -4,7 +4,6 @@ description: "The Microsoft C++ reference to the __try and __except structured e
 ms.date: 08/25/2020
 f1_keywords: ["_abnormal_termination_cpp", "_exception_code_cpp", "_exception_info", "__except", "_except", "_exception_code", "__except_cpp", "_exception_info_cpp"]
 helpviewer_keywords: ["__try keyword [C++]", "EXCEPTION_CONTINUE_EXECUTION macro", "EXCEPTION_CONTINUE_SEARCH macro", "EXCEPTION_EXECUTE_HANDLER macro", "GetExceptionCode function", "try-catch keyword [C++], try-except keyword [C++]", "_exception_code keyword [C++]", "try-except keyword [C++]", "_exception_info keyword [C++]", "_abnormal_termination keyword [C++]"]
-ms.assetid: 30d60071-ea49-4bfb-a8e6-7a420de66381
 ---
 # `try-except` statement
 

--- a/docs/cpp/try-except-statement.md
+++ b/docs/cpp/try-except-statement.md
@@ -115,7 +115,7 @@ int filter(unsigned int code, struct _EXCEPTION_POINTERS *ep)
     {
         puts("didn't catch AV, unexpected.");
         return EXCEPTION_CONTINUE_SEARCH;
-    };
+    }
 }
 
 int main()

--- a/docs/cppcx/codesnippet/CPP/cppcx_strings/class1.cpp
+++ b/docs/cppcx/codesnippet/CPP/cppcx_strings/class1.cpp
@@ -55,11 +55,11 @@ void Test1()
     if (str1 == str2) { /* ... */ }
     if (str1->Equals(str2)) { /* ... */ }
     if (str1 != str2) { /* ... */ }
-    if (str1 < str2 || str1 > str2) { /* ... */};
+    if (str1 < str2 || str1 > str2) { /* ... */ }
     int result = String::CompareOrdinal(str1, str2);
     
-    if(str1 == nullptr) { /* ...*/};
-    if(str1->IsEmpty()) { /* ...*/};
+    if (str1 == nullptr) { /* ...*/ }
+    if (str1->IsEmpty()) { /* ...*/ }
 
    // Accessing individual characters in a String^
     auto it = str1->Begin();

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4220.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4220.md
@@ -23,7 +23,7 @@ int ( *pFunc2) ( int a, int b);
 
 int main()
 {
-   if ( pFunc1 != pFunc2 ) {};  // C4220
+   if ( pFunc1 != pFunc2 ) {}   // C4220
 }
 ```
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4220.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4220.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4220"
 title: "Compiler Warning (level 4) C4220"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4220"
+ms.date: 11/04/2016
 f1_keywords: ["C4220"]
 helpviewer_keywords: ["C4220"]
-ms.assetid: aba18868-825f-4763-9af6-3296406a80e4
 ---
 # Compiler Warning (level 4) C4220
 

--- a/docs/mfc/codesnippet/CPP/cdialog-class_2.cpp
+++ b/docs/mfc/codesnippet/CPP/cdialog-class_2.cpp
@@ -26,5 +26,5 @@ void CMyDialog::OnMenuShowAboutDialog()
    default:
       // Do something
       break;
-   };
+   }
 }

--- a/docs/standard-library/ctype-class.md
+++ b/docs/standard-library/ctype-class.md
@@ -466,7 +466,7 @@ int main() {
            << (maskarray[i] & ctype_base::alpha  "alpha"
                                                 : "not alpha")
            << endl;
-   };
+   }
 }
 ```
 

--- a/docs/standard-library/ios-base-class.md
+++ b/docs/standard-library/ios-base-class.md
@@ -665,7 +665,7 @@ void callback1( ios_base::event e, ios_base& stream, int arg )
     case ios_base::copyfmt_event:
         cout << "an copyfmt event" << endl;
         break;
-    };
+    }
 }
 
 void callback2( ios_base::event e, ios_base& stream, int arg )
@@ -682,7 +682,7 @@ void callback2( ios_base::event e, ios_base& stream, int arg )
     case ios_base::copyfmt_event:
         cout << "an copyfmt event" << endl;
         break;
-    };
+    }
 }
 
 int main( )

--- a/docs/standard-library/iterator-traits-struct.md
+++ b/docs/standard-library/iterator-traits-struct.md
@@ -1,7 +1,7 @@
 ---
 title: "iterator_traits Struct"
 description: "Learn more about: iterator_traits Struct"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["xutility/std::iterator_traits"]
 helpviewer_keywords: ["iterator_traits struct", "iterator_traits class"]
 ---

--- a/docs/standard-library/iterator-traits-struct.md
+++ b/docs/standard-library/iterator-traits-struct.md
@@ -88,7 +88,7 @@ function( it i1, it i2 )
       x = *i1;
       cout << x << " ";
       i1++;
-   };
+   }
    cout << endl;
 };
 

--- a/docs/standard-library/other-one-argument-output-stream-manipulators.md
+++ b/docs/standard-library/other-one-argument-output-stream-manipulators.md
@@ -51,7 +51,7 @@ void fb( ios_base& os, char * somename )
    {
       for( int i=0; i < l; i++ )
       (*pos) << ' ';
-   };
+   }
 */
 }
 

--- a/docs/standard-library/other-one-argument-output-stream-manipulators.md
+++ b/docs/standard-library/other-one-argument-output-stream-manipulators.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Other One-Argument Output Stream Manipulators"
 title: "Other One-Argument Output Stream Manipulators"
-ms.date: "11/04/2016"
+description: "Learn more about: Other One-Argument Output Stream Manipulators"
+ms.date: 11/04/2016
 helpviewer_keywords: ["output streams, one-argument manipulators"]
-ms.assetid: e381dee8-6b16-4cef-805a-4a6a1d2b696b
 ---
 # Other One-Argument Output Stream Manipulators
 

--- a/docs/standard-library/output-stream-manipulators-with-one-argument-int-or-long.md
+++ b/docs/standard-library/output-stream-manipulators-with-one-argument-int-or-long.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Output Stream Manipulators with One Argument (int or long)"
 title: "Output Stream Manipulators with One Argument (int or long)"
-ms.date: "11/04/2016"
+description: "Learn more about: Output Stream Manipulators with One Argument (int or long)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["output streams, int or long argument manipulators"]
-ms.assetid: 338f3164-b5e2-4c5a-a605-7d9dc3629ca1
 ---
 # Output Stream Manipulators with One Argument (int or long)
 

--- a/docs/standard-library/output-stream-manipulators-with-one-argument-int-or-long.md
+++ b/docs/standard-library/output-stream-manipulators-with-one-argument-int-or-long.md
@@ -25,7 +25,7 @@ void fb( ios_base& os, int l )
    {
       for( int i=0; i < l; i++ )
       (*pos) << ' ';
-   };
+   }
 }
 
 _Smanip<int>

--- a/docs/standard-library/raw-storage-iterator-class.md
+++ b/docs/standard-library/raw-storage-iterator-class.md
@@ -261,7 +261,7 @@ int main( void )
    std::raw_storage_iterator<int*,int> it( pInt );
    for ( int i = 0; i < 5; i++, it++ ) {
       *it = 2 * i;
-   };
+   }
 
    for ( int i = 0; i < 5; i++ ) cout << "array " << i << " = " << pInt[i] << endl;
 


### PR DESCRIPTION
A continuation of #5393 for other constructs.