### PR TITLE
Update "C++ standard library header files" topic

### DIFF
--- a/docs/standard-library/cpp-standard-library-header-files.md
+++ b/docs/standard-library/cpp-standard-library-header-files.md
@@ -1,7 +1,7 @@
 ---
 title: "C++ standard library header files"
 description: "C++ standard library header files, categorized"
-ms.date: 06/22/2025
+ms.date: 03/05/2026
 helpviewer_keywords: ["header files, C++ Standard Library", "C++ Standard Library, header files"]
 ---
 # C++ standard library header files
@@ -18,25 +18,25 @@ Header files for the C++ standard library and extensions, by category.
 | Atomic operations |  [`<atomic>`](atomic.md)<sup>11</sup> |
 | C library wrappers | [`<cassert>`](cassert.md), [`<ccomplex>`](ccomplex.md)<sup>11 a b</sup>, [`<cctype>`](cctype.md), [`<cerrno>`](cerrno.md), [`<cfenv>`](cfenv.md)<sup>11</sup>, [`<cfloat>`](cfloat.md), [`<cinttypes>`](cinttypes.md)<sup>11</sup>, [`<ciso646>`](ciso646.md)<sup>b</sup>, [`<climits>`](climits.md), [`<clocale>`](clocale.md), [`<cmath>`](cmath.md), [`<csetjmp>`](csetjmp.md), [`<csignal>`](csignal.md), [`<cstdalign>`](cstdalign.md)<sup>11 a b</sup>, [`<cstdarg>`](cstdarg.md), [`<cstdbool>`](cstdbool.md)<sup>11 a b</sup>, [`<cstddef>`](cstddef.md), [`<cstdint>`](cstdint.md)<sup>11</sup>, [`<cstdio>`](cstdio.md), [`<cstdlib>`](cstdlib.md), [`<cstring>`](cstring.md), [`<ctgmath>`](ctgmath.md)<sup>11 a b</sup>, [`<ctime>`](ctime.md), [`<cuchar>`](cuchar.md)<sup>11</sup>, [`<cwchar>`](cwchar.md), [`<cwctype>`](cwctype.md) |
 | Concepts | `<concepts>`<sup>20</sup> |
-| [Containers](stl-containers.md) | `<hive>`<sup>26</sup> |
-| Sequence containers | [`<array>`](array.md)<sup>11</sup>, [`<deque>`](deque.md), [`<forward_list>`](forward-list.md)<sup>11</sup>, `<inplace_vector>`<sup>26</sup>, [`<list>`](list.md), [`<vector>`](vector.md) |
+| [Containers](stl-containers.md) | |
+| Sequence containers | [`<array>`](array.md)<sup>11</sup>, [`<deque>`](deque.md), [`<forward_list>`](forward-list.md)<sup>11</sup>, [`<list>`](list.md), [`<vector>`](vector.md) |
 | Ordered associative containers| [`<map>`](map.md), [`<set>`](set.md) |
 | Unordered associative containers | [`<unordered_map>`](unordered-map.md)<sup>11</sup>, [`<unordered_set>`](unordered-set.md)<sup>11</sup> |
-| Container adaptors | `<flat_map>`<sup>23</sup>, `<flat_set>`<sup>23</sup>, [`<queue>`](queue.md), [`<stack>`](stack.md) |
+| Container adaptors | [`<queue>`](queue.md), [`<stack>`](stack.md) |
 | Container views | `<mdspan>`<sup>23</sup>, [`<span>`](span.md)<sup>20</sup> |
-| Diagnostics | `<debugging>`<sup>26</sup>, `<stacktrace>`<sup>23</sup> |
+| Diagnostics | `<stacktrace>`<sup>23</sup> |
 | [Errors and exception handling](../cpp/errors-and-exception-handling-modern-cpp.md) | [`<cassert>`](cassert.md), [`<exception>`](exception.md), [`<stdexcept>`](stdexcept.md), [`<system_error>`](system-error.md)<sup>11</sup> |
 | General utilities | [`<any>`](any.md)<sup>17</sup>, [`<bit>`](bit.md)<sup>20</sup>, [`<bitset>`](bitset.md), [`<cstdlib>`](cstdlib.md), [`<execution>`](execution.md)<sup>17</sup>, `<expected>`<sup>23</sup>, [`<functional>`](functional.md), [`<memory>`](memory.md), [`<memory_resource>`](memory-resource.md)<sup>17</sup>, [`<optional>`](optional.md)<sup>17</sup>, [`<ratio>`](ratio.md)<sup>11</sup>, [`<scoped_allocator>`](scoped-allocator.md)<sup>11</sup>, [`<tuple>`](tuple.md)<sup>11</sup>, [`<type_traits>`](type-traits.md)<sup>11</sup>, [`<typeindex>`](typeindex.md)<sup>11</sup>, [`<utility>`](utility.md), [`<variant>`](variant.md)<sup>17</sup> |
 | [I/O and formatting](../text/string-and-i-o-formatting-modern-cpp.md) | [`<cinttypes>`](cinttypes.md)<sup>11</sup>, [`<cstdio>`](cstdio.md), [`<filesystem>`](filesystem.md)<sup>17</sup>, `<format>`<sup>20</sup>, [`<fstream>`](fstream.md), [`<iomanip>`](iomanip.md), [`<ios>`](ios.md), [`<iosfwd>`](iosfwd.md), [`<iostream>`](iostream.md), [`<istream>`](istream.md), [`<ostream>`](ostream.md), `<print>`<sup>23</sup>, `<spanstream>`<sup>23</sup>, [`<sstream>`](sstream.md), [`<streambuf>`](streambuf.md), [`<strstream>`](strstream.md)<sup>c</sup>, `<syncstream>`<sup>20</sup> |
 | Iterators | [`<iterator>`](iterator.md) |
