### PR TITLE
Add `cpp` language for code blocks in error or warning references

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
@@ -14,7 +14,7 @@ This warning is obsolete in Visual Studio 2015. In Visual Studio 2013 and earlie
 
 This example generates C2797:
 
-```
+```cpp
 #include <vector>
 struct S {
     S() : v1{1} {} // C2797, VS2013 RTM incorrectly calls 'vector(size_type)'
@@ -26,7 +26,7 @@ struct S {
 
 This example also generates C2797:
 
-```
+```cpp
 struct S1 {
     int i;
 };
@@ -40,7 +40,7 @@ struct S2 {
 
 To fix this issue, you can use explicit construction of inner lists. For example:
 
-```
+```cpp
 #include <vector>
 typedef std::vector<int> Vector;
 struct S {
@@ -53,7 +53,7 @@ struct S {
 
 If you do not require list initialization:
 
-```
+```cpp
 struct S {
     S() : s1("") {}
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2797"
 title: "Compiler Error C2797"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2797"
+ms.date: 11/04/2016
 f1_keywords: ["C2797"]
 helpviewer_keywords: ["C2797"]
-ms.assetid: 9fb26d35-eb5c-46fc-9ff5-756fba5bdaff
 ---
 # Compiler Error C2797
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2891"
 title: "Compiler Error C2891"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2891"
+ms.date: 11/04/2016
 f1_keywords: ["C2891"]
 helpviewer_keywords: ["C2891"]
-ms.assetid: e12cfb2d-df45-4b0d-b155-c51d17e812fa
 ---
 # Compiler Error C2891
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
@@ -12,13 +12,13 @@ ms.assetid: e12cfb2d-df45-4b0d-b155-c51d17e812fa
 
 You can't take the address of a template parameter unless it is an lvalue. Type parameters are not lvalues because they have no address. Non-type values in template parameter lists that are not lvalues also do not have an address. This is an example of code that causes Compiler Error C2891, because the value passed as the template parameter is a compiler-generated copy of the template argument.
 
-```
+```cpp
 template <int i> int* f() { return &i; }
 ```
 
 Template parameters that are lvalues, such as reference types, can have their address taken.
 
-```
+```cpp
 template <int& r> int* f() { return &r; }
 ```
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3457.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3457.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3457"
 title: "Compiler Error C3457"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3457"
+ms.date: 11/04/2016
 f1_keywords: ["C3457"]
 helpviewer_keywords: ["C3457"]
-ms.assetid: 5c1e366a-fa75-4cca-b9a3-86d4ebe4090e
 ---
 # Compiler Error C3457
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3457.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3457.md
@@ -16,7 +16,7 @@ Source annotation attributes, unlike CLR custom attribute or compiler attributes
 
 The following sample generates C3457.
 
-```
+```cpp
 #include "SourceAnnotations.h"
 [vc_attributes::Post( 1 )] int f();   // C3457
 [vc_attributes::Post( Valid=vc_attributes::Yes )] int f2();   // OK

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
@@ -12,7 +12,7 @@ ms.assetid: aede18d5-fefc-4da9-9b69-adfe90bfa742
 
 You cannot qualify the `decltype()` keyword with any type specifier. For example, the following code fragment yields error C3554.
 
-```
+```cpp
 int x;
 unsigned decltype(x); // C3554
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3554"
 title: "Compiler Error C3554"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3554"
+ms.date: 11/04/2016
 f1_keywords: ["C3554"]
 helpviewer_keywords: ["C3554"]
-ms.assetid: aede18d5-fefc-4da9-9b69-adfe90bfa742
 ---
 # Compiler Error C3554
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3733.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3733.md
@@ -14,7 +14,7 @@ The wrong syntax was used for a COM event. To fix this error, change the event t
 
 The following sample generates C3733:
 
-```
+```cpp
 #define _ATL_ATTRIBUTES 1
 #include "atlbase.h"
 #include "atlcom.h"

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3733.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3733.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3733"
 title: "Compiler Error C3733"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3733"
+ms.date: 11/04/2016
 f1_keywords: ["C3733"]
 helpviewer_keywords: ["C3733"]
-ms.assetid: 0cc1a9fe-1400-4be3-b35a-16435cba7a5a
 ---
 # Compiler Error C3733
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4626.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4626.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4626"
 title: "Compiler Warning (level 4) C4626"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4626"
+ms.date: 11/04/2016
 f1_keywords: ["C4626"]
 helpviewer_keywords: ["C4626"]
-ms.assetid: 7f822ff4-a4a3-4f17-b45b-e8b7b4659a14
 ---
 # Compiler Warning (level 4) C4626
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4626.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4626.md
@@ -16,7 +16,7 @@ This warning is off by default. See [Compiler Warnings That Are Off by Default](
 
 The following sample generates C4626 and shows how to fix it:
 
-```
+```cpp
 // C4626
 // compile with: /W4
 #pragma warning(default : 4626)


### PR DESCRIPTION
Add `cpp` language for code blocks in error or warning references and update metadata.