### PR TITLE
Update unconventional single column table in `Concurrency::graphics::direct3d` namespace reference

### DIFF
--- a/docs/parallel/amp/reference/concurrency-graphics-direct3d-namespace.md
+++ b/docs/parallel/amp/reference/concurrency-graphics-direct3d-namespace.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: Concurrency::graphics::direct3d Namespace"
 title: "Concurrency::graphics::direct3d Namespace"
-ms.date: "11/04/2016"
+description: "Learn more about: Concurrency::graphics::direct3d Namespace"
+ms.date: 11/04/2016
 f1_keywords: ["amp_graphics/Concurrency::graphics::direct3d", "amp_short_vectors/Concurrency::graphics::direct3d"]
-ms.assetid: be283331-07cf-46e4-91a1-e8aa85d4ec8e
 ---
 # Concurrency::graphics::direct3d Namespace
 

--- a/docs/parallel/amp/reference/concurrency-graphics-direct3d-namespace.md
+++ b/docs/parallel/amp/reference/concurrency-graphics-direct3d-namespace.md
@@ -19,13 +19,13 @@ namespace direct3d;
 
 ### Functions
 
-|Name<br /><br /> Description|
-|--------------------------|
-|[get_sampler](concurrency-graphics-direct3d-namespace-functions.md#get_sampler)<br /><br /> Get the Direct3D sampler state interface on the given accelerator view that represents the specified sampler object.|
-|[get_texture](concurrency-graphics-direct3d-namespace-functions.md#get_texture)<br /><br /> Gets the Direct3D texture interface underlying the specified [texture](texture-class.md) object.|
-|[make_sampler](concurrency-graphics-direct3d-namespace-functions.md#make_sampler)<br /><br /> Create a sampler from a Direct3D sampler state interface pointer.|
-|[make_texture](concurrency-graphics-direct3d-namespace-functions.md#make_texture)<br /><br /> Creates a [texture](texture-class.md) object by using the specified parameters.|
-|[msad4](concurrency-graphics-direct3d-namespace-functions.md#msad4)<br /><br /> Compares a 4-byte reference value and an 8-byte source value and accumulates a vector of 4 sums.|
+|Name|Description|
+|----------|-----------------|
+|[get_sampler](concurrency-graphics-direct3d-namespace-functions.md#get_sampler)|Get the Direct3D sampler state interface on the given accelerator view that represents the specified sampler object.|
+|[get_texture](concurrency-graphics-direct3d-namespace-functions.md#get_texture)|Gets the Direct3D texture interface underlying the specified [texture](texture-class.md) object.|
+|[make_sampler](concurrency-graphics-direct3d-namespace-functions.md#make_sampler)|Create a sampler from a Direct3D sampler state interface pointer.|
+|[make_texture](concurrency-graphics-direct3d-namespace-functions.md#make_texture)|Creates a [texture](texture-class.md) object by using the specified parameters.|
+|[msad4](concurrency-graphics-direct3d-namespace-functions.md#msad4)|Compares a 4-byte reference value and an 8-byte source value and accumulates a vector of 4 sums.|
 
 ## Requirements
 


### PR DESCRIPTION
Update unconventional single column table to follow related topics such as [`docs/parallel/amp/reference/concurrency-graphics-namespace.md`](https://github.com/MicrosoftDocs/cpp-docs/blob/45fdb38aa4947fc6646b7727e816e136e636941b/docs/parallel/amp/reference/concurrency-graphics-namespace.md) and [`docs/parallel/amp/reference/concurrency-precise-math-namespace.md`](https://github.com/MicrosoftDocs/cpp-docs/blob/45fdb38aa4947fc6646b7727e816e136e636941b/docs/parallel/amp/reference/concurrency-precise-math-namespace.md). Here is how the table is rendered:

<img width="903" height="819" alt="image" src="https://github.com/user-attachments/assets/75ee5443-2f07-4f7e-ad95-23e4e25afcb0" />
