### PR TITLE
Structure error references in range [C2001, C2020]

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
@@ -22,7 +22,7 @@ Ending the first line with \n is not sufficient.
 
 ## Example
 
-The following sample generates C2001:
+The following example generates C2001:
 
 ```cpp
 // C2001.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2001"
 title: "Compiler Error C2001"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2001"
+ms.date: 11/04/2016
 f1_keywords: ["C2001"]
 helpviewer_keywords: ["C2001"]
-ms.assetid: 0c3a7821-d8e5-4398-ab5a-4116d46e8dda
 ---
 # Compiler Error C2001
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
@@ -10,6 +10,8 @@ ms.assetid: 0c3a7821-d8e5-4398-ab5a-4116d46e8dda
 
 > newline in constant
 
+## Remarks
+
 A string constant cannot be continued on a second line unless you do the following:
 
 - End the first line with a backslash.
@@ -18,7 +20,7 @@ A string constant cannot be continued on a second line unless you do the followi
 
 Ending the first line with \n is not sufficient.
 
-## Examples
+## Example
 
 The following sample generates C2001:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2001.md
@@ -8,7 +8,7 @@ ms.assetid: 0c3a7821-d8e5-4398-ab5a-4116d46e8dda
 ---
 # Compiler Error C2001
 
-newline in constant
+> newline in constant
 
 A string constant cannot be continued on a second line unless you do the following:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
@@ -8,7 +8,7 @@ ms.assetid: 91982314-203a-4de1-b884-94e39a623f61
 ---
 # Compiler Error C2002
 
-invalid wide-character constant
+> invalid wide-character constant
 
 The multibyte-character constant is not valid.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2002"
 title: "Compiler Error C2002"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2002"
+ms.date: 11/04/2016
 f1_keywords: ["C2002"]
 helpviewer_keywords: ["C2002"]
-ms.assetid: 91982314-203a-4de1-b884-94e39a623f61
 ---
 # Compiler Error C2002
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2002.md
@@ -10,6 +10,8 @@ ms.assetid: 91982314-203a-4de1-b884-94e39a623f61
 
 > invalid wide-character constant
 
+## Remarks
+
 The multibyte-character constant is not valid.
 
 ### To fix by checking the following possible causes

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
@@ -8,6 +8,6 @@ ms.assetid: 3161bc08-593d-4448-9fd3-4e3810be9e82
 ---
 # Compiler Error C2003
 
-expected 'defined id'
+> expected 'defined id'
 
 An identifier must follow the preprocessor keyword.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
@@ -10,4 +10,6 @@ ms.assetid: 3161bc08-593d-4448-9fd3-4e3810be9e82
 
 > expected 'defined id'
 
+## Remarks
+
 An identifier must follow the preprocessor keyword.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2003.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2003"
 title: "Compiler Error C2003"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2003"
+ms.date: 11/04/2016
 f1_keywords: ["C2003"]
 helpviewer_keywords: ["C2003"]
-ms.assetid: 3161bc08-593d-4448-9fd3-4e3810be9e82
 ---
 # Compiler Error C2003
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
@@ -10,11 +10,13 @@ ms.assetid: d81526dd-3a00-4593-87b0-d910d3d29bca
 
 > expected 'defined(id)'
 
+## Remarks
+
 An identifier must appear in the parentheses following the preprocessor keyword.
 
 This error can also be generated as a result of compiler conformance work that was done for Visual Studio .NET 2003: missing parenthesis in preprocessor directive. If the closing parenthesis is missing from a preprocessor directive, the compiler will generate an error.
 
-## Examples
+## Example
 
 The following sample generates C2004:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
@@ -8,7 +8,7 @@ ms.assetid: d81526dd-3a00-4593-87b0-d910d3d29bca
 ---
 # Compiler Error C2004
 
-expected 'defined(id)'
+> expected 'defined(id)'
 
 An identifier must appear in the parentheses following the preprocessor keyword.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
@@ -18,7 +18,7 @@ This error can also be generated as a result of compiler conformance work that w
 
 ## Example
 
-The following sample generates C2004:
+The following example generates C2004:
 
 ```cpp
 // C2004.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2004.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2004"
 title: "Compiler Error C2004"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2004"
+ms.date: 11/04/2016
 f1_keywords: ["C2004"]
 helpviewer_keywords: ["C2004"]
-ms.assetid: d81526dd-3a00-4593-87b0-d910d3d29bca
 ---
 # Compiler Error C2004
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
@@ -8,7 +8,7 @@ ms.assetid: 090530ed-e0ec-4358-833a-ca24260e7ffe
 ---
 # Compiler Error C2005
 
