### PR TITLE
Remove more superfluous semicolons after function definition

### DIFF
--- a/docs/atl/codesnippet/CPP/atl-collection-classes_1.cpp
+++ b/docs/atl/codesnippet/CPP/atl-collection-classes_1.cpp
@@ -29,7 +29,7 @@ public:
          return true;
       else
          return false;
-   };
+   }
 };
 
 void DoAtlCustomTraitsList()

--- a/docs/c-runtime-library/reference/get-purecall-handler-set-purecall-handler.md
+++ b/docs/c-runtime-library/reference/get-purecall-handler-set-purecall-handler.md
@@ -64,7 +64,7 @@ class CDerived;
 class CBase
 {
 public:
-   CBase(CDerived *derived): m_pDerived(derived) {};
+   CBase(CDerived *derived): m_pDerived(derived) {}
    ~CBase();
    virtual void function(void) = 0;
 
@@ -74,8 +74,8 @@ public:
 class CDerived : public CBase
 {
 public:
-   CDerived() : CBase(this) {};   // C4355
-   virtual void function(void) {};
+   CDerived() : CBase(this) {}   // C4355
+   virtual void function(void) {}
 };
 
 CBase::~CBase()

--- a/docs/c-runtime-library/reference/get-purecall-handler-set-purecall-handler.md
+++ b/docs/c-runtime-library/reference/get-purecall-handler-set-purecall-handler.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _get_purecall_handler, _set_purecall_handler"
 title: "_get_purecall_handler, _set_purecall_handler"
-ms.date: "1/14/2021"
+description: "Learn more about: _get_purecall_handler, _set_purecall_handler"
+ms.date: 1/14/2021
 api_name: ["_set_purecall_handler", "_set_purecall_handler_m", "_get_purecall_handler"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_set_purecall_handler", "_set_purecall_handler_m", "set_purecall_handler_m", "set_purecall_handler", "stdlib/_set_purecall_handler", "stdlib/_get_purecall_handler", "_get_purecall_handler"]
 helpviewer_keywords: ["_set_purecall_handler function", "set_purecall_handler function", "purecall_handler", "set_purecall_handler_m function", "_purecall_handler", "_set_purecall_handler_m function", "_get_purecall_handler function"]
-ms.assetid: 2759b878-8afa-4129-86e7-72afc2153d9c
 ---
 # `_get_purecall_handler`, `_set_purecall_handler`
 

--- a/docs/code-quality/c28208.md
+++ b/docs/code-quality/c28208.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C28208"
 title: Warning C28208
+description: "Learn more about: Warning C28208"
 ms.date: 10/03/2022
 f1_keywords: ["C28208", "FUNCTION_TYPE_REDECLARATION", "__WARNING_FUNCTION_TYPE_REDECLARATION"]
 helpviewer_keywords: ["C28208"]
-ms.assetid: e9a8ce37-3b05-4202-b078-5570ae496d1d
 ---
 # Warning C28208
 

--- a/docs/code-quality/c28208.md
+++ b/docs/code-quality/c28208.md
@@ -30,8 +30,8 @@ typedef void test_type(void*);
 #include "c28208_example.h"
 test_type my_test1;
 test_type my_test2;
-void my_test1(int* x){};  // Generates C28208
-void my_test2(void* x){};  // Doesn't generate C28208
+void my_test1(int* x){}  // Generates C28208
+void my_test2(void* x){}  // Doesn't generate C28208
 
 int main()
 {

--- a/docs/cpp/class-templates.md
+++ b/docs/cpp/class-templates.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Class Templates"
 title: "Class Templates"
+description: "Learn more about: Class Templates"
 ms.date: 06/30/2022
 helpviewer_keywords: ["classes [C++], operating on type", "class templates", "templates, class templates"]
-ms.assetid: 633a53c8-24ee-4c23-8c88-e7c3cb0b7ac3
 ---
 # Class Templates
 

--- a/docs/cpp/class-templates.md
+++ b/docs/cpp/class-templates.md
@@ -28,15 +28,15 @@ public:
 
 template< class T, int i > MyStack< T, i >::MyStack( void )
 {
-};
+}
 
 template< class T, int i > void MyStack< T, i >::push( const T item )
 {
-};
+}
 
 template< class T, int i > T& MyStack< T, i >::pop( void )
 {
-};
+}
 
 int main()
 {

--- a/docs/cpp/decltype-cpp.md
+++ b/docs/cpp/decltype-cpp.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: decltype (C++)"
 title: "decltype (C++)"
+description: "Learn more about: decltype (C++)"
 ms.date: 09/14/2023
 f1_keywords: ["decltype_cpp"]
 helpviewer_keywords: ["operators [C++], decltype", "decltype operator", "operators [C++], type of an expression", "operators [C++], deduce expression type"]

--- a/docs/cpp/decltype-cpp.md
+++ b/docs/cpp/decltype-cpp.md
@@ -60,7 +60,7 @@ In C++11, you can use the **`decltype`** type specifier on a trailing return typ
 
 ```cpp
 template<typename T, typename U>
-UNKNOWN func(T&& t, U&& u){ return t + u; };
+UNKNOWN func(T&& t, U&& u){ return t + u; }
 ```
 
 The introduction of the **`decltype`** type specifier enables a developer to obtain the type of the expression that the function template returns. Use the *alternative function declaration syntax* that is shown later, the **`auto`** keyword, and the **`decltype`** type specifier to declare a *late-specified* return type. The late-specified return type is determined when the declaration is compiled, instead of when it's coded.
@@ -75,12 +75,12 @@ In the following code example, the late-specified return type of the `myFunc` fu
 //C++11
 template<typename T, typename U>
 auto myFunc(T&& t, U&& u) -> decltype (forward<T>(t) + forward<U>(u))
-        { return forward<T>(t) + forward<U>(u); };
+        { return forward<T>(t) + forward<U>(u); }
 
 //C++14
 template<typename T, typename U>
 decltype(auto) myFunc(T&& t, U&& u)
-        { return forward<T>(t) + forward<U>(u); };
+        { return forward<T>(t) + forward<U>(u); }
 ```
 
 ## `decltype` and forwarding functions (C++11)

--- a/docs/cpp/explicit-specialization-of-function-templates.md
+++ b/docs/cpp/explicit-specialization-of-function-templates.md
@@ -21,7 +21,7 @@ This declaration enables you to define a different function for **`double`** var
 // explicit_specialization.cpp
 template<class T> void f(T t)
 {
-};
+}
 
 // Explicit specialization of f with 'char' with the
 // template argument explicitly specified:

--- a/docs/cpp/explicit-specialization-of-function-templates.md
+++ b/docs/cpp/explicit-specialization-of-function-templates.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Explicit Specialization of Function Templates"
 title: "Explicit Specialization of Function Templates"
-ms.date: "11/04/2016"
+description: "Learn more about: Explicit Specialization of Function Templates"
+ms.date: 11/04/2016
 helpviewer_keywords: ["overriding, functions", "function templates, specialization", "explicit specialization of function templates", "declaring functions [C++], specialization of function template", "specialization of function templates"]
-ms.assetid: eb0fcb73-eaed-42a1-9b83-14b055a34bf8
 ---
 # Explicit Specialization of Function Templates
 

--- a/docs/cpp/explicitly-defaulted-and-deleted-functions.md
+++ b/docs/cpp/explicitly-defaulted-and-deleted-functions.md
@@ -44,7 +44,7 @@ These rules can complicate the implementation of what should be straight-forward
 ```cpp
 struct noncopyable
 {
-  noncopyable() {};
+  noncopyable() {}
 
 private:
   noncopyable(const noncopyable&);

--- a/docs/cpp/explicitly-defaulted-and-deleted-functions.md
+++ b/docs/cpp/explicitly-defaulted-and-deleted-functions.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Explicitly Defaulted and Deleted Functions"
 title: "Explicitly Defaulted and Deleted Functions"
-ms.date: "11/04/2016"
+description: "Learn more about: Explicitly Defaulted and Deleted Functions"
+ms.date: 11/04/2016
 ---
 # Explicitly Defaulted and Deleted Functions
 

--- a/docs/cpp/initializers.md
+++ b/docs/cpp/initializers.md
@@ -1,7 +1,7 @@
 ---
 title: "Initializers"
-ms.date: "07/29/2019"
 description: "How to initialize classes, structs, arrays and fundamental types in C++."
+ms.date: 07/29/2019
 helpviewer_keywords: ["arrays [C++], array-element initializers", "aggregate initializers [C++]"]
 ---
 # Initializers

--- a/docs/cpp/initializers.md
+++ b/docs/cpp/initializers.md
@@ -51,8 +51,8 @@ Initializers may take these forms:
     };
     class PointConsumer{
     public:
-        void set_point(Point p){};
-        void set_points(initializer_list<Point> my_list){};
+        void set_point(Point p){}
+        void set_points(initializer_list<Point> my_list){}
     };
     int main() {
         PointConsumer pc{};

--- a/docs/cpp/safebuffers.md
+++ b/docs/cpp/safebuffers.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: safebuffers"
 title: "safebuffers"
-ms.date: "11/04/2016"
+description: "Learn more about: safebuffers"
+ms.date: 11/04/2016
 f1_keywords: ["safebuffers_cpp"]
 helpviewer_keywords: ["__declspec keyword (C++), safebuffers", "safebuffers __declspec keyword"]
-ms.assetid: 0b0dce14-4523-44d2-8070-5dd0fdabc618
 ---
 # safebuffers
 

--- a/docs/cpp/safebuffers.md
+++ b/docs/cpp/safebuffers.md
@@ -50,7 +50,7 @@ static int checkBuffers() {
     BUFFER cb;
     // Use the buffer...
     return 0;
-};
+}
 static __declspec(safebuffers)
     int noCheckBuffers() {
     BUFFER ncb;

--- a/docs/cpp/selectany.md
+++ b/docs/cpp/selectany.md
@@ -56,7 +56,7 @@ extern __declspec(selectany) int x5;
 // OK: dynamic initialization of global object
 class X {
 public:
-X(int i){i++;};
+X(int i){i++;}
 int i;
 };
 

--- a/docs/cpp/selectany.md
+++ b/docs/cpp/selectany.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: `selectany`"
 title: "selectany"
-ms.date: "11/04/2016"
+description: "Learn more about: `selectany`"
+ms.date: 11/04/2016
 f1_keywords: ["selectany_cpp"]
 helpviewer_keywords: ["__declspec keyword [C++], selectany", "selectany __declspec keyword"]
-ms.assetid: 9c353017-5a42-4f50-b741-bd13da1ce84d
 ---
 # `selectany`
 

--- a/docs/cpp/single-inheritance.md
+++ b/docs/cpp/single-inheritance.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Single Inheritance"
 title: "Single Inheritance"
-ms.date: "11/19/2018"
+description: "Learn more about: Single Inheritance"
+ms.date: 11/19/2018
 helpviewer_keywords: ["single inheritance", "base classes [C++], indirect", "scope, scope resolution operator", "operators [C++], scope resolution", "scope resolution operator", "derived classes [C++], single base class", "inheritance, single"]
-ms.assetid: 1cb946ed-8b1b-4cf1-bde0-d9cecbfdc622
 ---
 # Single Inheritance
 

--- a/docs/cpp/single-inheritance.md
+++ b/docs/cpp/single-inheritance.md
@@ -74,7 +74,7 @@ Book::Book( char *name, long pagecount ) {
    Name = new char[ strlen( name ) + 1 ];
    strcpy_s( Name, strlen(Name), name );
    PageCount = pagecount;
-};
+}
 ```
 
 Note that the constructor for `Book`, (`Book::Book`), has access to the data member, `Name`. In a program, an object of type `Book` can be created and used as follows:

--- a/docs/cppcx/platform-object-class.md
+++ b/docs/cppcx/platform-object-class.md
@@ -166,7 +166,7 @@ public:
     virtual Platform::String^ ToString() override
     {
       return "I'm a Tree";
-    };
+    }
 };
 ```
 

--- a/docs/cppcx/platform-object-class.md
+++ b/docs/cppcx/platform-object-class.md
@@ -1,7 +1,7 @@
 ---
 title: "Platform::Object Class"
 description: "Learn more about: Platform::Object Class"
-ms.date: "12/30/2016"
+ms.date: 12/30/2016
 ms.topic: "reference"
 f1_keywords: ["VCCORLIB/Platform::Object::Object", "VCCORLIB/Platform::Object::Equals", "VCCORLIB/Platform::Object::GetHashCode", "VCCORLIB/Platform::Object::ReferenceEquals", "VCCORLIB/Platform::ToString", "VCCORLIB/Platform::GetType"]
 helpviewer_keywords: ["Object class"]

--- a/docs/dotnet/double-thunking-cpp.md
+++ b/docs/dotnet/double-thunking-cpp.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Double Thunking (C++)"
 title: "Double Thunking (C++)"
-ms.date: "11/04/2016"
+description: "Learn more about: Double Thunking (C++)"
+ms.date: 11/04/2016
 helpviewer_keywords: ["double thunks", "interop [C++], double thunking", "mixed assemblies [C++], double thunking", "/clr compiler option [C++], double thunking", "interoperability [C++], double thunking"]
-ms.assetid: a85090b2-dc3c-498a-b40c-340db229dd6f
 ms.topic: how-to
 ---
 # Double Thunking (C++)

--- a/docs/dotnet/double-thunking-cpp.md
+++ b/docs/dotnet/double-thunking-cpp.md
@@ -52,7 +52,7 @@ struct T {
 };
 
 struct S {
-   virtual void /* __clrcall */ f(T t) {};
+   virtual void /* __clrcall */ f(T t) {}
 } s;
 
 int main() {
@@ -101,7 +101,7 @@ struct T {
 };
 
 struct S {
-   virtual void /* __clrcall */ f(T t) {};
+   virtual void /* __clrcall */ f(T t) {}
 } s;
 
 int main() {

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2246.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2246.md
@@ -20,5 +20,5 @@ The following sample generates C2246:
 void func( void ) {
    class A { static int i; };   // C2246  i is local to func
    static int j;   // OK
-};
+}
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2246.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2246.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2246"
 title: "Compiler Error C2246"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2246"
+ms.date: 11/04/2016
 f1_keywords: ["C2246"]
 helpviewer_keywords: ["C2246"]
-ms.assetid: 4f3e4f83-21f3-4256-af96-43e0bb060311
 ---
 # Compiler Error C2246
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2249.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2249.md
@@ -20,9 +20,9 @@ The following sample generates C2249.
 // C2249.cpp
 class A {
 private:
-   void privFunc( void ) {};
+   void privFunc( void ) {}
 public:
-   void pubFunc( void ) {};
+   void pubFunc( void ) {}
 };
 
 class B : virtual public A {} b;

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2249.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2249.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2249"
 title: "Compiler Error C2249"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2249"
+ms.date: 11/04/2016
 f1_keywords: ["C2249"]
 helpviewer_keywords: ["C2249"]
-ms.assetid: bdd6697c-e04b-49b9-8e40-d9eb6d74f2b6
 ---
 # Compiler Error C2249
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2254.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2254.md
@@ -24,6 +24,6 @@ public:
    friend void func3();   // OK, friend not virtual nor pure
 };
 
-void func1() {};
-void func3() {};
+void func1() {}
+void func3() {}
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2254.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2254.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2254"
 title: "Compiler Error C2254"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2254"
+ms.date: 11/04/2016
 f1_keywords: ["C2254"]
 helpviewer_keywords: ["C2254"]
-ms.assetid: 49bb3d7e-3bdf-4af6-937c-fa627be412a9
 ---
 # Compiler Error C2254
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2614.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2614.md
@@ -21,12 +21,12 @@ The following sample generates C2614.
 // compile with: /c
 struct A {
    int i;
-   A( int ia ) : B( i ) {};   // C2614 B is not a member of A
+   A( int ia ) : B( i ) {}   // C2614 B is not a member of A
 };
 
 struct A2 {
    int B;
    int i;
-   A2( int ia ) : B( i ) {};   // OK
+   A2( int ia ) : B( i ) {}   // OK
 };
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2614.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2614.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2614"
 title: "Compiler Error C2614"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2614"
+ms.date: 11/04/2016
 f1_keywords: ["C2614"]
 helpviewer_keywords: ["C2614"]
-ms.assetid: a550c1d5-8718-4e17-a888-b2619e00fe11
 ---
 # Compiler Error C2614
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
@@ -34,13 +34,13 @@ The following sample generates C2664 and shows how to fix it.
 // C2664.cpp
 // C2664
 struct A {
-   void f(int i) {};
+   void f(int i) {}
 };
 
 struct B : public A {
    // To fix, uncomment the following line.
    // using A::f;
-   void f(A a) {};
+   void f(A a) {}
 };
 
 int main() {

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2664"
 title: "Compiler Error C2664"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2664"
+ms.date: 11/04/2016
 f1_keywords: ["C2664"]
 helpviewer_keywords: ["C2664"]
-ms.assetid: 3595d66e-cf87-4fda-a896-c0cd81f95db4
 ---
 # Compiler Error C2664
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
@@ -20,7 +20,7 @@ class C {
    static void func();
 };
 
-static void C::func(){};   // C2724
+static void C::func(){}   // C2724
 // try the following line instead
-// void C::func(){};
+// void C::func(){}
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2724"
 title: "Compiler Error C2724"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2724"
+ms.date: 11/04/2016
 f1_keywords: ["C2724"]
 helpviewer_keywords: ["C2724"]
-ms.assetid: 4e4664bc-8c96-4156-b79f-03436f532ea8
 ---
 # Compiler Error C2724
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2758"
 title: "Compiler Error C2758"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2758"
+ms.date: 11/04/2016
 f1_keywords: ["C2758"]
 helpviewer_keywords: ["C2758"]
-ms.assetid: 1d273034-194c-4926-9869-142d1b219cbe
 ---
 # Compiler Error C2758
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
@@ -20,8 +20,8 @@ The following sample generates C2758:
 struct A {
    const int i;
 
-   A(int n) { };   // C2758
+   A(int n) { }   // C2758
    // try the following line instead
-   // A(int n) : i{n} {};
+   // A(int n) : i{n} {}
 };
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2765.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2765"
 title: "Compiler Error C2765"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2765"
+ms.date: 11/04/2016
 f1_keywords: ["C2765"]
 helpviewer_keywords: ["C2765"]
-ms.assetid: 47ad86f3-a7e0-47ad-85ff-0f5534458cb9
 ---
 # Compiler Error C2765
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2765.md
@@ -16,7 +16,7 @@ The following sample generates C2765:
 
 ```cpp
 // C2765.cpp
-template<class T> void f(T t) {};
+template<class T> void f(T t) {}
 
 template<> void f<char>(char c = 'a') {}   // C2765
 // try the following line instead

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3068.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3068.md
@@ -42,5 +42,5 @@ void b(A){}
 
 __declspec(naked) void c() {
    b(A());   // C3068
-};
+}
 ```

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3068.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3068.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3068"
 title: "Compiler Error C3068"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3068"
+ms.date: 11/04/2016
 f1_keywords: ["C3068"]
 helpviewer_keywords: ["C3068"]
-ms.assetid: 613e3447-b4a8-4268-a661-297bed63ccdf
 ---
 # Compiler Error C3068
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3771"
 title: "Compiler Error C3771"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3771"
+ms.date: 11/04/2016
 f1_keywords: ["C3771"]
 helpviewer_keywords: ["C3771"]
-ms.assetid: 68c23b25-7f21-4eaa-8f7e-38fda1130a69
 ---
 # Compiler Error C3771
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
@@ -26,7 +26,7 @@ The following code example declares a class template and function in namespace `
 
 namespace NA {
 template<class T> class A {
-    void aFunction(T t) {};
+    void aFunction(T t) {}
     };
 }
 // using namespace NA;

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
@@ -25,7 +25,7 @@ The following sample generates C4355:
 class CDerived;
 class CBase {
 public:
-   CBase(CDerived *derived): m_pDerived(derived) {};
+   CBase(CDerived *derived): m_pDerived(derived) {}
    ~CBase();
    virtual void function() = 0;
 
@@ -34,8 +34,8 @@ public:
 
 class CDerived : public CBase {
 public:
-   CDerived() : CBase(this) {};   // C4355 "this" used in derived c'tor
-   virtual void function() {};
+   CDerived() : CBase(this) {}   // C4355 "this" used in derived c'tor
+   virtual void function() {}
 };
 
 CBase::~CBase() {

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1 and level 4, off) C4355"
 title: "Compiler Warning (level 1 and level 4, off) C4355"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1 and level 4, off) C4355"
+ms.date: 11/04/2016
 f1_keywords: ["C4355"]
 helpviewer_keywords: ["C4355"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4183.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4183.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4183"
 title: "Compiler Warning (level 1) C4183"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4183"
+ms.date: 11/04/2016
 f1_keywords: ["C4183"]
 helpviewer_keywords: ["C4183"]
-ms.assetid: dc48312c-4b34-44dd-80ff-eb5f11d5ca47
 ---
 # Compiler Warning (level 1) C4183
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4183.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4183.md
@@ -20,6 +20,6 @@ The following sample generates C4183:
 #pragma warning(disable : 4430)
 class MyClass1;
 class MyClass2 {
-   MyClass1() {};   // C4183
+   MyClass1() {}   // C4183
 };
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4353"
 title: "Compiler Warning (level 1) C4353"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4353"
+ms.date: 11/04/2016
 f1_keywords: ["C4353"]
 helpviewer_keywords: ["C4353"]
-ms.assetid: 6e79f186-ed82-4c95-9923-0ad5bb9c4db1
 ---
 # Compiler Warning (level 1) C4353
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
@@ -17,7 +17,7 @@ The following sample generates C4353:
 ```cpp
 // C4353.cpp
 // compile with: /W1
-void MyPrintf(void){};
+void MyPrintf(void){}
 #define X 0
 #if X
    #define DBPRINT MyPrint

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4722.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4722.md
@@ -25,7 +25,7 @@ The following sample generates C4722:
 class C {
 public:
    C();
-   ~C() { exit(1); };   // C4722
+   ~C() { exit(1); }   // C4722
 };
 
 extern void func (C*);

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4722.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4722.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4722"
 title: "Compiler Warning (level 1) C4722"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4722"
+ms.date: 11/04/2016
 f1_keywords: ["C4722"]
 helpviewer_keywords: ["C4722"]
-ms.assetid: d8660710-f67b-4f59-a5fd-59259475529e
 ---
 # Compiler Warning (level 1) C4722
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4747.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4747.md
@@ -35,5 +35,5 @@ The following sample generates C4747.
 
 BOOL WINAPI DllMain(HANDLE hInstance, ULONG Command, LPVOID Reserved) {
    return TRUE;
-};
+}
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4747.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4747.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4747"
 title: "Compiler Warning (level 1) C4747"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4747"
+ms.date: 11/04/2016
 f1_keywords: ["C4747"]
 helpviewer_keywords: ["C4747"]
-ms.assetid: af37befd-ba1f-4bdc-96e1-a953f7a2ad9c
 ---
 # Compiler Warning (level 1) C4747
 

--- a/docs/error-messages/tool-errors/math-error-m6111.md
+++ b/docs/error-messages/tool-errors/math-error-m6111.md
@@ -14,7 +14,7 @@ A floating-point operation resulted in a stack underflow on the 8087/287/387 cop
 This error is often caused by a call to a **`long double`** function that does not return a value. For example, the following generates this error when compiled and run:
 
 ```c
-long double ld() {};
+long double ld() {}
 int main ()
 {
   ld();

--- a/docs/porting/visual-cpp-change-history-2003-2015.md
+++ b/docs/porting/visual-cpp-change-history-2003-2015.md
@@ -1974,7 +1974,7 @@ Although these differences can affect your source code or other build artifacts,
              case settings::bit0 | settings::bit1:  // warning C4063
                 break;
         }
-    };
+    }
     ```
 
    Example of C4063 (after)

--- a/docs/porting/visual-cpp-what-s-new-2003-through-2015.md
+++ b/docs/porting/visual-cpp-what-s-new-2003-through-2015.md
@@ -784,7 +784,7 @@ Although these differences can affect your source code or other build artifacts,
         case settings::bit0 | settings::bit1:  // warning C4063
             break;
         }
-    };
+    }
    ```
 
    Example of C4063 (after)


### PR DESCRIPTION
Found more instances after #5393.