### PR TITLE
Clean up empty "Remarks" headings in standard library

### DIFF
--- a/docs/standard-library/allocators-functions.md
+++ b/docs/standard-library/allocators-functions.md
@@ -72,8 +72,6 @@ Yields `stdext::allocators::cache_chunklist<sizeof(Type)>`.
 #define CACHE_CHUNKLIST <cache_class>
 ```
 
-### Remarks
-
 ## <a name="cache_freelist"></a> CACHE_FREELIST
 
 Yields `stdext::allocators::cache_freelist<sizeof(Type), max>`.
@@ -82,8 +80,6 @@ Yields `stdext::allocators::cache_freelist<sizeof(Type), max>`.
 #define CACHE_FREELIST(max) <cache_class>
 ```
 
-### Remarks
-
 ## <a name="cache_suballoc"></a> CACHE_SUBALLOC
 
 Yields `stdext::allocators::cache_suballoc<sizeof(Type)>`.
@@ -91,8 +87,6 @@ Yields `stdext::allocators::cache_suballoc<sizeof(Type)>`.
 ```cpp
 #define CACHE_SUBALLOC <cache_class>
 ```
-
-### Remarks
 
 ## <a name="sync_default"></a> SYNC_DEFAULT
 

--- a/docs/standard-library/allocators-functions.md
+++ b/docs/standard-library/allocators-functions.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <allocators> macros"
 title: "<allocators> macros"
-ms.date: "11/04/2016"
+description: "Learn more about: <allocators> macros"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/std::ALLOCATOR_DECL", "allocators/std::CACHE_CHUNKLIST", "allocators/std::CACHE_FREELIST", "allocators/std::CACHE_SUBALLOC", "allocators/std::SYNC_DEFAULT"]
-ms.assetid: 9cb5ee07-1ff9-4594-ae32-3c8c6efb511a
 helpviewer_keywords: ["std::ALLOCATOR_DECL [C++]", "std::CACHE_CHUNKLIST [C++]", "std::CACHE_FREELIST [C++]", "std::CACHE_SUBALLOC [C++]", "std::SYNC_DEFAULT [C++]"]
 ---
 # `<allocators>` macros

--- a/docs/standard-library/basic-string-class.md
+++ b/docs/standard-library/basic-string-class.md
@@ -569,8 +569,6 @@ reference back();
 
 A reference to the last element of the string, which must be non-empty.
 
-### Remarks
-
 ## <a name="basic_string"></a> `basic_string::basic_string`
 
 Constructs a string that is empty, initialized by specific characters, or is a copy of all or part of another string object or C style (null-terminated) string.
@@ -1472,8 +1470,6 @@ const_reverse_iterator crend() const;
 ### Return value
 
 A `const` reverse iterator that addresses the location succeeding the last element in a reversed string (the location that had preceded the first element in the unreversed string).
-
-### Remarks
 
 ## <a name="copy_s"></a> `basic_string::_Copy_s`
 
@@ -2884,8 +2880,6 @@ reference front();
 ### Return value
 
 A reference to the first element of the string, which must be non-empty.
-
-### Remarks
 
 ## <a name="get_allocator"></a> `basic_string::get_allocator`
 

--- a/docs/standard-library/basic-stringbuf-class.md
+++ b/docs/standard-library/basic-stringbuf-class.md
@@ -365,8 +365,6 @@ void basic_stringbuf<T>::swap(basic_stringbuf& other)
 *other*\
 The basic_stringbuf whose contents will be swapped with this basic_stringbuf.
 
-### Remarks
-
 ## <a name="op_eq"></a> basic_stringbuf::operator=
 
 Assigns the contents of the basic_stringbuf on the right side of the operator to the basic_stringbuf on the left side.
@@ -379,8 +377,6 @@ basic_stringbuf& basic_stringbuf:: operator=(const basic_stringbuf& other)
 
 *other*\
 A basic_stringbuf whose contents, including locale traits, will be assigned to the stringbuf on the left side of the operator.
-
-### Remarks
 
 ## See also
 

--- a/docs/standard-library/basic-stringbuf-class.md
+++ b/docs/standard-library/basic-stringbuf-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: basic_stringbuf Class"
 title: "basic_stringbuf Class"
