### PR TITLE
Update `main` functions with omitted `int` return type

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2086.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2086.md
@@ -18,7 +18,7 @@ The following sample generates C2086:
 
 ```cpp
 // C2086.cpp
-main() {
+int main() {
   int a;
   int a;   // C2086 not an error in ANSI C
 }

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2086.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2086.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2086"
 title: "Compiler Error C2086"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2086"
+ms.date: 11/04/2016
 f1_keywords: ["C2086"]
 helpviewer_keywords: ["C2086"]
-ms.assetid: 4329bf72-90c8-444c-8524-4ef75e6b2139
 ---
 # Compiler Error C2086
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4744.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4744.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (Level 1) C4744"
 title: "Compiler Warning (Level 1) C4744"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (Level 1) C4744"
+ms.date: 11/04/2016
 f1_keywords: ["C4744"]
 helpviewer_keywords: ["C4744"]
-ms.assetid: f2a7d0b5-afd5-4926-abc3-cfbd367e3ff5
 ---
 # Compiler Warning (Level 1) C4744
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4744.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4744.md
@@ -37,7 +37,7 @@ The following sample generates C4744.
 
 extern unsigned global;
 
-main()
+int main()
 {
     printf_s("%d\n", global);
 }

--- a/docs/error-messages/tool-errors/math-error-m6111.md
+++ b/docs/error-messages/tool-errors/math-error-m6111.md
@@ -14,9 +14,9 @@ A floating-point operation resulted in a stack underflow on the 8087/287/387 cop
 
 This error is often caused by a call to a **`long double`** function that does not return a value. For example, the following generates this error when compiled and run:
 
-```
+```c
 long double ld() {};
-main ()
+int main ()
 {
   ld();
 }

--- a/docs/error-messages/tool-errors/math-error-m6111.md
+++ b/docs/error-messages/tool-errors/math-error-m6111.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6111"
 title: "Math Error M6111"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6111"
+ms.date: 11/04/2016
 f1_keywords: ["M6111"]
 helpviewer_keywords: ["M6111"]
-ms.assetid: c0fc13f8-33c8-4e3f-a440-126cc623441b
 ---
 # Math Error M6111
 

--- a/docs/intrinsics/debugbreak.md
+++ b/docs/intrinsics/debugbreak.md
@@ -34,7 +34,7 @@ The `__debugbreak` compiler intrinsic, similar to [DebugBreak](/windows/win32/ap
 For example:
 
 ```C
-main() {
+int main() {
    __debugbreak();
 }
 ```
@@ -42,7 +42,7 @@ main() {
 is similar to:
 
 ```C
-main() {
+int main() {
    __asm {
       int 3
    }

--- a/docs/intrinsics/debugbreak.md
+++ b/docs/intrinsics/debugbreak.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: __debugbreak"
 title: "__debugbreak"
-ms.date: "09/02/2019"
+description: "Learn more about: __debugbreak"
+ms.date: 09/02/2019
 f1_keywords: ["__debugbreak_cpp", "__debugbreak"]
 helpviewer_keywords: ["breakpoints, __debugbreak intrinsic", "__debugbreak intrinsic"]
-ms.assetid: 1d1e1c0c-891a-4613-ae4b-d790094ba830
 ---
 # __debugbreak
 

--- a/docs/parallel/openmp/a-examples.md
+++ b/docs/parallel/openmp/a-examples.md
@@ -1,8 +1,7 @@
 ---
-description: "Learn more about: A. Examples"
 title: "A. Examples"
-ms.date: "01/18/2019"
-ms.assetid: c0f6192f-a205-449b-b84c-cb30dbcc8b8f
+description: "Learn more about: A. Examples"
+ms.date: 01/18/2019
 ---
 # A. Examples
 

--- a/docs/parallel/openmp/a-examples.md
+++ b/docs/parallel/openmp/a-examples.md
@@ -854,7 +854,7 @@ The following example demonstrates the [num_threads](2-directives.md#23-parallel
 
 ```cpp
 #include <omp.h>
-main()
+int main()
 {
     omp_set_dynamic(1);
     ...


### PR DESCRIPTION
In C, omitting the `int` return type results in warning [C4431](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4431?view=msvc-170).
In C++, omitting the `int` return type results in error [C4430](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-c4430?view=msvc-170).