### PR TITLE
Trim excess space in headings

### DIFF
--- a/docs/atl/reference/catltransactionmanager-class.md
+++ b/docs/atl/reference/catltransactionmanager-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CAtlTransactionManager Class"
 title: "CAtlTransactionManager Class"
-ms.date: "11/04/2016"
+description: "Learn more about: CAtlTransactionManager Class"
+ms.date: 11/04/2016
 f1_keywords: ["CAtlTransactionManager", "ATLTRANSACTIONMANAGER/ATL::CAtlTransactionManager", "ATLTRANSACTIONMANAGER/ATL::Close", "ATLTRANSACTIONMANAGER/ATL::Commit", "ATLTRANSACTIONMANAGER/ATL::Create", "ATLTRANSACTIONMANAGER/ATL::CreateFile", "ATLTRANSACTIONMANAGER/ATL::DeleteFile", "ATLTRANSACTIONMANAGER/ATL::FindFirstFile", "ATLTRANSACTIONMANAGER/ATL::GetFileAttributes", "ATLTRANSACTIONMANAGER/ATL::GetFileAttributesEx", "ATLTRANSACTIONMANAGER/ATL::GetHandle", "ATLTRANSACTIONMANAGER/ATL::IsFallback", "ATLTRANSACTIONMANAGER/ATL::MoveFile", "ATLTRANSACTIONMANAGER/ATL::RegCreateKeyEx", "ATLTRANSACTIONMANAGER/ATL::RegDeleteKey", "ATLTRANSACTIONMANAGER/ATL::RegOpenKeyEx", "ATLTRANSACTIONMANAGER/ATL::Rollback", "ATLTRANSACTIONMANAGER/ATL::SetFileAttributes", "ATLTRANSACTIONMANAGER/ATL::m_bFallback", "ATLTRANSACTIONMANAGER/ATL::m_hTransaction"]
 helpviewer_keywords: ["CAtlTransactionManager class"]
-ms.assetid: b01732dc-1d16-4b42-bfac-b137fca2b740
 ---
 # CAtlTransactionManager Class
 

--- a/docs/atl/reference/catltransactionmanager-class.md
+++ b/docs/atl/reference/catltransactionmanager-class.md
@@ -66,7 +66,7 @@ class CAtlTransactionManager;
 
 **Header:** atltransactionmanager.h
 
-## <a name="dtor"></a>  ~CAtlTransactionManager
+## <a name="dtor"></a> ~CAtlTransactionManager
 
 CAtlTransactionManager destructor.
 

--- a/docs/atl/reference/ccomdynamicunkarray-class.md
+++ b/docs/atl/reference/ccomdynamicunkarray-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CComDynamicUnkArray Class"
 title: "CComDynamicUnkArray Class"
-ms.date: "11/04/2016"
+description: "Learn more about: CComDynamicUnkArray Class"
+ms.date: 11/04/2016
 f1_keywords: ["CComDynamicUnkArray", "ATLCOM/ATL::CComDynamicUnkArray", "ATLCOM/ATL::CComDynamicUnkArray::CComDynamicUnkArray", "ATLCOM/ATL::CComDynamicUnkArray::Add", "ATLCOM/ATL::CComDynamicUnkArray::begin", "ATLCOM/ATL::CComDynamicUnkArray::clear", "ATLCOM/ATL::CComDynamicUnkArray::end", "ATLCOM/ATL::CComDynamicUnkArray::GetAt", "ATLCOM/ATL::CComDynamicUnkArray::GetCookie", "ATLCOM/ATL::CComDynamicUnkArray::GetSize", "ATLCOM/ATL::CComDynamicUnkArray::GetUnknown", "ATLCOM/ATL::CComDynamicUnkArray::Remove"]
 helpviewer_keywords: ["connection points [C++], managing", "CComDynamicUnkArray class"]
-ms.assetid: 202470d7-9a1b-498f-b96d-659d681acd65
 ---
 # CComDynamicUnkArray Class
 

--- a/docs/atl/reference/ccomdynamicunkarray-class.md
+++ b/docs/atl/reference/ccomdynamicunkarray-class.md
@@ -194,7 +194,7 @@ int GetSize() const;
 
 The number of elements the array can store. `GetSize() == end() - begin()`.
 
-##  <a name="getunknown"></a> CComDynamicUnkArray::GetUnknown
+## <a name="getunknown"></a> CComDynamicUnkArray::GetUnknown
 
 Call this method to get the `IUnknown` pointer associated with a given cookie.
 

