### PR TITLE
Standardize capitalization of "See also" sections

### DIFF
--- a/docs/assembler/masm/mmword.md
+++ b/docs/assembler/masm/mmword.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: MMWORD"
 title: "MMWORD"
-ms.date: "12/17/2019"
+description: "Learn more about: MMWORD"
+ms.date: 12/17/2019
 f1_keywords: ["MMWORD"]
 helpviewer_keywords: ["MMWORD directive"]
-ms.assetid: b4c5a104-9078-4fb4-afc3-d1e63abe562a
 ---
 # MMWORD
 

--- a/docs/assembler/masm/mmword.md
+++ b/docs/assembler/masm/mmword.md
@@ -32,6 +32,6 @@ While both instructions work on 64-bit operands, **QWORD** is the type for 64-bi
     movq     mm0, mmword ptr [ebx]
 ```
 
-## See Also
+## See also
 
 [MASM BNF Grammar](masm-bnf-grammar.md)

--- a/docs/assembler/masm/xmmword.md
+++ b/docs/assembler/masm/xmmword.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: XMMWORD"
 title: "XMMWORD"
-ms.date: "12/17/2019"
+description: "Learn more about: XMMWORD"
+ms.date: 12/17/2019
 f1_keywords: ["XMMWORD"]
 helpviewer_keywords: ["XMMWORD directive"]
-ms.assetid: 18026d32-5cab-403e-ad7e-382fb41aa9b8
 ---
 # XMMWORD
 

--- a/docs/assembler/masm/xmmword.md
+++ b/docs/assembler/masm/xmmword.md
@@ -24,6 +24,6 @@ Used for 128-bit multimedia operands with MMX and SSE (XMM) instructions.
     movdqa   xmm0, xmmword ptr [ebx]
 ```
 
-## See Also
+## See also
 
 [MASM BNF Grammar](masm-bnf-grammar.md)

--- a/docs/build/reference/profile-performance-tools-profiler.md
+++ b/docs/build/reference/profile-performance-tools-profiler.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /PROFILE (Performance Tools Profiler)"
 title: "/PROFILE (Performance Tools Profiler)"
+description: "Learn more about: /PROFILE (Performance Tools Profiler)"
 ms.date: 10/13/2021
 f1_keywords: ["VC.Project.VCLinkerTool.Profile"]
 helpviewer_keywords: ["-PROFILE linker option", "/PROFILE linker option"]

--- a/docs/build/reference/profile-performance-tools-profiler.md
+++ b/docs/build/reference/profile-performance-tools-profiler.md
@@ -57,7 +57,7 @@ Because a **CMake** project doesn't have the usual **Property Pages** support, t
 
 1. Rebuild your solution.
 
-## See Also
+## See also
 
 [MSVC linker reference](linking.md)\
 [MSVC linker options](linker-options.md)

--- a/docs/code-quality/c28112.md
+++ b/docs/code-quality/c28112.md
@@ -35,7 +35,7 @@ InterlockedDecrement(&inter_var);
 InterlockedIncrement(&inter_var);
 ```
 
-## See Also
+## See also
 
 [InterlockedIncrement function (wdm.h)](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockedincrement)\
 [InterlockedDecrement function (wdm.h)](/windows-hardware/drivers/ddi/wdm/nf-wdm-interlockeddecrement)

--- a/docs/code-quality/c6504.md
+++ b/docs/code-quality/c6504.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Warning C6504"
 title: Warning C6504
+description: "Learn more about: Warning C6504"
 ms.date: 10/03/2022
 f1_keywords: ["C6504", "NULL_ON_NON_POINTER", "__WARNING_NULL_ON_NON_POINTER"]
 helpviewer_keywords: ["C6504"]
-ms.assetid: 6baeed46-e73d-4974-af16-7487c55b3473
 ---
 # Warning C6504
 

--- a/docs/code-quality/c6504.md
+++ b/docs/code-quality/c6504.md
@@ -60,6 +60,6 @@ void g(Point& pt)
 }
 ```
 
-## See Also
+## See also
 
 [Annotation Properties](using-sal-annotations-to-reduce-c-cpp-code-defects.md)

--- a/docs/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md
+++ b/docs/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md
@@ -47,6 +47,6 @@ The articles in this section of the documentation discuss aspects of SAL, provid
 
      Provides examples that show how to use SAL annotations. Also explains common pitfalls.
 
-## See Also
+## See also
 
 [SAL 2.0 Annotations for Windows Drivers](/windows-hardware/drivers/devtest/sal-2-annotations-for-windows-drivers)

