### PR TITLE
Simplify example and update C2556 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2556"
 title: "Compiler Error C2556"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2556"
+ms.date: 06/29/2025
 f1_keywords: ["C2556"]
 helpviewer_keywords: ["C2556"]
-ms.assetid: fc4399ad-45b3-49fd-be1f-0b13956a595a
 ---
 # Compiler Error C2556
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
@@ -10,9 +10,13 @@ ms.assetid: fc4399ad-45b3-49fd-be1f-0b13956a595a
 
 > '*function1*': overloaded function differs only by return type from '*function2*'
 
+## Remarks
+
 The overloaded functions have different return types but the same parameter list. Each overloaded function must have a distinct formal parameter list.
 
-The following sample generates C2556:
+## Example
+
+The following example generates C2556:
 
 ```cpp
 // C2556.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
@@ -8,7 +8,7 @@ ms.assetid: fc4399ad-45b3-49fd-be1f-0b13956a595a
 ---
 # Compiler Error C2556
 
-'identifier' : overloaded functions only differ by return type
+> '*function1*': overloaded function differs only by return type from '*function2*'
 
 The overloaded functions have different return types but the same parameter list. Each overloaded function must have a distinct formal parameter list.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2556.md
@@ -21,9 +21,7 @@ The following example generates C2556:
 ```cpp
 // C2556.cpp
 // compile with: /c
-class C {
-   int func();
-   double func();   // C2556
-   int func(int i);   // ok parameter lists differ
-};
+int func();
+double func();     // C2556
+int func(int i);   // OK parameter lists differ
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
+++ b/docs/error-messages/compiler-errors-2/compiler-errors-c2500-through-c2599.md
@@ -71,7 +71,7 @@ The articles in this section of the documentation explain a subset of the error 
 |[Compiler error C2553](compiler-error-C2553.md)|'*type* *derived_class*::*function*': overriding virtual function return type differs from '*type* *base_class*::*function*'|
 |Compiler error C2554|'*variable*': 'constinit' only allowed on a variable declaration with static or thread storage duration|
 |[Compiler error C2555](compiler-error-C2555.md)|'*derived_class*::*function*': overriding virtual function return type differs and is not covariant from '*base_class*::*function*'|
-|[Compiler error C2556](compiler-error-C2556.md)|'*type1* *class*::*function*': overloaded function differs only by return type from '*type2* *class*::*function*'|
+|[Compiler error C2556](compiler-error-C2556.md)|'*function1*': overloaded function differs only by return type from '*function2*'|
 |[Compiler error C2557](compiler-error-C2557.md)|'*identifier*': private and protected members cannot be initialized without a constructor|
 |[Compiler error C2558](compiler-error-C2558.md)|class '*class*': no copy constructor available or copy constructor is declared 'explicit'|
 |Compiler error C2559|'*identifier*': cannot overload a member function without ref-qualifier with a member function with ref-qualifier|


### PR DESCRIPTION
The enclosing class `C` in the example is removed as it's superfluous.