### PR TITLE
Add forward slash for `/std` compiler options

### DIFF
--- a/docs/cpp/nothrow-cpp.md
+++ b/docs/cpp/nothrow-cpp.md
@@ -20,7 +20,7 @@ A **`__declspec`** extended attribute which can be used in the declaration of fu
 
 We recommend that all new code use the [`noexcept`](noexcept-cpp.md) operator rather than `__declspec(nothrow)`.
 
-This attribute tells the compiler that the declared function and the functions it calls never throw an exception. However, it does not enforce the directive. In other words, it never causes [`std::terminate`](../standard-library/exception-functions.md#terminate) to be invoked, unlike **`noexcept`**, or in **`std:c++17`** mode (Visual Studio 2017 version 15.5 and later), `throw()`.
+This attribute tells the compiler that the declared function and the functions it calls never throw an exception. However, it does not enforce the directive. In other words, it never causes [`std::terminate`](../standard-library/exception-functions.md#terminate) to be invoked, unlike **`noexcept`**, or in **`/std:c++17`** mode (Visual Studio 2017 version 15.5 and later), `throw()`.
 
 With the synchronous exception handling model, now the default, the compiler can eliminate the mechanics of tracking the lifetime of certain unwindable objects in such a function, and significantly reduce the code size. Given the following preprocessor directive, the three function declarations below are equivalent in **`/std:c++14`** mode:
 

--- a/docs/cpp/nothrow-cpp.md
+++ b/docs/cpp/nothrow-cpp.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: nothrow (C++)"
 title: "nothrow (C++)"
-ms.date: "01/03/2018"
+description: "Learn more about: nothrow (C++)"
+ms.date: 01/03/2018
 f1_keywords: ["nothrow_cpp"]
 helpviewer_keywords: ["__declspec keyword [C++], nothrow", "nothrow __declspec keyword"]
-ms.assetid: 0a475139-459c-4ec6-99e8-7ecd0d7f44a3
 ---
 # `nothrow` (C++)
 

--- a/docs/standard-library/basic-string-view-class.md
+++ b/docs/standard-library/basic-string-view-class.md
@@ -138,7 +138,7 @@ If a function is asked to generate a sequence longer than [`max_size`](#max_size
 
 ## Requirements
 
-[`std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.
+[`/std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.
 
 **Header:** `<string_view>`
 
@@ -1013,7 +1013,7 @@ Null-terminated character string containing the prefix to look for.
 
 ### Remarks
 
-`starts_with()` is new in C++20. To use it, specify the [`std:c++20`](../build/reference/std-specify-language-standard-version.md) or later compiler option.
+`starts_with()` is new in C++20. To use it, specify the [`/std:c++20`](../build/reference/std-specify-language-standard-version.md) or later compiler option.
 
 See [`ends_with`](#ends_with) to see if a string ends with a suffix.
 

--- a/docs/standard-library/string-view.md
+++ b/docs/standard-library/string-view.md
@@ -6,7 +6,7 @@ helpviewer_keywords: ["string_view header"]
 ---
 # `<string_view>`
 
-Defines the class template `basic_string_view` and related types and operators. (Requires compiler option [`std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.)
+Defines the class template `basic_string_view` and related types and operators. (Requires compiler option [`/std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.)
 
 ## Syntax
 
@@ -60,7 +60,7 @@ The `<string_view>` operators can compare `string_view` objects to objects of an
 
 - **Namespace:** `std`
 
-- **Compiler Option:** [`std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.
+- **Compiler Option:** [`/std:c++17`](../build/reference/std-specify-language-standard-version.md) or later.
 
 ## See also
 


### PR DESCRIPTION
Add missing forward slash for `/std` compiler option mentions.