### PR TITLE
Improve "Function Objects in the C++ Standard Library" article

### DIFF
--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Function Objects in the C++ Standard Library"
 title: "Function Objects in the C++ Standard Library"
-ms.date: "03/15/2019"
+description: "Learn more about: Function Objects in the C++ Standard Library"
+ms.date: 06/22/2025
 helpviewer_keywords: ["functors", "C++ Standard Library, functors", "C++ Standard Library, function objects", "function objects"]
-ms.assetid: 85f8a735-2c7b-4f10-9c4d-95c666ec4192
 ---
 # Function Objects in the C++ Standard Library
 

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -7,13 +7,13 @@ ms.assetid: 85f8a735-2c7b-4f10-9c4d-95c666ec4192
 ---
 # Function Objects in the C++ Standard Library
 
-A *function object*, or *functor*, is any type that implements operator(). This operator is referred to as the *call operator* or sometimes the *application operator*. The C++ Standard Library uses function objects primarily as sorting criteria for containers and in algorithms.
+A *function object*, or *functor*, is any type that implements `operator()`. This operator is referred to as the *call operator* or sometimes the *application operator*. The C++ Standard Library uses function objects primarily as sorting criteria for containers and in algorithms.
 
 Function objects provide two main advantages over a straight function call. The first is that a function object can contain state. The second is that a function object is a type and therefore can be used as a template parameter.
 
 ## Creating a Function Object
 
-To create a function object, create a type and implement operator(), such as:
+To create a function object, create a type and implement `operator()`, such as:
 
 ```cpp
 class Functor
@@ -34,7 +34,7 @@ int main()
 }
 ```
 
-The last line of the `main` function shows how you call the function object. This call looks like a call to a function, but it's actually calling operator() of the Functor type. This similarity between calling a function object and a function is how the term function object came about.
+The last line of the `main` function shows how you call the function object. This call looks like a call to a function, but it's actually calling `operator()` of the `Functor` type. This similarity between calling a function object and a function is how the term function object came about.
 
 ## Function Objects and Containers
 

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -38,7 +38,7 @@ The last line of the `main` function shows how you call the function object. Thi
 
 ## Function Objects and Containers
 
-The C++ Standard Library contains several function objects in the [`<functional>`](../standard-library/functional.md) header file. One use of these function objects is as a sorting criterion for containers. For example, the `set` container is declared as follows:
+The C++ Standard Library contains several function objects in the [`<functional>`](functional.md) header file. One use of these function objects is as a sorting criterion for containers. For example, the `set` container is declared as follows:
 
 ```cpp
 template <class Key,
@@ -61,8 +61,8 @@ ForwardIterator remove_if(
     Predicate pred);
 ```
 
-The last argument to `remove_if` is a function object that returns a boolean value (a *predicate*). If the result of the function object is **`true`**, then the element is shifted such that it's beyond the new end returned by `remove_if`. You can use any of the function objects declared in the [`<functional>`](../standard-library/functional.md) header for the argument `pred` or you can create your own.
+The last argument to `remove_if` is a function object that returns a boolean value (a *predicate*). If the result of the function object is **`true`**, then the element is shifted such that it's beyond the new end returned by `remove_if`. You can use any of the function objects declared in the [`<functional>`](functional.md) header for the argument `pred` or you can create your own.
 
 ## See also
 
-[C++ Standard Library Reference](../standard-library/cpp-standard-library-reference.md)
+[C++ Standard Library Reference](cpp-standard-library-reference.md)

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -16,10 +16,10 @@ Function objects provide two main advantages over a regular function call. The f
 To create a function object, create a type and implement `operator()`, such as:
 
 ```cpp
-class Functor
+class LessThanFunctor
 {
 public:
-    int operator()(int a, int b)
+    bool operator()(int a, int b)
     {
         return a < b;
     }
@@ -27,14 +27,14 @@ public:
 
 int main()
 {
-    Functor f;
+    LessThanFunctor less_than;
     int a = 5;
     int b = 7;
-    int ans = f(a, b);
+    bool ans = less_than(a, b);
 }
 ```
 
-The last line of the `main` function shows how you call the function object. This call looks like a call to a function, but it's actually calling `operator()` of the `Functor` type. This similarity between calling a function object and a function is how the term function object came about.
+The last line of the `main` function shows how you call the function object. This call looks like a call to a function, but it's actually calling `operator()` of the `LessThanFunctor` type. This similarity between calling a function object and a function is how the term function object came about.
 
 ## Function Objects and Containers
 

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -9,7 +9,7 @@ ms.assetid: 85f8a735-2c7b-4f10-9c4d-95c666ec4192
 
 A *function object*, or *functor*, is any type that implements `operator()`. This operator is referred to as the *call operator* or sometimes the *application operator*. The C++ Standard Library uses function objects primarily as sorting criteria for containers and in algorithms.
 
