### PR TITLE
Clean up `_SECURE_SCL` reference

### DIFF
--- a/docs/standard-library/secure-scl.md
+++ b/docs/standard-library/secure-scl.md
@@ -6,32 +6,32 @@ f1_keywords: ["_SECURE_SCL"]
 helpviewer_keywords: ["_SECURE_SCL"]
 ms.assetid: 4ffbc788-cc12-4c6a-8cd7-490081675086
 ---
-# _SECURE_SCL
+# `_SECURE_SCL`
 
-Superseded by [_ITERATOR_DEBUG_LEVEL](../standard-library/iterator-debug-level.md), this macro defines whether [Checked Iterators](../standard-library/checked-iterators.md) are enabled. By default, checked iterators are enabled in Debug builds, and disabled in Retail builds.
+Superseded by [`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md), this macro defines whether [Checked Iterators](../standard-library/checked-iterators.md) are enabled. By default, checked iterators are enabled in Debug builds, and disabled in Retail builds.
 
 > [!IMPORTANT]
-> Direct use of the _SECURE_SCL macro is deprecated. Instead, use _ITERATOR_DEBUG_LEVEL to control checked iterator settings. For more information, see [_ITERATOR_DEBUG_LEVEL](../standard-library/iterator-debug-level.md).
+> Direct use of the `_SECURE_SCL` macro is deprecated. Instead, use `_ITERATOR_DEBUG_LEVEL` to control checked iterator settings. For more information, see [`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md).
 
 ## Remarks
 
-When checked iterators are enabled, unsafe iterator use causes a runtime error and the program is terminated. To enable checked iterators, set _ITERATOR_DEBUG_LEVEL to 1 or 2. This is equivalent to a _SECURE_SCL setting of 1, or enabled:
+When checked iterators are enabled, unsafe iterator use causes a runtime error and the program is terminated. To enable checked iterators, set `_ITERATOR_DEBUG_LEVEL` to 1 or 2. This is equivalent to a `_SECURE_SCL` setting of 1, or enabled:
 
 ```cpp
 #define _ITERATOR_DEBUG_LEVEL 1
 ```
 
-To disable checked iterators, set _ITERATOR_DEBUG_LEVEL to 0. This is equivalent to a _SECURE_SCL setting of 0, or disabled:
+To disable checked iterators, set `_ITERATOR_DEBUG_LEVEL` to 0. This is equivalent to a `_SECURE_SCL` setting of 0, or disabled:
 
 ```cpp
 #define _ITERATOR_DEBUG_LEVEL 0
 ```
 
-For information on how to disable warnings about checked iterators, see [_SCL_SECURE_NO_WARNINGS](../standard-library/scl-secure-no-warnings.md).
+For information on how to disable warnings about checked iterators, see [`_SCL_SECURE_NO_WARNINGS`](../standard-library/scl-secure-no-warnings.md).
 
 ## See also
 
-[_ITERATOR_DEBUG_LEVEL](../standard-library/iterator-debug-level.md)\
+[`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md)\
 [Checked Iterators](../standard-library/checked-iterators.md)\
 [Debug Iterator Support](../standard-library/debug-iterator-support.md)\
 [Safe Libraries: C++ Standard Library](../standard-library/safe-libraries-cpp-standard-library.md)

--- a/docs/standard-library/secure-scl.md
+++ b/docs/standard-library/secure-scl.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: _SECURE_SCL"
 title: "_SECURE_SCL"
-ms.date: "11/04/2016"
+description: "Learn more about: _SECURE_SCL"
+ms.date: 11/04/2016
 f1_keywords: ["_SECURE_SCL"]
 helpviewer_keywords: ["_SECURE_SCL"]
-ms.assetid: 4ffbc788-cc12-4c6a-8cd7-490081675086
 ---
 # `_SECURE_SCL`
 

--- a/docs/standard-library/secure-scl.md
+++ b/docs/standard-library/secure-scl.md
@@ -8,10 +8,10 @@ ms.assetid: 4ffbc788-cc12-4c6a-8cd7-490081675086
 ---
 # `_SECURE_SCL`
 
-Superseded by [`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md), this macro defines whether [Checked Iterators](../standard-library/checked-iterators.md) are enabled. By default, checked iterators are enabled in Debug builds, and disabled in Retail builds.
+Superseded by [`_ITERATOR_DEBUG_LEVEL`](iterator-debug-level.md), this macro defines whether [Checked Iterators](checked-iterators.md) are enabled. By default, checked iterators are enabled in Debug builds, and disabled in Retail builds.
 
 > [!IMPORTANT]
-> Direct use of the `_SECURE_SCL` macro is deprecated. Instead, use `_ITERATOR_DEBUG_LEVEL` to control checked iterator settings. For more information, see [`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md).
+> Direct use of the `_SECURE_SCL` macro is deprecated. Instead, use `_ITERATOR_DEBUG_LEVEL` to control checked iterator settings. For more information, see [`_ITERATOR_DEBUG_LEVEL`](iterator-debug-level.md).
 
 ## Remarks
 
@@ -27,11 +27,11 @@ To disable checked iterators, set `_ITERATOR_DEBUG_LEVEL` to 0. This is equivale
 #define _ITERATOR_DEBUG_LEVEL 0
 ```
 
-For information on how to disable warnings about checked iterators, see [`_SCL_SECURE_NO_WARNINGS`](../standard-library/scl-secure-no-warnings.md).
+For information on how to disable warnings about checked iterators, see [`_SCL_SECURE_NO_WARNINGS`](scl-secure-no-warnings.md).
 
 ## See also
 
-[`_ITERATOR_DEBUG_LEVEL`](../standard-library/iterator-debug-level.md)\
-[Checked Iterators](../standard-library/checked-iterators.md)\
-[Debug Iterator Support](../standard-library/debug-iterator-support.md)\
-[Safe Libraries: C++ Standard Library](../standard-library/safe-libraries-cpp-standard-library.md)
+[`_ITERATOR_DEBUG_LEVEL`](iterator-debug-level.md)\
+[Checked Iterators](checked-iterators.md)\
+[Debug Iterator Support](debug-iterator-support.md)\
+[Safe Libraries: C++ Standard Library](safe-libraries-cpp-standard-library.md)


### PR DESCRIPTION
Add backticks, simplify links, and update metadata.