--- a/docs/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md
+++ b/docs/code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md
@@ -1,13 +1,12 @@
 ---
-description: "Learn more about: Using SAL Annotations to Reduce C/C++ Code Defects"
 title: Using SAL Annotations to Reduce C/C++ Code Defects
+description: "Learn more about: Using SAL Annotations to Reduce C/C++ Code Defects"
 ms.date: 11/04/2016
 ms.topic: "concept-article"
 helpviewer_keywords:
   - "annotations"
   - "SAL annotations"
   - "code analysis, annotation"
-ms.assetid: a16e47d0-6f3e-4ed6-8883-459b2874e9a4
 ---
 # Using SAL Annotations to Reduce C/C++ Code Defects
 

--- a/docs/cpp/import-export-module.md
+++ b/docs/cpp/import-export-module.md
@@ -109,7 +109,7 @@ import // Always an identifier, never a keyword
 
 **End Microsoft Specific**
 
-## See Also
+## See also
 
 [Overview of modules in C++](modules-cpp.md)\
 [Import the C++ standard library using modules](tutorial-import-stl-named-module.md)

--- a/docs/cpp/import-export-module.md
+++ b/docs/cpp/import-export-module.md
@@ -1,9 +1,9 @@
 ---
 title: "module, import, export"
+description: Use import and export declarations to access and to publish types and functions defined in the specified module.
 ms.date: 02/13/2025
 f1_keywords: ["module_cpp", "import_cpp", "export_cpp"]
 helpviewer_keywords: ["modules [C++]", "modules [C++], import", "modules [C++], export"]
-description: Use import and export declarations to access and to publish types and functions defined in the specified module.
 ---
 # `module`, `import`, `export`
 

--- a/docs/ide/adding-a-property-visual-cpp.md
+++ b/docs/ide/adding-a-property-visual-cpp.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Add a property to an interface in a Microsoft Visual Studio C++ project"
 title: "Add a property"
+description: "Learn more about: Add a property to an interface in a Microsoft Visual Studio C++ project"
 ms.date: 04/12/2022
 f1_keywords: ["vc.codewiz.prop.overview"]
 helpviewer_keywords: ["interfaces, adding properties", "properties [C++], adding to interfaces", "names, add property wizard", "add property wizard", "stock properties, about stock properties", "stock properties"]

--- a/docs/ide/adding-a-property-visual-cpp.md
+++ b/docs/ide/adding-a-property-visual-cpp.md
@@ -53,7 +53,7 @@ The following section describes the UI that you'll use to add a property:
 
   For ATL interfaces **Put function** makes the property writable; that is, it creates the `Put` method for setting, or "putting," this property of the object. Select **Get**, **Put**, or both.
 
-## See Also
+## See also
 
 [Add IDL Property](add-interface-definition-library-property-wizard.md)
 

