### PR TITLE
Tidy up `_rot{l,r}{8,16}` intrinsics reference

### DIFF
--- a/docs/intrinsics/rotl8-rotl16.md
+++ b/docs/intrinsics/rotl8-rotl16.md
@@ -6,7 +6,7 @@ f1_keywords: ["_rotl8", "_rotl16"]
 helpviewer_keywords: ["_rotl8 intrinsic", "_rotl16 intrinsic"]
 ms.assetid: 8c519ab6-aef9-4f07-a387-daee8408368f
 ---
-# _rotl8, _rotl16
+# `_rotl8`, `_rotl16`
 
 **Microsoft Specific**
 
@@ -27,10 +27,10 @@ unsigned short _rotl16(
 
 ### Parameters
 
-*value*\
+*`value`*\
 [in] The value to rotate.
 
-*shift*\
+*`shift`*\
 [in] The number of bits to rotate.
 
 ## Return value
@@ -44,7 +44,7 @@ The rotated value.
 |`_rotl8`|x86, ARM, x64, ARM64|
 |`_rotl16`|x86, ARM, x64, ARM64|
 
-**Header file** \<intrin.h>
+**Header file**: `<intrin.h>`
 
 ## Remarks
 
@@ -93,5 +93,5 @@ Rotating unsigned short 0x12 left by 10 bits gives 0x4800
 
 ## See also
 
-[_rotr8, _rotr16](../intrinsics/rotr8-rotr16.md)\
+[`_rotr8`, `_rotr16`](../intrinsics/rotr8-rotr16.md)\
 [Compiler intrinsics](../intrinsics/compiler-intrinsics.md)

--- a/docs/intrinsics/rotl8-rotl16.md
+++ b/docs/intrinsics/rotl8-rotl16.md
@@ -61,7 +61,7 @@ Unlike a left-shift operation, when executing a left rotation, the high-order bi
 
 int main()
 {
-    unsigned char c = 'A', c1, c2;
+    unsigned char c = 'A';
 
     for (int i = 0; i < 8; i++)
     {

--- a/docs/intrinsics/rotl8-rotl16.md
+++ b/docs/intrinsics/rotl8-rotl16.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: _rotl8, _rotl16"
 title: "_rotl8, _rotl16"
-ms.date: "09/02/2019"
+description: "Learn more about: _rotl8, _rotl16"
+ms.date: 09/02/2019
 f1_keywords: ["_rotl8", "_rotl16"]
 helpviewer_keywords: ["_rotl8 intrinsic", "_rotl16 intrinsic"]
-ms.assetid: 8c519ab6-aef9-4f07-a387-daee8408368f
 ---
 # `_rotl8`, `_rotl16`
 

--- a/docs/intrinsics/rotl8-rotl16.md
+++ b/docs/intrinsics/rotl8-rotl16.md
@@ -93,5 +93,5 @@ Rotating unsigned short 0x12 left by 10 bits gives 0x4800
 
 ## See also
 
-[`_rotr8`, `_rotr16`](../intrinsics/rotr8-rotr16.md)\
-[Compiler intrinsics](../intrinsics/compiler-intrinsics.md)
+[`_rotr8`, `_rotr16`](rotr8-rotr16.md)\
+[Compiler intrinsics](compiler-intrinsics.md)

--- a/docs/intrinsics/rotr8-rotr16.md
+++ b/docs/intrinsics/rotr8-rotr16.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: _rotr8, _rotr16"
 title: "_rotr8, _rotr16"
-ms.date: "09/02/2019"
+description: "Learn more about: _rotr8, _rotr16"
+ms.date: 09/02/2019
 f1_keywords: ["_rotr16", "_rotr8"]
 helpviewer_keywords: ["_rotr8 intrinsic", "_rotr16 intrinsic"]
-ms.assetid: dfbd2c82-82b4-427a-ad52-51609027ebff
 ---
 # `_rotr8`, `_rotr16`
 

--- a/docs/intrinsics/rotr8-rotr16.md
+++ b/docs/intrinsics/rotr8-rotr16.md
@@ -94,5 +94,5 @@ Rotating unsigned short 0x12 right by 10 bits gives 0x480
 
 ## See also
 
-[`_rotl8`, `_rotl16`](../intrinsics/rotl8-rotl16.md)\
-[Compiler intrinsics](../intrinsics/compiler-intrinsics.md)
+[`_rotl8`, `_rotl16`](rotl8-rotl16.md)\
+[Compiler intrinsics](compiler-intrinsics.md)

--- a/docs/intrinsics/rotr8-rotr16.md
+++ b/docs/intrinsics/rotr8-rotr16.md
@@ -61,7 +61,7 @@ Unlike a right-shift operation, when executing a right rotation, the low-order b
 
 int main()
 {
-    unsigned char c = 'A', c1, c2;
+    unsigned char c = 'A';
 
     for (int i = 0; i < 8; i++)
     {

--- a/docs/intrinsics/rotr8-rotr16.md
+++ b/docs/intrinsics/rotr8-rotr16.md
@@ -6,7 +6,7 @@ f1_keywords: ["_rotr16", "_rotr8"]
 helpviewer_keywords: ["_rotr8 intrinsic", "_rotr16 intrinsic"]
 ms.assetid: dfbd2c82-82b4-427a-ad52-51609027ebff
 ---
-# _rotr8, _rotr16
+# `_rotr8`, `_rotr16`
 
 **Microsoft Specific**
 
@@ -27,10 +27,10 @@ unsigned short _rotr16(
 
 ### Parameters
 
-*value*\
+*`value`*\
 [in] The value to rotate.
 
-*shift*\
+*`shift`*\
 [in] The number of bits to rotate.
 
 ## Return value
@@ -44,7 +44,7 @@ The rotated value.
 |`_rotr8`|x86, ARM, x64, ARM64|
 |`_rotr16`|x86, ARM, x64, ARM64|
 
-**Header file** \<intrin.h>
+**Header file**: `<intrin.h>`
 
 ## Remarks
 
@@ -94,5 +94,5 @@ Rotating unsigned short 0x12 right by 10 bits gives 0x480
 
 ## See also
 
-[_rotl8, _rotl16](../intrinsics/rotl8-rotl16.md)\
+[`_rotl8`, `_rotl16`](../intrinsics/rotl8-rotl16.md)\
 [Compiler intrinsics](../intrinsics/compiler-intrinsics.md)


### PR DESCRIPTION
Remove `c1` and `c2` unreferenced local variable in the example and some other cleanups.