### PR TITLE
Edit pass on new "Troubleshoot template instantiation impact on build time" topic

### DIFF
--- a/docs/build-insights/tutorials/build-insights-template-view.md
+++ b/docs/build-insights/tutorials/build-insights-template-view.md
@@ -108,7 +108,7 @@ Template instantiation time collection is off by default to minimize build overh
 
 :::image type="content" source="./media/tools-options-build-insights.png" alt-text="Screenshot of the project property pages dialog. The settings are open to Build Insights > Trace Collection. The Collect Template Instantiation checkbox is selected.":::
 
-> [!Note]
+> [!NOTE]
 > Collecting template instantiation times increases build time due to the extra data collected. Only enable it when you want to analyze template instantiation bottlenecks.
 
 ## Run Build Insights to get template instantiation data


### PR DESCRIPTION
Best reviewed commit-by-commit.
- Remove erroneous mentions of `SmallValue.cpp` as this topic uses `TemplateAnalysis.cpp` instead (unlike in the blog [Templates View for Build Insights in Visual Studio](https://devblogs.microsoft.com/cppblog/templates-view-for-build-insights-in-visual-studio-2/)).
- Fix a typo of the build time in an image description ("4.066 seconds" -> "4.966 seconds").
- Trim all trailing spaces, remove superfluous semicolons, format code snippets, use caps for `[!NOTE]`, and add trailing newline at the end of the topic.