### PR TITLE
Convert CVTRES errors and warnings list into a table

### DIFF
--- a/docs/error-messages/tool-errors/cvtres-errors-cvt1100-through-cvt4001.md
+++ b/docs/error-messages/tool-errors/cvtres-errors-cvt1100-through-cvt4001.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: CVTRES errors and warnings (CVTxxxx)"
 title: "CVTRES errors and warnings"
-ms.date: "04/16/2019"
+description: "Learn more about: CVTRES errors and warnings (CVTxxxx)"
+ms.date: 04/16/2019
 f1_keywords: ["CVT1101", "CVT1102", "CVT1104", "CVT1106", "CVT1107", "CVT1108", "CVT1109", "CVT1110"]
-ms.assetid: ac94d0fb-0da3-4327-b3d9-ceaeb3fc2e4d
 ---
 # CVTRES errors and warnings (CVTxxxx)
 


### PR DESCRIPTION
Converting the plain list into a table has a couple of upsides:
- provides more information other than just reiterating what is shown on the left topic navigator
- allows for the addition of error/warning table entries (which shows the message) without a dedicated topic
- maintains consistency with the CXXXX error/warning index pages

I plan to do the same for all the other error/warning index pages.

Edit: All subsequent PRs are referenced below.