### PR TITLE
Trim front and back spaces in link destinations

### DIFF
--- a/docs/cpp/results-of-calling-example.md
+++ b/docs/cpp/results-of-calling-example.md
@@ -20,7 +20,7 @@ The **`__cdecl`** calling convention
 
 The C decorated name (**`__stdcall`**) is `_MyFunc@20`. The C++ decorated name is implementation-specific.
 
-![Diagram showing the stack and registers for the S T D call and this call calling conventions.](../cpp/media/vc37i02.gif )<br/>
+![Diagram showing the stack and registers for the S T D call and this call calling conventions.](../cpp/media/vc37i02.gif)<br/>
 The __stdcall and thiscall calling conventions
 
 ## `__fastcall`

--- a/docs/cpp/results-of-calling-example.md
+++ b/docs/cpp/results-of-calling-example.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Results of Calling Example"
 title: "Results of Calling Example"
-ms.date: "11/19/2018"
+description: "Learn more about: Results of Calling Example"
+ms.date: 11/19/2018
 helpviewer_keywords: ["examples [C++], results of calling", "results, thiscall call", "results, __fastcall keyword call", "results, __cdecl call", "results, __stdcall call"]
-ms.assetid: aa70a7cb-ba1d-4aa6-bd0a-ba783da2e642
 ---
 # Results of Calling Example
 

--- a/docs/linux/cmake-linux-configure.md
+++ b/docs/linux/cmake-linux-configure.md
@@ -130,7 +130,7 @@ To target WSL, select **Manage Configurations** in the configuration dropdown in
 
 The **CMakeSettings.json** window appears.
 
-![CMake settings dialog with the plus button highlighted which adds the selected configuration, which is Linux-GCC-debug.](media/cmake-linux-configurations.png )
+![CMake settings dialog with the plus button highlighted which adds the selected configuration, which is Linux-GCC-debug.](media/cmake-linux-configurations.png)
 
 Press **Add Configuration** (the green '+' button) and then choose **Linux-GCC-Debug** or **Linux-GCC-Release** if using GCC. Use the Clang variants if you're using the Clang/LLVM toolset.  Press **Select** and then **Ctrl+S** to save the configuration.
 

--- a/docs/overview/overview-of-cpp-development.md
+++ b/docs/overview/overview-of-cpp-development.md
@@ -1,7 +1,7 @@
 ---
 title: "Overview of C++ development in Visual Studio"
 description: "The Visual Studio IDE supports C++ development on Windows, Linux, Android and iOS with a code editor, debugger, test frameworks, static analyzers, and other programming tools."
-ms.date: "12/02/2019"
+ms.date: 12/02/2019
 helpviewer_keywords: ["Visual C++, development tools"]
 author: "tylermsft"
 ms.author: "twhitney"

--- a/docs/overview/overview-of-cpp-development.md
+++ b/docs/overview/overview-of-cpp-development.md
@@ -44,13 +44,13 @@ Source control enables you to coordinate work among multiple developers, isolate
 
 ::: moniker range=">=msvc-160"
 
-![Screenshot of the Team Explorer window in Visual Studio 2019.](media/vs2019-team-explorer.png )
+![Screenshot of the Team Explorer window in Visual Studio 2019.](media/vs2019-team-explorer.png)
 
 ::: moniker-end
 
 ::: moniker range="<=msvc-150"
 
-![Screenshot of the Team Explorer window in Visual Studio 2017.](media/vs2017-team-explorer.png )
+![Screenshot of the Team Explorer window in Visual Studio 2017.](media/vs2017-team-explorer.png)
 
 ::: moniker-end
 

--- a/docs/porting/fix-your-dependencies-on-library-internals.md
+++ b/docs/porting/fix-your-dependencies-on-library-internals.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Fix your dependencies on C++ library internals"
 title: "Fix your dependencies on C++ library internals"
-ms.date: "05/24/2017"
+description: "Learn more about: Fix your dependencies on C++ library internals"
+ms.date: 05/24/2017
 helpviewer_keywords: ["library internals in an upgraded Visual Studio C++ project", "_Hash_seq in an upgraded Visual Studio C++ project"]
-ms.assetid: 493e0452-6ecb-4edc-ae20-b6fce2d7d3c5
 ---
 # Fix your dependencies on C++ library internals
 

--- a/docs/porting/fix-your-dependencies-on-library-internals.md
+++ b/docs/porting/fix-your-dependencies-on-library-internals.md
@@ -13,13 +13,13 @@ In most cases, the What's New or Breaking Changes document for each release of V
 
 ## _Hash_seq
 
-The internal hash function `std::_Hash_seq(const unsigned char *, size_t)`, used to implement `std::hash` on some string types, was visible in recent versions of the Standard Library. This function implemented an [FNV-1a hash]( https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) on a character sequence.
+The internal hash function `std::_Hash_seq(const unsigned char *, size_t)`, used to implement `std::hash` on some string types, was visible in recent versions of the Standard Library. This function implemented an [FNV-1a hash](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) on a character sequence.
 
 To remove this dependency, you have a couple of options.
 
 - If your intent is to put a `const char *` sequence into an unordered container by using the same hash code machinery as `basic_string`, you can do that by using the `std::hash` template overload that takes a `std::string_view`, which returns that hash code in a portable way. The string library code may or may not rely on use of an FNV-1a hash in the future, so this is the best way to avoid a dependency on a particular hash algorithm.
 
-- If your intent is to generate an FNV-1a hash over arbitrary memory, we've made that code available on GitHub in the [VCSamples]( https://github.com/Microsoft/vcsamples) repository in a stand-alone header file, [fnv1a.hpp](https://github.com/Microsoft/VCSamples/tree/master/VC2015Samples/_Hash_seq), under an [MIT license](https://github.com/Microsoft/VCSamples/blob/master/license.txt). We've also included a copy here for your convenience. You can copy this code into a header file, add the header to any affected code, and then find and replace `_Hash_seq` by `fnv1a_hash_bytes`. You'll get identical behavior to the internal implementation in `_Hash_seq`.
+- If your intent is to generate an FNV-1a hash over arbitrary memory, we've made that code available on GitHub in the [VCSamples](https://github.com/Microsoft/vcsamples) repository in a stand-alone header file, [fnv1a.hpp](https://github.com/Microsoft/VCSamples/tree/master/VC2015Samples/_Hash_seq), under an [MIT license](https://github.com/Microsoft/VCSamples/blob/master/license.txt). We've also included a copy here for your convenience. You can copy this code into a header file, add the header to any affected code, and then find and replace `_Hash_seq` by `fnv1a_hash_bytes`. You'll get identical behavior to the internal implementation in `_Hash_seq`.
 
 ```cpp
 /*


### PR DESCRIPTION
Trim front and back spaces in link destinations and clean up metadata.