### PR TITLE
Structure error references in range [C1250, C1260]

### DIFF
--- a/docs/code-quality/c1250.md
+++ b/docs/code-quality/c1250.md
@@ -10,4 +10,6 @@ ms.assetid: 3f2385d7-e0d6-4574-8cea-342e82d0aea4
 
 > Unable to load plug-in '*plugin-name*'.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.

--- a/docs/code-quality/c1250.md
+++ b/docs/code-quality/c1250.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1250"
 description: "Learn more about: Fatal error C1250"
-title: Fatal error C1250
 ms.date: 10/04/2022
 f1_keywords: ["C1250", "FATALERROR_UnableToLoadPlugin"]
 helpviewer_keywords: ["C1250"]
-ms.assetid: 3f2385d7-e0d6-4574-8cea-342e82d0aea4
 ---
 # Fatal error C1250
 

--- a/docs/code-quality/c1251.md
+++ b/docs/code-quality/c1251.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1251"
 description: "Learn more about: Fatal error C1251"
-title: Fatal error C1251
 ms.date: 10/04/2022
 f1_keywords: ["C1251", "FATALERROR_UnableToLoadModel"]
 helpviewer_keywords: ["C1251"]
-ms.assetid: 0b46e0a5-c290-48d8-ba4e-f526ae68993b
 ---
 # Fatal error C1251
 

--- a/docs/code-quality/c1251.md
+++ b/docs/code-quality/c1251.md
@@ -10,4 +10,6 @@ ms.assetid: 0b46e0a5-c290-48d8-ba4e-f526ae68993b
 
 > Unable to load models.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the model file, not in the code being analyzed.

--- a/docs/code-quality/c1252.md
+++ b/docs/code-quality/c1252.md
@@ -10,6 +10,8 @@ ms.assetid: e88bf199-890d-4582-bb5c-c1238797145b
 
 > Circular or missing dependency between plugins: '*plugin-name*' requires GUID '*globally-unique-identifier*'
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin dependencies. It's not caused by an issue in the code being analyzed.
 
 In some cases, it's possible to work around this issue by disabling the **Enable Code Analysis on Build** property. To disable this build property, open the Property pages dialog for your project. In the **Solution Explorer** window, right-click on the project (not the solution) and select **Properties** in the shortcut menu. Set the **Configuration** to **All Configurations** and the **Platform** to **All Platforms**. Open the **Configuration Properties** > **Code Analysis** > **General** property page. Modify the **Enable Code Analysis on Build** property to **No**. Choose **OK** to save your changes, and then save your project files. Rebuild your project to verify that the issue no longer occurs.

--- a/docs/code-quality/c1252.md
+++ b/docs/code-quality/c1252.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1252"
 description: "Learn more about: Fatal error C1252"
-title: Fatal error C1252
 ms.date: 10/04/2022
 f1_keywords: ["C1252", "FATALERROR_CircularDependency"]
 helpviewer_keywords: ["C1252"]
-ms.assetid: e88bf199-890d-4582-bb5c-c1238797145b
 ---
 # Fatal error C1252
 

--- a/docs/code-quality/c1253.md
+++ b/docs/code-quality/c1253.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1253"
 description: "Learn more about: Fatal error C1253"
-title: Fatal error C1253
 ms.date: 10/04/2022
 f1_keywords: ["C1253", "FATALERROR_UnableToLoadModelFile"]
 helpviewer_keywords: ["C1253"]
-ms.assetid: 21a4062f-fde8-40e5-8dbd-6f892926d3d2
 ---
 # Fatal error C1253
 

--- a/docs/code-quality/c1253.md
+++ b/docs/code-quality/c1253.md
@@ -10,4 +10,6 @@ ms.assetid: 21a4062f-fde8-40e5-8dbd-6f892926d3d2
 
 > Unable to load model file.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the model file, not in the code being analyzed.

--- a/docs/code-quality/c1254.md
+++ b/docs/code-quality/c1254.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1254"
 description: "Learn more about: Fatal error C1254"
-title: Fatal error C1254
 ms.date: 10/04/2022
 f1_keywords: ["C1254", "FATALERROR_PluginVersionMismatch"]
 helpviewer_keywords: ["C1254"]
-ms.assetid: cb1377cf-869e-432d-941f-71f77134f97a
 ---
 # Fatal error C1254
 

--- a/docs/code-quality/c1254.md
+++ b/docs/code-quality/c1254.md
@@ -10,4 +10,6 @@ ms.assetid: cb1377cf-869e-432d-941f-71f77134f97a
 
 > Plugin version mismatch: '*module*' version '*version-number*' doesn't match the version '*version-number*' of the PREfast driver
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error with the plugin version, not in the code being analyzed.

