### PR TITLE
Clean up unnecessary use of `&nbsp;`

### DIFF
--- a/docs/dotnet/auto-gcroot-class.md
+++ b/docs/dotnet/auto-gcroot-class.md
@@ -47,8 +47,8 @@ The managed type to be embedded.
 |---------|-----------|
 |[`auto_gcroot::operator->`](#operator-arrow)|The member access operator.|  
 |[auto_gcroot::operator=](#operator-assign)|Assignment operator.|
-|[auto_gcroot::operator&nbsp;auto_gcroot](#operator-auto-gcroot)|Type-cast operator between `auto_gcroot` and compatible types.|
-|[auto_gcroot::operator&nbsp;bool](#operator-bool)|Operator for using `auto_gcroot` in a conditional expression.|  
+|[auto_gcroot::operator auto_gcroot](#operator-auto-gcroot)|Type-cast operator between `auto_gcroot` and compatible types.|
+|[auto_gcroot::operator bool](#operator-bool)|Operator for using `auto_gcroot` in a conditional expression.|  
 |[auto_gcroot::operator!](#operator-logical-not)|Operator for using `auto_gcroot` in a conditional expression.|
 
 ## Requirements

--- a/docs/dotnet/auto-gcroot-class.md
+++ b/docs/dotnet/auto-gcroot-class.md
@@ -1,7 +1,7 @@
 ---
 title: "auto_gcroot Class"
 description: "Learn more about: auto_gcroot Class"
-ms.date: "01/16/2019"
+ms.date: 01/16/2019
 ms.topic: "reference"
 f1_keywords: ["msclr::auto_gcroot::auto_gcroot", "msclr::auto_gcroot::attach", "msclr::auto_gcroot::get", "msclr::auto_gcroot::release", "msclr::auto_gcroot::reset", "msclr::auto_gcroot::swap", "msclr::auto_gcroot::operator=", "msclr::auto_gcroot::operator->", "msclr::auto_gcroot::operator!", "msclr::auto_gcroot::operator auto_gcroot"]
 helpviewer_keywords: ["msclr::auto_gcroot"]

--- a/docs/dotnet/com-ptr-class.md
+++ b/docs/dotnet/com-ptr-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: com::ptr Class"
 title: "com::ptr Class"
-ms.date: "01/16/2019"
+description: "Learn more about: com::ptr Class"
+ms.date: 01/16/2019
 ms.topic: "reference"
 f1_keywords: ["msclr::com::ptr::ptr", "msclr::com::ptr::Attach", "msclr::com::ptr::CreateInstance", "msclr::com::ptr::Detach", "msclr::com::ptr::GetInterface", "msclr::com::ptr::QueryInterface", "msclr::com::ptr::Release", "msclr::com::ptr::operator=", "msclr::com::ptr::operator->", "msclr::com::ptr::operator!"]
 helpviewer_keywords: ["msclr::ptr class"]
-ms.assetid: 0144d0e4-919c-45f9-a3f8-fbc9edba32bf
 ---
 # com::ptr Class
 

--- a/docs/dotnet/com-ptr-class.md
+++ b/docs/dotnet/com-ptr-class.md
@@ -173,7 +173,7 @@ int main() {
 |---------|-----------|
 |[`ptr::operator->`](#operator-arrow)|Member access operator, used to call methods on the owned COM object.|
 |[ptr::operator=](#operator-assign)|Attaches a COM object to a `com::ptr`.|
-|[ptr::operator&nbsp;bool](#operator-bool)|Operator for using `com::ptr` in a conditional expression.|
+|[ptr::operator bool](#operator-bool)|Operator for using `com::ptr` in a conditional expression.|
 |[ptr::operator!](#operator-logical-not)|Operator to determine if the owned COM object is invalid.|
 
 ## Requirements

--- a/docs/dotnet/lock-class.md
+++ b/docs/dotnet/lock-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: lock Class"
 title: "lock Class"
-ms.date: "01/16/2019"
+description: "Learn more about: lock Class"
+ms.date: 01/16/2019
 ms.topic: "reference"
 f1_keywords: ["msclr::lock::lock", "msclr::lock::is_locked", "msclr::lock.is_locked", "msclr::lock::acquire", "msclr::lock::try_acquire", "msclr::lock::release", "msclr::lock::operator==", "msclr::lock::operator!="]
 helpviewer_keywords: ["msclr::lock class"]
-ms.assetid: 5123edd9-6aed-497d-9a0b-f4b6d6c0d666
 ---
 # lock Class
 

--- a/docs/dotnet/lock-class.md
+++ b/docs/dotnet/lock-class.md
@@ -45,7 +45,7 @@ Internally, the lock class uses <xref:System.Threading.Monitor> to synchronize a
 
 |Name|Description|
 |---------|-----------|
-|[lock::operator&nbsp;bool](#operator-bool)|Operator for using `lock` in a conditional expression.|
+|[lock::operator bool](#operator-bool)|Operator for using `lock` in a conditional expression.|
 |[lock::operator==](#operator-equality)|Equality operator.|
 |[lock::operator!=](#operator-inequality)|Inequality operator.|
 


### PR DESCRIPTION
Replace unnecessary uses of `&nbsp;` with a regular space.