### PR TITLE
Fix mismatched backtick in `<random>` header reference

### DIFF
--- a/docs/standard-library/random.md
+++ b/docs/standard-library/random.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: <random>"
 title: "<random>"
-ms.date: "08/24/2017"
+description: "Learn more about: <random>"
+ms.date: 08/24/2017
 f1_keywords: ["<random>"]
 helpviewer_keywords: ["random header"]
-ms.assetid: 60afc25c-b162-4811-97c1-1b65398d4c57
 ---
 # `<random>`
 

--- a/docs/standard-library/random.md
+++ b/docs/standard-library/random.md
@@ -17,7 +17,7 @@ Defines facilities for random number generation, allowing creation of uniformly 
 **Namespace:** std
 
 > [!NOTE]
-> The `<random>` library uses the `#include <initializer_list>' statement.
+> The `<random>` library uses the `#include <initializer_list>` statement.
 
 ## Summary
 


### PR DESCRIPTION
Fix mismatched backtick and update metadata.