### PR TITLE
Fix heading merged with description in `CRect` class reference

### DIFF
--- a/docs/atl-mfc-shared/reference/crect-class.md
+++ b/docs/atl-mfc-shared/reference/crect-class.md
@@ -745,7 +745,9 @@ rect.OffsetRect(230, 230);
 ASSERT(rect == CRect(230, 230, 265, 265));
 ```
 
-## <a name="operator_lpcrect"></a> `CRect::operator LPCRECT` Converts a `CRect` to an [`LPCRECT`](../../mfc/reference/data-types-mfc.md).
+## <a name="operator_lpcrect"></a> `CRect::operator LPCRECT`
+
+Converts a `CRect` to an [`LPCRECT`](../../mfc/reference/data-types-mfc.md).
 
 ```cpp
 operator LPCRECT() const throw();

--- a/docs/atl-mfc-shared/reference/crect-class.md
+++ b/docs/atl-mfc-shared/reference/crect-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CRect Class"
 title: "CRect Class"
-ms.date: "11/06/2018"
+description: "Learn more about: CRect Class"
+ms.date: 11/06/2018
 f1_keywords: ["CRect", "ATLTYPES/ATL::CRect", "ATLTYPES/ATL::CRect::CRect", "ATLTYPES/ATL::CRect::BottomRight", "ATLTYPES/ATL::CRect::CenterPoint", "ATLTYPES/ATL::CRect::CopyRect", "ATLTYPES/ATL::CRect::DeflateRect", "ATLTYPES/ATL::CRect::EqualRect", "ATLTYPES/ATL::CRect::Height", "ATLTYPES/ATL::CRect::InflateRect", "ATLTYPES/ATL::CRect::IntersectRect", "ATLTYPES/ATL::CRect::IsRectEmpty", "ATLTYPES/ATL::CRect::IsRectNull", "ATLTYPES/ATL::CRect::MoveToX", "ATLTYPES/ATL::CRect::MoveToXY", "ATLTYPES/ATL::CRect::MoveToY", "ATLTYPES/ATL::CRect::NormalizeRect", "ATLTYPES/ATL::CRect::OffsetRect", "ATLTYPES/ATL::CRect::PtInRect", "ATLTYPES/ATL::CRect::SetRect", "ATLTYPES/ATL::CRect::SetRectEmpty", "ATLTYPES/ATL::CRect::Size", "ATLTYPES/ATL::CRect::SubtractRect", "ATLTYPES/ATL::CRect::TopLeft", "ATLTYPES/ATL::CRect::UnionRect", "ATLTYPES/ATL::CRect::Width"]
 helpviewer_keywords: ["LPCRECT data type", "CRect class", "LPRECT operator", "RECT structure"]
-ms.assetid: dee4e752-15d6-4db4-b68f-1ad65b2ed6ca
 ---
 # `CRect` Class
 


### PR DESCRIPTION
Fix heading merged with description in `CRect` class reference, which looks like this:

![image](https://github.com/user-attachments/assets/5c7bdca9-71ec-4312-8548-169f1a0a049e)