-| Language support | [`<cfloat>`](cfloat.md), [`<climits>`](climits.md), [`<codecvt>`](codecvt.md)<sup>11 a</sup>, `<compare>`<sup>20</sup>, `<contracts>`<sup>26</sup>, `<coroutine>`<sup>20</sup>, [`<csetjmp>`](csetjmp.md), [`<csignal>`](csignal.md), [`<cstdarg>`](cstdarg.md), [`<cstddef>`](cstddef.md), [`<cstdint>`](cstdint.md)<sup>11</sup>, [`<cstdlib>`](cstdlib.md), [`<exception>`](exception.md), [`<initializer_list>`](initializer-list.md)<sup>11</sup>, [`<limits>`](limits.md), [`<new>`](new.md), `<source_location>`<sup>20</sup>, `<stdfloat>`<sup>23</sup>, [`<typeinfo>`](typeinfo.md), `<version>`<sup>20</sup> |
+| Language support | [`<cfloat>`](cfloat.md), [`<climits>`](climits.md), [`<codecvt>`](codecvt.md)<sup>11 a</sup>, `<compare>`<sup>20</sup>, `<coroutine>`<sup>20</sup>, [`<csetjmp>`](csetjmp.md), [`<csignal>`](csignal.md), [`<cstdarg>`](cstdarg.md), [`<cstddef>`](cstddef.md), [`<cstdint>`](cstdint.md)<sup>11</sup>, [`<cstdlib>`](cstdlib.md), [`<exception>`](exception.md), [`<initializer_list>`](initializer-list.md)<sup>11</sup>, [`<limits>`](limits.md), [`<new>`](new.md), `<source_location>`<sup>20</sup>, `<stdfloat>`<sup>23</sup>, [`<typeinfo>`](typeinfo.md), `<version>`<sup>20</sup> |
 | Localization | [`<clocale>`](clocale.md), [`<codecvt>`](codecvt.md)<sup>11 a</sup>, [`<cvt/wbuffer>`](cvt-wbuffer.md), [`<cvt/wstring>`](cvt-wstring.md), [`<locale>`](locale.md) |
-| Math and numerics | [`<bit>`](bit.md)<sup>20</sup>, [`<cfenv>`](cfenv.md)<sup>11</sup>, [`<cmath>`](cmath.md), [`<complex>`](complex.md), [`<cstdlib>`](cstdlib.md), [`<limits>`](limits.md), `<linalg>`<sup>26</sup>, `<numbers>`<sup>20</sup>, [`<numeric>`](numeric.md), [`<random>`](random.md)<sup>11</sup>, [`<ratio>`](ratio.md)<sup>11</sup>, `<simd>`<sup>26</sup>, [`<valarray>`](valarray.md) |
-| [Memory management](../cpp/smart-pointers-modern-cpp.md) | [`<allocators>`](allocators-header.md), `<hazard_pointer>`<sup>26</sup>, [`<memory>`](memory.md), [`<memory_resource>`](memory-resource.md)<sup>17</sup>, [`<new>`](new.md), [`<scoped_allocator>`](scoped-allocator.md)<sup>11</sup> |
-| Multithreading | [`<atomic>`](atomic.md)<sup>11</sup>, `<barrier>`<sup>20</sup>, [`<condition_variable>`](condition-variable.md)<sup>11</sup>, [`<future>`](future.md)<sup>11</sup>, `<latch>`<sup>20</sup>, [`<mutex>`](mutex.md)<sup>11</sup>, `<rcu>`<sup>26</sup>, `<semaphore>`<sup>20</sup>, [`<shared_mutex>`](shared-mutex.md)<sup>14</sup>, `<stop_token>`<sup>20</sup>, [`<thread>`](thread.md)<sup>11</sup> |
+| Math and numerics | [`<bit>`](bit.md)<sup>20</sup>, [`<cfenv>`](cfenv.md)<sup>11</sup>, [`<cmath>`](cmath.md), [`<complex>`](complex.md), [`<cstdlib>`](cstdlib.md), [`<limits>`](limits.md), `<numbers>`<sup>20</sup>, [`<numeric>`](numeric.md), [`<random>`](random.md)<sup>11</sup>, [`<ratio>`](ratio.md)<sup>11</sup>, [`<valarray>`](valarray.md) |
+| [Memory management](../cpp/smart-pointers-modern-cpp.md) | [`<allocators>`](allocators-header.md), [`<memory>`](memory.md), [`<memory_resource>`](memory-resource.md)<sup>17</sup>, [`<new>`](new.md), [`<scoped_allocator>`](scoped-allocator.md)<sup>11</sup> |
+| Multithreading | [`<atomic>`](atomic.md)<sup>11</sup>, `<barrier>`<sup>20</sup>, [`<condition_variable>`](condition-variable.md)<sup>11</sup>, [`<future>`](future.md)<sup>11</sup>, `<latch>`<sup>20</sup>, [`<mutex>`](mutex.md)<sup>11</sup>, `<semaphore>`<sup>20</sup>, [`<shared_mutex>`](shared-mutex.md)<sup>14</sup>, `<stop_token>`<sup>20</sup>, [`<thread>`](thread.md)<sup>11</sup> |
 | Ranges | `<generator>`<sup>23</sup>, [`<ranges>`](ranges.md)<sup>20</sup> |
 | Regular expressions | [`<regex>`](regex.md)<sup>11</sup> |