-\#line expected a line number, found 'token'
+> #line expected a line number, found 'token'
 
 The `#line` directive must be followed by a line number.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
@@ -10,7 +10,11 @@ ms.assetid: 090530ed-e0ec-4358-833a-ca24260e7ffe
 
 > #line expected a line number, found 'token'
 
+## Remarks
+
 The `#line` directive must be followed by a line number.
+
+## Example
 
 The following sample generates C2005:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2005"
 title: "Compiler Error C2005"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2005"
+ms.date: 11/04/2016
 f1_keywords: ["C2005"]
 helpviewer_keywords: ["C2005"]
-ms.assetid: 090530ed-e0ec-4358-833a-ca24260e7ffe
 ---
 # Compiler Error C2005
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2005.md
@@ -16,7 +16,7 @@ The `#line` directive must be followed by a line number.
 
 ## Example
 
-The following sample generates C2005:
+The following example generates C2005:
 
 ```cpp
 // C2005.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2006"]
 ---
 # Compiler Error C2006
 
-'directive': expected "FILENAME" or \<FILENAME>
+> 'directive': expected "FILENAME" or \<FILENAME>
 
 Directives such as [#include](../../preprocessor/hash-include-directive-c-cpp.md) or [#import](../../preprocessor/hash-import-directive-cpp.md) require a filename. To resolve the error, ensure the filename is valid and enclosed in either double quotes or angle brackets.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2006"
 description: "Learn more about: Compiler Error C2006"
-ms.date: "01/28/2025"
+ms.date: 01/28/2025
 f1_keywords: ["C2006"]
 helpviewer_keywords: ["C2006"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
@@ -15,7 +15,7 @@ Directives such as [#include](../../preprocessor/hash-include-directive-c-cpp.md
 
 ## Example
 
-The following sample generates C2006:
+The following example generates C2006:
 
 ```cpp
 // C2006.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2006.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2006"]
 
 > 'directive': expected "FILENAME" or \<FILENAME>
 
