### PR TITLE
Remove backtick for terms "MFC" and "ATL"

### DIFF
--- a/docs/build/reference/hint-files.md
+++ b/docs/build/reference/hint-files.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Hint Files"
 title: "Hint Files"
-ms.date: "02/26/2019"
+description: "Learn more about: Hint Files"
+ms.date: 02/26/2019
 f1_keywords: ["cpp.hint", "vc.hint.file"]
 helpviewer_keywords: ["stop file", "cpp.hint", "hint file", "cpp.stop", "Class View, hint file"]
-ms.assetid: 17194f66-cf62-4523-abec-77db0675ab65
 ---
 # Hint Files
 

--- a/docs/mfc/reference/cobarray-class.md
+++ b/docs/mfc/reference/cobarray-class.md
@@ -1,7 +1,7 @@
 ---
 title: "CObArray Class"
 description: "API reference for the `CObArray` MFC class which stores `CObject` pointers in an array."
-ms.date: "08/27/2020"
+ms.date: 08/27/2020
 f1_keywords: ["CObArray", "AFXCOLL/CObArray", "AFXCOLL/CObArray::CObArray", "AFXCOLL/CObArray::Add", "AFXCOLL/CObArray::Append", "AFXCOLL/CObArray::Copy", "AFXCOLL/CObArray::ElementAt", "AFXCOLL/CObArray::FreeExtra", "AFXCOLL/CObArray::GetAt", "AFXCOLL/CObArray::GetCount", "AFXCOLL/CObArray::GetData", "AFXCOLL/CObArray::GetSize", "AFXCOLL/CObArray::GetUpperBound", "AFXCOLL/CObArray::InsertAt", "AFXCOLL/CObArray::IsEmpty", "AFXCOLL/CObArray::RemoveAll", "AFXCOLL/CObArray::RemoveAt", "AFXCOLL/CObArray::SetAt", "AFXCOLL/CObArray::SetAtGrow", "AFXCOLL/CObArray::SetSize"]
 helpviewer_keywords: ["CObArray [MFC], CObArray", "CObArray [MFC], Add", "CObArray [MFC], Append", "CObArray [MFC], Copy", "CObArray [MFC], ElementAt", "CObArray [MFC], FreeExtra", "CObArray [MFC], GetAt", "CObArray [MFC], GetCount", "CObArray [MFC], GetData", "CObArray [MFC], GetSize", "CObArray [MFC], GetUpperBound", "CObArray [MFC], InsertAt", "CObArray [MFC], IsEmpty", "CObArray [MFC], RemoveAll", "CObArray [MFC], RemoveAt", "CObArray [MFC], SetAt", "CObArray [MFC], SetAtGrow", "CObArray [MFC], SetSize"]
 ---


### PR DESCRIPTION
The abbreviations "MFC" and "ATL" should not be encased in backticks.