### PR TITLE
Resolve cut off name for `/FU` in `toc.yml`

### DIFF
--- a/docs/build/toc.yml
+++ b/docs/build/toc.yml
@@ -552,7 +552,7 @@ items:
                       href: ../build/reference/fp-name-dot-pch-file.md
                     - name: /FR, /Fr (Create .Sbr file)
                       href: ../build/reference/fr-fr-create-dot-sbr-file.md
-                    - name: /FU (Name forced
+                    - name: "/FU (Name forced #using file)"
                       href: ../build/reference/fu-name-forced-hash-using-file.md
                     - name: /Fx (Merge injected code)
                       href: ../build/reference/fx-merge-injected-code.md


### PR DESCRIPTION
Added double quotes due to the "#" character.