### PR TITLE
Fix dangling "see ..." and clean up `complex` class template specializations

### DIFF
--- a/docs/standard-library/complex-double.md
+++ b/docs/standard-library/complex-double.md
@@ -29,13 +29,13 @@ constexpr explicit complex(const complex<long double>& complexNum);
 
 ### Parameters
 
-*RealVal*\
+*`RealVal`*\
 The value of type **`double`** for the real part of the complex number being constructed.
 
-*ImagVal*\
+*`ImagVal`*\
 The value of type **`double`** for the imaginary part of the complex number being constructed.
 
-*complexNum*\
+*`complexNum`*\
 The complex number of type **`float`** or of type **`long double`** whose real and imaginary parts are used to initialize a complex number of type **`double`** being constructed.
 
 ## Return Value
@@ -105,11 +105,11 @@ arg ( c3 ) = 0.896055 radians, which is 51.3402 degrees.
 
 ## Requirements
 
-**Header**: \<complex>
+**Header**: `<complex>`
 
-**Namespace:** std
+**Namespace:** `std`
 
 ## See also
 
-[complex Class](../standard-library/complex-class.md)\
+[`complex` Class](../standard-library/complex-class.md)\
 [Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-double.md
+++ b/docs/standard-library/complex-double.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: complex<double>"
 title: "complex<double>"
-ms.date: "11/04/2016"
+description: "Learn more about: complex<double>"
+ms.date: 11/04/2016
 f1_keywords: ["complex/std::complex<double>"]
 helpviewer_keywords: ["complex<double> function"]
-ms.assetid: 0d0b9d2a-9b9b-410b-82a0-86b6df127e47
 ---
 # `complex<double>`
 

--- a/docs/standard-library/complex-double.md
+++ b/docs/standard-library/complex-double.md
@@ -46,7 +46,7 @@ A complex number of type **`double`**.
 
 The explicit specialization of the class template complex to a complex class of type **`double`** differs from the class template only in the constructors it defines. The conversion from **`float`** to **`double`** is allowed to be implicit, but the conversion from **`long double`** to **`double`** is required to be **`explicit`**. The use of **`explicit`** rules out the initiation with type conversion using assignment syntax.
 
-For more information on the class template `complex`, see [complex Class](../standard-library/complex-class.md). For a list of members of the class template `complex`, see .
+For more information on the class template `complex` and its members, see [`complex` Class](complex-class.md).
 
 ## Example
 

--- a/docs/standard-library/complex-double.md
+++ b/docs/standard-library/complex-double.md
@@ -111,5 +111,5 @@ arg ( c3 ) = 0.896055 radians, which is 51.3402 degrees.
 
 ## See also
 
-[`complex` Class](../standard-library/complex-class.md)\
-[Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)
+[`complex` Class](complex-class.md)\
+[Thread Safety in the C++ Standard Library](thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-float.md
+++ b/docs/standard-library/complex-float.md
@@ -51,7 +51,7 @@ A complex number of type **`float`**.
 
 The explicit specialization of the class template complex to a complex class of type **`float`** differs from the class template only in the constructors it defines. The conversion from **`float`** to **`double`** is allowed to be implicit, but the less safe conversion from **`float`** to **`long double`** is required to be **`explicit`**. The use of **`explicit`** rules out the initiation with type conversion using assignment syntax.
 
-For more information on the class template `complex`, see [complex Class](../standard-library/complex-class.md). For a list of members of the class template `complex`, see .
+For more information on the class template `complex` and its members, see [`complex` Class](complex-class.md).
 
 ## Example
 

--- a/docs/standard-library/complex-float.md
+++ b/docs/standard-library/complex-float.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: complex<float>"
 title: "complex<float>"
-ms.date: "11/04/2016"
+description: "Learn more about: complex<float>"
+ms.date: 11/04/2016
 f1_keywords: ["complex/std::complex<float>"]
 helpviewer_keywords: ["complex<float> function"]
-ms.assetid: 1178eb1e-39bd-4017-89cd-aea95f813939
 ---
 # `complex<float>`
 

--- a/docs/standard-library/complex-float.md
+++ b/docs/standard-library/complex-float.md
@@ -117,5 +117,5 @@ arg ( c3 ) = 0.927295 radians, which is 53.1301 degrees.
 
 ## See also
 
-[`complex` Class](../standard-library/complex-class.md)\
-[Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)
+[`complex` Class](complex-class.md)\
+[Thread Safety in the C++ Standard Library](thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-float.md
+++ b/docs/standard-library/complex-float.md
@@ -34,13 +34,13 @@ constexpr complex(
 
 ### Parameters
 
-*_RealVal*\
+*`_RealVal`*\
 The value of type **`float`** for the real part of the complex number being constructed.
 
-*_ImagVal*\
+*`_ImagVal`*\
 The value of type **`float`** for the imaginary part of the complex number being constructed.
 
-*complexNum*\
+*`complexNum`*\
 The complex number of type **`double`** or of type **`long double`** whose real and imaginary parts are used to initialize a complex number of type **`float`** being constructed.
 
 ## Return Value
@@ -111,11 +111,11 @@ arg ( c3 ) = 0.927295 radians, which is 53.1301 degrees.
 
 ## Requirements
 
-**Header**: \<complex>
+**Header**: `<complex>`
 
-**Namespace:** std
+**Namespace:** `std`
 
 ## See also
 
-[complex Class](../standard-library/complex-class.md)\
+[`complex` Class](../standard-library/complex-class.md)\
 [Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-long-double.md
+++ b/docs/standard-library/complex-long-double.md
@@ -46,7 +46,7 @@ A complex number of type **`long double`**.
 
 The explicit specialization of the class template `complex` to a complex class of type **`long double`** differs from the class template only in the constructors it defines. The conversion from **`long double`** to **`float`** is allowed to be implicit, but the conversion from **`double`** to **`long double`** is required to be **`explicit`**. The use of **`explicit`** rules out the initiation with type conversion using assignment syntax.
 
-For more information on the class template `complex` and its members, see [complex Class](../standard-library/complex-class.md).
+For more information on the class template `complex` and its members, see [`complex` Class](complex-class.md).
 
 **Microsoft-specific**: The **`long double`** and **`double`** types have the same representation, but are distinct types. For more information, see [Built-in types](../cpp/fundamental-types-cpp.md).
 

--- a/docs/standard-library/complex-long-double.md
+++ b/docs/standard-library/complex-long-double.md
@@ -29,13 +29,13 @@ complex(
 
 ### Parameters
 
-*_RealVal*\
+*`_RealVal`*\
 The value of type **`long double`** for the real part of the complex number being constructed.
 
-*_ImagVal*\
+*`_ImagVal`*\
 The value of type **`long double`** for the imaginary part of the complex number being constructed.
 
-*complexNum*\
+*`complexNum`*\
 The complex number of type **`double`** or of type **`float`** whose real and imaginary parts are used to initialize a complex number of type **`long double`** being constructed.
 
 ## Return Value
@@ -108,11 +108,11 @@ arg( c3 ) = 0.927295 radians, which is 53.1301 degrees.
 
 ## Requirements
 
-**Header**: \<complex>
+**Header**: `<complex>`
 
-**Namespace:** std
+**Namespace:** `std`
 
 ## See also
 
-[complex Class](../standard-library/complex-class.md)\
+[`complex` Class](../standard-library/complex-class.md)\
 [Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-long-double.md
+++ b/docs/standard-library/complex-long-double.md
@@ -114,5 +114,5 @@ arg( c3 ) = 0.927295 radians, which is 53.1301 degrees.
 
 ## See also
 
-[`complex` Class](../standard-library/complex-class.md)\
-[Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)
+[`complex` Class](complex-class.md)\
+[Thread Safety in the C++ Standard Library](thread-safety-in-the-cpp-standard-library.md)

--- a/docs/standard-library/complex-long-double.md
+++ b/docs/standard-library/complex-long-double.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: complex<long double>"
 title: "complex<long double>"
-ms.date: "11/04/2016"
+description: "Learn more about: complex<long double>"
+ms.date: 11/04/2016
 f1_keywords: ["std::complex<long double>", "complex<long double>", "std.complex<long double>"]
 helpviewer_keywords: ["complex<long double> function"]
-ms.assetid: 37591991-b385-46e9-b727-d534dbc10432
 ---
 # `complex<long double>`
 


### PR DESCRIPTION
Fix dangling "see ..." by using the one in `complex<long double>`:

https://github.com/MicrosoftDocs/cpp-docs/blob/087e22d82bfcdf65f3b9aca942f6a4e9f3be50b6/docs/standard-library/complex-long-double.md?plain=1#L49