--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -19,7 +19,7 @@ This article contains information about *`CMakePresets.json`* integration with V
 
 We recommend *`CMakePresets.json`* as an alternative to *`CMakeSettings.json`*. Visual Studio never reads from both *`CMakePresets.json`* and *`CMakeSettings.json`* at the same time. To enable or disable *`CMakePresets.json`* integration in Visual Studio, see [Enable `CMakePresets.json` in Visual Studio 2019](#enable-cmakepresets-json-integration).
 
-## Supported CMake and  *`CMakePresets.json`* versions
+## Supported CMake and *`CMakePresets.json`* versions
 
 The supported *`CMakePresets.json`* and *`CMakeUserPresets.json`* schema versions depend on your version of Visual Studio:
 - Visual Studio 2019 version 16.10 and later support schema versions 2 and 3.
@@ -391,7 +391,7 @@ Instead, set the path to `vcpkg.cmake` by using the `VCPKG_ROOT` environment var
 
 If you're already using a CMake toolchain file and want to enable vcpkg integration, see [Using multiple toolchain files](/vcpkg/users/buildsystems/cmake-integration#using-multiple-toolchain-files). Follow those instructions to use an external toolchain file with a project by using vcpkg.
 
-## Variable substitution in  *`launch.vs.json`* and  *`tasks.vs.json`*
+## Variable substitution in *`launch.vs.json`* and *`tasks.vs.json`*
 
 *`CMakePresets.json`* supports variable substitution in *`launch.vs.json`* and *`tasks.vs.json`*. Here are some considerations:
 

--- a/docs/c-runtime-library/reference/itoa-s-itow-s.md
+++ b/docs/c-runtime-library/reference/itoa-s-itow-s.md
@@ -10,7 +10,7 @@ f1_keywords: ["_itoa_s", "_ltoa_s", "_ultoa_s", "_i64toa_s", "_ui64toa_s", "_ito
 helpviewer_keywords: ["_ui64toa_s function", "_itow_s function", "_i64tow_s function", "_itot_s function", "converting integers", "itow_s function", "i64toa_s function", "_ui64tow_s function", "integers, converting", "_i64tot_s function", "itoa_s function", "_itoa_s function", "ui64toa_s function", "i64tow_s function", "converting numbers, to strings", "_ui64tot_s function", "_i64toa_s function"]
 ms.assetid: eb746581-bff3-48b5-a973-bfc0a4478ecf
 ---
-# `_itoa_s`, `_ltoa_s`, `_ultoa_s`, `_i64toa_s`, `_ui64toa_s`, `_itow_s`,  `_ltow_s`,  `_ultow_s`, `_i64tow_s`, `_ui64tow_s`
+# `_itoa_s`, `_ltoa_s`, `_ultoa_s`, `_i64toa_s`, `_ui64toa_s`, `_itow_s`, `_ltow_s`, `_ultow_s`, `_i64tow_s`, `_ui64tow_s`
 
 Converts an integer to a string. These functions are versions of the [`_itoa`, `_itow` functions](itoa-itow.md) with security enhancements as described in [Security features in the CRT](../security-features-in-the-crt.md).
 

--- a/docs/c-runtime-library/reference/itoa-s-itow-s.md
+++ b/docs/c-runtime-library/reference/itoa-s-itow-s.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _itoa_s, _ltoa_s, _ultoa_s, _i64toa_s, _ui64toa_s, _itow_s,  _ltow_s,  _ultow_s, _i64tow_s, _ui64tow_s"
 title: "_itoa_s, _itow_s functions"
-ms.date: "4/2/2020"
+description: "Learn more about: _itoa_s, _ltoa_s, _ultoa_s, _i64toa_s, _ui64toa_s, _itow_s, _ltow_s, _ultow_s, _i64tow_s, _ui64tow_s"
+ms.date: 4/2/2020
 api_name: ["_itoa_s", "_ltoa_s", "_ultoa_s", "_i64toa_s", "_ui64toa_s", "_itow_s", "_ltow_s", "_ultow_s", "_i64tow_s", "_ui64tow_s", "_o__i64toa_s", "_o__i64tow_s", "_o__itoa_s", "_o__itow_s", "_o__ltoa_s", "_o__ltow_s", "_o__ui64toa_s", "_o__ui64tow_s", "_o__ultoa_s", "_o__ultow_s"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-convert-l1-1-0.dll", "ntoskrnl.exe"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_itoa_s", "_ltoa_s", "_ultoa_s", "_i64toa_s", "_ui64toa_s", "_itow_s", "_ltow_s", "_ultow_s", "_i64tow_s", "_ui64tow_s", "_itot_s", "_ltot_s", "_ultot_s", "_i64tot_s", "_ui64tot_s", "itoa_s", "ltoa_s", "ultoa_s", "i64toa_s", "ui64toa_s", "itow_s", "ltow_s", "ultow_s", "i64tow_s", "ui64tow_s", "itot_s", "ltot_s", "ultot_s", "i64tot_s", "ui64tot_s"]
 helpviewer_keywords: ["_ui64toa_s function", "_itow_s function", "_i64tow_s function", "_itot_s function", "converting integers", "itow_s function", "i64toa_s function", "_ui64tow_s function", "integers, converting", "_i64tot_s function", "itoa_s function", "_itoa_s function", "ui64toa_s function", "i64tow_s function", "converting numbers, to strings", "_ui64tot_s function", "_i64toa_s function"]
-ms.assetid: eb746581-bff3-48b5-a973-bfc0a4478ecf
 ---
 # `_itoa_s`, `_ltoa_s`, `_ultoa_s`, `_i64toa_s`, `_ui64toa_s`, `_itow_s`, `_ltow_s`, `_ultow_s`, `_i64tow_s`, `_ui64tow_s`
 

--- a/docs/code-quality/c26433.md
+++ b/docs/code-quality/c26433.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Warning C26433 OVERRIDE_EXPLICITLY"
 title: Warning C26433
+description: "Learn more about: Warning C26433 OVERRIDE_EXPLICITLY"
 ms.date: 01/18/2017
 f1_keywords: ["C26433", "OVERRIDE_EXPLICITLY"]
 helpviewer_keywords: ["C26433"]

--- a/docs/code-quality/c26433.md
+++ b/docs/code-quality/c26433.md
@@ -25,7 +25,7 @@ Warnings show up on function definitions, not declarations. It may be confusing,
 
 Code analysis name: `OVERRIDE_EXPLICITLY`
 
-## Example:  Implicit overriding
+## Example: Implicit overriding
 
 ```cpp
 class Shape {

--- a/docs/cpp/basic-concepts-cpp.md
+++ b/docs/cpp/basic-concepts-cpp.md
@@ -6,7 +6,7 @@ ms.date: "12/11/2019"
 helpviewer_keywords: ["C++, basic language concepts"]
 ms.assetid: 961801e6-2ffd-4bf1-bb71-7f55e48d9c79
 ---
-# Basic Concepts  (C++)
+# Basic Concepts (C++)
 
 This section explains concepts that are critical to understanding C++. C programmers will be familiar with many of these concepts, but there are some subtle differences that can cause unexpected program results. The following topics are included:
 

--- a/docs/cpp/basic-concepts-cpp.md
+++ b/docs/cpp/basic-concepts-cpp.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Basic Concepts  (C++)"
-title: "Basic Concepts  (C++)"
+title: "Basic Concepts (C++)"
+description: "Learn more about: Basic Concepts (C++)"
 ms.custom: "index-page"
-ms.date: "12/11/2019"
+ms.date: 12/11/2019
 helpviewer_keywords: ["C++, basic language concepts"]
-ms.assetid: 961801e6-2ffd-4bf1-bb71-7f55e48d9c79
 ---
 # Basic Concepts (C++)
 

--- a/docs/cpp/functions-with-variable-argument-lists-cpp.md
+++ b/docs/cpp/functions-with-variable-argument-lists-cpp.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Functions with Variable Argument Lists  (C++)"
-title: "Functions with Variable Argument Lists  (C++)"
+title: "Functions with Variable Argument Lists (C++)"
+description: "Learn more about: Functions with Variable Argument Lists (C++)"
 ms.date: 05/01/2025
 helpviewer_keywords: ["arguments [C++], variable number of", "variable argument lists", "declarators, functions", "argument lists [C++], variable number of", "declaring functions [C++], variables", "function calls, variable number of arguments"]
 ---

--- a/docs/cpp/functions-with-variable-argument-lists-cpp.md
+++ b/docs/cpp/functions-with-variable-argument-lists-cpp.md
@@ -4,7 +4,7 @@ title: "Functions with Variable Argument Lists  (C++)"
 ms.date: 05/01/2025
 helpviewer_keywords: ["arguments [C++], variable number of", "variable argument lists", "declarators, functions", "argument lists [C++], variable number of", "declaring functions [C++], variables", "function calls, variable number of arguments"]
 ---
-# Functions with Variable Argument Lists  (C++)
+# Functions with Variable Argument Lists (C++)
 
 Function declarations that have ellipsis (...) as the last argument take a variable number of arguments. C++ provides type checking only for the explicitly declared arguments. You can use variable argument lists when the number and types of arguments to the function can vary. The `printf` family of functions is an example of functions that have variable argument lists.
 

--- a/docs/cppcx/platform-stringreference-class.md
+++ b/docs/cppcx/platform-stringreference-class.md
@@ -140,7 +140,7 @@ A reference to an object of type `StringReference`.
 
 Because `StringReference` is a standard C++ class and not a ref class, it does not appear in the **Object Browser**.
 
-## <a name="operator-call"></a> StringReference::operator()  Operator
+## <a name="operator-call"></a> StringReference::operator() Operator
 
 Converts a `StringReference` object to a `Platform::String^` object.
 

--- a/docs/cppcx/platform-stringreference-class.md
+++ b/docs/cppcx/platform-stringreference-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Platform::StringReference Class"
 title: "Platform::StringReference Class"
-ms.date: "12/30/2016"
+description: "Learn more about: Platform::StringReference Class"
+ms.date: 12/30/2016
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::StringReference::StringReference", "VCCORLIB/Platform::StringReference::Data", "VCCORLIB/Platform::StringReference::Length", "VCCORLIB/Platform::StringReference::GetHSTRING", "VCCORLIB/Platform::StringReference::GetString"]
-ms.assetid: 2d09c7ec-0f16-458e-83ed-7225a1b9221e
 ---
 # Platform::StringReference Class
 

--- a/docs/data/catalog-information-mfc-data-access.md
+++ b/docs/data/catalog-information-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["tables [C++], catalog information", "tables [C++]", "ODBC [C++], catalog information", "catalog information database [C++]", "databases [C++], catalog information database"]
 ms.assetid: c184e80f-ff17-409f-9df8-05275080bb8d
 ---
-# Catalog Information  (MFC Data Access)
+# Catalog Information (MFC Data Access)
 
 Information about the tables in a data source can include the names of tables and the columns in them, table privileges, names of primary and foreign keys, information about predefined queries or stored procedures, information about indexes on tables, and statistics about tables.
 

--- a/docs/data/catalog-information-mfc-data-access.md
+++ b/docs/data/catalog-information-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Catalog Information  (MFC Data Access)"
-title: "Catalog Information  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Catalog Information (MFC Data Access)"
+description: "Learn more about: Catalog Information (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["tables [C++], catalog information", "tables [C++]", "ODBC [C++], catalog information", "catalog information database [C++]", "databases [C++], catalog information database"]
-ms.assetid: c184e80f-ff17-409f-9df8-05275080bb8d
 ---
 # Catalog Information (MFC Data Access)
 

--- a/docs/data/changes-you-might-make-to-the-default-code-mfc-data-access.md
+++ b/docs/data/changes-you-might-make-to-the-default-code-mfc-data-access.md
@@ -1,7 +1,7 @@
 ---
-title: "Changes You Might Make to the Default Code  (MFC Data Access)"
-description: "Learn more about: Changes You Might Make to the Default Code  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Changes You Might Make to the Default Code (MFC Data Access)"
+description: "Learn more about: Changes You Might Make to the Default Code (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views [C++], customizing default code"]
 ---
 # Changes You Might Make to the Default Code (MFC Data Access)

--- a/docs/data/changes-you-might-make-to-the-default-code-mfc-data-access.md
+++ b/docs/data/changes-you-might-make-to-the-default-code-mfc-data-access.md
@@ -4,7 +4,7 @@ description: "Learn more about: Changes You Might Make to the Default Code  (MFC
 ms.date: "11/04/2016"
 helpviewer_keywords: ["record views [C++], customizing default code"]
 ---
-# Changes You Might Make to the Default Code  (MFC Data Access)
+# Changes You Might Make to the Default Code (MFC Data Access)
 
 The [MFC Application Wizard](../mfc/reference/database-support-mfc-application-wizard.md) writes a recordset class for you that selects all records in a single table. You will often want to modify that behavior in one or more of the following ways:
 

--- a/docs/data/command-handlers-for-record-scrolling-mfc-data-access.md
+++ b/docs/data/command-handlers-for-record-scrolling-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["record views [C++], scrolling", "record scrolling [C++]", "scrolling records"]
 ms.assetid: f8b13477-2a37-459e-a30c-806fb78165ac
 ---
-# Command Handlers for Record Scrolling  (MFC Data Access)
+# Command Handlers for Record Scrolling (MFC Data Access)
 
 The [CRecordView](../mfc/reference/crecordview-class.md) class provides default command handling for the following standard commands:
 

--- a/docs/data/command-handlers-for-record-scrolling-mfc-data-access.md
+++ b/docs/data/command-handlers-for-record-scrolling-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Command Handlers for Record Scrolling  (MFC Data Access)"
-title: "Command Handlers for Record Scrolling  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Command Handlers for Record Scrolling (MFC Data Access)"
+description: "Learn more about: Command Handlers for Record Scrolling (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views [C++], scrolling", "record scrolling [C++]", "scrolling records"]
-ms.assetid: f8b13477-2a37-459e-a30c-806fb78165ac
 ---
 # Command Handlers for Record Scrolling (MFC Data Access)
 

--- a/docs/data/data-exchange-for-record-views-mfc-data-access.md
+++ b/docs/data/data-exchange-for-record-views-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/19/2018"
 helpviewer_keywords: ["RFX (record field exchange), data exchange mechanism", "RFX (record field exchange), record views", "record views, data exchange", "DDX (dialog data exchange), record views", "RFX (record field exchange)"]
 ms.assetid: abc52ca7-6997-47a7-98f3-f347f52b1f72
 ---
-# Data Exchange for Record Views   (MFC Data Access)
+# Data Exchange for Record Views (MFC Data Access)
 
 When you use [Add Class](../mfc/reference/adding-an-mfc-odbc-consumer.md) to map the controls in a record view's dialog template resource to the fields of a recordset, the framework manages data exchange in both directions — from recordset to controls and from controls to recordset. Using the DDX mechanism means that you do not have to write the code to transfer data back and forth yourself.
 

--- a/docs/data/data-exchange-for-record-views-mfc-data-access.md
+++ b/docs/data/data-exchange-for-record-views-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Data Exchange for Record Views   (MFC Data Access)"
-title: "Data Exchange for Record Views   (MFC Data Access)"
-ms.date: "11/19/2018"
+title: "Data Exchange for Record Views (MFC Data Access)"
+description: "Learn more about: Data Exchange for Record Views (MFC Data Access)"
+ms.date: 11/19/2018
 helpviewer_keywords: ["RFX (record field exchange), data exchange mechanism", "RFX (record field exchange), record views", "record views, data exchange", "DDX (dialog data exchange), record views", "RFX (record field exchange)"]
-ms.assetid: abc52ca7-6997-47a7-98f3-f347f52b1f72
 ---
 # Data Exchange for Record Views (MFC Data Access)
 

--- a/docs/data/designing-and-creating-a-record-view-mfc-data-access.md
+++ b/docs/data/designing-and-creating-a-record-view-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Designing and Creating a Record View  (MFC Data Access)"
-title: "Designing and Creating a Record View  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Designing and Creating a Record View (MFC Data Access)"
+description: "Learn more about: Designing and Creating a Record View (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["designing forms", "record views, creating", "forms [C++], designing", "record views, designing", "application wizards [C++], creating record view classes", "designing record views"]
-ms.assetid: 1d6f5439-754f-4b8b-a19d-841a4657827b
 ---
 # Designing and Creating a Record View (MFC Data Access)
 

--- a/docs/data/designing-and-creating-a-record-view-mfc-data-access.md
+++ b/docs/data/designing-and-creating-a-record-view-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["designing forms", "record views, creating", "forms [C++], designing", "record views, designing", "application wizards [C++], creating record view classes", "designing record views"]
 ms.assetid: 1d6f5439-754f-4b8b-a19d-841a4657827b
 ---
-# Designing and Creating a Record View  (MFC Data Access)
+# Designing and Creating a Record View (MFC Data Access)
 
 You can create your record view class with the [MFC Application Wizard](../mfc/reference/database-support-mfc-application-wizard.md). If you use an application wizard, it creates the record view class and a dialog template resource for it (without controls). You must use the Visual C++ Dialog editor to add controls to the dialog template resource. On the other hand, if you use **Add Class**, you must first create the dialog template resource in the Dialog editor and then create the record view class.
 

--- a/docs/data/features-of-record-view-classes-mfc-data-access.md
+++ b/docs/data/features-of-record-view-classes-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Features of Record View Classes  (MFC Data Access)"
-title: "Features of Record View Classes  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Features of Record View Classes (MFC Data Access)"
+description: "Learn more about: Features of Record View Classes (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views, classes", "record view classes"]
-ms.assetid: e7b2820f-09c4-483f-83c0-317e8be42bdf
 ---
 # Features of Record View Classes (MFC Data Access)
 

--- a/docs/data/features-of-record-view-classes-mfc-data-access.md
+++ b/docs/data/features-of-record-view-classes-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["record views, classes", "record view classes"]
 ms.assetid: e7b2820f-09c4-483f-83c0-317e8be42bdf
 ---
-# Features of Record View Classes  (MFC Data Access)
+# Features of Record View Classes (MFC Data Access)
 
 You can do form-based data-access programming with class [CFormView](../mfc/reference/cformview-class.md), but [CRecordView](../mfc/reference/crecordview-class.md) is generally a better class to derive from. In addition to its `CFormView` features, `CRecordView`:
 

--- a/docs/data/filling-a-list-box-from-a-second-recordset-mfc-data-access.md
+++ b/docs/data/filling-a-list-box-from-a-second-recordset-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["record views, filling list boxes", "list boxes, filling from second recordset", "recordsets [C++], filling list boxes or combo boxes", "CComboBox class, filling object from second rowset", "ODBC recordsets [C++], filling list boxes or combo boxes", "combo boxes [C++], filling from second recordset", "CListCtrl class, filling from second recordset"]
 ms.assetid: 360c0834-da6b-4dc0-bcea-80e9acd611f0
 ---
-# Filling a List Box from a Second Recordset  (MFC Data Access)
+# Filling a List Box from a Second Recordset (MFC Data Access)
 
 By default, a record view is associated with a single recordset object, whose fields are mapped to the record view's controls. Sometimes you might want to put a list box or combo box control in your record view and fill it with values from a second recordset object. The user can use the list box to select a new category of information to display in the record view. This topic explains how and when to do that.
 

--- a/docs/data/filling-a-list-box-from-a-second-recordset-mfc-data-access.md
+++ b/docs/data/filling-a-list-box-from-a-second-recordset-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Filling a List Box from a Second Recordset  (MFC Data Access)"
-title: "Filling a List Box from a Second Recordset  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Filling a List Box from a Second Recordset (MFC Data Access)"
+description: "Learn more about: Filling a List Box from a Second Recordset (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views, filling list boxes", "list boxes, filling from second recordset", "recordsets [C++], filling list boxes or combo boxes", "CComboBox class, filling object from second rowset", "ODBC recordsets [C++], filling list boxes or combo boxes", "combo boxes [C++], filling from second recordset", "CListCtrl class, filling from second recordset"]
-ms.assetid: 360c0834-da6b-4dc0-bcea-80e9acd611f0
 ---
 # Filling a List Box from a Second Recordset (MFC Data Access)
 

--- a/docs/data/odbc/sql-customizing-your-recordsets-sql-statement-odbc.md
+++ b/docs/data/odbc/sql-customizing-your-recordsets-sql-statement-odbc.md
@@ -82,11 +82,11 @@ The following table shows the possibilities for the *lpszSQL* parameter to `Open
 
 \* `m_nFields` must be less than or equal to the number of columns specified in the **SELECT** statement. The data type of each column specified in the **SELECT** statement must be the same as the data type of the corresponding RFX output column.
 
-### Case 1   lpszSQL = NULL
+### Case 1 lpszSQL = NULL
 
 The recordset selection depends on what `GetDefaultSQL` returns when `CRecordset::Open` calls it. Cases 2 through 5 describe the possible strings.
 
-### Case 2   lpszSQL = a Table Name
+### Case 2 lpszSQL = a Table Name
 
 The recordset uses record field exchange (RFX) to build the column list from the column names provided in the RFX function calls in the recordset class's override of `DoFieldExchange`. If you used a wizard to declare your recordset class, this case has the same result as case 1 (provided that you pass the same table name you specified in the wizard). If you do not use a wizard to write your class, case 2 is the simplest way to construct the SQL statement.
 
@@ -120,7 +120,7 @@ SELECT CourseID, InstructorID, RoomNo, Schedule, SectionNo
     FROM SECTION
 ```
 
-### Case 3   lpszSQL = a SELECT/FROM Statement
+### Case 3 lpszSQL = a SELECT/FROM Statement
 
 You specify the column list by hand rather than relying on RFX to construct it automatically. You might want to do this when:
 
@@ -138,11 +138,11 @@ You specify the column list by hand rather than relying on RFX to construct it a
 
    For information and an example, see [Recordset: Performing a Join (ODBC)](../../data/odbc/recordset-performing-a-join-odbc.md).
 
-### Case 4   lpszSQL = SELECT/FROM Plus WHERE and/or ORDER BY
+### Case 4 lpszSQL = SELECT/FROM Plus WHERE and/or ORDER BY
 
 You specify everything: the column list (based on the RFX calls in `DoFieldExchange`), the table list, and the contents of a **WHERE** and/or an **ORDER BY** clause. If you specify your **WHERE** and/or **ORDER BY** clauses this way, do not use `m_strFilter` and/or `m_strSort`.
 
-### Case 5   lpszSQL = a Stored Procedure Call
+### Case 5 lpszSQL = a Stored Procedure Call
 
 If you need to call a predefined query (such as a stored procedure in a Microsoft SQL Server database), you must write a **CALL** statement in the string you pass to *lpszSQL*. The wizards do not support declaring a recordset class for calling a predefined query. Not all predefined queries return records.
 

--- a/docs/data/odbc/sql-customizing-your-recordsets-sql-statement-odbc.md
+++ b/docs/data/odbc/sql-customizing-your-recordsets-sql-statement-odbc.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: SQL: Customizing Your Recordset's SQL Statement (ODBC)"
 title: "SQL: Customizing Your Recordset's SQL Statement (ODBC)"
-ms.date: "11/04/2016"
+description: "Learn more about: SQL: Customizing Your Recordset's SQL Statement (ODBC)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["recordsets, SQL statements", "ODBC recordsets, SQL statements", "SQL statements, customizing", "SQL statements, recordset", "customizing SQL statements", "overriding, SQL statements", "SQL, opening recordsets"]
-ms.assetid: 72293a08-cef2-4be2-aa1c-30565fcfbaf9
 ---
 # SQL: Customizing Your Recordset's SQL Statement (ODBC)
 

--- a/docs/data/record-view-code-created-by-application-wizard-mfc-data-access.md
+++ b/docs/data/record-view-code-created-by-application-wizard-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Record View Code Created by Application Wizard  (MFC Data Access)"
-title: "Record View Code Created by Application Wizard  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Record View Code Created by Application Wizard (MFC Data Access)"
+description: "Learn more about: Record View Code Created by Application Wizard (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["application wizards [C++], record view code", "record views, refreshing controls", "record views, application wizard code"]
-ms.assetid: 18fd4703-5939-491d-b759-985f767b951f
 ---
 # Record View Code Created by Application Wizard (MFC Data Access)
 

--- a/docs/data/record-view-code-created-by-application-wizard-mfc-data-access.md
+++ b/docs/data/record-view-code-created-by-application-wizard-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["application wizards [C++], record view code", "record views, refreshing controls", "record views, application wizard code"]
 ms.assetid: 18fd4703-5939-491d-b759-985f767b951f
 ---
-# Record View Code Created by Application Wizard  (MFC Data Access)
+# Record View Code Created by Application Wizard (MFC Data Access)
 
 The [MFC Application Wizard](../mfc/reference/database-support-mfc-application-wizard.md) overrides the view's `OnInitialUpdate` and `OnGetRecordset` member functions. After the framework creates the frame window, document, and view, it calls `OnInitialUpdate` to initialize the view. `OnInitialUpdate` obtains a pointer to the recordset from the document. A call to the base class [CView::OnInitialUpdate](../mfc/reference/cview-class.md#oninitialupdate) function opens the recordset. The following code shows this process for a `CRecordView`:
 

--- a/docs/data/record-views-mfc-data-access.md
+++ b/docs/data/record-views-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Record Views  (MFC Data Access)"
-title: "Record Views  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Record Views (MFC Data Access)"
+description: "Learn more about: Record Views (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["MFC [C++], record views", "ODBC recordsets [C++], record views", "databases [C++], record views", "record views [C++]", "forms [C++], data access tasks"]
-ms.assetid: 562122d9-01d8-4284-acf6-ea109ab0408d
 ---
 # Record Views (MFC Data Access)
 

--- a/docs/data/record-views-mfc-data-access.md
+++ b/docs/data/record-views-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["MFC [C++], record views", "ODBC recordsets [C++], record views", "databases [C++], record views", "record views [C++]", "forms [C++], data access tasks"]
 ms.assetid: 562122d9-01d8-4284-acf6-ea109ab0408d
 ---
-# Record Views  (MFC Data Access)
+# Record Views (MFC Data Access)
 
 This section applies only to the MFC ODBC classes. For information about OLE DB record views, see [COleDBRecordView](../mfc/reference/coledbrecordview-class.md) and [Using OLE DB Record Views](../data/oledb/using-ole-db-record-views.md).
 

--- a/docs/data/schema-mfc-data-access.md
+++ b/docs/data/schema-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["structures [C++], database", "databases [C++], schema", "database schema [C++], about database schemas", "database schema [C++]", "schemas [C++], database", "structures [C++]"]
 ms.assetid: 7d17e35f-1ccf-4853-b915-5b8c7a45b9ee
 ---
-# Schema  (MFC Data Access)
+# Schema (MFC Data Access)
 
 A database schema describes the current structure of the tables and database views in the database. In general, wizard-generated code assumes that the schema for the table or tables accessed by a recordset will not change, but the database classes can deal with some schema changes, such as adding, reordering, or deleting unbound columns. If a table changes, you must manually update the recordset for the table, then recompile your application.
 

--- a/docs/data/schema-mfc-data-access.md
+++ b/docs/data/schema-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Schema  (MFC Data Access)"
-title: "Schema  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Schema (MFC Data Access)"
+description: "Learn more about: Schema (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["structures [C++], database", "databases [C++], schema", "database schema [C++], about database schemas", "database schema [C++]", "schemas [C++], database", "structures [C++]"]
-ms.assetid: 7d17e35f-1ccf-4853-b915-5b8c7a45b9ee
 ---
 # Schema (MFC Data Access)
 

--- a/docs/data/supporting-navigation-in-a-record-view-mfc-data-access.md
+++ b/docs/data/supporting-navigation-in-a-record-view-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["records [C++], navigating", "record views, navigation", "navigation [C++], in record view"]
 ms.assetid: 227f2a6d-87c9-4656-807a-8e246965bcce
 ---
-# Supporting Navigation in a Record View  (MFC Data Access)
+# Supporting Navigation in a Record View (MFC Data Access)
 
 This topic explains how to support movement from record to record in your [CRecordView](../mfc/reference/crecordview-class.md) class, including information about:
 

--- a/docs/data/supporting-navigation-in-a-record-view-mfc-data-access.md
+++ b/docs/data/supporting-navigation-in-a-record-view-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Supporting Navigation in a Record View  (MFC Data Access)"
-title: "Supporting Navigation in a Record View  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Supporting Navigation in a Record View (MFC Data Access)"
+description: "Learn more about: Supporting Navigation in a Record View (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["records [C++], navigating", "record views, navigation", "navigation [C++], in record view"]
-ms.assetid: 227f2a6d-87c9-4656-807a-8e246965bcce
 ---
 # Supporting Navigation in a Record View (MFC Data Access)
 

--- a/docs/data/transactions-mfc-data-access.md
+++ b/docs/data/transactions-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Transactions  (MFC Data Access)"
-title: "Transactions  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Transactions (MFC Data Access)"
+description: "Learn more about: Transactions (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["transactions [C++], support for", "transactions [C++]", "databases [C++], transactions"]
-ms.assetid: f80afbfe-1517-4fec-8870-9ffc70a58b05
 ---
 # Transactions (MFC Data Access)
 

--- a/docs/data/transactions-mfc-data-access.md
+++ b/docs/data/transactions-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["transactions [C++], support for", "transactions [C++]", "databases [C++], transactions"]
 ms.assetid: f80afbfe-1517-4fec-8870-9ffc70a58b05
 ---
-# Transactions  (MFC Data Access)
+# Transactions (MFC Data Access)
 
 The concept of a transaction was developed to handle cases in which the resulting state of the database depends on the total success of a series of operations. This could come about because successive operations might modify the results of previous operations. In such cases, if any one operation fails, the resulting state could be indeterminate.
 

--- a/docs/data/user-interface-updating-for-record-views-mfc-data-access.md
+++ b/docs/data/user-interface-updating-for-record-views-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: User-Interface Updating for Record Views  (MFC Data Access)"
-title: "User-Interface Updating for Record Views  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "User-Interface Updating for Record Views (MFC Data Access)"
+description: "Learn more about: User-Interface Updating for Record Views (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["user interfaces, updating", "menus, updating as context changes", "record views, user interface"]
-ms.assetid: 2c7914b6-2dc3-40c3-b2f2-8371da2a4063
 ---
 # User-Interface Updating for Record Views (MFC Data Access)
 

--- a/docs/data/user-interface-updating-for-record-views-mfc-data-access.md
+++ b/docs/data/user-interface-updating-for-record-views-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["user interfaces, updating", "menus, updating as context changes", "record views, user interface"]
 ms.assetid: 2c7914b6-2dc3-40c3-b2f2-8371da2a4063
 ---
-# User-Interface Updating for Record Views  (MFC Data Access)
+# User-Interface Updating for Record Views (MFC Data Access)
 
 `CRecordView` provides default user-interface update handlers for the navigation commands. These handlers automate enabling and disabling the user-interface objects — menu items and toolbar buttons. The application wizard supplies standard menus and, if you choose the **Dockable Toolbar** option, a set of toolbar buttons for the commands. If you create a record view class using `CRecordView`, you might want to add similar user-interface objects to your application.
 

--- a/docs/data/using-a-record-view-mfc-data-access.md
+++ b/docs/data/using-a-record-view-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["record views, customizing default code"]
 ms.assetid: 91f2828f-0666-4273-ae28-e4703fd98521
 ---
-# Using a Record View  (MFC Data Access)
+# Using a Record View (MFC Data Access)
 
 This topic explains how you might commonly customize the default code for record views that the wizard writes for you. Typically, you want to constrain the record selection with a [filter](../data/odbc/recordset-filtering-records-odbc.md) or [parameters](../data/odbc/recordset-parameterizing-a-recordset-odbc.md), perhaps [sort](../data/odbc/recordset-sorting-records-odbc.md) the records, customize the SQL statement.
 

--- a/docs/data/using-a-record-view-mfc-data-access.md
+++ b/docs/data/using-a-record-view-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Using a Record View  (MFC Data Access)"
-title: "Using a Record View  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Using a Record View (MFC Data Access)"
+description: "Learn more about: Using a Record View (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views, customizing default code"]
-ms.assetid: 91f2828f-0666-4273-ae28-e4703fd98521
 ---
 # Using a Record View (MFC Data Access)
 

--- a/docs/data/your-role-in-working-with-a-record-view-mfc-data-access.md
+++ b/docs/data/your-role-in-working-with-a-record-view-mfc-data-access.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Your Role in Working with a Record View  (MFC Data Access)"
-title: "Your Role in Working with a Record View  (MFC Data Access)"
-ms.date: "11/04/2016"
+title: "Your Role in Working with a Record View (MFC Data Access)"
+description: "Learn more about: Your Role in Working with a Record View (MFC Data Access)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["record views, customizing default code", "MFC, record views"]
-ms.assetid: 691e89a5-ff21-4ca3-9278-69d4678288bb
 ---
 # Your Role in Working with a Record View (MFC Data Access)
 

--- a/docs/data/your-role-in-working-with-a-record-view-mfc-data-access.md
+++ b/docs/data/your-role-in-working-with-a-record-view-mfc-data-access.md
@@ -5,7 +5,7 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["record views, customizing default code", "MFC, record views"]
 ms.assetid: 691e89a5-ff21-4ca3-9278-69d4678288bb
 ---
-# Your Role in Working with a Record View  (MFC Data Access)
+# Your Role in Working with a Record View (MFC Data Access)
 
 The following table shows what you typically must do to work with a record view and what the framework does for you.
 

--- a/docs/dotnet/auto-handle-class.md
+++ b/docs/dotnet/auto-handle-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: auto_handle Class"
 title: "auto_handle Class"
-ms.date: "01/16/2019"
+description: "Learn more about: auto_handle Class"
+ms.date: 01/16/2019
 ms.topic: "reference"
 f1_keywords: ["msclr::auto_handle::auto_handle", "msclr::auto_handle::get", "msclr::auto_handle::release", "msclr::auto_handle::reset", "msclr::auto_handle::swap", "msclr::auto_handle::operator->", "msclr::auto_handle::operator=", "msclr::auto_handle::operator auto_handle", "msclr::auto_handle::operator!"]
 helpviewer_keywords: ["msclr::auto_handle class"]
-ms.assetid: a65604d1-ecbb-44fd-ae2f-696ddeeed9d6
 ---
 # auto_handle Class
 

--- a/docs/dotnet/auto-handle-class.md
+++ b/docs/dotnet/auto-handle-class.md
@@ -25,14 +25,14 @@ The managed type to be embedded.
 
 ## <a name="members"></a> Members
 
-### Public constructors  
+### Public constructors
 
 |Name|Description|  
 |---------|-----------|  
 |[auto_handle::auto_handle](#auto-handle)|The `auto_handle` constructor.|  
 |[auto_handle::~auto_handle](#tilde-auto-handle)|The `auto_handle` destructor.|  
 
-### Public methods  
+### Public methods
 
 |Name|Description|  
 |---------|-----------|  

--- a/docs/extensions/abstract-cpp-component-extensions.md
+++ b/docs/extensions/abstract-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["abstract", "abstract_cpp"]
 helpviewer_keywords: ["abstract keyword [C++]"]
 ms.assetid: cbae3408-0378-4ac8-b70d-c016b381a6d5
 ---
-# abstract  (C++/CLI and C++/CX)
+# abstract (C++/CLI and C++/CX)
 
 The **abstract** keyword declares either:
 

--- a/docs/extensions/abstract-cpp-component-extensions.md
+++ b/docs/extensions/abstract-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: abstract  (C++/CLI and C++/CX)"
-title: "abstract  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "abstract (C++/CLI and C++/CX)"
+description: "Learn more about: abstract (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["abstract", "abstract_cpp"]
 helpviewer_keywords: ["abstract keyword [C++]"]
-ms.assetid: cbae3408-0378-4ac8-b70d-c016b381a6d5
 ---
 # abstract (C++/CLI and C++/CX)
 

--- a/docs/extensions/attribute-parameter-types-cpp-component-extensions.md
+++ b/docs/extensions/attribute-parameter-types-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Attribute Parameter Types  (C++/CLI and C++/CX)"
-title: "Attribute Parameter Types  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Attribute Parameter Types (C++/CLI and C++/CX)"
+description: "Learn more about: Attribute Parameter Types (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["custom attributes, parameter types"]
-ms.assetid: d9f127a3-7f08-456f-acc6-256805632712
 ---
 # Attribute Parameter Types (C++/CLI and C++/CX)
 

--- a/docs/extensions/attribute-parameter-types-cpp-component-extensions.md
+++ b/docs/extensions/attribute-parameter-types-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["custom attributes, parameter types"]
 ms.assetid: d9f127a3-7f08-456f-acc6-256805632712
 ---
-# Attribute Parameter Types  (C++/CLI and C++/CX)
+# Attribute Parameter Types (C++/CLI and C++/CX)
 
 Values passed to attributes must be known to the compiler at compile time.  Attribute parameters can be of the following types:
 

--- a/docs/extensions/boxing-cpp-component-extensions.md
+++ b/docs/extensions/boxing-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["boxing, C++"]
 ms.assetid: b5fd2c98-c578-4f83-8257-6dd663478665
 ---
-# Boxing  (C++/CLI and C++/CX)
+# Boxing (C++/CLI and C++/CX)
 
 The conversion of value types to objects is called *boxing*, and the conversion of objects to value types is called *unboxing*.
 

--- a/docs/extensions/boxing-cpp-component-extensions.md
+++ b/docs/extensions/boxing-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Boxing  (C++/CLI and C++/CX)"
-title: "Boxing  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Boxing (C++/CLI and C++/CX)"
+description: "Learn more about: Boxing (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["boxing, C++"]
-ms.assetid: b5fd2c98-c578-4f83-8257-6dd663478665
 ---
 # Boxing (C++/CLI and C++/CX)
 

--- a/docs/extensions/classes-and-structs-cpp-component-extensions.md
+++ b/docs/extensions/classes-and-structs-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: ref class and ref struct  (C++/CLI and C++/CX)"
 title: "ref class and ref struct (C++/CLI and C++/CX)"
-ms.date: "05/30/2019"
+description: "Learn more about: ref class and ref struct (C++/CLI and C++/CX)"
+ms.date: 05/30/2019
 ms.topic: "reference"
 f1_keywords: ["ref class", "value class", "ref struct", "value struct",]
 helpviewer_keywords: ["ref class keyword [C++]", "value class keyword [C++]", "value struct keyword [C++]", "ref struct keyword [C++]"]
-ms.assetid: 5c360764-b229-49c6-9357-66213afbc372
 ---
 # ref class and ref struct (C++/CLI and C++/CX)
 

--- a/docs/extensions/classes-and-structs-cpp-component-extensions.md
+++ b/docs/extensions/classes-and-structs-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["ref class", "value class", "ref struct", "value struct",]
 helpviewer_keywords: ["ref class keyword [C++]", "value class keyword [C++]", "value struct keyword [C++]", "ref struct keyword [C++]"]
 ms.assetid: 5c360764-b229-49c6-9357-66213afbc372
 ---
-# ref class and ref struct  (C++/CLI and C++/CX)
+# ref class and ref struct (C++/CLI and C++/CX)
 
 The **ref class** or **ref struct** extensions declare a class or struct whose *object lifetime* is administered automatically. When the object is no longer accessible or goes out of scope, the memory is released.
 

--- a/docs/extensions/context-sensitive-keywords-cpp-component-extensions.md
+++ b/docs/extensions/context-sensitive-keywords-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["internal_CPP"]
 helpviewer_keywords: ["context-sensitive keywords"]
 ms.assetid: e33da089-f434-44e9-8cce-4668d05a8939
 ---
-# Context-Sensitive Keywords  (C++/CLI and C++/CX)
+# Context-Sensitive Keywords (C++/CLI and C++/CX)
 
 *Context-sensitive keywords* are language elements that are recognized only in specific contexts. Outside the specific context, a context-sensitive keyword can be a user-defined symbol.
 

--- a/docs/extensions/context-sensitive-keywords-cpp-component-extensions.md
+++ b/docs/extensions/context-sensitive-keywords-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Context-Sensitive Keywords  (C++/CLI and C++/CX)"
-title: "Context-Sensitive Keywords  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Context-Sensitive Keywords (C++/CLI and C++/CX)"
+description: "Learn more about: Context-Sensitive Keywords (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["internal_CPP"]
 helpviewer_keywords: ["context-sensitive keywords"]
-ms.assetid: e33da089-f434-44e9-8cce-4668d05a8939
 ---
 # Context-Sensitive Keywords (C++/CLI and C++/CX)
 

--- a/docs/extensions/delegate-cpp-component-extensions.md
+++ b/docs/extensions/delegate-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: delegate  (C++/CLI and C++/CX)"
-title: "delegate  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "delegate (C++/CLI and C++/CX)"
+description: "Learn more about: delegate (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["delegate_cpp", "delegate"]
 helpviewer_keywords: ["delegate keyword [C++]"]
-ms.assetid: 03caf23d-7873-4a23-9b34-becf42aaf429
 ---
 # delegate (C++/CLI and C++/CX)
 

--- a/docs/extensions/delegate-cpp-component-extensions.md
+++ b/docs/extensions/delegate-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["delegate_cpp", "delegate"]
 helpviewer_keywords: ["delegate keyword [C++]"]
 ms.assetid: 03caf23d-7873-4a23-9b34-becf42aaf429
 ---
-# delegate  (C++/CLI and C++/CX)
+# delegate (C++/CLI and C++/CX)
 
 Declares a type that represents a function pointer.
 

--- a/docs/extensions/enum-class-cpp-component-extensions.md
+++ b/docs/extensions/enum-class-cpp-component-extensions.md
@@ -5,7 +5,7 @@ ms.date: "10/12/2018"
 ms.topic: "reference"
 ms.assetid: 8010fa8c-bad6-45b4-8214-b4db64d7ffe1
 ---
-# enum class  (C++/CLI and C++/CX)
+# enum class (C++/CLI and C++/CX)
 
 Declares an enumeration at namespace scope, which is a user-defined type consisting of a set of named constants called enumerators.
 

--- a/docs/extensions/enum-class-cpp-component-extensions.md
+++ b/docs/extensions/enum-class-cpp-component-extensions.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: enum class  (C++/CLI and C++/CX)"
-title: "enum class  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "enum class (C++/CLI and C++/CX)"
+description: "Learn more about: enum class (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
-ms.assetid: 8010fa8c-bad6-45b4-8214-b4db64d7ffe1
 ---
 # enum class (C++/CLI and C++/CX)
 

--- a/docs/extensions/exception-handling-cpp-component-extensions.md
+++ b/docs/extensions/exception-handling-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Exception Handling  (C++/CLI and C++/CX)"
-title: "Exception Handling  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Exception Handling (C++/CLI and C++/CX)"
+description: "Learn more about: Exception Handling (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["structured exception handling [C++], managed exceptions", "Exception class, managed applications", "exception handling", "C++ exception handling", "exception handling, types of", "System::Exception class in managed applications"]
-ms.assetid: ccb11fe8-6938-41ac-b477-a183e85865b9
 ---
 # Exception Handling (C++/CLI and C++/CX)
 

--- a/docs/extensions/exception-handling-cpp-component-extensions.md
+++ b/docs/extensions/exception-handling-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["structured exception handling [C++], managed exceptions", "Exception class, managed applications", "exception handling", "C++ exception handling", "exception handling, types of", "System::Exception class in managed applications"]
 ms.assetid: ccb11fe8-6938-41ac-b477-a183e85865b9
 ---
-# Exception Handling  (C++/CLI and C++/CX)
+# Exception Handling (C++/CLI and C++/CX)
 
 Applications compiled with the `/ZW` compiler option or `/clr` compiler option both use *exceptions* to handle unexpected errors during program execution. The following topics discuss exception handling in either C++/CX or C++/CLI applications.
 

--- a/docs/extensions/explicit-overrides-cpp-component-extensions.md
+++ b/docs/extensions/explicit-overrides-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["overriding, override [C++]"]
 ms.assetid: 4ec3eaf5-163b-4df8-8f16-7a2ec04c3d0f
 ---
-# Explicit Overrides  (C++/CLI and C++/CX)
+# Explicit Overrides (C++/CLI and C++/CX)
 
 This topic discusses how to explicitly override a member of a base class or interface. A named (explicit) override should only be used to override a method with a derived method that has a different name.
 

--- a/docs/extensions/explicit-overrides-cpp-component-extensions.md
+++ b/docs/extensions/explicit-overrides-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Explicit Overrides  (C++/CLI and C++/CX)"
-title: "Explicit Overrides  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Explicit Overrides (C++/CLI and C++/CX)"
+description: "Learn more about: Explicit Overrides (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["overriding, override [C++]"]
-ms.assetid: 4ec3eaf5-163b-4df8-8f16-7a2ec04c3d0f
 ---
 # Explicit Overrides (C++/CLI and C++/CX)
 

--- a/docs/extensions/generics-cpp-component-extensions.md
+++ b/docs/extensions/generics-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["generic_cpp", "generic"]
 helpviewer_keywords: ["generics [C++]"]
 ms.assetid: c7ccc316-a411-4c00-b2e2-f0c0eadc6cfd
 ---
-# Generics  (C++/CLI and C++/CX)
+# Generics (C++/CLI and C++/CX)
 
 Generics are parameterized types and methods. In this section, find out which generic features both the Windows Runtime and the common language runtime support, and which ones only the common language runtime supports. You'll also find out how to author your own generic methods and types in C++/CLI, and how to use generic types authored in a .NET Framework language in C++/CLI. Finally, this section provides a comparison of generics and C++ templates.
 

--- a/docs/extensions/generics-cpp-component-extensions.md
+++ b/docs/extensions/generics-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-title: "Generics  (C++/CLI and C++/CX)"
+title: "Generics (C++/CLI and C++/CX)"
 description: "Links to content about the C++/CLI and C++/CX generics features, types, and methods."
 ms.date: 09/25/2020
 ms.topic: "reference"
 f1_keywords: ["generic_cpp", "generic"]
 helpviewer_keywords: ["generics [C++]"]
-ms.assetid: c7ccc316-a411-4c00-b2e2-f0c0eadc6cfd
 ---
 # Generics (C++/CLI and C++/CX)
 

--- a/docs/extensions/handle-to-object-operator-hat-cpp-component-extensions.md
+++ b/docs/extensions/handle-to-object-operator-hat-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Handle to Object Operator (^)  (C++/CLI and C++/CX)"
-title: "Handle to Object Operator (^)  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Handle to Object Operator (^) (C++/CLI and C++/CX)"
+description: "Learn more about: Handle to Object Operator (^) (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["^ handle to object [C++]"]
-ms.assetid: 70c411e6-be57-4468-a944-6ea7be89f392
 ---
 # Handle to Object Operator (^) (C++/CLI and C++/CX)
 

--- a/docs/extensions/handle-to-object-operator-hat-cpp-component-extensions.md
+++ b/docs/extensions/handle-to-object-operator-hat-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["^ handle to object [C++]"]
 ms.assetid: 70c411e6-be57-4468-a944-6ea7be89f392
 ---
-# Handle to Object Operator (^)  (C++/CLI and C++/CX)
+# Handle to Object Operator (^) (C++/CLI and C++/CX)
 
 The *handle declarator* (`^`, pronounced "hat"), modifies the type [specifier](../cpp/declarations-and-definitions-cpp.md) to mean that the declared object should be automatically deleted when the system determines that the object is no longer accessible.
 

--- a/docs/extensions/interface-class-cpp-component-extensions.md
+++ b/docs/extensions/interface-class-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
+title: "interface class (C++/CLI and C++/CX)"
 description: "Learn more about: interface class (C++/CLI and C++/CX)"
-title: "interface class  (C++/CLI and C++/CX)"
 ms.date: 04/15/2022
 ms.topic: "reference"
 f1_keywords: ["interface_CPP", "interface class", "interface class_CPP"]
 helpviewer_keywords: ["interface class keyword", "interface struct keyword"]
-ms.assetid: 3ccea701-f50b-4da7-ad6b-f0ee1203e2b9
 ---
 # `interface class` (C++/CLI and C++/CX)
 

--- a/docs/extensions/interface-class-cpp-component-extensions.md
+++ b/docs/extensions/interface-class-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["interface_CPP", "interface class", "interface class_CPP"]
 helpviewer_keywords: ["interface class keyword", "interface struct keyword"]
 ms.assetid: 3ccea701-f50b-4da7-ad6b-f0ee1203e2b9
 ---
-# `interface class`  (C++/CLI and C++/CX)
+# `interface class` (C++/CLI and C++/CX)
 
 Declares an interface.  For information on native interfaces, see [`__interface`](../cpp/interface.md).
 

--- a/docs/extensions/new-new-slot-in-vtable-cpp-component-extensions.md
+++ b/docs/extensions/new-new-slot-in-vtable-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: new (new slot in vtable)  (C++/CLI and C++/CX)"
-title: "new (new slot in vtable)  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "new (new slot in vtable) (C++/CLI and C++/CX)"
+description: "Learn more about: new (new slot in vtable) (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["new keyword [C++]"]
-ms.assetid: 1a9a5704-f02f-46ae-ad65-f0f2b6dbabc3
 ---
 # new (new slot in vtable) (C++/CLI and C++/CX)
 

--- a/docs/extensions/new-new-slot-in-vtable-cpp-component-extensions.md
+++ b/docs/extensions/new-new-slot-in-vtable-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["new keyword [C++]"]
 ms.assetid: 1a9a5704-f02f-46ae-ad65-f0f2b6dbabc3
 ---
-# new (new slot in vtable)  (C++/CLI and C++/CX)
+# new (new slot in vtable) (C++/CLI and C++/CX)
 
 The **`new`** keyword indicates that a virtual member will get a new slot in the vtable.
 

--- a/docs/extensions/nullptr-cpp-component-extensions.md
+++ b/docs/extensions/nullptr-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["__nullptr keyword (C++)", "nullptr keyword [C++]"]
 ms.assetid: 594cfbf7-06cb-4366-9ede-c0b703e1d095
 ---
-# nullptr  (C++/CLI and C++/CX)
+# nullptr (C++/CLI and C++/CX)
 
 The **`nullptr`** keyword represents a *null pointer value*. Use a null pointer value to indicate that an object handle, interior pointer, or native pointer type does not point to an object.
 

--- a/docs/extensions/nullptr-cpp-component-extensions.md
+++ b/docs/extensions/nullptr-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: nullptr  (C++/CLI and C++/CX)"
-title: "nullptr  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "nullptr (C++/CLI and C++/CX)"
+description: "Learn more about: nullptr (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["__nullptr keyword (C++)", "nullptr keyword [C++]"]
-ms.assetid: 594cfbf7-06cb-4366-9ede-c0b703e1d095
 ---
 # nullptr (C++/CLI and C++/CX)
 

--- a/docs/extensions/override-cpp-component-extensions.md
+++ b/docs/extensions/override-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["overriding, override keyword [C++]", "override keyword [C++]"]
 ms.assetid: 34d19257-1686-4fcd-96f5-af07c70ba914
 ---
-# override  (C++/CLI and C++/CX)
+# override (C++/CLI and C++/CX)
 
 The **override** context-sensitive keyword indicates that a member of a type overrides a base class or a base interface member.
 

--- a/docs/extensions/override-cpp-component-extensions.md
+++ b/docs/extensions/override-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: override  (C++/CLI and C++/CX)"
-title: "override  (C++/CLI and C++/CX)"
-ms.date: "11/04/2016"
+title: "override (C++/CLI and C++/CX)"
+description: "Learn more about: override (C++/CLI and C++/CX)"
+ms.date: 11/04/2016
 ms.topic: "reference"
 helpviewer_keywords: ["overriding, override keyword [C++]", "override keyword [C++]"]
-ms.assetid: 34d19257-1686-4fcd-96f5-af07c70ba914
 ---
 # override (C++/CLI and C++/CX)
 

--- a/docs/extensions/override-specifiers-cpp-component-extensions.md
+++ b/docs/extensions/override-specifiers-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Override Specifiers  (C++/CLI and C++/CX)"
-title: "Override Specifiers  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Override Specifiers (C++/CLI and C++/CX)"
+description: "Learn more about: Override Specifiers (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["override specifiers, C++", "override specifiers"]
-ms.assetid: 155bbf6f-4722-4654-afb1-9cb52af799fb
 ---
 # Override Specifiers (C++/CLI and C++/CX)
 

--- a/docs/extensions/override-specifiers-cpp-component-extensions.md
+++ b/docs/extensions/override-specifiers-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["override specifiers, C++", "override specifiers"]
 ms.assetid: 155bbf6f-4722-4654-afb1-9cb52af799fb
 ---
-# Override Specifiers  (C++/CLI and C++/CX)
+# Override Specifiers (C++/CLI and C++/CX)
 
 *Override specifiers* modify how inherited types and members of inherited types behave in derived types.
 

--- a/docs/extensions/partial-cpp-component-extensions.md
+++ b/docs/extensions/partial-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: partial  (C++/CLI and C++/CX)"
-title: "partial  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "partial (C++/CLI and C++/CX)"
+description: "Learn more about: partial (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["partial_CPP"]
 helpviewer_keywords: ["partial", "C++/CX, partial"]
-ms.assetid: 43adf1f5-10c5-44aa-a66f-7507e2bdabf8
 ---
 # partial (C++/CLI and C++/CX)
 

--- a/docs/extensions/partial-cpp-component-extensions.md
+++ b/docs/extensions/partial-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["partial_CPP"]
 helpviewer_keywords: ["partial", "C++/CX, partial"]
 ms.assetid: 43adf1f5-10c5-44aa-a66f-7507e2bdabf8
 ---
-# partial  (C++/CLI and C++/CX)
+# partial (C++/CLI and C++/CX)
 
 The **partial** keyword enables different parts of the same ref class to be authored independently and in different files.
 

--- a/docs/extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md
+++ b/docs/extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["lang", "cli"]
 helpviewer_keywords: ["lang namespace", "cli namespace"]
 ms.assetid: 9d38bd1e-dc78-47d1-a84b-9b4683e52c9c
 ---
-# Platform, default, and cli Namespaces  (C++/CLI and C++/CX)
+# Platform, default, and cli Namespaces (C++/CLI and C++/CX)
 
 A namespace qualifies the names of language elements so the names do not conflict with otherwise identical names elsewhere in the source code. For example, a name collision might prevent the compiler from recognizing [Context-Sensitive Keywords](context-sensitive-keywords-cpp-component-extensions.md). Namespaces are used by the compiler but are not preserved in the compiled assembly.
 

--- a/docs/extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md
+++ b/docs/extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Platform, default, and cli Namespaces  (C++/CLI and C++/CX)"
-title: "Platform, default, and cli Namespaces  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "Platform, default, and cli Namespaces (C++/CLI and C++/CX)"
+description: "Learn more about: Platform, default, and cli Namespaces (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["lang", "cli"]
 helpviewer_keywords: ["lang namespace", "cli namespace"]
-ms.assetid: 9d38bd1e-dc78-47d1-a84b-9b4683e52c9c
 ---
 # Platform, default, and cli Namespaces (C++/CLI and C++/CX)
 

--- a/docs/extensions/ref-new-gcnew-cpp-component-extensions.md
+++ b/docs/extensions/ref-new-gcnew-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["gcnew", "ref new", "gcnew_cpp"]
 helpviewer_keywords: ["ref new keyword (C++)", "gcnew keyword [C++]"]
 ms.assetid: 388a62da-c2df-4a94-a9a2-205b53e577da
 ---
-# ref new, gcnew  (C++/CLI and C++/CX)
+# ref new, gcnew (C++/CLI and C++/CX)
 
 The **ref new** aggregate keyword allocates an instance of a type that is garbage collected when the object becomes inaccessible, and that returns a handle ([^](handle-to-object-operator-hat-cpp-component-extensions.md)) to the allocated object.
 

--- a/docs/extensions/ref-new-gcnew-cpp-component-extensions.md
+++ b/docs/extensions/ref-new-gcnew-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: ref new, gcnew  (C++/CLI and C++/CX)"
-title: "ref new, gcnew  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "ref new, gcnew (C++/CLI and C++/CX)"
+description: "Learn more about: ref new, gcnew (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["gcnew", "ref new", "gcnew_cpp"]
 helpviewer_keywords: ["ref new keyword (C++)", "gcnew keyword [C++]"]
-ms.assetid: 388a62da-c2df-4a94-a9a2-205b53e577da
 ---
 # ref new, gcnew (C++/CLI and C++/CX)
 

--- a/docs/extensions/sealed-cpp-component-extensions.md
+++ b/docs/extensions/sealed-cpp-component-extensions.md
@@ -7,7 +7,7 @@ f1_keywords: ["sealed_cpp", "sealed"]
 helpviewer_keywords: ["sealed keyword [C++]"]
 ms.assetid: 3d0d688a-41aa-45f5-a25a-65c44206521e
 ---
-# sealed  (C++/CLI and C++/CX)
+# sealed (C++/CLI and C++/CX)
 
 **sealed** is a context-sensitive keyword for ref classes that indicates that a virtual member cannot be overridden, or that a type cannot be used as a base type.
 

--- a/docs/extensions/sealed-cpp-component-extensions.md
+++ b/docs/extensions/sealed-cpp-component-extensions.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: sealed  (C++/CLI and C++/CX)"
-title: "sealed  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "sealed (C++/CLI and C++/CX)"
+description: "Learn more about: sealed (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 f1_keywords: ["sealed_cpp", "sealed"]
 helpviewer_keywords: ["sealed keyword [C++]"]
-ms.assetid: 3d0d688a-41aa-45f5-a25a-65c44206521e
 ---
 # sealed (C++/CLI and C++/CX)
 

--- a/docs/extensions/string-cpp-component-extensions.md
+++ b/docs/extensions/string-cpp-component-extensions.md
@@ -1,6 +1,6 @@
 ---
-title: "String  (C++/CLI and C++/CX)"
-description: "Learn more about: String  (C++/CLI and C++/CX)"
+title: "String (C++/CLI and C++/CX)"
+description: "Learn more about: String (C++/CLI and C++/CX)"
 ms.date: 10/08/2018
 ms.topic: "reference"
 helpviewer_keywords: ["string support with /clr", "/clr compiler option [C++], string support"]

--- a/docs/extensions/string-cpp-component-extensions.md
+++ b/docs/extensions/string-cpp-component-extensions.md
@@ -5,7 +5,7 @@ ms.date: 10/08/2018
 ms.topic: "reference"
 helpviewer_keywords: ["string support with /clr", "/clr compiler option [C++], string support"]
 ---
-# String  (C++/CLI and C++/CX)
+# String (C++/CLI and C++/CX)
 
 The Windows Runtime and common language runtime represent strings as objects whose allocated memory is managed automatically. That is, you are not required to explicitly discard the memory for a string when the string variable goes out of scope or your application ends. To indicate that the lifetime of a string object is to be managed automatically, declare the string type with the [handle-to-object (^)](handle-to-object-operator-hat-cpp-component-extensions.md) modifier.
 

--- a/docs/extensions/typeid-cpp-component-extensions.md
+++ b/docs/extensions/typeid-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["typeid keyword [C++]"]
 ms.assetid: e9706cae-e7c4-4d6d-b474-646d73df3e70
 ---
-# typeid  (C++/CLI and C++/CX)
+# typeid (C++/CLI and C++/CX)
 
 Gets a value that indicates the type of an object.
 

--- a/docs/extensions/typeid-cpp-component-extensions.md
+++ b/docs/extensions/typeid-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: typeid  (C++/CLI and C++/CX)"
-title: "typeid  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "typeid (C++/CLI and C++/CX)"
+description: "Learn more about: typeid (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["typeid keyword [C++]"]
-ms.assetid: e9706cae-e7c4-4d6d-b474-646d73df3e70
 ---
 # typeid (C++/CLI and C++/CX)
 

--- a/docs/extensions/user-defined-attributes-cpp-component-extensions.md
+++ b/docs/extensions/user-defined-attributes-cpp-component-extensions.md
@@ -6,7 +6,7 @@ ms.topic: "reference"
 helpviewer_keywords: ["metadata, extending", "custom attributes, extending metadata"]
 ms.assetid: 98b29048-a3ea-4698-8441-f149cdaec9fb
 ---
-# User-Defined Attributes  (C++/CLI and C++/CX)
+# User-Defined Attributes (C++/CLI and C++/CX)
 
 C++/CLI and C++/CX enable you to create platform-specific attributes that extend the metadata of an interface, class or structure, method, parameter, or enumeration. These attributes are distinct from the [standard C++ attributes](../cpp/attributes.md).
 

--- a/docs/extensions/user-defined-attributes-cpp-component-extensions.md
+++ b/docs/extensions/user-defined-attributes-cpp-component-extensions.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: User-Defined Attributes  (C++/CLI and C++/CX)"
-title: "User-Defined Attributes  (C++/CLI and C++/CX)"
-ms.date: "10/12/2018"
+title: "User-Defined Attributes (C++/CLI and C++/CX)"
+description: "Learn more about: User-Defined Attributes (C++/CLI and C++/CX)"
+ms.date: 10/12/2018
 ms.topic: "reference"
 helpviewer_keywords: ["metadata, extending", "custom attributes, extending metadata"]
-ms.assetid: 98b29048-a3ea-4698-8441-f149cdaec9fb
 ---
 # User-Defined Attributes (C++/CLI and C++/CX)
 

--- a/docs/linux/connect-to-your-remote-linux-computer.md
+++ b/docs/linux/connect-to-your-remote-linux-computer.md
@@ -203,7 +203,7 @@ Logs include connections, all commands sent to the remote machine (their text, e
 
 You can configure the output to go to a file or to the **Cross Platform Logging** pane in the Output window. For MSBuild-based Linux projects, MSBuild commands sent to the remote machine aren't routed to the **Output Window** because they're emitted out-of-process. Instead, they're logged to a file, with a prefix of `msbuild_`.
 
-## Command-line utility for the Connection Manager  
+## Command-line utility for the Connection Manager
 
 **Visual Studio 2019 version 16.5 or later**: *`ConnectionManager.exe`* is a command-line utility to manage remote development connections outside of Visual Studio. It's useful for tasks such as provisioning a new development machine. Or, you can use it to set up Visual Studio for continuous integration. For examples and a complete reference to the `ConnectionManager` command, see [ConnectionManager reference](connectionmanager-reference.md).  
 

--- a/docs/linux/set-up-fips-compliant-secure-remote-linux-development.md
+++ b/docs/linux/set-up-fips-compliant-secure-remote-linux-development.md
@@ -128,7 +128,7 @@ You've successfully set up `ssh`, created and deployed encryption keys, and test
 
    For more information on troubleshooting your connection, see [Connect to your remote Linux computer](connect-to-your-remote-linux-computer.md).
 
-## Command-line utility for the Connection Manager  
+## Command-line utility for the Connection Manager
 
 **Visual Studio 2019 version 16.5 or later**: `ConnectionManager.exe` is a command-line utility to manage remote development connections outside of Visual Studio. It's useful for tasks such as provisioning a new development machine. Or, you can use it to set up Visual Studio for continuous integration. For examples and a complete reference to the ConnectionManager command, see [ConnectionManager reference](connectionmanager-reference.md).  
 

--- a/docs/parallel/amp/reference/runtime-exception-class.md
+++ b/docs/parallel/amp/reference/runtime-exception-class.md
@@ -82,7 +82,7 @@ The `runtime_exception` object to copy.
 
 The `runtime_exception` object.
 
-## <a name="dtor"></a>  ~runtime_exception Destructor
+## <a name="dtor"></a> ~runtime_exception Destructor
 
 Destroys the object.
 

--- a/docs/parallel/amp/reference/runtime-exception-class.md
+++ b/docs/parallel/amp/reference/runtime-exception-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: runtime_exception Class"
 title: "runtime_exception Class"
-ms.date: "03/27/2019"
+description: "Learn more about: runtime_exception Class"
+ms.date: 03/27/2019
 f1_keywords: ["runtime_exception", "AMPRT/runtime_exception", "AMPRT/Concurrency::runtime_exception", "AMPRT/Concurrency::runtime_exception::get_error_code"]
 helpviewer_keywords: ["runtime_exception class"]
-ms.assetid: 8fe3ce2c-3d4c-4b9c-95e8-e592f37adefd
 ---
 # runtime_exception Class
 

--- a/docs/parallel/concrt/how-to-use-exception-handling-to-break-from-a-parallel-loop.md
+++ b/docs/parallel/concrt/how-to-use-exception-handling-to-break-from-a-parallel-loop.md
@@ -23,7 +23,7 @@ The following example shows the `for_all` method. It uses the [concurrency::para
 
 [!code-cpp[concrt-task-tree-search#1](../../parallel/concrt/codesnippet/cpp/how-to-use-exception-handling-to-break-from-a-parallel-loop_2.cpp)]
 
-## Example:  Search the tree for a value
+## Example: Search the tree for a value
 
 The following example shows the `search_for_value` function, which searches for a value in the provided `tree` object. This function passes to the `for_all` method a work function that throws when it finds a tree node that contains the provided value.
 

--- a/docs/parallel/concrt/how-to-use-exception-handling-to-break-from-a-parallel-loop.md
+++ b/docs/parallel/concrt/how-to-use-exception-handling-to-break-from-a-parallel-loop.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: How to: Use Exception Handling to Break from a Parallel Loop"
 title: "How to: Use Exception Handling to Break from a Parallel Loop"
-ms.date: "11/04/2016"
+description: "Learn more about: How to: Use Exception Handling to Break from a Parallel Loop"
+ms.date: 11/04/2016
 helpviewer_keywords: ["search algorithm, writing [Concurrency Runtime]", "writing a search algorithm [Concurrency Runtime]"]
-ms.assetid: 16d7278c-2d10-4014-9f58-f1899e719ff9
 ---
 # How to: Use Exception Handling to Break from a Parallel Loop
 

--- a/docs/sanitizers/error-stack-buffer-underflow.md
+++ b/docs/sanitizers/error-stack-buffer-underflow.md
@@ -74,7 +74,7 @@ cl example2.cpp /fsanitize=address /Zi
 devenv /debugexe example2.exe
 ```
 
-### Resulting error  - stack underflow on thread
+### Resulting error - stack underflow on thread
 
 :::image type="content" source="media/stack-buffer-underflow-example-2.png" alt-text="Screenshot of debugger displaying stack-buffer-underflow error in example 2.":::
 

--- a/docs/standard-library/day-class.md
+++ b/docs/standard-library/day-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::day", "chrono/std::chrono::day::ok", "chrono/
 helpviewer_keywords: ["std::chrono [C++], day"]
 dev_langs: ["C++"]
 ---
-# `day` class  
+# `day` class
 
 Represents a day of the month. For example, the 25th day of the month.
 

--- a/docs/standard-library/drop-view-class.md
+++ b/docs/standard-library/drop-view-class.md
@@ -85,7 +85,7 @@ If you specify more elements to drop than exist in the underlying range, then an
 
 The best way to create a `drop_view` is by using the [`views::drop`](range-adaptors.md#drop) range adaptor. Range adaptors are the intended way to create view classes. The view types are exposed in case you want to create your own custom view type.
 
-### Example:  `drop_view`
+### Example: `drop_view`
 
 ```cpp
 // requires /std:c++20 or later

--- a/docs/standard-library/elements-view-class.md
+++ b/docs/standard-library/elements-view-class.md
@@ -95,7 +95,7 @@ The best way to create an `elements_view` is by using the [`elements`](range-ada
 1\) Create an `elements_view` from the specified view.\
 2\) Default construct an `elements_view`.
 
-### Example:  `elements_view`
+### Example: `elements_view`
 
 ```cpp
 // requires /std:c++20 or later

--- a/docs/standard-library/hash-map-operators.md
+++ b/docs/standard-library/hash-map-operators.md
@@ -211,7 +211,7 @@ The hash_multimaps hm1 and hm2 are not equal.
 The hash_multimaps hm1 and hm3 are equal.
 ```
 
-## <a name="op_eq_eq_mm"></a> operator==  (hash_multimap)
+## <a name="op_eq_eq_mm"></a> operator== (hash_multimap)
 
 > [!NOTE]
 > This API is obsolete. The alternative is [unordered_multimap Class](unordered-multimap-class.md).

--- a/docs/standard-library/keys-view-class.md
+++ b/docs/standard-library/keys-view-class.md
@@ -96,7 +96,7 @@ The best way to create an `keys_view` is by using the [`keys`](range-adaptors.md
 1\) Create a `keys_view` from the specified view.\
 2\) The default constructor creates an empty `keys_view`.
 
-### Example:  `keys_view`
+### Example: `keys_view`
 
 ```cpp
 // requires /std:c++20 or later

--- a/docs/standard-library/month-class.md
+++ b/docs/standard-library/month-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::month", "chrono/std::chrono::month::January",
 helpviewer_keywords: ["std::chrono [C++], month"]
 dev_langs: ["C++"]
 ---
-# `month` class  
+# `month` class
 
 Represents a month of a year. For example, July.
 

--- a/docs/standard-library/month-class.md
+++ b/docs/standard-library/month-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: month Class"
 title: "month class"
-ms.date: "6/25/2021"
+description: "Learn more about: month Class"
+ms.date: 6/25/2021
 f1_keywords: ["chrono/std::chrono::month", "chrono/std::chrono::month::January", "chrono/std::chrono::month::February", "chrono/std::chrono::month::March","chrono/std::chrono::month::April","chrono/std::chrono::month::May","chrono/std::chrono::month::June","chrono/std::chrono::month::July","chrono/std::chrono::month::August","chrono/std::chrono::month::September","chrono/std::chrono::month::October","chrono/std::chrono::month::November","chrono/std::chrono::month::December","chrono/std::chrono::month::operator++", "chrono/std::chrono::month::operator--", "chrono/std::chrono::month::operator unsigned", "chrono/std::chrono::month::ok"]
 helpviewer_keywords: ["std::chrono [C++], month"]
 dev_langs: ["C++"]

--- a/docs/standard-library/month-day-class.md
+++ b/docs/standard-library/month-day-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: month_day Class"
 title: "month_day class"
-ms.date: "6/28/2021"
+description: "Learn more about: month_day Class"
+ms.date: 6/28/2021
 f1_keywords: ["chrono/std::chrono::month_day", "chrono/std::chrono::month_day::day", "chrono/std::chrono::month_day::month", "chrono/std::chrono::month_day::ok"]
 helpviewer_keywords: ["std::chrono [C++], month_day"]
 dev_langs: ["C++"]

--- a/docs/standard-library/month-day-class.md
+++ b/docs/standard-library/month-day-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::chrono [C++], month_day"]
 dev_langs: ["C++"]
 ---
 
-# `month_day` class  
+# `month_day` class
 
 Represents a specific day of a specific month. The year isn't specified.
 

--- a/docs/standard-library/month-day-last-class.md
+++ b/docs/standard-library/month-day-last-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::chrono [C++], month_day_last"]
 dev_langs: ["C++"]
 ---
 
-# `month_day_last` class  
+# `month_day_last` class
 
  Represents the last day of a month.
 

--- a/docs/standard-library/month-day-last-class.md
+++ b/docs/standard-library/month-day-last-class.md
@@ -1,7 +1,7 @@
 ---
 title: "month_day_last class"
 description: "Learn more about: month_day_last Class"
-ms.date: "06/28/2021"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::month_day_last", "chrono/std::chrono::month_day_last::month", "chrono/std::chrono::month_day_last::ok"]
 helpviewer_keywords: ["std::chrono [C++], month_day_last"]
 dev_langs: ["C++"]

--- a/docs/standard-library/month-weekday-class.md
+++ b/docs/standard-library/month-weekday-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: month_weekday Class"
 title: "month_weekday class"
-ms.date: "06/28/2021"
+description: "Learn more about: month_weekday Class"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::month_weekday", "chrono/std::chrono::month_weekday::weekday", "chrono/std::chrono::month_weekday::month", "chrono/std::chrono::month_weekday::ok", "chrono/std::chrono::month_weekday::weekday_indexed"]
 helpviewer_keywords: ["std::chrono [C++], month_weekday"]
 dev_langs: ["C++"]

--- a/docs/standard-library/month-weekday-class.md
+++ b/docs/standard-library/month-weekday-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::chrono [C++], month_weekday"]
 dev_langs: ["C++"]
 ---
 
-# `month_weekday` class  
+# `month_weekday` class
 
 Represents the nth weekday of a specific month.
 

--- a/docs/standard-library/month-weekday-last-class.md
+++ b/docs/standard-library/month-weekday-last-class.md
@@ -1,7 +1,7 @@
 ---
 title: "month_weekday_last class"
 description: "Learn more about: month_weekday_last Class"
-ms.date: "6/28/2021"
+ms.date: 6/28/2021
 f1_keywords: ["chrono/std::chrono::month_weekday_last", "chrono/std::chrono::month_weekday_last::ok", "std::chrono::month_weekday_last::month_weekday_last", "chrono/std::chrono::month_weekday_last::ok", "chrono/std::chrono::month_weekday_last::month"]
 helpviewer_keywords: ["std::chrono [C++], month_weekday_last"]
 dev_langs: ["C++"]

--- a/docs/standard-library/month-weekday-last-class.md
+++ b/docs/standard-library/month-weekday-last-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::month_weekday_last", "chrono/std::chrono::mon
 helpviewer_keywords: ["std::chrono [C++], month_weekday_last"]
 dev_langs: ["C++"]
 ---
-# `month_weekday_last` class  
+# `month_weekday_last` class
 
 Represents the last weekday of a month.
 

--- a/docs/standard-library/recursive-mutex-class.md
+++ b/docs/standard-library/recursive-mutex-class.md
@@ -59,7 +59,7 @@ Constructs a `recursive_mutex` object that is not locked.
 recursive_mutex();
 ```
 
-## <a name="dtorrecursive_mutex_destructor"></a>  ~recursive_mutex
+## <a name="dtorrecursive_mutex_destructor"></a> ~recursive_mutex
 
 Releases any resources that are used by the object.
 

--- a/docs/standard-library/recursive-mutex-class.md
+++ b/docs/standard-library/recursive-mutex-class.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: recursive_mutex Class"
 title: "recursive_mutex Class"
-ms.date: "11/04/2016"
+description: "Learn more about: recursive_mutex Class"
+ms.date: 11/04/2016
 f1_keywords: ["mutex/std::recursive_mutex", "mutex/std::recursive_mutex::recursive_mutex", "mutex/std::recursive_mutex::lock", "mutex/std::recursive_mutex::try_lock", "mutex/std::recursive_mutex::unlock"]
-ms.assetid: eb5ffd1b-7e78-4559-8391-bb220ead42fc
 helpviewer_keywords: ["std::recursive_mutex [C++]", "std::recursive_mutex [C++], recursive_mutex", "std::recursive_mutex [C++], lock", "std::recursive_mutex [C++], try_lock", "std::recursive_mutex [C++], unlock"]
 ---
 # recursive_mutex Class

--- a/docs/standard-library/recursive-timed-mutex-class.md
+++ b/docs/standard-library/recursive-timed-mutex-class.md
@@ -61,7 +61,7 @@ Constructs a `recursive_timed_mutex` object that is not locked.
 recursive_timed_mutex();
 ```
 
-## <a name="dtorrecursive_timed_mutex_destructor"></a>  ~recursive_timed_mutex Destructor
+## <a name="dtorrecursive_timed_mutex_destructor"></a> ~recursive_timed_mutex Destructor
 
 Releases any resources that are used by the `recursive_timed_mutex` object.
 

--- a/docs/standard-library/recursive-timed-mutex-class.md
+++ b/docs/standard-library/recursive-timed-mutex-class.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: recursive_timed_mutex Class"
 title: "recursive_timed_mutex Class"
-ms.date: "11/04/2016"
+description: "Learn more about: recursive_timed_mutex Class"
+ms.date: 11/04/2016
 f1_keywords: ["mutex/std::recursive_timed_mutex", "mutex/std::recursive_timed_mutex::recursive_timed_mutex", "mutex/std::recursive_timed_mutex::lock", "mutex/std::recursive_timed_mutex::try_lock", "mutex/std::recursive_timed_mutex::try_lock_for", "mutex/std::recursive_timed_mutex::try_lock_until", "mutex/std::recursive_timed_mutex::unlock"]
-ms.assetid: 59cc2d5c-ed80-45f3-a0a8-05652a8ead7e
 helpviewer_keywords: ["std::recursive_timed_mutex [C++]", "std::recursive_timed_mutex [C++], recursive_timed_mutex", "std::recursive_timed_mutex [C++], lock", "std::recursive_timed_mutex [C++], try_lock", "std::recursive_timed_mutex [C++], try_lock_for", "std::recursive_timed_mutex [C++], try_lock_until", "std::recursive_timed_mutex [C++], unlock"]
 ---
 # recursive_timed_mutex Class

--- a/docs/standard-library/unique-lock-class.md
+++ b/docs/standard-library/unique-lock-class.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: unique_lock Class"
 title: "unique_lock Class"
+description: "Learn more about: unique_lock Class"
 ms.date: 06/20/2022
 f1_keywords: ["mutex/std::unique_lock"]
-ms.assetid: f4ed8ba9-c8af-446f-8ef0-0b356bad14bd
 ms.custom: devdivchpfy22
 ---
 

--- a/docs/standard-library/unique-lock-class.md
+++ b/docs/standard-library/unique-lock-class.md
@@ -298,7 +298,7 @@ The remaining constructors store & *Mtx* as the stored `mutex` pointer. Ownershi
 |`Rel_time`|Ownership is determined by calling `try_lock_for(Rel_time)`.|
 |`Abs_time`|Ownership is determined by calling `try_lock_until(Abs_time)`.|
 
-## <a name="dtorunique_lock_destructor"></a>  ~unique_lock Destructor
+## <a name="dtorunique_lock_destructor"></a> ~unique_lock Destructor
 
 Releases any resources that are associated with the `unique_lock` object.
 

--- a/docs/standard-library/weekday-class.md
+++ b/docs/standard-library/weekday-class.md
@@ -5,7 +5,7 @@ ms.date: "6/25/2021"
 f1_keywords: ["chrono/std::chrono::weekday", "chrono/std::chrono::weekday::January", "chrono/std::chrono::weekday::February", "chrono/std::chrono::weekday::March","chrono/std::chrono::weekday::April","chrono/std::chrono::weekday::May","chrono/std::chrono::weekday::June","chrono/std::chrono::weekday::July","chrono/std::chrono::weekday::August","chrono/std::chrono::weekday::September","chrono/std::chrono::weekday::October","chrono/std::chrono::weekday::November","chrono/std::chrono::weekday::December","chrono/std::chrono::weekday::operator++", "chrono/std::chrono::weekday::operator--", "chrono/std::chrono::weekday::operator unsigned", "chrono/std::chrono::weekday::ok", "chrono/std::chrono::weekday::iso_encoding", "chrono/std::chrono::weekday::c_encoding"]
 helpviewer_keywords: ["std::chrono [C++], weekday"]
 ---
-# `weekday` class  
+# `weekday` class
 
 Represents a day of the week in the [Gregorian calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar). For example, Tuesday.
 

--- a/docs/standard-library/weekday-class.md
+++ b/docs/standard-library/weekday-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: weekday Class"
 title: "weekday class"
-ms.date: "6/25/2021"
+description: "Learn more about: weekday Class"
+ms.date: 6/25/2021
 f1_keywords: ["chrono/std::chrono::weekday", "chrono/std::chrono::weekday::January", "chrono/std::chrono::weekday::February", "chrono/std::chrono::weekday::March","chrono/std::chrono::weekday::April","chrono/std::chrono::weekday::May","chrono/std::chrono::weekday::June","chrono/std::chrono::weekday::July","chrono/std::chrono::weekday::August","chrono/std::chrono::weekday::September","chrono/std::chrono::weekday::October","chrono/std::chrono::weekday::November","chrono/std::chrono::weekday::December","chrono/std::chrono::weekday::operator++", "chrono/std::chrono::weekday::operator--", "chrono/std::chrono::weekday::operator unsigned", "chrono/std::chrono::weekday::ok", "chrono/std::chrono::weekday::iso_encoding", "chrono/std::chrono::weekday::c_encoding"]
 helpviewer_keywords: ["std::chrono [C++], weekday"]
 ---

--- a/docs/standard-library/weekdayindexed-class.md
+++ b/docs/standard-library/weekdayindexed-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: weekday_indexed Class"
 title: "weekday_indexed class"
-ms.date: "06/25/2021"
+description: "Learn more about: weekday_indexed Class"
+ms.date: 06/25/2021
 f1_keywords: ["chrono/std::chrono::weekday_indexed", "chrono/std::chrono::weekday_indexed::ok", "std::chrono::weekday_indexed::weekday", "std::chrono::weekday_indexed::ok"]
 helpviewer_keywords: ["std::chrono [C++], weekday_indexed"]
 ---

--- a/docs/standard-library/weekdayindexed-class.md
+++ b/docs/standard-library/weekdayindexed-class.md
@@ -5,7 +5,7 @@ ms.date: "06/25/2021"
 f1_keywords: ["chrono/std::chrono::weekday_indexed", "chrono/std::chrono::weekday_indexed::ok", "std::chrono::weekday_indexed::weekday", "std::chrono::weekday_indexed::ok"]
 helpviewer_keywords: ["std::chrono [C++], weekday_indexed"]
 ---
-# `weekday_indexed` class  
+# `weekday_indexed` class
 
 Combines a weekday, representing a day of the week in the Gregorian calendar, with an index in the range [1, 5] that represents the weekday of the month (1st, 2nd, 3rd, and so on).
 

--- a/docs/standard-library/weekdaylast-class.md
+++ b/docs/standard-library/weekdaylast-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::weekday_last", "chrono/std::chrono::weekday_l
 helpviewer_keywords: ["std::chrono [C++], weekday_last"]
 ---
 
-# `weekday_last` class  
+# `weekday_last` class
 
 Represents the last weekday of a month.
 

--- a/docs/standard-library/weekdaylast-class.md
+++ b/docs/standard-library/weekdaylast-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: weekday_last Class"
 title: "weekday_last class"
-ms.date: "06/28/2021"
+description: "Learn more about: weekday_last Class"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::weekday_last", "chrono/std::chrono::weekday_last::ok", "std::chrono::weekday_last::weekday", "chrono/std::chrono::weekday_last::ok", "chrono/std::chrono::weekday_last::weekday"]
 helpviewer_keywords: ["std::chrono [C++], weekday_last"]
 ---

--- a/docs/standard-library/year-class.md
+++ b/docs/standard-library/year-class.md
@@ -5,7 +5,7 @@ ms.date: "06/28/2021"
 f1_keywords: ["chrono/std::chrono::year", "chrono/std::chrono::year::operator++", "chrono/std::chrono::year::operator--", "chrono/std::chrono::year::operator+=", "chrono/std::chrono::year::operator-=", "chrono/std::chrono::year::operator int", "chrono/std::chrono::year::is_leap", "chrono/std::chrono::year::max", "chrono/std::chrono::min", "chrono/std::chrono::year::ok"]
 helpviewer_keywords: ["std::chrono [C++], year"]
 ---
-# `year` class  
+# `year` class
 
 Represents a year in the [Gregorian calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar).
 

--- a/docs/standard-library/year-class.md
+++ b/docs/standard-library/year-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: year Class"
 title: "year class"
-ms.date: "06/28/2021"
+description: "Learn more about: year Class"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::year", "chrono/std::chrono::year::operator++", "chrono/std::chrono::year::operator--", "chrono/std::chrono::year::operator+=", "chrono/std::chrono::year::operator-=", "chrono/std::chrono::year::operator int", "chrono/std::chrono::year::is_leap", "chrono/std::chrono::year::max", "chrono/std::chrono::min", "chrono/std::chrono::year::ok"]
 helpviewer_keywords: ["std::chrono [C++], year"]
 ---

--- a/docs/standard-library/year-month-class.md
+++ b/docs/standard-library/year-month-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::year_month", "chrono/std::chrono::year_month:
 helpviewer_keywords: ["std::chrono [C++], year_month"]
 dev_langs: ["C++"]
 ---
-# `year_month` class  
+# `year_month` class
 
 Represents a month and year. The day isn't specified.
 

--- a/docs/standard-library/year-month-class.md
+++ b/docs/standard-library/year-month-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: year_month class"
 title: "year_month class"
-ms.date: "06/28/2021"
+description: "Learn more about: year_month class"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::year_month", "chrono/std::chrono::year_month::operator+=", "chrono/std::chrono::year_month::operator-=", "chrono/std::chrono::year_month::ok"]
 helpviewer_keywords: ["std::chrono [C++], year_month"]
 dev_langs: ["C++"]

--- a/docs/standard-library/year-month-day-class.md
+++ b/docs/standard-library/year-month-day-class.md
@@ -1,7 +1,7 @@
 ---
 title: "year_month_day class"
 description: "Learn more about: year_month_day class"
-ms.date: "06/28/2021"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::year_month_day", "chrono/std::chrono::year::operator+=", "chrono/std::chrono::year::operator-=", "chrono/std::chrono::year::sysdays", "chrono/std::chrono::year::localdays", "chrono/std::chrono::year::ok"]
 helpviewer_keywords: ["std::chrono [C++], year_month_day"]
 ---

--- a/docs/standard-library/year-month-day-class.md
+++ b/docs/standard-library/year-month-day-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::year_month_day", "chrono/std::chrono::year::o
 helpviewer_keywords: ["std::chrono [C++], year_month_day"]
 ---
 
-# `year_month_day` class  
+# `year_month_day` class
 
 Represents a month, year, and day.
 

--- a/docs/standard-library/year-month-day-last-class.md
+++ b/docs/standard-library/year-month-day-last-class.md
@@ -6,7 +6,7 @@ f1_keywords: ["chrono/std::chrono::year_month_day_last", "chrono/std::chrono::ye
 helpviewer_keywords: ["std::chrono [C++], year_month_day_last"]
 dev_langs: ["C++"]
 ---
-# `year_month_day_last` class  
+# `year_month_day_last` class
 
  Represents the last day of a specific year and month.
 

--- a/docs/standard-library/year-month-day-last-class.md
+++ b/docs/standard-library/year-month-day-last-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: year_month_day_last class"
 title: "year_month_day_last class"
-ms.date: "06/28/2021"
+description: "Learn more about: year_month_day_last class"
+ms.date: 06/28/2021
 f1_keywords: ["chrono/std::chrono::year_month_day_last", "chrono/std::chrono::year_month_day_last::operator+=", "chrono/std::chrono::year_month_day_last::operator-=", "chrono/std::chrono::year_month_day_last::sysdays", "chrono/std::chrono::year_month_day_last::local_days", "chrono/std::chrono::year_month_day_last::day", "chrono/std::chrono::year_month_day_last::year", "chrono/std::chrono::year_month_day_last::ok"]
 helpviewer_keywords: ["std::chrono [C++], year_month_day_last"]
 dev_langs: ["C++"]

--- a/docs/standard-library/year-month-weekday-class.md
+++ b/docs/standard-library/year-month-weekday-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::chrono [C++], year_month_weekday"]
 dev_langs: ["C++"]
 ---
 
-# `year_month_weekday` class  
+# `year_month_weekday` class
 
 Represents a specific year, month, and nth weekday of the month.
 

--- a/docs/standard-library/year-month-weekday-last-class.md
+++ b/docs/standard-library/year-month-weekday-last-class.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: year_month_weekday_last class"
 title: "year_month_weekday_last class"
-ms.date: "06/30/2021"
+description: "Learn more about: year_month_weekday_last class"
+ms.date: 06/30/2021
 f1_keywords: ["chrono/std::chrono::year_month_weekday_last", "chrono/std::chrono::year_month_weekday_last::month", "chrono/std::chrono::year_month_weekday_last::year", "chrono/std::chrono::year_month_weekday_last::weekday", "chrono/std::chrono::year_month_weekday_last::weekday_last", "chrono/std::chrono::year_month_weekday_last::sys_days", "chrono/std::chrono::year_month_weekday_last::local_days", "chrono/std::chrono::year_month_weekday_last::ok", "chrono/std::chrono::year_month_weekday_last::operator+=", "chrono/std::chrono::year_month_weekday_last::operator-=", "chrono/std::chrono::year_month_weekday_last::operator local_days", "chrono/std::chrono::year_month_weekday_last::operator sys_days"]
 helpviewer_keywords: ["std::chrono [C++], year_month_weekday_last"]
 dev_langs: ["C++"]

--- a/docs/standard-library/year-month-weekday-last-class.md
+++ b/docs/standard-library/year-month-weekday-last-class.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["std::chrono [C++], year_month_weekday_last"]
 dev_langs: ["C++"]
 ---
 
-# `year_month_weekday_last` class  
+# `year_month_weekday_last` class
 
 A specific year, month, and last weekday of the month.
 

--- a/docs/windows/latest-supported-vc-redist.md
+++ b/docs/windows/latest-supported-vc-redist.md
@@ -55,7 +55,7 @@ Download other versions, including long term servicing release channel (LTSC) ve
 
 - The Visual C++ Redistributable supports several command-line options. For more information, see [Command-line options for the Redistributable packages](./redistributing-visual-cpp-files.md#command-line-options-for-the-redistributable-packages).
 
-## Visual Studio 2013 (VC++ 12.0)  (no longer supported)
+## Visual Studio 2013 (VC++ 12.0) (no longer supported)
 
 These links download the latest available en-US Microsoft Visual C++ Redistributable packages for Visual Studio 2013.
 You can download other versions and languages from [Update for Visual C++ 2013 Redistributable Package](https://support.microsoft.com/topic/update-for-visual-c-2013-redistributable-package-d8ccd6a5-4e26-c290-517b-8da6cfdf4f10) or from [my.visualstudio.com](https://my.visualstudio.com/).
@@ -70,7 +70,7 @@ You can download other versions and languages from [Update for Visual C++ 2013 R
 - [Multibyte MFC Library for Visual Studio 2013](https://my.visualstudio.com/Downloads?pid=1430). This MFC add-on for Visual Studio 2013 contains the multibyte character set (MBCS) version of the Microsoft Foundation Class (MFC) Library.
 - [Visual C++ 2013 Runtime for Sideloaded Windows 8.1 apps](https://download.microsoft.com/download/5/f/0/5f0f8404-9329-44a9-8176-ed6f7f746f25/vclibs_redist_packages.zip). For more information, see [C++ Runtime for Sideloaded Windows 8.1 apps](https://devblogs.microsoft.com/cppblog/c-runtime-for-sideloaded-windows-8-1-apps/) on the C++ Team Blog.
 
-## Visual Studio 2012 (VC++ 11.0) Update 4  (no longer supported)
+## Visual Studio 2012 (VC++ 11.0) Update 4 (no longer supported)
 
 > [!NOTE]
 > Visual Studio 2012 [reached end of extended support on Jan 10, 2023](/lifecycle/products/visual-studio-2012)


### PR DESCRIPTION
Trim excess leading, middle, and trailing space in headings.