--- a/docs/code-quality/c1255.md
+++ b/docs/code-quality/c1255.md
@@ -10,4 +10,6 @@ ms.assetid: a97da6bd-06dc-42bf-9158-0de1ebb90d4a
 
 > PCH data for plugin '*plugin-name*' has incorrect length.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the tool, not in the code being analyzed.

--- a/docs/code-quality/c1255.md
+++ b/docs/code-quality/c1255.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1255"
 description: "Learn more about: Fatal error C1255"
-title: Fatal error C1255
 ms.date: 10/04/2022
 f1_keywords: ["C1255", "FATALERROR_PCHSyncLost"]
 helpviewer_keywords: ["C1255"]
-ms.assetid: a97da6bd-06dc-42bf-9158-0de1ebb90d4a
 ---
 # Fatal error C1255
 

--- a/docs/code-quality/c1256.md
+++ b/docs/code-quality/c1256.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1256"
 description: "Learn more about: Fatal error C1256"
-title: Fatal error C1256
 ms.date: 10/04/2022
 f1_keywords: ["C1256", "FATALERROR_PCHInconsistent"]
 helpviewer_keywords: ["C1256"]
-ms.assetid: 4d65e495-f9d9-435c-ba51-1cf5b4cc2309
 ---
 # Fatal error C1256
 

--- a/docs/code-quality/c1256.md
+++ b/docs/code-quality/c1256.md
@@ -10,4 +10,6 @@ ms.assetid: 4d65e495-f9d9-435c-ba51-1cf5b4cc2309
 
 > '*plugin-name*': PCH must be both written and read.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the tool, not in the code being analyzed.

--- a/docs/code-quality/c1257.md
+++ b/docs/code-quality/c1257.md
@@ -1,10 +1,9 @@
 ---
+title: "Fatal error C1257"
 description: "Learn more about: Fatal error C1257"
-title: Fatal error C1257
 ms.date: 10/04/2022
 f1_keywords: ["C1257", "FATALERROR_InitFailure"]
 helpviewer_keywords: ["C1257"]
-ms.assetid: 38d3ec05-01ba-42b3-aac6-077e92bf2ded
 ---
 # Fatal error C1257
 

--- a/docs/code-quality/c1257.md
+++ b/docs/code-quality/c1257.md
@@ -10,4 +10,6 @@ ms.assetid: 38d3ec05-01ba-42b3-aac6-077e92bf2ded
 
 > '*Plugin-name*': Initialization Failure.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.

--- a/docs/code-quality/c1258.md
+++ b/docs/code-quality/c1258.md
@@ -9,4 +9,6 @@ helpviewer_keywords: ["C1258"]
 
 > Failed to save XML Log file '*filename*'. *Message*.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.

--- a/docs/code-quality/c1258.md
+++ b/docs/code-quality/c1258.md
@@ -1,6 +1,6 @@
 ---
+title: "Fatal error C1258"
 description: "Learn more about: Fatal error C1258"
-title: Fatal error C1258
 ms.date: 10/04/2022
 f1_keywords: ["C1258", "FATALERROR_SaveToXmlFailed"]
 helpviewer_keywords: ["C1258"]

--- a/docs/code-quality/c1259.md
+++ b/docs/code-quality/c1259.md
@@ -1,6 +1,6 @@
 ---
+title: "Fatal error C1259"
 description: "Learn more about: Fatal error C1259"
-title: Fatal error C1259
 ms.date: 10/04/2022
 f1_keywords: ["C1259", "FATALERROR_FatalError"]
 helpviewer_keywords: ["C1259"]

--- a/docs/code-quality/c1259.md
+++ b/docs/code-quality/c1259.md
@@ -9,4 +9,6 @@ helpviewer_keywords: ["C1259"]
 
 > A fatal error was issued by a plugin.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.

--- a/docs/code-quality/c1260.md
+++ b/docs/code-quality/c1260.md
@@ -9,4 +9,6 @@ helpviewer_keywords: ["C1260"]
 
 > The plugins '*plugin-1*' and '*plugin-2*' share the same id. It is not supported to load the same plugin twice.
 
+## Remarks
+
 The Code Analysis tool reports this error when there's an internal error in the plugin, not in the code being analyzed.

--- a/docs/code-quality/c1260.md
+++ b/docs/code-quality/c1260.md
@@ -1,6 +1,6 @@
 ---
+title: "Fatal error C1260"
 description: "Learn more about: Fatal error C1260"
-title: Fatal error C1260
 ms.date: 10/04/2022
 f1_keywords: ["C1260", "FATALERROR_DuplicateId"]
 helpviewer_keywords: ["C1260"]


### PR DESCRIPTION
I missed this range of errors while doing #5507, since it belongs in `/code-quality` rather than the usual `/error-messages`.

This is batch 7 that structures error/warning references. See #5465 for more information.