### PR TITLE
Update "Output-File (/F) Options" topic

### DIFF
--- a/docs/build/reference/output-file-f-options.md
+++ b/docs/build/reference/output-file-f-options.md
@@ -5,31 +5,31 @@ ms.date: "11/04/2016"
 helpviewer_keywords: ["output files", "output files, compiler options [C++]", "cl.exe compiler, output files"]
 ms.assetid: f6367f30-2710-4178-b43a-639eed824acb
 ---
-# Output-File (/F) Options
+# Output-File (`/F`) Options
 
 The output-file options create or rename output files. They affect all C or C++ source files specified in the CL environment variable, on the command line, or in any command file.
 
-- [/FA, /Fa (Listing File)](fa-fa-listing-file.md)
+- [`/FA`, `/Fa` (Listing File)](fa-fa-listing-file.md)
 
 - [Specifying the Pathname](specifying-the-pathname.md)
 
-- [/Fd (Name PDB File)](fd-program-database-file-name.md)
+- [`/Fd` (Name PDB File)](fd-program-database-file-name.md)
 
-- [/Fe (Name EXE File)](fe-name-exe-file.md)
+- [`/Fe` (Name EXE File)](fe-name-exe-file.md)
 
-- [/FI (Name Forced Include File)](fi-name-forced-include-file.md)
+- [`/FI` (Name Forced Include File)](fi-name-forced-include-file.md)
 
-- [/Fm (Name Mapfile)](fm-name-mapfile.md)
+- [`/Fm` (Name Mapfile)](fm-name-mapfile.md)
 
-- [/Fo (Name Object File)](fo-object-file-name.md)
+- [`/Fo` (Name Object File)](fo-object-file-name.md)
 
-- [/Fp (Name .pch File)](fp-name-dot-pch-file.md)
+- [`/Fp` (Name .pch File)](fp-name-dot-pch-file.md)
 
-- [/FR, /Fr (Create .sbr File)](fr-fr-create-dot-sbr-file.md)
+- [`/FR`, `/Fr` (Create .sbr File)](fr-fr-create-dot-sbr-file.md)
 
-- [/FU (Name Forced #using File)](fu-name-forced-hash-using-file.md)
+- [`/FU` (Name Forced #using File)](fu-name-forced-hash-using-file.md)
 
-- [/Fx (Merge Injected Code)](fx-merge-injected-code.md)
+- [`/Fx` (Merge Injected Code)](fx-merge-injected-code.md)
 
 ## See also
 

--- a/docs/build/reference/output-file-f-options.md
+++ b/docs/build/reference/output-file-f-options.md
@@ -1,6 +1,6 @@
 ---
 description: "Learn more about: Output-File (/F) Options"
-title: "Output-File (-F) Options"
+title: "Output-File (/F) Options"
 ms.date: "11/04/2016"
 helpviewer_keywords: ["output files", "output files, compiler options [C++]", "cl.exe compiler, output files"]
 ms.assetid: f6367f30-2710-4178-b43a-639eed824acb

--- a/docs/build/reference/output-file-f-options.md
+++ b/docs/build/reference/output-file-f-options.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Output-File (/F) Options"
 title: "Output-File (/F) Options"
-ms.date: "11/04/2016"
+description: "Learn more about: Output-File (/F) Options"
+ms.date: 11/04/2016
 helpviewer_keywords: ["output files", "output files, compiler options [C++]", "cl.exe compiler, output files"]
-ms.assetid: f6367f30-2710-4178-b43a-639eed824acb
 ---
 # Output-File (`/F`) Options
 

--- a/docs/build/reference/output-file-f-options.md
+++ b/docs/build/reference/output-file-f-options.md
@@ -33,5 +33,5 @@ The output-file options create or rename output files. They affect all C or C++ 
 
 ## See also
 
-[MSVC Compiler Options](compiler-options.md)<br/>
+[MSVC Compiler Options](compiler-options.md)\
 [MSVC Compiler Command-Line Syntax](compiler-command-line-syntax.md)

--- a/docs/build/reference/output-file-f-options.md
+++ b/docs/build/reference/output-file-f-options.md
@@ -13,9 +13,13 @@ The output-file options create or rename output files. They affect all C or C++ 
 
 - [Specifying the Pathname](specifying-the-pathname.md)
 
+- [`/FD` (IDE Minimal Rebuild)](fd-ide-minimal-rebuild.md)
+
 - [`/Fd` (Name PDB File)](fd-program-database-file-name.md)
 
 - [`/Fe` (Name EXE File)](fe-name-exe-file.md)
+
+- [`/Fi` (Preprocess output file name)](fi-preprocess-output-file-name.md)
 
 - [`/FI` (Name Forced Include File)](fi-name-forced-include-file.md)
 


### PR DESCRIPTION
- Change title to match TOC and article
- Add 2 missing entries ([`/FD` (IDE Minimal Rebuild)](https://github.com/MicrosoftDocs/cpp-docs/blob/df4242d2a81e97ed4da3e0f11672f8336c09da26/docs/build/reference/fd-ide-minimal-rebuild.md) and [`/Fi` (Preprocess output file name)](https://github.com/MicrosoftDocs/cpp-docs/blob/df4242d2a81e97ed4da3e0f11672f8336c09da26/docs/build/reference/fi-preprocess-output-file-name.md))
- Replace `br` elements, add backticks, and update metadata

Best reviewed one commit at a time, since the combined diff jumbles up all the entries.