### PR TITLE
Merge duplicate sentences about `_asm` synonym in `__asm` reference

### DIFF
--- a/docs/assembler/inline/asm.md
+++ b/docs/assembler/inline/asm.md
@@ -28,7 +28,7 @@ The **`__asm`** keyword invokes the inline assembler and can appear wherever a C
 
 ## Remarks
 
-If used without braces, the **`__asm`** keyword means that the rest of the line is an assembly-language statement. If used with braces, it means that each line between the braces is an assembly-language statement. For compatibility with previous versions, **`_asm`** is a synonym for **`__asm`**.
+If used without braces, the **`__asm`** keyword means that the rest of the line is an assembly-language statement. If used with braces, it means that each line between the braces is an assembly-language statement. For compatibility with previous versions, **`_asm`** is a synonym for **`__asm`** unless compiler option [`/Za` (Disable language extensions)](../../build/reference/za-ze-disable-language-extensions.md) is specified.
 
 Since the **`__asm`** keyword is a statement separator, you can put assembly instructions on the same line.
 
@@ -41,8 +41,6 @@ __asm int 3
 didn't cause native code to be generated when compiled with **/clr**; the compiler translated the instruction to a CLR break instruction.
 
 `__asm int 3` now results in native code generation for the function. If you want a function to cause a break point in your code and if you want that function compiled to MSIL, use [__debugbreak](../../intrinsics/debugbreak.md).
-
-For compatibility with previous versions, **`_asm`** is a synonym for **`__asm`** unless compiler option [/Za \(Disable language extensions)](../../build/reference/za-ze-disable-language-extensions.md) is specified.
 
 ## Example
 

--- a/docs/assembler/inline/asm.md
+++ b/docs/assembler/inline/asm.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: `__asm`"
 title: "__asm"
-ms.date: "10/09/2018"
+description: "Learn more about: `__asm`"
+ms.date: 10/09/2018
+ms.topic: reference
 f1_keywords: ["__asm", "_asm", "__asm_cpp"]
 helpviewer_keywords: ["__asm keyword [C++], vs. asm blocks", "__asm keyword [C++]"]
-ms.assetid: 77ff3bc9-a492-4b5e-85e1-fa4e414e79cd
-ms.topic: reference
 ---
 # `__asm`
 


### PR DESCRIPTION
Merge the second sentence (introduced in commit https://github.com/MicrosoftDocs/cpp-docs/commit/1e5e302c8739a2e7120f69c199a3264f9196154e) into the first, with 2 small tweaks (backticks for `/Za` and remove superfluous escape for open parenthesis).

<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/fc13f331-8bef-4717-8915-0b0be049af4e" />
