### PR TITLE
Fix invalid `std::` prefix for `public` keyword and update `value_compare` class reference

### DIFF
--- a/docs/standard-library/value-compare-class.md
+++ b/docs/standard-library/value-compare-class.md
@@ -38,7 +38,7 @@ For `hash_set`s and `hash_multiset`s, which are simple containers where the key 
 
 ## Example
 
-See the example for [`hash_map::value_comp`](../standard-library/hash-map-class.md#value_comp) for an example of how to declare and use `value_compare`.
+See the example for [`hash_map::value_comp`](hash-map-class.md#value_comp) for an example of how to declare and use `value_compare`.
 
 ## Requirements
 
@@ -48,6 +48,6 @@ See the example for [`hash_map::value_comp`](../standard-library/hash-map-class.
 
 ## See also
 
-[`binary_function` Struct](../standard-library/binary-function-struct.md)\
-[Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)\
-[C++ Standard Library Reference](../standard-library/cpp-standard-library-reference.md)
+[`binary_function` Struct](binary-function-struct.md)\
+[Thread Safety in the C++ Standard Library](thread-safety-in-the-cpp-standard-library.md)\
+[C++ Standard Library Reference](cpp-standard-library-reference.md)

--- a/docs/standard-library/value-compare-class.md
+++ b/docs/standard-library/value-compare-class.md
@@ -6,9 +6,9 @@ f1_keywords: ["hash_map/std::value_compare"]
 helpviewer_keywords: ["value_compare class"]
 ms.assetid: c306c5b9-3505-4357-aa6b-216451b951ed
 ---
-# value_compare Class
+# `value_compare` Class
 
-Provides a function object that can compare the elements of a hash_map by comparing the values of their keys to determine their relative order in the hash_map.
+Provides a function object that can compare the elements of a `hash_map` by comparing the values of their keys to determine their relative order in the `hash_map`.
 
 ## Syntax
 
@@ -32,22 +32,22 @@ protected:
 
 ## Remarks
 
-The comparison criteria provided by value_compare between `value_types` of whole elements contained by a hash_map is induced from a comparison between the keys of the respective elements by the auxiliary class construction. The member function operator uses the object `comp` of type `key_compare` stored in the function object provided by value_compare to compare the sort-key components of two elements.
+The comparison criteria provided by `value_compare` between `value_types` of whole elements contained by a `hash_map` is induced from a comparison between the keys of the respective elements by the auxiliary class construction. The member function operator uses the object `comp` of type `key_compare` stored in the function object provided by `value_compare` to compare the sort-key components of two elements.
 
-For hash_sets and hash_multisets, which are simple containers where the key values are identical to the element values, value_compare is equivalent to `key_compare`; for hash_maps and hash_multimaps they are not, because the value of the type `pair` elements is not identical to the value of the element's key.
+For `hash_set`s and `hash_multiset`s, which are simple containers where the key values are identical to the element values, `value_compare` is equivalent to `key_compare`; for `hash_map`s and `hash_multimap`s they are not, because the value of the type `pair` elements is not identical to the value of the element's key.
 
 ## Example
 
-See the example for [hash_map::value_comp](../standard-library/hash-map-class.md#value_comp) for an example of how to declare and use value_compare.
+See the example for [`hash_map::value_comp`](../standard-library/hash-map-class.md#value_comp) for an example of how to declare and use `value_compare`.
 
 ## Requirements
 
-**Header:** \<hash_map>
+**Header:** `<hash_map>`
 
-**Namespace:** stdext
+**Namespace:** `stdext`
 
 ## See also
 
-[binary_function Struct](../standard-library/binary-function-struct.md)\
+[`binary_function` Struct](../standard-library/binary-function-struct.md)\
 [Thread Safety in the C++ Standard Library](../standard-library/thread-safety-in-the-cpp-standard-library.md)\
 [C++ Standard Library Reference](../standard-library/cpp-standard-library-reference.md)

--- a/docs/standard-library/value-compare-class.md
+++ b/docs/standard-library/value-compare-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: value_compare Class"
 title: "value_compare Class"
-ms.date: "11/04/2016"
+description: "Learn more about: value_compare Class"
+ms.date: 11/04/2016
 f1_keywords: ["hash_map/std::value_compare"]
 helpviewer_keywords: ["value_compare class"]
-ms.assetid: c306c5b9-3505-4357-aa6b-216451b951ed
 ---
 # `value_compare` Class
 

--- a/docs/standard-library/value-compare-class.md
+++ b/docs/standard-library/value-compare-class.md
@@ -14,7 +14,7 @@ Provides a function object that can compare the elements of a hash_map by compar
 
 ```cpp
 class value_compare
-    : std::public binary_function<value_type, value_type, bool>
+    : public binary_function<value_type, value_type, bool>
 {
 public:
     bool operator()(


### PR DESCRIPTION
Remove invalid `std::` prefix for `public` keyword and some cleanups.