### PR TITLE
Fix mismatched double quotes in `f1_keywords` metadata

### DIFF
--- a/docs/mfc/reference/cmemfile-class.md
+++ b/docs/mfc/reference/cmemfile-class.md
@@ -2,7 +2,7 @@
 title: "CMemFile Class"
 description: "Describes the functions available in the CMemFile class which allows you to work with memory files."
 ms.date: 07/23/2020
-f1_keywords: ["CMemFile", "AFX/CMemFile", "AFX/CMemFile::CMemFile", "AFX/CMemFile::Attach", "AFX/CMemFile::Detach", "AFX/CMemFile::Alloc", "AFX/CMemFile::Free", "AFX/CmemFile::GetBufferPtr", AFX/CMemFile::GrowFile", "AFX/CMemFile::Memcpy", "AFX/CMemFile::Realloc"]
+f1_keywords: ["CMemFile", "AFX/CMemFile", "AFX/CMemFile::CMemFile", "AFX/CMemFile::Attach", "AFX/CMemFile::Detach", "AFX/CMemFile::Alloc", "AFX/CMemFile::Free", "AFX/CmemFile::GetBufferPtr", "AFX/CMemFile::GrowFile", "AFX/CMemFile::Memcpy", "AFX/CMemFile::Realloc"]
 helpviewer_keywords: ["CMemFile [MFC], CMemFile", "CMemFile [MFC], Attach", "CMemFile [MFC], Detach", "CMemFile [MFC], Alloc", "CMemFile [MFC], Free", "CMemFile [MFC], GetBufferPtr", "CMemFile [MFC], GrowFile", "CMemFile [MFC], Memcpy", "CMemFile [MFC], Realloc"]
 ---
 # CMemFile Class

--- a/docs/standard-library/high-resolution-clock-struct.md
+++ b/docs/standard-library/high-resolution-clock-struct.md
@@ -4,7 +4,7 @@ title: high_resolution_clock struct
 ms.custom: ""
 ms.date: 08/19/2021
 ms.topic: "reference"
-f1_keywords: ["chrono/std::chrono::high_resolution_clock", chrono/std::chrono::high_resolution_clock::now", "chrono/std::chrono::high_resolution_clock::is_steady constant"]
+f1_keywords: ["chrono/std::chrono::high_resolution_clock", "chrono/std::chrono::high_resolution_clock::now", "chrono/std::chrono::high_resolution_clock::is_steady constant"]
 helpviewer_keywords: ["std::chrono [C++], high_resolution_clock"]
 dev_langs: ["C++"]
 author: "tylermsft"

--- a/docs/standard-library/high-resolution-clock-struct.md
+++ b/docs/standard-library/high-resolution-clock-struct.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: high_resolution_clock struct"
 title: high_resolution_clock struct
+description: "Learn more about: high_resolution_clock struct"
 ms.custom: ""
 ms.date: 08/19/2021
 ms.topic: "reference"

--- a/docs/standard-library/local_t.md
+++ b/docs/standard-library/local_t.md
@@ -2,7 +2,7 @@
 title: "local_t struct"
 description: "Learn more about: local_t struct"
 ms.date: 09/02/2021
-f1_keywords: ["chrono/std::chrono::local_t", chrono/std::chrono::local_time", "chrono/std::chrono::local_days", "chrono/std::chrono::local_seconds"]
+f1_keywords: ["chrono/std::chrono::local_t", "chrono/std::chrono::local_time", "chrono/std::chrono::local_days", "chrono/std::chrono::local_seconds"]
 helpviewer_keywords: ["std::chrono [C++], local_t"]
 dev_langs: ["C++"]
 ---


### PR DESCRIPTION
Fix mismatched double quotes in `f1_keywords` metadata and perform a tiny tweak.