### PR TITLE
Improve C4324 warning reference

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C4324"]
 
 > '*structname*': structure was padded due to alignment specifier
 
+## Remarks
+
 Padding was added at the end of a structure because you specified an alignment specifier, such as [__declspec(align)](../../cpp/align-cpp.md).
+
+## Example
 
 For example, the following code generates C4324:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C4324"]
 
 ## Remarks
 
-Padding was added at the end of a structure because you specified an alignment specifier, such as [__declspec(align)](../../cpp/align-cpp.md).
+Padding was added at the end of a class/struct/union because you specified an alignment specifier, such as [`alignas`](../../cpp/alignas-specifier.md) or [`__declspec(align)`](../../cpp/align-cpp.md).
 
 ## Example
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
@@ -15,17 +15,21 @@ Padding was added at the end of a class/struct/union because you specified an al
 
 ## Example
 
-For example, the following code generates C4324:
+For example, `S1` and `S2` generates C4324 because padding is added when the specified alignment is greater than the default alignment of `1` and `4` respectively:
 
 ```cpp
 // C4324.cpp
-// compile with: /W4
-struct __declspec(align(32)) A
+// compile with: /W4 /c
+
+struct alignas(4) S1 {};   // C4324
+
+struct alignas(8) S2
 {
-   char a;
+    int i;
 };   // C4324
 
-int main()
+struct alignas(4) S3
 {
-}
+    int i;
+};   // OK
 ```

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4324"
 title: "Compiler Warning (level 4) C4324"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4324"
+ms.date: 07/22/2025
 f1_keywords: ["C4324"]
 helpviewer_keywords: ["C4324"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4324.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4324"]
 ---
 # Compiler Warning (level 4) C4324
 
-> '*structname*': structure was padded due to alignment specifier
+> '*type*': structure was padded due to alignment specifier
 
 ## Remarks
 

--- a/docs/error-messages/compiler-warnings/compiler-warnings-c4200-through-c4399.md
+++ b/docs/error-messages/compiler-warnings/compiler-warnings-c4200-through-c4399.md
@@ -113,7 +113,7 @@ The articles in this section describe Microsoft C/C++ compiler warning messages 
 |Compiler warning (level 1) C4321|automatically generating an IID for interface '*interface*'|
 |Compiler warning (level 1) C4322|automatically generating a CLSID for class '*class*'|
 |Compiler warning (level 1) C4323|re-using registered CLSID for class '*class*'|
-|[Compiler warning (level 4) C4324](compiler-warning-level-4-c4324.md)|'*structname*': structure was padded due to alignment specifier|
+|[Compiler warning (level 4) C4324](compiler-warning-level-4-c4324.md)|'*type*': structure was padded due to alignment specifier|
 |[Compiler warning (level 1) C4325](compiler-warning-level-1-c4325.md)|attributes for standard section '*section*' ignored|
 |[Compiler warning (level 1) C4326](compiler-warning-level-1-c4326.md)|return type of '*function*' should be '*type1*' instead of '*type2*'|
 |Compiler warning C4327|'*assignment*': indirection alignment of LHS ('*alignment1*') is greater than RHS ('*alignment2*')|


### PR DESCRIPTION
- Add "Remarks" and "Example" headings
- Change "structname" in warning message to "type" as C4324 also applies to `class` and `union`
- Add some details about "class/struct/union" and `alignas` in the remarks
- Improve example:
  - Remove superfluous `main` function and add `/c` flag
  - Prefer standard `alignas` over `__declspec(align)`
  - Extend the example with an empty struct and okay case
- Update metadata