### PR TITLE
Structure error references in range [C2161, C2180]

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
@@ -8,7 +8,7 @@ ms.assetid: d6798821-13bb-4e60-924f-85f7bf955387
 ---
 # Compiler Error C2161
 
-'##' cannot occur at the end of a macro definition
+> '##' cannot occur at the end of a macro definition
 
 A macro definition ended with a token-pasting operator (##).
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2161"
 title: "Compiler Error C2161"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2161"
+ms.date: 11/04/2016
 f1_keywords: ["C2161"]
 helpviewer_keywords: ["C2161"]
-ms.assetid: d6798821-13bb-4e60-924f-85f7bf955387
 ---
 # Compiler Error C2161
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
@@ -10,7 +10,11 @@ ms.assetid: d6798821-13bb-4e60-924f-85f7bf955387
 
 > '##' cannot occur at the end of a macro definition
 
+## Remarks
+
 A macro definition ended with a token-pasting operator (##).
+
+## Example
 
 The following sample generates C2161:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2161.md
@@ -16,7 +16,7 @@ A macro definition ended with a token-pasting operator (##).
 
 ## Example
 
-The following sample generates C2161:
+The following example generates C2161:
 
 ```cpp
 // C2161.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2162"
 description: "Learn more about: Compiler Error C2162"
-ms.date: "03/30/2025"
+ms.date: 03/30/2025
 f1_keywords: ["C2162"]
 helpviewer_keywords: ["C2162"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2162.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2162"]
 
 > expected macro formal parameter
 
+## Remarks
+
 The token following a [stringizing operator (#)](../../preprocessor/stringizing-operator-hash.md) or a [charizing operator (#@)](../../preprocessor/charizing-operator-hash-at.md) is not a formal parameter.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2163"
 title: "Compiler Error C2163"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2163"
+ms.date: 11/04/2016
 f1_keywords: ["C2163"]
 helpviewer_keywords: ["C2163"]
-ms.assetid: 6428d1e9-1ba1-46fc-bbf6-91d6fef2734c
 ---
 # Compiler Error C2163
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
@@ -8,6 +8,6 @@ ms.assetid: 6428d1e9-1ba1-46fc-bbf6-91d6fef2734c
 ---
 # Compiler Error C2163
 
-'function' : not available as an intrinsic function
+> 'function' : not available as an intrinsic function
 
 An `intrinsic` or `function` pragma lists a function not available in intrinsic form. For example, certain intrinsics are not available when compiling a program that uses /clr programming.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2163.md
@@ -10,4 +10,6 @@ ms.assetid: 6428d1e9-1ba1-46fc-bbf6-91d6fef2734c
 
 > 'function' : not available as an intrinsic function
 
+## Remarks
+
 An `intrinsic` or `function` pragma lists a function not available in intrinsic form. For example, certain intrinsics are not available when compiling a program that uses /clr programming.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
@@ -8,7 +8,7 @@ ms.assetid: 55df5024-68a8-45a8-ae6c-e6dba35318a2
 ---
 # Compiler Error C2164
 
-'function' : intrinsic function not declared
+> 'function' : intrinsic function not declared
 
 An `intrinsic` pragma uses an undeclared function (only occurs with **/Oi**). Or, one of the compiler intrinsics was used without including its header file.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
@@ -10,7 +10,11 @@ ms.assetid: 55df5024-68a8-45a8-ae6c-e6dba35318a2
 
 > 'function' : intrinsic function not declared
 
+## Remarks
+
 An `intrinsic` pragma uses an undeclared function (only occurs with **/Oi**). Or, one of the compiler intrinsics was used without including its header file.
+
+## Example
 
 The following sample generates C2164:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
@@ -16,7 +16,7 @@ An `intrinsic` pragma uses an undeclared function (only occurs with **/Oi**). Or
 
 ## Example
 
-The following sample generates C2164:
+The following example generates C2164:
 
 ```c
 // C2164.c

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2164.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2164"
 title: "Compiler Error C2164"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2164"
+ms.date: 11/04/2016
 f1_keywords: ["C2164"]
 helpviewer_keywords: ["C2164"]
-ms.assetid: 55df5024-68a8-45a8-ae6c-e6dba35318a2
 ---
 # Compiler Error C2164
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
@@ -10,7 +10,11 @@ ms.assetid: b108313b-b8cb-4dce-b2ec-f2b31c9cdc87
 
 > 'keyword' : cannot modify pointers to data
 
+## Remarks
+
 The **`__stdcall`**, **`__cdecl`**, or **`__fastcall`** keyword attempts to modify a pointer to data.
+
+## Example
 
 The following sample generates C2165:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
@@ -16,7 +16,7 @@ The **`__stdcall`**, **`__cdecl`**, or **`__fastcall`** keyword attempts to modi
 
 ## Example
 
-The following sample generates C2165:
+The following example generates C2165:
 
 ```cpp
 // C2165.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
@@ -8,7 +8,7 @@ ms.assetid: b108313b-b8cb-4dce-b2ec-f2b31c9cdc87
 ---
 # Compiler Error C2165
 
-'keyword' : cannot modify pointers to data
+> 'keyword' : cannot modify pointers to data
 
 The **`__stdcall`**, **`__cdecl`**, or **`__fastcall`** keyword attempts to modify a pointer to data.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2165.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2165"
 title: "Compiler Error C2165"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2165"
+ms.date: 11/04/2016
 f1_keywords: ["C2165"]
 helpviewer_keywords: ["C2165"]
-ms.assetid: b108313b-b8cb-4dce-b2ec-f2b31c9cdc87
 ---
 # Compiler Error C2165
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
@@ -10,4 +10,6 @@ ms.assetid: 3de3de96-12cd-47df-b24e-34cc9747ef83
 
 > 'function' : too many actual parameters for intrinsic function
 
+## Remarks
+
 A reference to an `intrinsic` function has too many parameters.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
@@ -8,6 +8,6 @@ ms.assetid: 3de3de96-12cd-47df-b24e-34cc9747ef83
 ---
 # Compiler Error C2167
 
-'function' : too many actual parameters for intrinsic function
+> 'function' : too many actual parameters for intrinsic function
 
 A reference to an `intrinsic` function has too many parameters.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2167.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2167"
 title: "Compiler Error C2167"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2167"
+ms.date: 11/04/2016
 f1_keywords: ["C2167"]
 helpviewer_keywords: ["C2167"]
-ms.assetid: 3de3de96-12cd-47df-b24e-34cc9747ef83
 ---
 # Compiler Error C2167
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
@@ -8,6 +8,6 @@ ms.assetid: 625e7dc3-ca74-4980-8268-8d5c0245e376
 ---
 # Compiler Error C2168
 
-'function' : too few actual parameters for intrinsic function
+> 'function' : too few actual parameters for intrinsic function
 
 A reference to an `intrinsic` function has too few parameters.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
@@ -10,4 +10,6 @@ ms.assetid: 625e7dc3-ca74-4980-8268-8d5c0245e376
 
 > 'function' : too few actual parameters for intrinsic function
 
+## Remarks
+
 A reference to an `intrinsic` function has too few parameters.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2168.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2168"
 title: "Compiler Error C2168"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2168"
+ms.date: 11/04/2016
 f1_keywords: ["C2168"]
 helpviewer_keywords: ["C2168"]
-ms.assetid: 625e7dc3-ca74-4980-8268-8d5c0245e376
 ---
 # Compiler Error C2168
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
@@ -8,6 +8,6 @@ ms.assetid: 97f700bd-1044-46f5-b276-3d7570ee7708
 ---
 # Compiler Error C2169
 
-'function' : intrinsic function, cannot be defined
+> 'function' : intrinsic function, cannot be defined
 
 A function definition appears for a function already declared `intrinsic`.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
@@ -10,4 +10,6 @@ ms.assetid: 97f700bd-1044-46f5-b276-3d7570ee7708
 
 > 'function' : intrinsic function, cannot be defined
 
+## Remarks
+
 A function definition appears for a function already declared `intrinsic`.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2169.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2169"
 title: "Compiler Error C2169"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2169"
+ms.date: 11/04/2016
 f1_keywords: ["C2169"]
 helpviewer_keywords: ["C2169"]
-ms.assetid: 97f700bd-1044-46f5-b276-3d7570ee7708
 ---
 # Compiler Error C2169
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2170.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2170.md
@@ -8,7 +8,7 @@ ms.assetid: d5c663f0-2459-4e11-a8bf-a52b62f3c71d
 ---
 # Compiler Error C2170
 
-'identifier' : not declared as a function, cannot be intrinsic
+> 'identifier' : not declared as a function, cannot be intrinsic
 
 ### To fix by checking the following possible causes
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2170.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2170.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2170"
 title: "Compiler Error C2170"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2170"
+ms.date: 11/04/2016
 f1_keywords: ["C2170"]
 helpviewer_keywords: ["C2170"]
-ms.assetid: d5c663f0-2459-4e11-a8bf-a52b62f3c71d
 ---
 # Compiler Error C2170
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
@@ -10,6 +10,8 @@ ms.assetid: a80343b5-ab3f-4413-b6f1-3ce9d7e519e5
 
 > 'operator' : illegal on operands of type 'type'
 
+## Remarks
+
 A unary operator is used with an invalid operand type.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
@@ -16,7 +16,7 @@ A unary operator is used with an invalid operand type.
 
 ## Examples
 
-The following sample generates C2171.
+The following example generates C2171.
 
 ```cpp
 // C2171.cpp
@@ -30,7 +30,7 @@ int main() {
 }
 ```
 
-The following sample generates C2171.
+The following example generates C2171.
 
 ```cpp
 // C2171_b.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2171"
 title: "Compiler Error C2171"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2171"
+ms.date: 11/04/2016
 f1_keywords: ["C2171"]
 helpviewer_keywords: ["C2171"]
-ms.assetid: a80343b5-ab3f-4413-b6f1-3ce9d7e519e5
 ---
 # Compiler Error C2171
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2171.md
@@ -8,7 +8,7 @@ ms.assetid: a80343b5-ab3f-4413-b6f1-3ce9d7e519e5
 ---
 # Compiler Error C2171
 
-'operator' : illegal on operands of type 'type'
+> 'operator' : illegal on operands of type 'type'
 
 A unary operator is used with an invalid operand type.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
@@ -8,6 +8,6 @@ ms.assetid: 31183ea7-858d-4273-932a-d865af7059b1
 ---
 # Compiler Error C2172
 
-'function' : actual parameter is not a pointer : parameter number
+> 'function' : actual parameter is not a pointer : parameter number
 
 Parameter `number` is not a pointer. The function expects a pointer.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
@@ -10,4 +10,6 @@ ms.assetid: 31183ea7-858d-4273-932a-d865af7059b1
 
 > 'function' : actual parameter is not a pointer : parameter number
 
+## Remarks
+
 Parameter `number` is not a pointer. The function expects a pointer.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2172.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2172"
 title: "Compiler Error C2172"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2172"
+ms.date: 11/04/2016
 f1_keywords: ["C2172"]
 helpviewer_keywords: ["C2172"]
-ms.assetid: 31183ea7-858d-4273-932a-d865af7059b1
 ---
 # Compiler Error C2172
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2173"
 title: "Compiler Error C2173"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2173"
+ms.date: 11/04/2016
 f1_keywords: ["C2173"]
 helpviewer_keywords: ["C2173"]
-ms.assetid: 4df592b8-609b-41a5-b4fc-966eb5bb2d1a
 ---
 # Compiler Error C2173
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
@@ -10,4 +10,6 @@ ms.assetid: 4df592b8-609b-41a5-b4fc-966eb5bb2d1a
 
 > 'function' : actual parameter is not a pointer : parameter number1, parameter list number2
 
+## Remarks
+
 Parameter `number1` passed to parameter list `number2` is not a pointer. The function expects a pointer.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2173.md
@@ -8,6 +8,6 @@ ms.assetid: 4df592b8-609b-41a5-b4fc-966eb5bb2d1a
 ---
 # Compiler Error C2173
 
-'function' : actual parameter is not a pointer : parameter number1, parameter list number2
+> 'function' : actual parameter is not a pointer : parameter number1, parameter list number2
 
 Parameter `number1` passed to parameter list `number2` is not a pointer. The function expects a pointer.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2174"
 title: "Compiler Error C2174"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2174"
+ms.date: 11/04/2016
 f1_keywords: ["C2174"]
 helpviewer_keywords: ["C2174"]
-ms.assetid: 161d563c-76e9-47e9-9142-7812e9ea169e
 ---
 # Compiler Error C2174
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
@@ -8,6 +8,6 @@ ms.assetid: 161d563c-76e9-47e9-9142-7812e9ea169e
 ---
 # Compiler Error C2174
 
-'function' : actual parameter has type 'void' : parameter number1, parameter list number2
+> 'function' : actual parameter has type 'void' : parameter number1, parameter list number2
 
 Parameter `number1` passed to parameter list `number2` is a **`void`** parameter. Parameters cannot have type **`void`**. Use **`void*`** instead.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2174.md
@@ -10,4 +10,6 @@ ms.assetid: 161d563c-76e9-47e9-9142-7812e9ea169e
 
 > 'function' : actual parameter has type 'void' : parameter number1, parameter list number2
 
+## Remarks
+
 Parameter `number1` passed to parameter list `number2` is a **`void`** parameter. Parameters cannot have type **`void`**. Use **`void*`** instead.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
@@ -8,6 +8,6 @@ ms.assetid: 3a8fa90b-2b29-414a-bb55-cf27c2bf989a
 ---
 # Compiler Error C2175
 
-'locale' : invalid locale
+> 'locale' : invalid locale
 
 The specified locale is not valid. See [Language and Country/Region Strings](../../c-runtime-library/locale-names-languages-and-country-region-strings.md) in the *Run-Time Library Reference* for supported locales.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
@@ -10,4 +10,6 @@ ms.assetid: 3a8fa90b-2b29-414a-bb55-cf27c2bf989a
 
 > 'locale' : invalid locale
 
+## Remarks
+
 The specified locale is not valid. See [Language and Country/Region Strings](../../c-runtime-library/locale-names-languages-and-country-region-strings.md) in the *Run-Time Library Reference* for supported locales.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2175.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2175"
 title: "Compiler Error C2175"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2175"
+ms.date: 11/04/2016
 f1_keywords: ["C2175"]
 helpviewer_keywords: ["C2175"]
-ms.assetid: 3a8fa90b-2b29-414a-bb55-cf27c2bf989a
 ---
 # Compiler Error C2175
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
@@ -16,7 +16,7 @@ A constant value is too large for the variable type it is assigned.
 
 ## Example
 
-The following sample generates C2177:
+The following example generates C2177:
 
 ```cpp
 // C2177.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2177"
 title: "Compiler Error C2177"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2177"
+ms.date: 11/04/2016
 f1_keywords: ["C2177"]
 helpviewer_keywords: ["C2177"]
-ms.assetid: 2a39a880-cddb-4d3e-a572-645a14c4c478
 ---
 # Compiler Error C2177
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
@@ -10,7 +10,11 @@ ms.assetid: 2a39a880-cddb-4d3e-a572-645a14c4c478
 
 > constant too big
 
+## Remarks
+
 A constant value is too large for the variable type it is assigned.
+
+## Example
 
 The following sample generates C2177:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2177.md
@@ -8,7 +8,7 @@ ms.assetid: 2a39a880-cddb-4d3e-a572-645a14c4c478
 ---
 # Compiler Error C2177
 
-constant too big
+> constant too big
 
 A constant value is too large for the variable type it is assigned.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
@@ -10,6 +10,8 @@ ms.assetid: 79a14158-17f3-4221-bd06-9d675c49cef4
 
 > '*identifier*' cannot be declared with '*specifier*' specifier
 
+## Remarks
+
 A **`mutable`** specifier was used in a declaration, but the specifier is not allowed in this context.
 
 The **`mutable`** specifier can be applied only to names of class data members, and cannot be applied to names declared **`const`** or **`static`**, and cannot be applied to reference members.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2178"
 title: "Compiler Error C2178"
-ms.date: "05/08/2017"
+description: "Learn more about: Compiler Error C2178"
+ms.date: 05/08/2017
 f1_keywords: ["C2178"]
 helpviewer_keywords: ["C2178"]
-ms.assetid: 79a14158-17f3-4221-bd06-9d675c49cef4
 ---
 # Compiler Error C2178
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
@@ -8,7 +8,7 @@ ms.assetid: 79a14158-17f3-4221-bd06-9d675c49cef4
 ---
 # Compiler Error C2178
 
-'*identifier*' cannot be declared with '*specifier*' specifier
+> '*identifier*' cannot be declared with '*specifier*' specifier
 
 A **`mutable`** specifier was used in a declaration, but the specifier is not allowed in this context.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2178.md
@@ -18,7 +18,7 @@ The **`mutable`** specifier can be applied only to names of class data members, 
 
 ## Example
 
-The following sample shows how C2178 may occur, and how to fix it.
+The following example shows how C2178 may occur, and how to fix it.
 
 ```cpp
 // C2178.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
@@ -10,6 +10,8 @@ ms.assetid: f929bfc6-3964-4e54-87d6-7529b9b6c0b9
 
 > 'type' : an attribute argument cannot use type parameters
 
+## Remarks
+
 A generic type parameter is resolved at runtime. However, an attribute parameter must be resolved at compile time. Therefore, you cannot use a generic type parameter as an argument to an attribute.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
@@ -16,7 +16,7 @@ A generic type parameter is resolved at runtime. However, an attribute parameter
 
 ## Example
 
-The following sample generates C2179.
+The following example generates C2179.
 
 ```cpp
 // C2179.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
@@ -8,7 +8,7 @@ ms.assetid: f929bfc6-3964-4e54-87d6-7529b9b6c0b9
 ---
 # Compiler Error C2179
 
-'type' : an attribute argument cannot use type parameters
+> 'type' : an attribute argument cannot use type parameters
 
 A generic type parameter is resolved at runtime. However, an attribute parameter must be resolved at compile time. Therefore, you cannot use a generic type parameter as an argument to an attribute.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2179.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2179"
 title: "Compiler Error C2179"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2179"
+ms.date: 11/04/2016
 f1_keywords: ["C2179"]
 helpviewer_keywords: ["C2179"]
-ms.assetid: f929bfc6-3964-4e54-87d6-7529b9b6c0b9
 ---
 # Compiler Error C2179
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
@@ -16,7 +16,7 @@ The controlling expression in an **`if`**, **`while`**, **`for`**, or **`do`** s
 
 ## Example
 
-The following sample generates C2180:
+The following example generates C2180:
 
 ```c
 // C2180.c

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2180"
 title: "Compiler Error C2180"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2180"
+ms.date: 11/04/2016
 f1_keywords: ["C2180"]
 helpviewer_keywords: ["C2180"]
-ms.assetid: ea71b39e-b977-48a7-b7bd-af68ef5e263b
 ---
 # Compiler Error C2180
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
@@ -8,7 +8,7 @@ ms.assetid: ea71b39e-b977-48a7-b7bd-af68ef5e263b
 ---
 # Compiler Error C2180
 
-controlling expression has type 'type'
+> controlling expression has type 'type'
 
 The controlling expression in an **`if`**, **`while`**, **`for`**, or **`do`** statement is an expression cast to **`void`**. To fix this issue, change the controlling expression to one that produces a **`bool`** or a type that can be converted to **`bool`**.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2180.md
@@ -10,7 +10,11 @@ ms.assetid: ea71b39e-b977-48a7-b7bd-af68ef5e263b
 
 > controlling expression has type 'type'
 
+## Remarks
+
 The controlling expression in an **`if`**, **`while`**, **`for`**, or **`do`** statement is an expression cast to **`void`**. To fix this issue, change the controlling expression to one that produces a **`bool`** or a type that can be converted to **`bool`**.
+
+## Example
 
 The following sample generates C2180:
 


### PR DESCRIPTION
C2166 is skipped due to #5473.

This is batch 17 that structures error/warning references. See #5465 for more information.