### PR TITLE
Update `Relog` and variants in build insights reference

### DIFF
--- a/docs/build-insights/reference/sdk/functions/relog-a.md
+++ b/docs/build-insights/reference/sdk/functions/relog-a.md
@@ -4,7 +4,7 @@ description: "The C++ Build Insights SDK RelogA function reference."
 ms.date: "02/12/2020"
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "RelogA", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
-# RelogA
+# `RelogA`
 
 ::: moniker range="<=msvc-140"
 
@@ -26,17 +26,17 @@ enum RESULT_CODE RelogA(
 
 ### Parameters
 
-*inputLogFile*\
+*`inputLogFile`*\
 The input ETW trace that you wish to read events from.
 
-*outputLogFile*\
+*`outputLogFile`*\
 The file in which to write the new events.
 
-*relogDescriptor*\
-Pointer to a [RELOG_DESCRIPTOR](../other-types/relog-descriptor-struct.md) object. Use this object to configure the relogging session.
+*`relogDescriptor`*\
+Pointer to a [`RELOG_DESCRIPTOR`](../other-types/relog-descriptor-struct.md) object. Use this object to configure the relogging session.
 
 ### Return Value
 
-A result code from the [RESULT_CODE](../other-types/result-code-enum.md) enum.
+A result code from the [`RESULT_CODE`](../other-types/result-code-enum.md) enum.
 
 ::: moniker-end

--- a/docs/build-insights/reference/sdk/functions/relog-a.md
+++ b/docs/build-insights/reference/sdk/functions/relog-a.md
@@ -1,7 +1,7 @@
 ---
 title: "RelogA"
 description: "The C++ Build Insights SDK RelogA function reference."
-ms.date: "02/12/2020"
+ms.date: 02/12/2020
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "RelogA", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
 # `RelogA`

--- a/docs/build-insights/reference/sdk/functions/relog-w.md
+++ b/docs/build-insights/reference/sdk/functions/relog-w.md
@@ -4,7 +4,7 @@ description: "The C++ Build Insights SDK RelogW function reference."
 ms.date: "02/12/2020"
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "RelogW", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
-# RelogW
+# `RelogW`
 
 ::: moniker range="<=msvc-140"
 
@@ -26,17 +26,17 @@ enum RESULT_CODE RelogW(
 
 ### Parameters
 
-*inputLogFile*\
+*`inputLogFile`*\
 The input ETW trace that you wish to read events from.
 
-*outputLogFile*\
+*`outputLogFile`*\
 The file in which to write the new events.
 
-*relogDescriptor*\
-Pointer to a [RELOG_DESCRIPTOR](../other-types/relog-descriptor-struct.md) object. Use this object to configure the relogging session.
+*`relogDescriptor`*\
+Pointer to a [`RELOG_DESCRIPTOR`](../other-types/relog-descriptor-struct.md) object. Use this object to configure the relogging session.
 
 ### Return Value
 
-A result code from the [RESULT_CODE](../other-types/result-code-enum.md) enum.
+A result code from the [`RESULT_CODE`](../other-types/result-code-enum.md) enum.
 
 ::: moniker-end

--- a/docs/build-insights/reference/sdk/functions/relog-w.md
+++ b/docs/build-insights/reference/sdk/functions/relog-w.md
@@ -1,7 +1,7 @@
 ---
 title: "RelogW"
 description: "The C++ Build Insights SDK RelogW function reference."
-ms.date: "02/12/2020"
+ms.date: 02/12/2020
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "RelogW", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
 # `RelogW`

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -41,13 +41,15 @@ RESULT_CODE Relog(
     StaticReloggerGroup<TReloggerGroupMembers...> reloggerGroup);
 ```
 
-### Parameters
+### Template parameters
 
 *`TAnalyzerGroupMembers`*\
 This parameter is always deduced.
 
 *`TReloggerGroupMembers`*\
 This parameter is always deduced.
+
+### Parameters
 
 *`inputLogFile`*\
 The input ETW trace that you wish to read events from.

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -4,7 +4,7 @@ description: "The C++ Build Insights SDK Relog function reference."
 ms.date: "02/12/2020"
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "Relog", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
-# Relog
+# `Relog`
 
 ::: moniker range="<=msvc-140"
 
@@ -43,39 +43,39 @@ RESULT_CODE Relog(
 
 ### Parameters
 
-*TAnalyzerGroupMembers*\
+*`TAnalyzerGroupMembers`*\
 This parameter is always deduced.
 
-*TReloggerGroupMembers*\
+*`TReloggerGroupMembers`*\
 This parameter is always deduced.
 
-*inputLogFile*\
+*`inputLogFile`*\
 The input ETW trace that you wish to read events from.
 
-*outputLogFile*\
+*`outputLogFile`*\
 The file in which to write the new events.
 
-*numberOfAnalysisPasses*\
+*`numberOfAnalysisPasses`*\
 The number of analysis passes to run on the input trace. The trace gets passed through the provided analyzer group once per analysis pass.
 
-*systemEventsRetentionFlags*\
-A bitmask that specifies which system ETW events to keep in the relogged trace. For more information, see [RELOG_RETENTION_SYSTEM_EVENT_FLAGS](../other-types/relog-retention-system-event-flags-constants.md).
+*`systemEventsRetentionFlags`*\
+A bitmask that specifies which system ETW events to keep in the relogged trace. For more information, see [`RELOG_RETENTION_SYSTEM_EVENT_FLAGS`](../other-types/relog-retention-system-event-flags-constants.md).
 
-*analyzerGroup*\
-The analyzer group used for the analysis phase of the relogging session. Call [MakeStaticAnalyzerGroup](make-static-analyzer-group.md) to create an analyzer group. To use a dynamic analyzer group obtained from [MakeDynamicAnalyzerGroup](make-dynamic-analyzer-group.md), first encapsulate it inside a static analyzer group by passing its address to `MakeStaticAnalyzerGroup`.
+*`analyzerGroup`*\
+The analyzer group used for the analysis phase of the relogging session. Call [`MakeStaticAnalyzerGroup`](make-static-analyzer-group.md) to create an analyzer group. To use a dynamic analyzer group obtained from [`MakeDynamicAnalyzerGroup`](make-dynamic-analyzer-group.md), first encapsulate it inside a static analyzer group by passing its address to `MakeStaticAnalyzerGroup`.
 
-*reloggerGroup*\
-The relogger group that relogs events into the trace file specified in *outputLogFile*. Call [MakeStaticReloggerGroup](make-static-relogger-group.md) to create a relogger group. To use a dynamic relogger group obtained from [MakeDynamicReloggerGroup](make-dynamic-relogger-group.md), first encapsulate it inside a static relogger group by passing its address to `MakeStaticReloggerGroup`.
+*`reloggerGroup`*\
+The relogger group that relogs events into the trace file specified in *`outputLogFile`*. Call [`MakeStaticReloggerGroup`](make-static-relogger-group.md) to create a relogger group. To use a dynamic relogger group obtained from [`MakeDynamicReloggerGroup`](make-dynamic-relogger-group.md), first encapsulate it inside a static relogger group by passing its address to `MakeStaticReloggerGroup`.
 
 ### Return Value
 
-A result code from the [RESULT_CODE](../other-types/result-code-enum.md) enum.
+A result code from the [`RESULT_CODE`](../other-types/result-code-enum.md) enum.
 
 ### Remark
 
-The input trace is passed through the analyzer group *numberOfAnalysisPasses* times. There's no similar option for relogging passes. The trace is passed trough the relogger group only once, after all analysis passes are complete.
+The input trace is passed through the analyzer group *`numberOfAnalysisPasses`* times. There's no similar option for relogging passes. The trace is passed trough the relogger group only once, after all analysis passes are complete.
 
-The relogging of system events like CPU samples from within a relogger class isn't supported. Use the *systemEventsRetentionFlags* parameter to decide which system events to keep in the output trace.
+The relogging of system events like CPU samples from within a relogger class isn't supported. Use the *`systemEventsRetentionFlags`* parameter to decide which system events to keep in the output trace.
 
 The `relog` function depends on the COM API. You must call `CoInitialize` before you call `relog`. Call `CoUninitialize` once `relog` has finished. If you call `relog` without a call to `CoInitialize` first, you'll get error code 9 (`RESULT_CODE_FAILURE_START_RELOGGER`).
 

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -79,6 +79,6 @@ The input trace is passed through the analyzer group *`numberOfAnalysisPasses`* 
 
 The relogging of system events like CPU samples from within a relogger class isn't supported. Use the *`systemEventsRetentionFlags`* parameter to decide which system events to keep in the output trace.
 
-The `relog` function depends on the COM API. You must call `CoInitialize` before you call `relog`. Call `CoUninitialize` once `relog` has finished. If you call `relog` without a call to `CoInitialize` first, you'll get error code 9 (`RESULT_CODE_FAILURE_START_RELOGGER`).
+The `relog` function depends on the COM API. You must call [`CoInitialize`](/windows/win32/api/objbase/nf-objbase-coinitialize) before you call `relog`. Call [`CoUninitialize`](/windows/win32/api/combaseapi/nf-combaseapi-couninitialize) once `relog` has finished. If you call `relog` without a call to `CoInitialize` first, you'll get error code 9 (`RESULT_CODE_FAILURE_START_RELOGGER`).
 
 ::: moniker-end

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -44,10 +44,10 @@ RESULT_CODE Relog(
 ### Template parameters
 
 *`TAnalyzerGroupMembers`*\
-This parameter is always deduced.
+This template parameter pack is always deduced.
 
 *`TReloggerGroupMembers`*\
-This parameter is always deduced.
+This template parameter pack is always deduced.
 
 ### Parameters
 

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -1,7 +1,7 @@
 ---
 title: "Relog"
 description: "The C++ Build Insights SDK Relog function reference."
-ms.date: "02/12/2020"
+ms.date: 02/12/2020
 helpviewer_keywords: ["C++ Build Insights", "C++ Build Insights SDK", "Relog", "throughput analysis", "build time analysis", "vcperf.exe"]
 ---
 # `Relog`

--- a/docs/build-insights/reference/sdk/functions/relog.md
+++ b/docs/build-insights/reference/sdk/functions/relog.md
@@ -71,7 +71,7 @@ The relogger group that relogs events into the trace file specified in *`outputL
 
 A result code from the [`RESULT_CODE`](../other-types/result-code-enum.md) enum.
 
-### Remark
+### Remarks
 
 The input trace is passed through the analyzer group *`numberOfAnalysisPasses`* times. There's no similar option for relogging passes. The trace is passed trough the relogger group only once, after all analysis passes are complete.
 


### PR DESCRIPTION
- Add "s" to only "Remark" heading in the entire repository
- Bunch of improvements to reference for `Relog` and variants