+description: "Learn more about: basic_stringbuf Class"
 ms.date: 06/10/2022
 f1_keywords: ["sstream/std::basic_stringbuf", "sstream/std::basic_stringbuf::allocator_type", "sstream/std::basic_stringbuf::char_type", "sstream/std::basic_stringbuf::int_type", "sstream/std::basic_stringbuf::off_type", "sstream/std::basic_stringbuf::pos_type", "sstream/std::basic_stringbuf::traits_type", "sstream/std::basic_stringbuf::overflow", "sstream/std::basic_stringbuf::pbackfail", "sstream/std::basic_stringbuf::seekoff", "sstream/std::basic_stringbuf::seekpos", "sstream/std::basic_stringbuf::str", "sstream/std::basic_stringbuf::underflow"]
 helpviewer_keywords: ["std::basic_stringbuf [C++]", "std::basic_stringbuf [C++], allocator_type", "std::basic_stringbuf [C++], char_type", "std::basic_stringbuf [C++], int_type", "std::basic_stringbuf [C++], off_type", "std::basic_stringbuf [C++], pos_type", "std::basic_stringbuf [C++], traits_type", "std::basic_stringbuf [C++], overflow", "std::basic_stringbuf [C++], pbackfail", "std::basic_stringbuf [C++], seekoff", "std::basic_stringbuf [C++], seekpos", "std::basic_stringbuf [C++], str", "std::basic_stringbuf [C++], underflow"]
-ms.assetid: 40c85f9e-42a5-4a65-af5c-23c8e3bf8113
 ms.custom: devdivchpfy22
 ---
 

--- a/docs/standard-library/cache-chunklist-class.md
+++ b/docs/standard-library/cache-chunklist-class.md
@@ -64,8 +64,6 @@ The number of elements in the array to be allocated.
 
 A pointer to the allocated object.
 
-### Remarks
-
 ## <a name="cache_chunklist"></a> cache_chunklist::cache_chunklist
 
 Constructs an object of type `cache_chunklist`.
@@ -73,8 +71,6 @@ Constructs an object of type `cache_chunklist`.
 ```cpp
 cache_chunklist();
 ```
-
-### Remarks
 
 ## <a name="deallocate"></a> cache_chunklist::deallocate
 
@@ -91,8 +87,6 @@ A pointer to the first object to be deallocated from storage.
 
 *count*\
 The number of objects to be deallocated from storage.
-
-### Remarks
 
 ## See also
 

--- a/docs/standard-library/cache-chunklist-class.md
+++ b/docs/standard-library/cache-chunklist-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: cache_chunklist Class"
 title: "cache_chunklist Class"
-ms.date: "11/04/2016"
+description: "Learn more about: cache_chunklist Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::cache_chunklist", "allocators/stdext::cache_chunklist::allocate", "allocators/stdext::cache_chunklist::deallocate"]
 helpviewer_keywords: ["stdext::cache_chunklist", "stdext::cache_chunklist [C++], allocate", "stdext::cache_chunklist [C++], deallocate"]
-ms.assetid: af19eccc-4ae7-4a34-bbb2-81e397424cb9
 ---
 # cache_chunklist Class
 

--- a/docs/standard-library/cache-freelist-class.md
+++ b/docs/standard-library/cache-freelist-class.md
@@ -67,8 +67,6 @@ The number of elements in the array to be allocated.
 
 A pointer to the allocated object.
 
-### Remarks
-
 ## <a name="cache_freelist"></a> cache_freelist::cache_freelist
 
 Constructs an object of type `cache_freelist`.
@@ -76,8 +74,6 @@ Constructs an object of type `cache_freelist`.
 ```cpp
 cache_freelist();
 ```
-
-### Remarks
 
 ## <a name="deallocate"></a> cache_freelist::deallocate
 
@@ -94,8 +90,6 @@ A pointer to the first object to be deallocated from storage.
 
 *count*\
 The number of objects to be deallocated from storage.
-
-### Remarks
 
 ## See also
 

--- a/docs/standard-library/cache-freelist-class.md
+++ b/docs/standard-library/cache-freelist-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: cache_freelist Class"
 title: "cache_freelist Class"
-ms.date: "11/04/2016"
+description: "Learn more about: cache_freelist Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::cache_freelist", "allocators/stdext::cache_freelist::allocate", "allocators/stdext::cache_freelist::deallocate"]
 helpviewer_keywords: ["stdext::cache_freelist", "stdext::cache_freelist [C++], allocate", "stdext::cache_freelist [C++], deallocate"]
-ms.assetid: 840694de-36ba-470f-8dae-2b723d5a8cd9
 ---
 # cache_freelist Class
 

--- a/docs/standard-library/cache-suballoc-class.md
+++ b/docs/standard-library/cache-suballoc-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: cache_suballoc Class"
 title: "cache_suballoc Class"