-| Strings and character data | [`<charconv>`](charconv.md)<sup>17</sup>, [`<cctype>`](cctype.md), [`<cstdlib>`](cstdlib.md), [`<cstring>`](cstring.md), [`<cuchar>`](cuchar.md)<sup>11</sup>, [`<cwchar>`](cwchar.md), [`<cwctype>`](cwctype.md), [`<regex>`](regex.md)<sup>11</sup>, [`<string>`](string.md), [`<string_view>`](string-view.md)<sup>17</sup>, `<text_encoding>`<sup>26</sup> |
+| Strings and character data | [`<charconv>`](charconv.md)<sup>17</sup>, [`<cctype>`](cctype.md), [`<cstdlib>`](cstdlib.md), [`<cstring>`](cstring.md), [`<cuchar>`](cuchar.md)<sup>11</sup>, [`<cwchar>`](cwchar.md), [`<cwctype>`](cwctype.md), [`<regex>`](regex.md)<sup>11</sup>, [`<string>`](string.md), [`<string_view>`](string-view.md)<sup>17</sup> |
 | Time | [`<chrono>`](chrono.md)<sup>11</sup>, [`<ctime>`](ctime.md) |
 
 <sup>11</sup> Added in the C++11 standard.\
@@ -44,7 +44,6 @@ Header files for the C++ standard library and extensions, by category.
 <sup>17</sup> Added in the C++17 standard.\
 <sup>20</sup> Added in the C++20 standard.\
 <sup>23</sup> Added in the C++23 standard.\
-<sup>26</sup> Added in the draft C++26 standard.\
 <sup>a</sup> Deprecated in the C++17 standard.\
 <sup>b</sup> Removed in the C++20 standard.\
 <sup>c</sup> Deprecated in the C++98 standard.


### PR DESCRIPTION
I didn't add the new headers to the `msvc-140` table, since it's very different from the top one, and I don't think there is much value in maintaining a custom table for an old version like VS2015. I have thoughts on removing the `msvc-140` table and cleaning up the moniker range thing we currently have. What do you think @TylerMSFT?

Edit: I now see that the 2015 version is added in https://github.com/MicrosoftDocs/cpp-docs/commit/7497b107b24aa05f0f46dfb946dd7ee70b9cc127 by Colin Robertson. Not sure why though.

- Change inverted "Adaptor containers" to the correct "Container adaptors"
- Update superscript entries:
  - C++20 is no longer a draft
  - Add C++23 and draft C++26
- Handle the old `<contract>` header that was pulled from C++20
- Add new "Diagnostics" category for `<debugging>` and `<stacktrace>`
- Add a bunch of new headers:
  - `<source_location>`
  - `<stdfloat>`
  - `<debugging>`
  - `<stacktrace>`
  - `<expected>`
  - `<flat_map>`
  - `<flat_set>`
  - `<hive>`
  - `<inplace_vector>`
  - `<mdspan>`
  - `<generator>`
  - `<format>`
  - `<text_encoding>`
  - `<linalg>`
  - `<numbers>`
  - `<simd>`
  - `<print>`
  - `<spanstream>`
  - `<barrier>`
  - `<hazard_pointer>`
  - `<latch>`
  - `<rcu>`
  - `<semaphore>`
  - `<stop_token>`
