### PR TITLE
Add missing square brackets for `[[nodiscard]]` in C4834 reference

### DIFF
--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -43,7 +43,7 @@ int square_of(int i) { return i * i; }
 int main()
 {
     square_of(42); // warning C4834: discarding return value of function with 'nodiscard' attribute
-    // If ignoring the [[nodiscard] attribute is unintentional, make use of the return value as intended:
+    // If ignoring the [[nodiscard]] attribute is unintentional, make use of the return value as intended:
     // For example:
     std::cout << "square_of(42) = " << square_of(42) << "\n"; // Ok
     // Or:

--- a/docs/error-messages/compiler-warnings/c4834.md
+++ b/docs/error-messages/compiler-warnings/c4834.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn about the cause and fixes for Compiler warning (level 1) C4834."
 title: "Compiler warning (Level 1) C4834"
+description: "Learn about the cause and fixes for Compiler warning (level 1) C4834."
 ms.date: 01/18/2024
 f1_keywords: ["C4834"]
 helpviewer_keywords: ["C4834"]


### PR DESCRIPTION
Add missing `]` for `[[nodiscard]]`.