--- a/docs/ide/live-share-cpp.md
+++ b/docs/ide/live-share-cpp.md
@@ -44,7 +44,7 @@ To end a session, select **End Collaboration Session** from the **Sharing** drop
 For more information about **Live Share** in Visual Studio, see [What is Visual Studio Live Share?](/visualstudio/liveshare/). For more information about Live Share in Visual Studio Code, see [
 Live Share](https://marketplace.visualstudio.com/items?itemName=ms-vsliveshare.vsliveshare).
 
-## See Also
+## See also
 
 [Edit and refactor code (C++)](writing-and-refactoring-code-cpp.md)</br>
 [Navigate your C++ code base in Visual Studio](navigate-code-cpp.md)</br>

--- a/docs/ide/live-share-cpp.md
+++ b/docs/ide/live-share-cpp.md
@@ -1,7 +1,7 @@
 ---
 title: "Collaborate with Live Share for C++ in Visual Studio"
 description: "Use Live Share for C++ in Visual Studio to collaborate and share code in real time."
-ms.date: "05/24/2019"
+ms.date: 05/24/2019
 ---
 # Collaborate using Live Share for C++
 

--- a/docs/ide/read-and-understand-code-cpp.md
+++ b/docs/ide/read-and-understand-code-cpp.md
@@ -106,7 +106,7 @@ Right click on any function call and view a recursive list of all the functions 
 
 ![Screenshot of the Call Hierarchy window which shows calls to and from Floating_to_wstring(). For example, to_wstring() calls Floating_to_wstring().](../ide/media/vs2015_cpp_call_hierarchy.png)
 
-## See Also
+## See also
 
 [Edit and refactor code (C++)](writing-and-refactoring-code-cpp.md)</br>
 [Navigate your C++ code base in Visual Studio](navigate-code-cpp.md)</br>

--- a/docs/ide/writing-and-refactoring-code-cpp.md
+++ b/docs/ide/writing-and-refactoring-code-cpp.md
@@ -178,7 +178,7 @@ Options for enabling and configuring C++-specific editing features are located u
 
 Experimental features, which may or may not be included in a future version of Visual Studio, are found in the [Text Editor C++ Experimental](/visualstudio/ide/reference/options-text-editor-c-cpp-experimental) dialog. In Visual Studio 2017 and later you can enable **Predictive IntelliSense** in this dialog.
 
-## See Also
+## See also
 
 [Read and understand C++ code](read-and-understand-code-cpp.md)</br>
 [Navigate your C++ code base in Visual Studio](navigate-code-cpp.md)</br>

--- a/docs/ide/writing-and-refactoring-code-cpp.md
+++ b/docs/ide/writing-and-refactoring-code-cpp.md
@@ -1,7 +1,7 @@
 ---
 title: "Edit and refactor C++ code in Visual Studio"
 description: "Use the C++ code editor in Visual Studio to format, navigate, understand and refactor your code."
-ms.date: "09/20/2022"
+ms.date: 09/20/2022
 ms.topic: "overview"
 ms.custom: intro-overview
 ---

--- a/docs/linux/set-up-fips-compliant-secure-remote-linux-development.md
+++ b/docs/linux/set-up-fips-compliant-secure-remote-linux-development.md
@@ -160,7 +160,7 @@ Microsoft blog post on [Why We're Not Recommending "FIPS mode" Anymore](https://
 
 [SSH Server Configuration](https://www.ssh.com/ssh/sshd_config)
 
-## See Also
+## See also
 
 [Configure a Linux project](configure-a-linux-project.md)\
 [Configure a Linux CMake project](cmake-linux-project.md)\

--- a/docs/mfc/reference/add-interface-definition-library-mfc-property-wizard.md
+++ b/docs/mfc/reference/add-interface-definition-library-mfc-property-wizard.md
@@ -167,7 +167,7 @@ If you're adding a property to an MFC dispinterface, you can choose one of the f
 |`ReadyState`|Returns or sets the control's `ReadyState` property.<br/>A control can be uninitialized, initialized, loading, interactive, or complete.<br/>For more information, see [READYSTATE](/previous-versions/aa768362\(v=vs.85\)) in the *Internet SDK*.|
 |`Text`|Returns or sets the text contained in a control.<br/>Has no **Member variable** implementation type.|
 
-## See Also
+## See also
 
 [Add Property](../../ide/adding-a-property-visual-cpp.md)
 

--- a/docs/mfc/reference/add-interface-definition-library-mfc-property-wizard.md
+++ b/docs/mfc/reference/add-interface-definition-library-mfc-property-wizard.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Use the Microsoft Visual Studio Add IDL MFC property wizard to add a property to an IDL interface in your MFC or ATL project"
 title: "Add an IDL MFC property"
-ms.date: "04/14/2022"
+description: "Learn more about: Use the Microsoft Visual Studio Add IDL MFC property wizard to add a property to an IDL interface in your MFC or ATL project"
+ms.date: 04/14/2022
 f1_keywords: ["vc.codewiz.prop.overview"]
 helpviewer_keywords: ["interfaces, adding properties", "properties [C++], adding to interfaces", "names, add property wizard", "add property wizard", "stock properties, about stock properties", "stock properties"]
 ms.custom: devdivchpfy22

--- a/docs/windows/latest-supported-vc-redist.md
+++ b/docs/windows/latest-supported-vc-redist.md
@@ -117,7 +117,7 @@ Download Redistributable files for other languages and architectures from:
 
 - Redistributable files for X86, X64, and IA64 architectures are available from [Microsoft Visual C++ 2005 Service Pack 1 Redistributable Package MFC Security Update](https://www.microsoft.com/download/details.aspx?id=26347).
 
-## See Also
+## See also
 
 - [C++ binary compatibility between Visual Studio versions](../porting/binary-compat-2015-2017.md)
 - [How to audit Visual C++ Runtime version usage](redist-version-auditing.md)


### PR DESCRIPTION
Stumbled upon #829 and decided to check the count of "## See also" vs "## See Also":

| Search term | Count |
| -- | -- |
| ## See also | 6441 |
| ## See Also | 14 |

Hence, this PR standardizes the remaining ones to a uniform version.