### PR TITLE
Update `f1_keywords` and `helpviewer_keywords` for "Attributes in C++" article

### DIFF
--- a/docs/cpp/attributes.md
+++ b/docs/cpp/attributes.md
@@ -1,8 +1,8 @@
 ---
 description: "Learn more about: Attributes in C++"
 title: "Attributes in C++"
-f1_keywords: ["deprecated", "no_return", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
-helpviewer_keywords: ["deprecated", "no_return", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
+f1_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
+helpviewer_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
 ms.date: 4/13/2023
 ---
 

--- a/docs/cpp/attributes.md
+++ b/docs/cpp/attributes.md
@@ -1,8 +1,8 @@
 ---
 description: "Learn more about: Attributes in C++"
 title: "Attributes in C++"
-f1_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
-helpviewer_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::intrinsic", "msvc::no_tls_guard"]
+f1_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::flatten", "msvc::forceinline", "msvc::forceinline_calls", "msvc::intrinsic", "msvc::noinline", "msvc::noinline_calls", "msvc::no_tls_guard"]
+helpviewer_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::flatten", "msvc::forceinline", "msvc::forceinline_calls", "msvc::intrinsic", "msvc::noinline", "msvc::noinline_calls", "msvc::no_tls_guard"]
 ms.date: 4/13/2023
 ---
 

--- a/docs/cpp/attributes.md
+++ b/docs/cpp/attributes.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Attributes in C++"
 title: "Attributes in C++"
+description: "Learn more about: Attributes in C++"
 f1_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::flatten", "msvc::forceinline", "msvc::forceinline_calls", "msvc::intrinsic", "msvc::noinline", "msvc::noinline_calls", "msvc::no_tls_guard"]
 helpviewer_keywords: ["deprecated", "noreturn", "carries_dependency", "fallthrough", "nodiscard", "maybe_unused", "likely", "unlikely", "gsl::suppress", "msvc::flatten", "msvc::forceinline", "msvc::forceinline_calls", "msvc::intrinsic", "msvc::noinline", "msvc::noinline_calls", "msvc::no_tls_guard"]
 ms.date: 4/13/2023


### PR DESCRIPTION
- Remove underscore in the existing `no_return` entry to match the name of the attribute
- Add the following new entries that were missing:
  - `msvc::flatten`
  - `msvc::forceinline`
  - `msvc::forceinline_calls`
  - `msvc::noinline`
  - `msvc::noinline_calls`

Best reviewed one commit at a time for a clearer diff.