### PR TITLE
Tidy up C2018 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2018"
 title: "Compiler Error C2018"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2018"
+ms.date: 06/21/2025
 f1_keywords: ["C2018"]
 helpviewer_keywords: ["C2018"]
-ms.assetid: 86b54573-dca0-4446-be1a-e3ac489c073b
 ---
 # Compiler Error C2018
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
@@ -16,20 +16,12 @@ The source file contains an unexpected ASCII character, which is identified by i
 
 ## Example
 
-The following sample generates C2018:
+The following example generates C2018:
 
 ```cpp
 // C2018.cpp
-int main() {
-   @   // C2018
-}
-```
-
-Possible resolution:
-
-```cpp
-// C2018b.cpp
-int main() {
-
+int main()
+{
+    @   // C2018
 }
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
@@ -10,7 +10,11 @@ ms.assetid: 86b54573-dca0-4446-be1a-e3ac489c073b
 
 > unknown character 'hexnumber'
 
+## Remarks
+
 The source file contains an unexpected ASCII character, which is identified by its hex number. To resolve the error, remove the character.
+
+## Example
 
 The following sample generates C2018:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2018.md
@@ -8,7 +8,7 @@ ms.assetid: 86b54573-dca0-4446-be1a-e3ac489c073b
 ---
 # Compiler Error C2018
 
-unknown character 'hexnumber'
+> unknown character 'hexnumber'
 
 The source file contains an unexpected ASCII character, which is identified by its hex number. To resolve the error, remove the character.
 


### PR DESCRIPTION
Even though I added the example in https://github.com/MicrosoftDocs/cpp-docs/commit/7a0e011807ad74092ceab7f9adb3d3920564be82 (some 2 years ago), the possible resolution code snippet does seem superfluous and adds some visual clutter, especially with the presence of "To resolve the error, remove the character." in the remarks section.

I want to eliminate example duplication where the second snippet is just the original with a minor fix, since this presentation has very poor UX, due the need for users to "spot the difference", and it drastically increases the aforementioned visual clutter.