### PR TITLE
Fill in empty table headers

### DIFF
--- a/docs/atl/atl-utilities-reference.md
+++ b/docs/atl/atl-utilities-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "ATL utilities reference"
 description: "Learn more about: ATL utilities reference"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 ---
 # ATL utilities reference
 

--- a/docs/standard-library/any-functions.md
+++ b/docs/standard-library/any-functions.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about the free functions for use with the std::any class in the C++ Standard Library."
 title: "<any> functions"
+description: "Learn more about the free functions for use with the std::any class in the C++ Standard Library."
 ms.date: 09/20/2021
 f1_keywords: ["any/std::any_cast", "any/std::make_any", "any/std::swap"]
 no-loc: ["any", "std", "class"]


### PR DESCRIPTION
Tables should not have empty headers, hence this PR adds basic "Name" and "Description" column headers.