### PR TITLE
Tweak "Walkthrough: Create a traditional Windows desktop application (C++)"

### DIFF
--- a/docs/windows/walkthrough-creating-windows-desktop-applications-cpp.md
+++ b/docs/windows/walkthrough-creating-windows-desktop-applications-cpp.md
@@ -248,7 +248,7 @@ Next, learn how to create the code for a Windows desktop application in Visual S
 
    ```cpp
    // The parameters to ShowWindow explained:
-   // hWnd: the value returned from CreateWindow
+   // hWnd: the value returned from CreateWindowEx
    // nCmdShow: the fourth parameter from WinMain
    ShowWindow(hWnd,
       nCmdShow);
@@ -335,7 +335,7 @@ Next, learn how to create the code for a Windows desktop application in Visual S
       if (!hWnd)
       {
          MessageBox(NULL,
-            _T("Call to CreateWindow failed!"),
+            _T("Call to CreateWindowEx failed!"),
             _T("Windows Desktop Guided Tour"),
             NULL);
 
@@ -343,7 +343,7 @@ Next, learn how to create the code for a Windows desktop application in Visual S
       }
 
       // The parameters to ShowWindow explained:
-      // hWnd: the value returned from CreateWindow
+      // hWnd: the value returned from CreateWindowEx
       // nCmdShow: the fourth parameter from WinMain
       ShowWindow(hWnd, nCmdShow);
       UpdateWindow(hWnd);
@@ -522,7 +522,7 @@ As promised, the complete code for the working application follows.
       if (!hWnd)
       {
          MessageBox(NULL,
-            _T("Call to CreateWindow failed!"),
+            _T("Call to CreateWindowEx failed!"),
             _T("Windows Desktop Guided Tour"),
             NULL);
 
@@ -530,7 +530,7 @@ As promised, the complete code for the working application follows.
       }
 
       // The parameters to ShowWindow explained:
-      // hWnd: the value returned from CreateWindow
+      // hWnd: the value returned from CreateWindowEx
       // nCmdShow: the fourth parameter from WinMain
       ShowWindow(hWnd,
          nCmdShow);


### PR DESCRIPTION
- Fix "does" typo
- Replace "length" with "height" in `CreateWindowEx` parameters explanation to match the actual `nHeight` parameter
- Fix outdated mentions of `CreateWindow` which were missed in commit https://github.com/MicrosoftDocs/cpp-docs/commit/d263a1b29f5b085b8a13c5e6e10d8ae243addf9e