+## Remarks
+
 Directives such as [#include](../../preprocessor/hash-include-directive-c-cpp.md) or [#import](../../preprocessor/hash-import-directive-cpp.md) require a filename. To resolve the error, ensure the filename is valid and enclosed in either double quotes or angle brackets.
+
+## Example
 
 The following sample generates C2006:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2007"
 title: "Compiler Error C2007"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2007"
+ms.date: 11/04/2016
 f1_keywords: ["C2007"]
 helpviewer_keywords: ["C2007"]
-ms.assetid: ecd09d99-5036-408b-9e46-bc15488f049e
 ---
 # Compiler Error C2007
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
@@ -10,7 +10,11 @@ ms.assetid: ecd09d99-5036-408b-9e46-bc15488f049e
 
 > #define syntax
 
+## Remarks
+
 No identifier appears after a `#define`. To resolve the error, use an identifier.
+
+## Example
 
 The following sample generates C2007:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
@@ -8,7 +8,7 @@ ms.assetid: ecd09d99-5036-408b-9e46-bc15488f049e
 ---
 # Compiler Error C2007
 
-\#define syntax
+> #define syntax
 
 No identifier appears after a `#define`. To resolve the error, use an identifier.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2007.md
@@ -16,7 +16,7 @@ No identifier appears after a `#define`. To resolve the error, use an identifier
 
 ## Example
 
-The following sample generates C2007:
+The following example generates C2007:
 
 ```cpp
 // C2007.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
@@ -10,7 +10,11 @@ ms.assetid: e748ccbe-ffd4-4008-aca7-e53c25225209
 
 > 'character' : unexpected in macro definition
 
+## Remarks
+
 The character appears immediately following the macro name. To resolve the error, there must be a space after the macro name.
+
+## Example
 
 The following sample generates C2008:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
@@ -8,7 +8,7 @@ ms.assetid: e748ccbe-ffd4-4008-aca7-e53c25225209
 ---
 # Compiler Error C2008
 
-'character' : unexpected in macro definition
+> 'character' : unexpected in macro definition
 
 The character appears immediately following the macro name. To resolve the error, there must be a space after the macro name.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
@@ -16,7 +16,7 @@ The character appears immediately following the macro name. To resolve the error
 
 ## Example
 
-The following sample generates C2008:
+The following example generates C2008:
 
 ```cpp
 // C2008.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2008.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2008"
 title: "Compiler Error C2008"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2008"
+ms.date: 11/04/2016
 f1_keywords: ["C2008"]
 helpviewer_keywords: ["C2008"]
-ms.assetid: e748ccbe-ffd4-4008-aca7-e53c25225209
 ---
 # Compiler Error C2008
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
@@ -8,7 +8,7 @@ ms.assetid: fe9d94ed-20a5-4d83-b9c4-60ee69d2f30a
 ---
 # Compiler Error C2009
 
-reuse of macro formal 'identifier'
+> reuse of macro formal 'identifier'
 
 The formal parameter list of a macro definition uses the identifier more than once. Identifiers in the macro's parameter list must be unique.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2009"
 title: "Compiler Error C2009"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2009"
+ms.date: 11/04/2016
 f1_keywords: ["C2009"]
 helpviewer_keywords: ["C2009"]
-ms.assetid: fe9d94ed-20a5-4d83-b9c4-60ee69d2f30a
 ---
 # Compiler Error C2009
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
@@ -10,9 +10,11 @@ ms.assetid: fe9d94ed-20a5-4d83-b9c4-60ee69d2f30a
 
 > reuse of macro formal 'identifier'
 
+## Remarks
+
 The formal parameter list of a macro definition uses the identifier more than once. Identifiers in the macro's parameter list must be unique.
 
-## Examples
+## Example
 
 The following sample generates C2009:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2009.md
@@ -16,7 +16,7 @@ The formal parameter list of a macro definition uses the identifier more than on
 
 ## Example
 
-The following sample generates C2009:
+The following example generates C2009:
 
 ```cpp
 // C2009.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
@@ -10,7 +10,11 @@ ms.assetid: 5795ed1d-e206-410b-b7b4-528d125c67b4
 
 > 'character' : unexpected in macro formal parameter list
 
+## Remarks
+
 The character is used incorrectly in the formal parameter list of a macro definition. Remove the character to resolve the error.
+
+## Example
 
 The following sample generates C2010:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
@@ -16,7 +16,7 @@ The character is used incorrectly in the formal parameter list of a macro defini
 
 ## Example
 
-The following sample generates C2010:
+The following example generates C2010:
 
 ```cpp
 // C2010.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
@@ -8,7 +8,7 @@ ms.assetid: 5795ed1d-e206-410b-b7b4-528d125c67b4
 ---
 # Compiler Error C2010
 
-'character' : unexpected in macro formal parameter list
+> 'character' : unexpected in macro formal parameter list
 
 The character is used incorrectly in the formal parameter list of a macro definition. Remove the character to resolve the error.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2010.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2010"
 title: "Compiler Error C2010"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2010"
+ms.date: 11/04/2016
 f1_keywords: ["C2010"]
 helpviewer_keywords: ["C2010"]
-ms.assetid: 5795ed1d-e206-410b-b7b4-528d125c67b4
 ---
 # Compiler Error C2010
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
@@ -8,7 +8,7 @@ ms.assetid: 992c9d51-e850-4d53-b86b-02e73b38249c
 ---
 # Compiler Error C2011
 
-'identifier' : 'type' type redefinition
+> 'identifier' : 'type' type redefinition
 
 The identifier was already defined as `type`. Check for redefinitions of the identifier.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
@@ -20,7 +20,7 @@ If you need to find the initial declaration of the redefined type, you can use t
 
 ## Example
 
-The following sample generates C2011 and shows one way to fix it:
+The following example generates C2011 and shows one way to fix it:
 
 ```cpp
 // C2011.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
@@ -10,11 +10,15 @@ ms.assetid: 992c9d51-e850-4d53-b86b-02e73b38249c
 
 > 'identifier' : 'type' type redefinition
 
+## Remarks
+
 The identifier was already defined as `type`. Check for redefinitions of the identifier.
 
 You may also get C2011 if you import a header file or type library more than once into the same file. To prevent multiple inclusions of the types defined in a header file, use include guards or a `#pragma`[once](../../preprocessor/once.md) directive in the header file.
 
 If you need to find the initial declaration of the redefined type, you can use the [/P](../../build/reference/p-preprocess-to-a-file.md) compiler flag to generate the preprocessed output passed to the compiler. You can use text search tools to find instances of the redefined identifier in the output file.
+
+## Example
 
 The following sample generates C2011 and shows one way to fix it:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2011.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2011"
 title: "Compiler Error C2011"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2011"
+ms.date: 11/04/2016
 f1_keywords: ["C2011"]
 helpviewer_keywords: ["C2011"]
-ms.assetid: 992c9d51-e850-4d53-b86b-02e73b38249c
 ---
 # Compiler Error C2011
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
@@ -16,7 +16,7 @@ An `#include` directive lacks the required filename.
 
 ## Example
 
-The following sample generates C2012:
+The following example generates C2012:
 
 ```cpp
 // C2012.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
@@ -8,7 +8,7 @@ ms.assetid: 9f0d8162-c0b3-4234-a41f-836fdb75c84e
 ---
 # Compiler Error C2012
 
-missing name following '<'
+> missing name following '<'
 
 An `#include` directive lacks the required filename.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
@@ -10,7 +10,11 @@ ms.assetid: 9f0d8162-c0b3-4234-a41f-836fdb75c84e
 
 > missing name following '<'
 
+## Remarks
+
 An `#include` directive lacks the required filename.
+
+## Example
 
 The following sample generates C2012:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2012.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2012"
 title: "Compiler Error C2012"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2012"
+ms.date: 11/04/2016
 f1_keywords: ["C2012"]
 helpviewer_keywords: ["C2012"]
-ms.assetid: 9f0d8162-c0b3-4234-a41f-836fdb75c84e
 ---
 # Compiler Error C2012
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2013"
 title: "Compiler Error C2013"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2013"
+ms.date: 11/04/2016
 f1_keywords: ["C2013"]
 helpviewer_keywords: ["C2013"]
-ms.assetid: 6b5c955c-53da-48ee-8533-64ef5b905173
 ---
 # Compiler Error C2013
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
@@ -16,7 +16,7 @@ An `#include` directive lacks a closing angle bracket. Add the closing bracket t
 
 ## Example
 
-The following sample generates C2013:
+The following example generates C2013:
 
 ```cpp
 // C2013.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
@@ -10,7 +10,11 @@ ms.assetid: 6b5c955c-53da-48ee-8533-64ef5b905173
 
 > missing '>'
 
+## Remarks
+
 An `#include` directive lacks a closing angle bracket. Add the closing bracket to resolve the error.
+
+## Example
 
 The following sample generates C2013:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2013.md
@@ -8,7 +8,7 @@ ms.assetid: 6b5c955c-53da-48ee-8533-64ef5b905173
 ---
 # Compiler Error C2013
 
-missing '>'
+> missing '>'
 
 An `#include` directive lacks a closing angle bracket. Add the closing bracket to resolve the error.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
@@ -8,7 +8,7 @@ ms.assetid: 231d8e9c-48c0-4027-99a3-245d186275ec
 ---
 # Compiler Error C2014
 
-preprocessor command must start as first nonwhite space
+> preprocessor command must start as first nonwhite space
 
 The `#` sign of a preprocessor directive must be the first character on a line that is not white space.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2014"
 title: "Compiler Error C2014"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2014"
+ms.date: 11/04/2016
 f1_keywords: ["C2014"]
 helpviewer_keywords: ["C2014"]
-ms.assetid: 231d8e9c-48c0-4027-99a3-245d186275ec
 ---
 # Compiler Error C2014
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
@@ -10,7 +10,11 @@ ms.assetid: 231d8e9c-48c0-4027-99a3-245d186275ec
 
 > preprocessor command must start as first nonwhite space
 
+## Remarks
+
 The `#` sign of a preprocessor directive must be the first character on a line that is not white space.
+
+## Example
 
 The following sample generates C2014:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2014.md
@@ -16,7 +16,7 @@ The `#` sign of a preprocessor directive must be the first character on a line t
 
 ## Example
 
-The following sample generates C2014:
+The following example generates C2014:
 
 ```cpp
 // C2014.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
@@ -10,6 +10,8 @@ ms.assetid: 8f40af0a-3a5a-4d6a-8ed7-125966e6bfed
 
 > too many characters in constant
 
+## Remarks
+
 A character constant contains more than two characters. The limit is one character for standard character constants and two characters for long character constants.
 
 An escape sequence, such as \t, is converted to a single character.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2015"
 title: "Compiler Error C2015"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2015"
+ms.date: 11/04/2016
 f1_keywords: ["C2015"]
 helpviewer_keywords: ["C2015"]
-ms.assetid: 8f40af0a-3a5a-4d6a-8ed7-125966e6bfed
 ---
 # Compiler Error C2015
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
@@ -8,7 +8,7 @@ ms.assetid: 8f40af0a-3a5a-4d6a-8ed7-125966e6bfed
 ---
 # Compiler Error C2015
 
-too many characters in constant
+> too many characters in constant
 
 A character constant contains more than two characters. The limit is one character for standard character constants and two characters for long character constants.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2015.md
@@ -18,7 +18,7 @@ An escape sequence, such as \t, is converted to a single character.
 
 ## Examples
 
-The following sample generates C2015:
+The following example generates C2015:
 
 ```cpp
 // C2015.cpp
@@ -28,7 +28,7 @@ char test1 = 'error';   // C2015
 char test2 = 'e';   // OK
 ```
 
-C2015 can also occur when using a Microsoft extension, character constants converted to integers.  The following sample generates C2015:
+C2015 can also occur when using a Microsoft extension, character constants converted to integers.  The following example generates C2015:
 
 ```cpp
 // C2015b.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2016.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2016.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Error C2016"
 title: "Compiler Error C2016"
+description: "Learn more about: Compiler Error C2016"
 ms.date: 08/18/2022
 f1_keywords: ["C2016"]
 helpviewer_keywords: ["C2016"]

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2016.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2016.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2016"]
 
 > C requires that a struct or union has at least one member
 
+## Remarks
+
 The compiler found a **`struct`** or **`union`** defined with no members, which isn't allowed in C. For more information, see [Structures](../../c-language/structure-declarations.md) and [Unions](../../c-language/union-declarations.md).
 
 To resolve this error, create at least one member in your **`struct`** or **`union`**.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2017"
 title: "Compiler Error C2017"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2017"
+ms.date: 11/04/2016
 f1_keywords: ["C2017"]
 helpviewer_keywords: ["C2017"]
-ms.assetid: 1083eed9-9906-4a97-883c-54e52d7e82cd
 ---
 # Compiler Error C2017
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
@@ -16,7 +16,7 @@ An escape sequence, such as \t, appears outside of a character or string constan
 
 ## Examples
 
-The following sample generates C2017:
+The following example generates C2017:
 
 ```cpp
 // C2017.cpp
@@ -28,7 +28,7 @@ int main() {
 
 C2017 can occur when the stringize operator is used with strings that include escape sequences.
 
-The following sample generates C2017:
+The following example generates C2017:
 
 ```cpp
 // C2017b.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
@@ -8,7 +8,7 @@ ms.assetid: 1083eed9-9906-4a97-883c-54e52d7e82cd
 ---
 # Compiler Error C2017
 
-illegal escape sequence
+> illegal escape sequence
 
 An escape sequence, such as \t, appears outside of a character or string constant.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2017.md
@@ -10,7 +10,11 @@ ms.assetid: 1083eed9-9906-4a97-883c-54e52d7e82cd
 
 > illegal escape sequence
 
+## Remarks
+
 An escape sequence, such as \t, appears outside of a character or string constant.
+
+## Examples
 
 The following sample generates C2017:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
@@ -16,7 +16,7 @@ The character followed a `#` sign but it is not the first letter of a preprocess
 
 ## Example
 
-The following sample generates C2019:
+The following example generates C2019:
 
 ```cpp
 // C2019.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2019"
 title: "Compiler Error C2019"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2019"
+ms.date: 11/04/2016
 f1_keywords: ["C2019"]
 helpviewer_keywords: ["C2019"]
-ms.assetid: 4f37b1e1-9eca-418f-a4c3-141e8512d7b6
 ---
 # Compiler Error C2019
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
@@ -8,7 +8,7 @@ ms.assetid: 4f37b1e1-9eca-418f-a4c3-141e8512d7b6
 ---
 # Compiler Error C2019
 
-expected preprocessor directive, found 'character'
+> expected preprocessor directive, found 'character'
 
 The character followed a `#` sign but it is not the first letter of a preprocessor directive.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2019.md
@@ -10,7 +10,11 @@ ms.assetid: 4f37b1e1-9eca-418f-a4c3-141e8512d7b6
 
 > expected preprocessor directive, found 'character'
 
+## Remarks
+
 The character followed a `#` sign but it is not the first letter of a preprocessor directive.
+
+## Example
 
 The following sample generates C2019:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2020"
 title: "Compiler Error C2020"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2020"
+ms.date: 11/04/2016
 f1_keywords: ["C2020"]
 helpviewer_keywords: ["C2020"]
-ms.assetid: 486f98ed-6574-4d82-89e3-74b5a61ed419
 ---
 # Compiler Error C2020
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
@@ -10,4 +10,6 @@ ms.assetid: 486f98ed-6574-4d82-89e3-74b5a61ed419
 
 > 'member' : 'class' member redefinition
 
+## Remarks
+
 A member inherited from a base class or structure is redefined. Inherited members cannot be redefined unless declared as **`virtual`** in the base class.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2020.md
@@ -8,6 +8,6 @@ ms.assetid: 486f98ed-6574-4d82-89e3-74b5a61ed419
 ---
 # Compiler Error C2020
 
-'member' : 'class' member redefinition
+> 'member' : 'class' member redefinition
 
 A member inherited from a base class or structure is redefined. Inherited members cannot be redefined unless declared as **`virtual`** in the base class.


### PR DESCRIPTION
This is batch 9 that structures error/warning references. See #5465 for more information.