### PR TITLE
Fix syntax error and format code in "Postfix Increment and Decrement Operators"

### DIFF
--- a/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
@@ -53,9 +53,9 @@ int main() {
 Postincrement and postdecrement operations on enumerated types are not supported:
 
 ```cpp
-enum Compass { North, South, East, West );
+enum Compass { North, South, East, West };
 Compass myCompass;
-for( myCompass = North; myCompass != West; myCompass++ ) // Error
+for( myCompass = North; myCompass != West; myCompass++ ); // Error
 ```
 
 ## See also

--- a/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
@@ -51,6 +51,11 @@ int main()
 }
 ```
 
+```Output
+10
+11
+```
+
 Postincrement and postdecrement operations on enumerated types are not supported:
 
 ```cpp

--- a/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Postfix Increment and Decrement Operators: ++ and --"
 title: "Postfix Increment and Decrement Operators: ++ and --"
-ms.date: "11/04/2016"
+description: "Learn more about: Postfix Increment and Decrement Operators: ++ and --"
+ms.date: 11/04/2016
 f1_keywords: ["--", "++"]
 helpviewer_keywords: ["increment operators [C++], syntax", "member-selection operators [C++]", "-- operator [C++], postfix decrement operators", "postfix operators [C++]", "++ operator [C++], postfix increment operators", "decrement operators [C++], syntax", "operators [C++], postfix", "decrement operators [C++]"]
-ms.assetid: 0204d5c8-51b0-4108-b8a1-074c5754d89c
 ---
 # Postfix Increment and Decrement Operators: `++` and `--`
 

--- a/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
+++ b/docs/cpp/postfix-increment-and-decrement-operators-increment-and-decrement.md
@@ -43,10 +43,11 @@ The following code illustrates the postfix increment operator:
 #include <iostream>
 using namespace std;
 
-int main() {
-   int i = 10;
-   cout << i++ << endl;
-   cout << i << endl;
+int main()
+{
+    int i = 10;
+    cout << i++ << endl;
+    cout << i << endl;
 }
 ```
 
@@ -55,7 +56,7 @@ Postincrement and postdecrement operations on enumerated types are not supported
 ```cpp
 enum Compass { North, South, East, West };
 Compass myCompass;
-for( myCompass = North; myCompass != West; myCompass++ ); // Error
+for (myCompass = North; myCompass != West; myCompass++); // Error
 ```
 
 ## See also


### PR DESCRIPTION
Fix syntax errors (mismatched brace and missing semicolon), format code, and add output for the first example.