### PR TITLE
Replace backslash with forward slash in `f1_keywords` metadata

### DIFF
--- a/docs/c-runtime-library/reference/fabs-fabsf-fabsl.md
+++ b/docs/c-runtime-library/reference/fabs-fabsf-fabsl.md
@@ -1,7 +1,7 @@
 ---
 title: "fabs, fabsf, fabsl"
 description: "API reference for fabs, fabsf, and fabsl; which calculate the absolute value of a floating-point value."
-ms.date: "1/15/2021"
+ms.date: 1/15/2021
 api_name: ["fabsf", "fabs", "fabsl", "_o_fabs", "_o_fabsf"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-math-l1-1-0.dll"]
 api_type: ["DLLExport"]


### PR DESCRIPTION
The `math/...` entries in `f1_keywords` should use forward slash instead of backslash, as seen in some examples:

https://github.com/MicrosoftDocs/cpp-docs/blob/6d9d9590ea2ecc59b0d75f82fc15d43430c5149c/docs/c-runtime-library/reference/isnan-isnan-isnanf.md?plain=1#L9

https://github.com/MicrosoftDocs/cpp-docs/blob/6d9d9590ea2ecc59b0d75f82fc15d43430c5149c/docs/c-runtime-library/reference/atof-atof-l-wtof-wtof-l.md?plain=1#L9

https://github.com/MicrosoftDocs/cpp-docs/blob/6d9d9590ea2ecc59b0d75f82fc15d43430c5149c/docs/c-runtime-library/reference/fmin-fminf-fminl.md?plain=1#L9