### PR TITLE
Tweak C4172 warning reference

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -10,9 +10,13 @@ ms.assetid: a8d2bf65-d8b1-4fe3-8340-a223d7e7fde6
 
 > returning address of local variable or temporary
 
+## Remarks
+
 A function returns the address of a local variable or temporary object. Local variables and temporary objects are destroyed when a function returns, so the address returned is not valid.
 
 Redesign the function so that it does not return the address of a local object.
+
+## Example
 
 The following sample generates C4172:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -22,13 +22,22 @@ The following example generates C4172:
 ```cpp
 // C4172.cpp
 // compile with: /c /W1
+
+const int* func1()
+{
+    int i = 42;
+	return &i; // C4172
+}
+
 float f = 1.f;
 
-const double& func()
+const double& func2()
 // Try one of the following lines instead:
-// const float& func()
-// const auto& func()
+// const float& func2()
+// const auto& func2()
 {
+    // The problem is that a temporary is created to convert f to a double.
+    // C4172 in this case refers to returning the address of a temporary
     return f;   // C4172
 }
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -8,7 +8,7 @@ ms.assetid: a8d2bf65-d8b1-4fe3-8340-a223d7e7fde6
 ---
 # Compiler Warning (level 1) C4172
 
-returning address of local variable or temporary
+> returning address of local variable or temporary
 
 A function returns the address of a local variable or temporary object. Local variables and temporary objects are destroyed when a function returns, so the address returned is not valid.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4172"
 title: "Compiler Warning (level 1) C4172"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4172"
+ms.date: 06/20/2025
 f1_keywords: ["C4172"]
 helpviewer_keywords: ["C4172"]
-ms.assetid: a8d2bf65-d8b1-4fe3-8340-a223d7e7fde6
 ---
 # Compiler Warning (level 1) C4172
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -26,7 +26,7 @@ The following example generates C4172:
 const int* func1()
 {
     int i = 42;
-	return &i; // C4172
+    return &i;   // C4172
 }
 
 float f = 1.f;
@@ -37,7 +37,7 @@ const double& func2()
 // const auto& func2()
 {
     // The problem is that a temporary is created to convert f to a double.
-    // C4172 in this case refers to returning the address of a temporary
+    // C4172 in this case refers to returning the address of a temporary.
     return f;   // C4172
 }
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -18,16 +18,18 @@ Redesign the function so that it does not return the address of a local object.
 
 ## Example
 
-The following sample generates C4172:
+The following example generates C4172:
 
 ```cpp
 // C4172.cpp
-// compile with: /W1 /LD
-float f = 10;
+// compile with: /c /W1
+float f = 1.f;
 
-const double& bar() {
-// try the following line instead
-// const float& bar() {
-   return f;   // C4172
+const double& func()
+// Try one of the following lines instead:
+// const float& func()
+// const auto& func()
+{
+    return f;   // C4172
 }
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4172.md
@@ -1,13 +1,13 @@
 ---
 title: "Compiler Warning (level 1) C4172"
 description: "Learn more about: Compiler Warning (level 1) C4172"
-ms.date: 06/20/2025
+ms.date: 06/25/2025
 f1_keywords: ["C4172"]
 helpviewer_keywords: ["C4172"]
 ---
 # Compiler Warning (level 1) C4172
 
-> returning address of local variable or temporary
+> returning address of local variable or temporary : *optional_context*
 
 ## Remarks
 

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4000-through-c4199.md
@@ -138,7 +138,7 @@ The articles in this section describe Microsoft C/C++ compiler warning messages 
 |[Compiler warning (level 1) C4166](compiler-warning-level-1-c4166.md)|illegal calling convention for constructor/destructor|
 |[Compiler warning (level 1) C4167](compiler-warning-level-1-c4167.md)|'*function*': only available as an intrinsic function|
 |[Compiler warning (level 1) C4168](compiler-warning-level-1-c4168.md)|compiler limit: out of debugger types, delete program database '*database*' and rebuild|
-|[Compiler warning (level 1) C4172](compiler-warning-level-1-c4172.md)|returning address of local variable or temporary *optional_context*|
+|[Compiler warning (level 1) C4172](compiler-warning-level-1-c4172.md)|returning address of local variable or temporary : *optional_context*|
 |[Compiler warning (level 1) C4174](compiler-warning-level-1-c4174.md)|'*name*': not available as a `#pragma component`|
 |[Compiler warning (level 1) C4175](compiler-warning-level-1-c4175.md)|`#pragma component(browser, on)`: browser info must initially be specified on the command line|
 |[Compiler warning (level 1) C4176](compiler-warning-level-1-c4176.md)|'*subcomponent*': unknown subcomponent for `#pragma component` browser|


### PR DESCRIPTION
- Add blockquotes for warning message
- Add "Remarks" and "Example" headings
- Tweak example
  - Use `/c` flag instead of `/LD`
  - Initialize global variable `f` with a float literal instead
  - Rename `bar` to `func`
  - Add another possible resolution with `const auto&`
  - Format example