### PR TITLE
Remove outdated example and update C2998 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
@@ -9,4 +9,6 @@ helpviewer_keywords: ["C2998"]
 
 > '*identifier*': cannot be a template definition
 
+## Remarks
+
 The compiler could not process the syntax used in the template definition.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
@@ -11,11 +11,3 @@ ms.assetid: 8193d491-b5d9-4477-acb1-cf166889c070
 > '*identifier*': cannot be a template definition
 
 The compiler could not process the syntax used in the template definition.
-
-The following sample generates C2998:
-
-```cpp
-// C2998.cpp
-// compile with: /c
-template <class T> int x = 1018; // C2998
-```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
@@ -8,7 +8,7 @@ ms.assetid: 8193d491-b5d9-4477-acb1-cf166889c070
 ---
 # Compiler Error C2998
 
-'identifier' : cannot be a template definition
+> '*identifier*': cannot be a template definition
 
 The compiler could not process the syntax used in the template definition.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2998.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2998"
 title: "Compiler Error C2998"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2998"
+ms.date: 06/29/2025
 f1_keywords: ["C2998"]
 helpviewer_keywords: ["C2998"]
-ms.assetid: 8193d491-b5d9-4477-acb1-cf166889c070
 ---
 # Compiler Error C2998
 

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2900-through-c3499.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2900-through-c3499.md
@@ -113,7 +113,7 @@ The articles in this section of the documentation explain a subset of the error 
 | [Compiler error C2995](compiler-error-c2995.md) | '*declaration*': function template has already been defined |
 | [Compiler error C2996](compiler-error-c2996.md) | '*function*': recursive function template definition |
 | Compiler error C2997 | '*function*': array bound cannot be deduced from a default member initializer |
-| [Compiler error C2998](compiler-error-c2998.md) | '*declarator*': cannot be a template definition |
+| [Compiler error C2998](compiler-error-c2998.md) | '*identifier*': cannot be a template definition |
 
 ## See also
 


### PR DESCRIPTION
The old example is presumably written before variable template got introduced in C++14, which made that definition well formed. I tried and could not get the compiler to emit C2998, hence the example should be removed for now.