### PR TITLE
Improve C2469 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2469.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2469.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2469"
 description: "Learn more about: Compiler Error C2469"
-ms.date: 07/23/2025
+ms.date: 2/27/2026
 f1_keywords: ["C2469"]
 helpviewer_keywords: ["C2469"]
 ---
@@ -11,29 +11,25 @@ helpviewer_keywords: ["C2469"]
 
 ## Remarks
 
-The [`new` operator](../../cpp/new-operator-cpp.md) was passed an invalid type.
+The [`new` operator](../../cpp/new-operator-cpp.md) allocates memory and constructs an object of the specified type. Since `void` isn't a constructible type, use `::operator new(size)` to allocate raw memory without object construction.
 
 ## Example: Wrong allocation type
 
-Check if you meant to allocate `void` or some other type, such as `int`:
-
 ```cpp
-// C2469_wrong_allocation_type.cpp
-
+// compile with /c
 int main()
 {
-    int* ptr1 = new void;   // C2469
-    int* ptr2 = new int;    // OK
+    void* ptr1 = new void;   // C2469
+    int*  ptr2 = new int;    // OK
 }
 ```
 
 ## Example: Allocate untyped memory
 
-If you meant to allocate untyped memory, use `::operator new` instead:
+To allocate untyped memory, use `::operator new`:
 
 ```cpp
-// C2469_allocate_untyped_memory.cpp
-
+// compile with /c
 int main()
 {
     void* ptr1 = new void;            // C2469


### PR DESCRIPTION
- Change error message to one with explicit reference to `new` and `void` as it seems newer (commit https://github.com/MicrosoftDocs/cpp-docs/commit/062031c7e1454df22636fe97788b729f8a24a0e8 added this variant to the index page, while the older one is there since the first commit in 2016) and the error does not seem to apply to anything other than operator `new` with type `void`.
- Add "Remarks" heading and tweak its contents to reflect the new error message.
- Overhaul the existing example and add a new one based on the user's intent (i.e. they specified the wrong allocation type versus they made an invalid attempt to allocate untyped memory (see [c++ - Using new on void pointer - Stack Overflow](https://stackoverflow.com/questions/14111900/using-new-on-void-pointer))).
- Update metadata