-Function objects provide two main advantages over a straight function call. The first is that a function object can contain state. The second is that a function object is a type and therefore can be used as a template parameter.
+Function objects provide two main advantages over a regular function call. The first is that a function object can contain state. The second is that a function object is a type and therefore can be used as a template parameter.
 
 ## Creating a Function Object
 
@@ -51,7 +51,7 @@ The second template argument is the function object `less`. This function object
 
 ## Function Objects and Algorithms
 
-Another use of functional objects is in algorithms. For example, the `remove_if` algorithm is declared as follows:
+Another use of function objects is in algorithms. For example, the `remove_if` algorithm is declared as follows:
 
 ```cpp
 template <class ForwardIterator, class Predicate>
@@ -61,7 +61,7 @@ ForwardIterator remove_if(
     Predicate pred);
 ```
 
-The last argument to `remove_if` is a function object that returns a boolean value (a *predicate*). If the result of the function object is **`true`**, then the element is removed from the container being accessed by the iterators `first` and `last`. You can use any of the function objects declared in the [`<functional>`](../standard-library/functional.md) header for the argument `pred` or you can create your own.
+The last argument to `remove_if` is a function object that returns a boolean value (a *predicate*). If the result of the function object is **`true`**, then the element is shifted such that it's beyond the new end returned by `remove_if`. You can use any of the function objects declared in the [`<functional>`](../standard-library/functional.md) header for the argument `pred` or you can create your own.
 
 ## See also
 

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -42,9 +42,9 @@ The C++ Standard Library contains several function objects in the [`<functional>
 
 ```cpp
 template <class Key,
-    class Traits=less<Key>,
-    class Allocator=allocator<Key>>
-class set
+    class Compare = std::less<Key>,
+    class Allocator = std::allocator<Key>>
+class set;
 ```
 
 The second template argument is the function object [`less`](less-struct.md). This function object returns **`true`** if the first parameter is less than the second parameter. Since some containers sort their elements, the container needs a way of comparing two elements. The comparison is done by using the function object. You can define your own sorting criteria for containers by creating a function object and specifying it in the template list for the container.
@@ -54,11 +54,11 @@ The second template argument is the function object [`less`](less-struct.md). Th
 Another use of function objects is in algorithms. For example, the [`remove_if`](algorithm-functions.md#remove_if) algorithm is declared as follows:
 
 ```cpp
-template <class ForwardIterator, class Predicate>
+template <class ForwardIterator, class UnaryPredicate>
 ForwardIterator remove_if(
     ForwardIterator first,
     ForwardIterator last,
-    Predicate pred);
+    UnaryPredicate pred);
 ```
 
 The last argument to `remove_if` is a function object that returns a boolean value (a *predicate*). If the result of the function object is **`true`**, then the element is shifted such that it's beyond the new end returned by `remove_if`. You can use any of the function objects declared in the [`<functional>`](functional.md) header for the argument `pred` or you can create your own.

--- a/docs/standard-library/function-objects-in-the-stl.md
+++ b/docs/standard-library/function-objects-in-the-stl.md
@@ -38,7 +38,7 @@ The last line of the `main` function shows how you call the function object. Thi
 
 ## Function Objects and Containers
 
-The C++ Standard Library contains several function objects in the [`<functional>`](functional.md) header file. One use of these function objects is as a sorting criterion for containers. For example, the `set` container is declared as follows:
+The C++ Standard Library contains several function objects in the [`<functional>`](functional.md) header file. One use of these function objects is as a sorting criterion for containers. For example, the [`set`](set-class.md) container is declared as follows:
 
 ```cpp
 template <class Key,
@@ -47,11 +47,11 @@ template <class Key,
 class set
 ```
 
-The second template argument is the function object `less`. This function object returns **`true`** if the first parameter is less than the second parameter. Since some containers sort their elements, the container needs a way of comparing two elements. The comparison is done by using the function object. You can define your own sorting criteria for containers by creating a function object and specifying it in the template list for the container.
+The second template argument is the function object [`less`](less-struct.md). This function object returns **`true`** if the first parameter is less than the second parameter. Since some containers sort their elements, the container needs a way of comparing two elements. The comparison is done by using the function object. You can define your own sorting criteria for containers by creating a function object and specifying it in the template list for the container.
 
 ## Function Objects and Algorithms
 
-Another use of function objects is in algorithms. For example, the `remove_if` algorithm is declared as follows:
+Another use of function objects is in algorithms. For example, the [`remove_if`](algorithm-functions.md#remove_if) algorithm is declared as follows:
 
 ```cpp
 template <class ForwardIterator, class Predicate>


### PR DESCRIPTION
- Bunch of cleanups and simple improvements
- Improve "Creating a Function Object" example:
  - `operator()` should return a `bool` since it's doing `<` comparisons
  - Use more descriptive names for clarity
- Update the syntax for `set` and `remove_if`
- Attempt to clarify that `remove_if` doesn't actually remove items from the container