### PR TITLE
Elide unneeded trailing period or semicolon in headings

### DIFF
--- a/docs/data/oledb/creating-an-updatable-provider.md
+++ b/docs/data/oledb/creating-an-updatable-provider.md
@@ -174,7 +174,7 @@ Making sure that the data store can handle changes.
 
 Handling NULL values.
 
-### Handling default values.
+### Handling default values
 
 To implement your own `FlushData` method, you need to:
 

--- a/docs/data/oledb/creating-an-updatable-provider.md
+++ b/docs/data/oledb/creating-an-updatable-provider.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Creating an Updatable Provider"
 title: "Creating an Updatable Provider"
-ms.date: "08/16/2018"
+description: "Learn more about: Creating an Updatable Provider"
+ms.date: 08/16/2018
 helpviewer_keywords: ["OLE DB providers, updatable", "notifications, support in providers", "OLE DB providers, creating"]
-ms.assetid: bdfd5c9f-1c6f-4098-822c-dd650e70ab82
 ---
 # Creating an Updatable Provider
 

--- a/docs/mfc/reference/cmditabinfo-class.md
+++ b/docs/mfc/reference/cmditabinfo-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CMDITabInfo Class"
 title: "CMDITabInfo Class"
-ms.date: "11/04/2016"
+description: "Learn more about: CMDITabInfo Class"
+ms.date: 11/04/2016
 f1_keywords: ["CMDITabInfo", "AFXMDICLIENTAREAWND/CMDITabInfo", "AFXMDICLIENTAREAWND/CMDITabInfo::Serialize", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bAutoColor", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bDocumentMenu", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bEnableTabSwap", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bFlatFrame", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bTabCloseButton", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bTabCustomTooltips", "AFXMDICLIENTAREAWND/CMDITabInfo::m_bTabIcons", "AFXMDICLIENTAREAWND/CMDITabInfo::m_nTabBorderSize", "AFXMDICLIENTAREAWND/CMDITabInfo::m_style", "AFXMDICLIENTAREAWND/CMDITabInfo::m_tabLocation"]
 helpviewer_keywords: ["CMDITabInfo [MFC], Serialize", "CMDITabInfo [MFC], m_bAutoColor", "CMDITabInfo [MFC], m_bDocumentMenu", "CMDITabInfo [MFC], m_bEnableTabSwap", "CMDITabInfo [MFC], m_bFlatFrame", "CMDITabInfo [MFC], m_bTabCloseButton", "CMDITabInfo [MFC], m_bTabCustomTooltips", "CMDITabInfo [MFC], m_bTabIcons", "CMDITabInfo [MFC], m_nTabBorderSize", "CMDITabInfo [MFC], m_style", "CMDITabInfo [MFC], m_tabLocation"]
-ms.assetid: 988ae1b7-4f7f-4239-b88f-7e28b3291c5e
 ---
 # CMDITabInfo Class
 

--- a/docs/mfc/reference/cmditabinfo-class.md
+++ b/docs/mfc/reference/cmditabinfo-class.md
@@ -64,7 +64,7 @@ The following example demonstrates how to set the values of the various member v
 
 **Header:** afxmdiclientareawnd.h
 
-## <a name="m_bactivetabclosebutton_"></a> CMDITabInfo::m_bActiveTabCloseButton;
+## <a name="m_bactivetabclosebutton_"></a> CMDITabInfo::m_bActiveTabCloseButton
 
 Specifies whether a **Close** button is displayed on the label of the active tab.
 

--- a/docs/mfc/testing-properties-and-events-with-test-container.md
+++ b/docs/mfc/testing-properties-and-events-with-test-container.md
@@ -37,7 +37,7 @@ At this point you can test your control's properties or events.
 
    The property now contains the new value.
 
-#### To test events and specify the destination of event information.
+#### To test events and specify the destination of event information
 
 1. On the **Options** menu, click **Logging**.
 

--- a/docs/mfc/testing-properties-and-events-with-test-container.md
+++ b/docs/mfc/testing-properties-and-events-with-test-container.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Testing Properties and Events with Test Container"
 title: "Testing Properties and Events with Test Container"
-ms.date: "11/04/2016"
+description: "Learn more about: Testing Properties and Events with Test Container"
+ms.date: 11/04/2016
 helpviewer_keywords: ["testing, test containers", "tstcon32.exe", "debugging ActiveX controls", "test container", "ActiveX Control Test Container", "ActiveX controls [MFC], testing", "properties [MFC], testing"]
-ms.assetid: 626867cf-fe53-4c30-8973-55bb93ef3917
 ms.topic: how-to
 ---
 # Testing Properties and Events with Test Container

--- a/docs/porting/porting-guide-spy-increment.md
+++ b/docs/porting/porting-guide-spy-increment.md
@@ -1,8 +1,7 @@
 ---
-description: "Learn more about: Porting Guide: Spy++"
 title: "Porting Guide: Spy++"
-ms.date: "10/23/2019"
-ms.assetid: e558f759-3017-48a7-95a9-b5b779d5e51d
+description: "Learn more about: Porting Guide: Spy++"
+ms.date: 10/23/2019
 ms.topic: concept-article
 ---
 # Porting Guide: Spy++

--- a/docs/porting/porting-guide-spy-increment.md
+++ b/docs/porting/porting-guide-spy-increment.md
@@ -15,7 +15,7 @@ Spy++ is a widely used GUI diagnostic tool for the Windows desktop that provides
 
 We considered this case to be typical for porting Windows desktop applications that use MFC and the Win32 API, especially for old projects that have not been updated with each release of Visual C++ since Visual C++ 6.0.
 
-## <a name="convert_project_file"></a> Step 1. Converting the project file.
+## <a name="convert_project_file"></a> Step 1. Converting the project file
 
 The project file, two old .dsw files from Visual C++ 6.0, converted easily with no issues that require further attention. One project is the Spy++ application. The other is SpyHk, written in C, a supporting DLL. More complex projects might not upgrade as easily, as discussed [here](../porting/visual-cpp-porting-and-upgrading-guide.md).
 


### PR DESCRIPTION
Elide unneeded trailing period or semicolon in headings and update metadata.