### PR TITLE
Clean up superfluous trailing spaces in `toc.yml`s

### DIFF
--- a/docs/build/toc.yml
+++ b/docs/build/toc.yml
@@ -408,7 +408,7 @@ items:
             - name: Command line property pages
               href: ../build/reference/command-line-property-pages.md
             - name: NMake property page
-              href: ../build/reference/nmake-property-page.md                
+              href: ../build/reference/nmake-property-page.md
             - name: Manifest Tool property pages
               href: ../build/reference/manifest-tool-property-pages.md
             - name: Resources property pages
@@ -1181,7 +1181,7 @@ items:
               href: ../build/reference/nmake-reference.md
             - name: NMAKE projects in Visual Studio
               href: ../build/reference/creating-a-makefile-project.md
-            - name: Running NMAKE 
+            - name: Running NMAKE
               href: ../build/reference/running-nmake.md
             - name: Makefile contents and features
               href: ../build/reference/contents-of-a-makefile.md

--- a/docs/c-language/toc.yml
+++ b/docs/c-language/toc.yml
@@ -444,7 +444,7 @@ items:
               - name: Inline assembler (C)
                 href: ../c-language/inline-assembler-c.md
               - name: _Noreturn (C)
-                href: ../c-language/noreturn.md                
+                href: ../c-language/noreturn.md
           - name: DLL import and export functions
             items: 
               - name: DLL import and export functions

--- a/docs/c-runtime-library/toc.yml
+++ b/docs/c-runtime-library/toc.yml
@@ -75,7 +75,7 @@ items:
     - name: Global state in the CRT
       href: ../c-runtime-library/global-state.md
     - name: Type-generic math
-      href: ../c-runtime-library/tgmath.md 
+      href: ../c-runtime-library/tgmath.md
     - name: C runtime (CRT) and C++ Standard Library (STL) .lib files
       href: ../c-runtime-library/crt-library-features.md
 - name: Universal C runtime routines by category

--- a/docs/cpp/toc.yml
+++ b/docs/cpp/toc.yml
@@ -369,7 +369,7 @@ items:
         - name: Pimpl idiom for compile-time encapsulation
           href: ../cpp/pimpl-for-compile-time-encapsulation-modern-cpp.md
         - name: Portability at ABI boundaries
-          href: ../cpp/portability-at-abi-boundaries-modern-cpp.md 
+          href: ../cpp/portability-at-abi-boundaries-modern-cpp.md
         - name: Constructors
           items: 
             - name: Constructors

--- a/docs/cross-platform/toc.yml
+++ b/docs/cross-platform/toc.yml
@@ -2,7 +2,7 @@ items:
 - name: Cross-platform mobile development with C++
   href: ../cross-platform/index.yml
 - name: Overview
-  href: ../cross-platform/visual-cpp-for-cross-platform-mobile-development.md 
+  href: ../cross-platform/visual-cpp-for-cross-platform-mobile-development.md
 - name: Get Started
   expanded: true
   items:

--- a/docs/embedded/toc.yml
+++ b/docs/embedded/toc.yml
@@ -19,7 +19,7 @@ items:
       href: ./peripheral-view.md
     - name: RTOS View
       href: ./rtos-view.md
-    - name: Serial Monitor 
+    - name: Serial Monitor
       href: ./serial-monitor.md
     - name: vcpkg artifacts
       href: https://devblogs.microsoft.com/cppblog/vcpkg-artifacts/

--- a/docs/error-messages/toc.yml
+++ b/docs/error-messages/toc.yml
@@ -4437,7 +4437,7 @@ items:
       href: tool-errors/cvtres-fatal-error-cvt1105.md
     - name: CVTRES warning CVT4001
       href: tool-errors/cvtres-warning-cvt4001.md
-- name: Expression evaluator errors 
+- name: Expression evaluator errors
   expanded: false
   items: 
     - name: Expression evaluator errors (CXXxxxx)

--- a/docs/get-started/toc.yml
+++ b/docs/get-started/toc.yml
@@ -25,7 +25,7 @@ items:
   items:
     - name: Create a console app
       href: tutorial-console-cpp.md
-    - name: Create a Universal Windows Platform app 
+    - name: Create a Universal Windows Platform app
       href: /windows/uwp/cpp-and-winrt-apis/get-started
     - name: Create a Windows Desktop app
       href: /windows/desktop/learnwin32/learn-to-program-for-windows
@@ -44,9 +44,9 @@ items:
   items:
     - name: Open code from a repo
       href: /visualstudio/get-started/tutorial-open-project-from-repo
-    - name: Write and edit code 
+    - name: Write and edit code
       href: /visualstudio/get-started/tutorial-editor
-    - name: Compile and build 
+    - name: Compile and build
       href: /visualstudio/ide/compiling-and-building-in-visual-studio
     - name: Debug your C++ code
       href: /visualstudio/debugger/quickstart-debug-with-cplusplus

--- a/docs/ide/toc.yml
+++ b/docs/ide/toc.yml
@@ -93,7 +93,7 @@ items:
     - name: Add a method
       href: ../ide/adding-a-method-visual-cpp.md
     - name: Add an IDL method
-      href: ../ide/add-interface-definition-library-method-wizard.md 
+      href: ../ide/add-interface-definition-library-method-wizard.md
     - name: Add a property
       href: ../ide/adding-a-property-visual-cpp.md
     - name: Add an IDL property

--- a/docs/intrinsics/toc.yml
+++ b/docs/intrinsics/toc.yml
@@ -40,7 +40,7 @@ items:
         - name: _bittestandset, _bittestandset64
           href: ../intrinsics/bittestandset-bittestandset64.md
         - name: __check_isa_support, __check_arch_support
-          href: ../intrinsics/check-isa-arch-support.md          
+          href: ../intrinsics/check-isa-arch-support.md
         - name: __cpuid, __cpuidex
           href: ../intrinsics/cpuid-cpuidex.md
         - name: __debugbreak

--- a/docs/mfc/toc.yml
+++ b/docs/mfc/toc.yml
@@ -2919,6 +2919,6 @@ items:
     - name: Add a method to an IDL interface in a MFC project
       href: reference/add-idl-mfc-method-wizard.md
     - name: Add a property to an IDL interface in a MFC project
-      href: reference/add-interface-definition-library-mfc-property-wizard.md 
+      href: reference/add-interface-definition-library-mfc-property-wizard.md
     - name: MFC class wizard
-      href: reference/mfc-class-wizard.md    
+      href: reference/mfc-class-wizard.md

--- a/docs/preprocessor/toc.yml
+++ b/docs/preprocessor/toc.yml
@@ -7,7 +7,7 @@ items:
     - name: Preprocessor
       href: ../preprocessor/preprocessor.md
     - name: New preprocessor overview
-      href: ../preprocessor/preprocessor-experimental-overview.md                  
+      href: ../preprocessor/preprocessor-experimental-overview.md
     - name: Phases of translation
       href: ../preprocessor/phases-of-translation.md
     - name: Preprocessor directives

--- a/docs/standard-library/toc.yml
+++ b/docs/standard-library/toc.yml
@@ -169,9 +169,9 @@ items:
           href: gps-clock-class.md
         - name: hh_mm_ss class
           href: hhmmss-class.md
-        - name: high_resolution_clock struct 
+        - name: high_resolution_clock struct
           href: high-resolution-clock-struct.md
-        - name: is_clock struct 
+        - name: is_clock struct
           href: is-clock-struct.md
         - name: last_spec
           href: last-spec-struct.md


### PR DESCRIPTION
Clean up superfluous trailing spaces for `name` and `href` in various `toc.yml`s.