-ms.date: "11/04/2016"
+description: "Learn more about: cache_suballoc Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::cache_suballoc", "allocators/stdext::cache_suballoc::allocate", "allocators/stdext::cache_suballoc::deallocate"]
 helpviewer_keywords: ["stdext::cache_suballoc", "stdext::cache_suballoc [C++], allocate", "stdext::cache_suballoc [C++], deallocate"]
-ms.assetid: 9ea9c5e9-1dcc-45d0-b3a7-a56a93d88898
 ---
 # cache_suballoc Class
 

--- a/docs/standard-library/cache-suballoc-class.md
+++ b/docs/standard-library/cache-suballoc-class.md
@@ -64,8 +64,6 @@ The number of elements in the array to be allocated.
 
 A pointer to the allocated object.
 
-### Remarks
-
 ## <a name="cache_suballoc"></a> cache_suballoc::cache_suballoc
 
 Constructs an object of type `cache_suballoc`.
@@ -73,8 +71,6 @@ Constructs an object of type `cache_suballoc`.
 ```cpp
 cache_suballoc();
 ```
-
-### Remarks
 
 ## <a name="deallocate"></a> cache_suballoc::deallocate
 
@@ -91,8 +87,6 @@ A pointer to the first object to be deallocated from storage.
 
 *count*\
 The number of objects to be deallocated from storage.
-
-### Remarks
 
 ## See also
 

--- a/docs/standard-library/error-category-class.md
+++ b/docs/standard-library/error-category-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: error_category Class"
 title: "error_category Class"
+description: "Learn more about: error_category Class"
 ms.date: 06/15/2022
 f1_keywords: ["system_error/std::error_category", "system_error/std::error_category::value_type", "system_error/std::error_category::default_error_condition", "system_error/std::error_category::equivalent", "system_error/std::error_category::message", "system_error/std::error_category::name"]
 helpviewer_keywords: ["std::error_category", "std::error_category::value_type", "std::error_category::default_error_condition", "std::error_category::equivalent", "std::error_category::message", "std::error_category::name"]
-ms.assetid: e0a71e14-852d-4905-acd6-5f8ed426706d
 ms.custom: devdivchpfy22
 ---
 

