### PR TITLE
Update warning level flag for example in C4373 warning reference

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4373.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4373.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4373"
 title: "Compiler Warning (level 4) C4373"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4373"
+ms.date: 11/04/2016
 f1_keywords: ["C4373"]
 helpviewer_keywords: ["C4373"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4373.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4373.md
@@ -21,7 +21,7 @@ The following code example generates warning C4373. To resolve this issue, make 
 
 ```cpp
 // c4373.cpp
-// compile with: /c /W3
+// compile with: /c /W4
 #include <stdio.h>
 struct Base
 {


### PR DESCRIPTION
The title and heading was correctly updated from level 3 to 4 in commit https://github.com/MicrosoftDocs/cpp-docs/commit/6f82bf9577da8dc6ab932658fed17da787fccf0a. However, the warning level flag in the example is left unchanged, such that the example will not generate C4373.