### PR TITLE
Resolve incomprehensible term "wiprlhext" in "Visual Studio C++ samples" topic

### DIFF
--- a/docs/overview/visual-cpp-samples.md
+++ b/docs/overview/visual-cpp-samples.md
@@ -218,7 +218,7 @@ Previous versions of Visual Studio included C++ sample code. The sample code was
 |--|--|
 | [Button](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates use of an in-place active menu, a stock property page, and the About box control option. |
 | [Circ](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates ActiveX control basics. These include control painting, stock and custom properties, stock and custom events, use of colors and fonts, the stock font property page, the default property page, and versioning. |
-| [CmnCtrl](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates some of the new controls available with MFC on wiprlhext: The command link button (`CButton`), the pager control (`CPagerCtrl`), the split button (`CSplitButton`), and the network address control (`CNetAddressCtrl`). |
+| [CmnCtrl](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates some of the new controls available with MFC on Windows Vista: The command link button (`CButton`), the pager control (`CPagerCtrl`), the split button (`CSplitButton`), and the network address control (`CNetAddressCtrl`). |
 | [Contain](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates a Visual Editing Container Application. |
 | [Image](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | Demonstrates how to use MFC to build an ActiveX control that downloads data asynchronously. |
 | [Licensed](https://github.com/Microsoft/VCSamples/tree/master/VC2010Samples/MFC/controls) | A control that enforces use of a design-time and run-time license. |


### PR DESCRIPTION
Searching for "wiprlhext" does not yield any meaningful results and according to https://github.com/microsoft/VCSamples/blob/master/VC2010Samples/MFC/controls/cmnctrl/ReadMe.htm, the correct replacement should be "Windows Vista":

![image](https://github.com/user-attachments/assets/39878ac5-0673-4743-906d-86067e5aa886)