--- a/docs/standard-library/error-category-class.md
+++ b/docs/standard-library/error-category-class.md
@@ -71,8 +71,6 @@ The error code value to store in the [error_condition](../standard-library/error
 
 Returns `error_condition(_Errval, *this)`.
 
-### Remarks
-
 ### <a name="equivalent"></a> equivalent
 
 Returns a value that specifies whether error objects are equivalent.
@@ -128,8 +126,6 @@ The error code value to describe.
 #### Return Value
 
 Returns a descriptive name of the error code *val* for the category. If the error code is unrecognized, returns `"unknown error"`.
-
-#### Remarks
 
 ### <a name="name"></a> name
 

--- a/docs/standard-library/error-code-class.md
+++ b/docs/standard-library/error-code-class.md
@@ -82,8 +82,6 @@ Returns the error category.
 const error_category& category() const;
 ```
 
-#### Remarks
-
 ### <a name="clear"></a> clear
 
 Clears the error code value and category.

--- a/docs/standard-library/error-code-class.md
+++ b/docs/standard-library/error-code-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: error_code Class"
 title: "error_code Class"
-ms.date: "11/04/2016"
+description: "Learn more about: error_code Class"
+ms.date: 11/04/2016
 f1_keywords: ["system_error/std::error_code", "system_error/std::error_code::value_type", "system_error/std::error_code::assign", "system_error/std::error_code::category", "system_error/std::error_code::clear", "system_error/std::error_code::default_error_condition", "system_error/std::error_code::message", "system_error/std::error_code::operator bool"]
 helpviewer_keywords: ["std::error_code", "std::error_code::value_type", "std::error_code::assign", "std::error_code::category", "std::error_code::clear", "std::error_code::default_error_condition", "std::error_code::message"]
-ms.assetid: c09b4a96-cb14-4281-a319-63543f9b2b4a
 ---
 # error_code Class
 

--- a/docs/standard-library/error-condition-class.md
+++ b/docs/standard-library/error-condition-class.md
@@ -84,8 +84,6 @@ const error_category& category() const;
 
 A reference to the stored error category
 
-#### Remarks
-
 ### <a name="clear"></a> clear
 
 Clears the error code value and category.
@@ -263,8 +261,6 @@ value_type value() const;
 #### Return Value
 
 The stored error code value of type [value_type](#value_type).
-
-#### Remarks
 
 ### <a name="value_type"></a> value_type
 

--- a/docs/standard-library/forward-list-class.md
+++ b/docs/standard-library/forward-list-class.md
@@ -168,8 +168,6 @@ iterator before_begin();
 
 A forward iterator that points just before the first element of the sequence (or just before the end of an empty sequence).
 
-### Remarks
-
 ## <a name="begin"></a> `begin`
 
 Returns an iterator addressing the first element in a forward list.
@@ -183,8 +181,6 @@ iterator begin();
 
 A forward iterator that points at the first element of the sequence (or just beyond the end of an empty sequence).
 
-### Remarks
-
 ## <a name="cbefore_begin"></a> `cbefore_begin`
 
 Returns a const iterator addressing the position before the first element in a forward list.
@@ -196,8 +192,6 @@ const_iterator cbefore_begin() const;
 ### Return Value
 
 A forward iterator that points just before the first element of the sequence (or just before the end of an empty sequence).
-
-### Remarks
 
 ## <a name="cbegin"></a> `cbegin`
 
@@ -285,8 +279,6 @@ typedef typename Allocator::const_pointer
     const_pointer;
 ```
 
-### Remarks
-
 ## <a name="const_reference"></a> `const_reference`
 
 A type that provides a constant reference to an element in the forward list.
@@ -294,8 +286,6 @@ A type that provides a constant reference to an element in the forward list.
 ```cpp
 typedef typename Allocator::const_reference const_reference;
 ```
-
-### Remarks
 
 ## <a name="difference_type"></a> `difference_type`
 
@@ -576,8 +566,6 @@ size_type max_size() const;
 ### Return Value
 
 The length of the longest sequence that the object can control.
-
-### Remarks
 
 ## <a name="merge"></a> `merge`
 

--- a/docs/standard-library/freelist-class.md
+++ b/docs/standard-library/freelist-class.md
@@ -56,8 +56,6 @@ Constructs an object of type `freelist`.
 freelist();
 ```
 
-### Remarks
-
 ## <a name="pop"></a> freelist::pop
 
 Removes the first memory block from the free list.

--- a/docs/standard-library/freelist-class.md
+++ b/docs/standard-library/freelist-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: freelist Class"
 title: "freelist Class"
-ms.date: "11/04/2016"
+description: "Learn more about: freelist Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::freelist", "allocators/stdext::freelist::pop", "allocators/stdext::freelist::push"]
 helpviewer_keywords: ["stdext::freelist", "stdext::freelist [C++], pop", "stdext::freelist [C++], push"]
-ms.assetid: 8ad7e35c-4c80-4479-8ede-1a2497b06d71
 ---
 # freelist Class
 

--- a/docs/standard-library/hash-map-class.md
+++ b/docs/standard-library/hash-map-class.md
@@ -371,8 +371,6 @@ Erases all the elements of a `hash_map`.
 void clear();
 ```
 
-### Remarks
-
 ### Example
 
 The following example demonstrates the use of the `hash_map::clear` member function.
@@ -462,8 +460,6 @@ A type that provides a reference to a **`const`** element stored in a `hash_map`
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::const_reference const_reference;
 ```
-
-### Remarks
 
 ### Example
 
@@ -917,8 +913,6 @@ bool empty() const;
 
 **`true`** if the `hash_map` is empty; **`false`** if the `hash_map` is nonempty.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1047,8 +1041,6 @@ The argument key value to be compared with the sort key of an element from the `
 A pair of iterators such that the first is the [`lower_bound`](#lower_bound) of the key and the second is the [`upper_bound`](#upper_bound) of the key.
 
 To access the first iterator of a pair `pr` returned by the member function, use `pr.first` and to dereference the lower bound iterator, use `*(pr.first)`. To access the second iterator of a pair `pr` returned by the member function, use `pr.second` and to dereference the upper bound iterator, use `*(pr.second)`.
-
-### Remarks
 
 ### Example
 
@@ -1815,8 +1807,6 @@ An [`iterator`](#iterator) or [`const_iterator`](#const_iterator) that addresses
 
 If the return value of `lower_bound` is assigned to a `const_iterator`, the `hash_map` object can't be modified. If the return value of `lower_bound` is assigned to a `iterator`, the `hash_map` object can be modified.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1903,8 +1893,6 @@ size_type max_size() const;
 ### Return Value
 
 The maximum possible length of the `hash_map`.
-
-### Remarks
 
 ### Example
 
@@ -2196,8 +2184,6 @@ A type that provides a reference to an element stored in a `hash_map`.
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::reference reference;
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2378,8 +2364,6 @@ size_type size() const;
 
 The current length of the `hash_map`.
 
-### Remarks
-
 ### Example
 
 The following example demonstrates the use of the `hash_map::size` member function.
@@ -2423,8 +2407,6 @@ An unsigned integer type that can represent the number of elements in a `hash_ma
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::size_type size_type;
 ```
-
-### Remarks
 
 ### Example
 
@@ -2527,8 +2509,6 @@ The argument key value to be compared with the sort key value of an element from
 An [`iterator`](#iterator) or [`const_iterator`](#const_iterator) that addresses the location of an element in a `hash_map` that with a key that is greater than the argument key, or that addresses the location succeeding the last element in the `hash_map` if no match is found for the key.
 
 If the return value is assigned to a `const_iterator`, the `hash_map` object can't be modified. If the return value is assigned to an `iterator`, the `hash_map` object can be modified.
-
-### Remarks
 
 ### Example
 

--- a/docs/standard-library/hash-multimap-class.md
+++ b/docs/standard-library/hash-multimap-class.md
@@ -326,8 +326,6 @@ Erases all the elements of a hash_multimap.
 void clear();
 ```
 
-### Remarks
-
 ### Example
 
 The following example demonstrates the use of the hash_multimap::clear member function.
@@ -417,8 +415,6 @@ A type that provides a reference to a **`const`** element stored in a hash_multi
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::const_reference const_reference;
 ```
-
-### Remarks
 
 ### Example
 
@@ -875,8 +871,6 @@ bool empty() const;
 
 **`true`** if the hash_multimap is empty; **`false`** if the hash_multimap is nonempty.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1005,8 +999,6 @@ The argument key to be compared with the sort key of an element from the hash_mu
 A pair of iterators such that the first is the [lower_bound](#lower_bound) of the key and the second is the [upper_bound](#upper_bound) of the key.
 
 To access the first iterator of a pair `pr` returned by the member function, use `pr`. **first** and to dereference the lower bound iterator, use \*(`pr`. **first**). To access the second iterator of a pair `pr` returned by the member function, use `pr`. **second** and to dereference the upper bound iterator, use \*(`pr`. **second**).
-
-### Remarks
 
 ### Example
 
@@ -1685,8 +1677,6 @@ An [iterator](#iterator) or [const_iterator](#const_iterator) that addresses the
 
 If the return value of `lower_bound` is assigned to a `const_iterator`, the hash_multimap object cannot be modified. If the return value of `lower_bound` is assigned to an `iterator`, the hash_multimap object can be modified.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1791,8 +1781,6 @@ size_type max_size() const;
 ### Return Value
 
 The maximum possible length of the hash_multimap.
-
-### Remarks
 
 ### Example
 
@@ -1988,8 +1976,6 @@ A type that provides a reference to an element stored in a hash_multimap.
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::reference reference;
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2164,8 +2150,6 @@ size_type size() const;
 
 The current length of the hash_multimap.
 
-### Remarks
-
 ### Example
 
 The following example demonstrates the use of the hash_multimap::size member function.
@@ -2209,8 +2193,6 @@ An unsigned integer type that counts the number of elements in a hash_multimap.
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::size_type size_type;
 ```
-
-### Remarks
 
 ### Example
 
@@ -2311,8 +2293,6 @@ The argument key to be compared with the sort key of an element from the hash_mu
 An [iterator](#iterator) or [const_iterator](#const_iterator) that addresses the location of an element in a hash_multimap with a key that is greater than the argument key, or that addresses the location succeeding the last element in the hash_multimap if no match is found for the key.
 
 If the return value of `upper_bound` is assigned to a `const_iterator`, the hash_multimap object cannot be modified. If the return value of `upper_bound` is assigned to a `iterator`, the hash_multimap object can be modified.
-
-### Remarks
 
 ### Example
 

--- a/docs/standard-library/hash-multiset-class.md
+++ b/docs/standard-library/hash-multiset-class.md
@@ -308,8 +308,6 @@ Erases all the elements of a hash_multiset.
 void clear();
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -387,8 +385,6 @@ A type that provides a reference to a **`const`** element stored in a hash_multi
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::const_reference const_reference;
 ```
-
-### Remarks
 
 ### Example
 
@@ -712,8 +708,6 @@ The value of an element to be inserted into the [hash_multiset](../standard-libr
 
 The `emplace` member function returns an iterator that points to the position where the new element was inserted.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -810,8 +804,6 @@ bool empty() const;
 ### Return Value
 
 **`true`** if the hash_multiset is empty; **`false`** if the hash_multiset is nonempty.
-
-### Remarks
 
 ### Example
 
@@ -1591,8 +1583,6 @@ The argument key to be compared with the sort key of an element from the hash_mu
 
 An [iterator](#iterator) or [const_iterator](#const_iterator) that addresses the location of the first element in a hash_multiset with a key that is equal to or greater than the argument key, or that addresses the location succeeding the last element in the hash_multiset if no match is found for the key.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1650,8 +1640,6 @@ size_type max_size() const;
 ### Return Value
 
 The maximum possible length of the hash_multiset.
-
-### Remarks
 
 ### Example
 
@@ -1845,8 +1833,6 @@ A type that provides a reference to an element stored in a hash_multiset.
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::reference reference;
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2004,8 +1990,6 @@ size_type size() const;
 
 The current length of the hash_multiset.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2046,8 +2030,6 @@ An unsigned integer type that can represent the number of elements in a hash_mul
 ```cpp
 typedef list<typename _Traits::value_type, typename _Traits::allocator_type>::size_type size_type;
 ```
-
-### Remarks
 
 ### Example
 
@@ -2148,8 +2130,6 @@ The argument key to be compared with the sort key of an element from the hash_mu
 ### Return Value
 
 An [iterator](#iterator) or [const_iterator](#const_iterator) that addresses the location of the first element in a hash_multiset with a key greater than the argument key, or that addresses the location succeeding the last element in the hash_multiset if no match is found for the key.
-
-### Remarks
 
 ### Example
 

--- a/docs/standard-library/hash-set-class.md
+++ b/docs/standard-library/hash-set-class.md
@@ -316,8 +316,6 @@ Erases all the elements of a hash_set.
 void clear();
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -395,8 +393,6 @@ A type that provides a reference to a **`const`** element stored in a hash_set f
 ```cpp
 typedef list<typename Traits::value_type, typename Traits::allocator_type>::const_reference const_reference;
 ```
-
-### Remarks
 
 ### Example
 
@@ -720,8 +716,6 @@ The value of an element to be inserted into the [hash_set](../standard-library/h
 
 The `emplace` member function returns a pair whose **`bool`** component returns **`true`** if an insertion was make and **`false`** if the `hash_set` already contained an element whose key had an equivalent value in the ordering, and whose iterator component returns the address where a new element was inserted or where the element was already located.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -818,8 +812,6 @@ bool empty() const;
 ### Return Value
 
 **`true`** if the hash_set is empty; **`false`** if the hash_set is nonempty.
-
-### Remarks
 
 ### Example
 
@@ -939,8 +931,6 @@ The argument key to be compared with the sort key of an element from the hash_se
 A pair of iterators where the first is the [lower_bound](../standard-library/set-class.md#lower_bound) of the key and the second is the [upper_bound](../standard-library/set-class.md#upper_bound) of the key.
 
 To access the first iterator of a pair pr returned by the member function, use `pr`. **first**, and to dereference the lower bound iterator, use \*(`pr`. **first**). To access the second iterator of a pair `pr` returned by the member function, use `pr`. **second**, and to dereference the upper bound iterator, use \*(`pr`. **second**).
-
-### Remarks
 
 ### Example
 
@@ -1583,8 +1573,6 @@ The argument key to be compared with the sort key of an element from the hash_se
 
 An `iterator` or `const_iterator` that addresses the location of an element in a hash_set that with a key that is equal to or greater than the argument key or that addresses the location succeeding the last element in the hash_set if no match is found for the key.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -1649,8 +1637,6 @@ size_type max_size() const;
 ### Return Value
 
 The maximum possible length of the hash_set.
-
-### Remarks
 
 ### Example
 
@@ -1844,8 +1830,6 @@ A type that provides a reference to an element stored in a hash_set.
 typedef list<typename Traits::value_type, typename Traits::allocator_type>::reference reference;
 ```
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2003,8 +1987,6 @@ size_type size() const;
 
 The current length of the hash_set.
 
-### Remarks
-
 ### Example
 
 ```cpp
@@ -2045,8 +2027,6 @@ An unsigned integer type that can represent the number of elements in a hash_set
 ```cpp
 typedef list<typename Traits::value_type, typename Traits::allocator_type>::size_type size_type;
 ```
-
-### Remarks
 
 ### Example
 
@@ -2147,8 +2127,6 @@ The argument key to be compared with the sort key of an element from the hash_se
 ### Return Value
 
 An `iterator` or `const_iterator` that addresses the location of an element in a hash_set that with a key that is equal to or greater than the argument key, or that addresses the location succeeding the last element in the hash_set if no match is found for the key.
-
-### Remarks
 
 ### Example
 

--- a/docs/standard-library/hash-set.md
+++ b/docs/standard-library/hash-set.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: <hash_set>"
 title: "<hash_set>"
-ms.date: "11/04/2016"
+description: "Learn more about: <hash_set>"
+ms.date: 11/04/2016
 f1_keywords: ["<hash_set>"]
 helpviewer_keywords: ["hash_set header"]
-ms.assetid: 6b556967-c808-4869-9b4d-f9e030864435
 ---
 # `<hash_set>`
 

--- a/docs/standard-library/hash-set.md
+++ b/docs/standard-library/hash-set.md
@@ -19,8 +19,6 @@ Defines the container class templates hash_set and hash_multiset and their suppo
 #include <hash_set>
 ```
 
-## Remarks
-
 ### Operators
 
 |Hash_set version|Hash_multiset version|Description|

--- a/docs/standard-library/iterator-concepts.md
+++ b/docs/standard-library/iterator-concepts.md
@@ -455,8 +455,6 @@ The iterator type.
 *`S`*\
 The sentinel type to test.
 
-### Remarks
-
 ### Example: `sized_sentinel_for`
 
 The following example uses the `sized_sentinel_for` concept to verify that the sentinel for a `vector<int>` can be subtracted from the vectors iterator in constant time:

--- a/docs/standard-library/memory-functions.md
+++ b/docs/standard-library/memory-functions.md
@@ -36,8 +36,6 @@ The object or function for which to obtain the true address.
 
 The actual address of the object or function referenced by *`value`*, even if an overloaded `operator&()` exists.
 
-### Remarks
-
 ## <a name="align"></a> `align`
 
 Fits storage of the given size, aligned by the given alignment specification, into the first possible address of the given storage.

--- a/docs/standard-library/sync-none-class.md
+++ b/docs/standard-library/sync-none-class.md
@@ -93,8 +93,6 @@ The cache object to compare for equality.
 
 The member function always returns **`true`**.
 
-### Remarks
-
 ## See also
 
 [\<allocators>](../standard-library/allocators-header.md)

--- a/docs/standard-library/sync-none-class.md
+++ b/docs/standard-library/sync-none-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: sync_none Class"
 title: "sync_none Class"
-ms.date: "11/04/2016"
+description: "Learn more about: sync_none Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::sync_none", "allocators/stdext::sync_none::allocate", "allocators/stdext::sync_none::deallocate", "allocators/stdext::sync_none::equals"]
 helpviewer_keywords: ["stdext::sync_none", "stdext::sync_none [C++], allocate", "stdext::sync_none [C++], deallocate", "stdext::sync_none [C++], equals"]
-ms.assetid: f7473cee-14f3-4fe1-88bc-68cd085e59e1
 ---
 # sync_none Class
 

--- a/docs/standard-library/sync-per-container-class.md
+++ b/docs/standard-library/sync-per-container-class.md
@@ -55,8 +55,6 @@ The cache object to compare for equality.
 
 The member function always returns **`false`**.
 
-### Remarks
-
 ## See also
 
 [\<allocators>](../standard-library/allocators-header.md)

--- a/docs/standard-library/sync-per-container-class.md
+++ b/docs/standard-library/sync-per-container-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: sync_per_container Class"
 title: "sync_per_container Class"
-ms.date: "11/04/2016"
+description: "Learn more about: sync_per_container Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::sync_per_container", "allocators/stdext::sync_per_container::equals"]
 helpviewer_keywords: ["sync_per_container class"]
-ms.assetid: 0b4b2904-b668-4d94-a422-d4f919cbffab
 ---
 # sync_per_container Class
 

--- a/docs/standard-library/sync-per-thread-class.md
+++ b/docs/standard-library/sync-per-thread-class.md
@@ -97,8 +97,6 @@ The cache object to compare for equality.
 
 **`false`** if no cache object has been allocated for this object or for *Other* in the current thread. Otherwise it returns the result of applying `operator==` to the two cache objects.
 
-### Remarks
-
 ## See also
 
 [\<allocators>](../standard-library/allocators-header.md)

--- a/docs/standard-library/sync-per-thread-class.md
+++ b/docs/standard-library/sync-per-thread-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: sync_per_thread Class"
 title: "sync_per_thread Class"
-ms.date: "11/04/2016"
+description: "Learn more about: sync_per_thread Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::sync_per_thread", "allocators/stdext::sync_per_thread::allocate", "allocators/stdext::sync_per_thread::deallocate", "allocators/stdext::sync_per_thread::equals"]
 helpviewer_keywords: ["stdext::sync_per_thread", "stdext::sync_per_thread [C++], allocate", "stdext::sync_per_thread [C++], deallocate", "stdext::sync_per_thread [C++], equals"]
-ms.assetid: 47bf75f8-5b02-4760-b1d3-3099d08fe14c
 ---
 # sync_per_thread Class
 

--- a/docs/standard-library/sync-shared-class.md
+++ b/docs/standard-library/sync-shared-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: sync_shared Class"
 title: "sync_shared Class"
-ms.date: "11/04/2016"
+description: "Learn more about: sync_shared Class"
+ms.date: 11/04/2016
 f1_keywords: ["allocators/stdext::sync_shared", "allocators/stdext::sync_shared::allocate", "allocators/stdext::sync_shared::deallocate", "allocators/stdext::sync_shared::equals"]
 helpviewer_keywords: ["stdext::sync_shared", "stdext::sync_shared [C++], allocate", "stdext::sync_shared [C++], deallocate", "stdext::sync_shared [C++], equals"]
-ms.assetid: cab3af9e-3d1a-4f2c-8580-0f89e5687d8e
 ---
 # sync_shared Class
 

--- a/docs/standard-library/sync-shared-class.md
+++ b/docs/standard-library/sync-shared-class.md
@@ -97,8 +97,6 @@ The cache to compare for equality.
 
 **`true`** if the result of `cache.equals(Other.cache)`, where `cache` represents the cache object, is **`true`**; otherwise, **`false`**.
 
-### Remarks
-
 ## See also
 
 [\<allocators>](../standard-library/allocators-header.md)

--- a/docs/standard-library/system-error-enums.md
+++ b/docs/standard-library/system-error-enums.md
@@ -94,8 +94,6 @@ class errc {
 };
 ```
 
-### Remarks
-
 ## <a name="io_errc"></a> io_errc
 
 Provides symbolic names for the error conditions in \<iostream>. Can be used to create [error_condition](../standard-library/error-condition-class.md) objects to be compared with the value that's returned by the [ios_base::failure](../standard-library/ios-base-class.md#failure)`code()` function.

--- a/docs/standard-library/system-error-enums.md
+++ b/docs/standard-library/system-error-enums.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: <system_error> enums"
 title: "<system_error> enums"
-ms.date: "11/04/2016"
+description: "Learn more about: <system_error> enums"
+ms.date: 11/04/2016
 f1_keywords: ["system_error/std::errc", "system_error/std::io_errc"]
-ms.assetid: b21321b7-404a-40de-8777-a85b77c6fa58
 ---
 # `<system_error>` enums
 

--- a/docs/standard-library/wstring-convert-class.md
+++ b/docs/standard-library/wstring-convert-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: wstring_convert Class"
 title: "wstring_convert Class"
-ms.date: "11/04/2016"
+description: "Learn more about: wstring_convert Class"
+ms.date: 11/04/2016
 f1_keywords: ["wstring/stdext::cvt::wstring_convert", "locale/std::wstring_convert::byte_string", "locale/std::wstring_convert::wide_string", "locale/std::wstring_convert::state_type", "locale/std::wstring_convert::int_type", "locale/std::wstring_convert::from_bytes", "locale/std::wstring_convert::to_bytes", "locale/std::wstring_convert::converted", "locale/std::wstring_convert::state"]
 helpviewer_keywords: ["stdext::cvt [C++], wstring_convert", "std::wstring_convert [C++], byte_string", "std::wstring_convert [C++], wide_string", "std::wstring_convert [C++], state_type", "std::wstring_convert [C++], int_type", "std::wstring_convert [C++], from_bytes", "std::wstring_convert [C++], to_bytes", "std::wstring_convert [C++], converted", "std::wstring_convert [C++], state"]
-ms.assetid: e34f5b65-d572-4bdc-ac69-20778712e376
 ---
 # wstring_convert Class
 

--- a/docs/standard-library/wstring-convert-class.md
+++ b/docs/standard-library/wstring-convert-class.md
@@ -161,8 +161,6 @@ state_type state() const;
 
 The [conversion state](../standard-library/wstring-convert-class.md) object that represents the state of the conversion.
 
-### Remarks
-
 ## <a name="state_type"></a> wstring_convert::state_type
 
 A type that represents the conversion state.


### PR DESCRIPTION
Clean up empty "Remarks" headings and update metadata in standard library.