### PR TITLE
Improve C4235 warning reference

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4235.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4235.md
@@ -21,7 +21,7 @@ The following example generates C4235 as the [Inline Assembler](../../assembler/
 
 ```cpp
 // C4235.cpp
-// processor: x64
+// processor: x64 (set compiler environment with vcvars64.bat)
 
 int main()
 {


### PR DESCRIPTION
Add example of using `__asm` on x64 as seen in [visual studio 2010 - Why I cannot compile the assembly codes for x64 platform with VC2010? - Stack Overflow](https://stackoverflow.com/questions/14038754/why-i-cannot-compile-the-assembly-codes-for-x64-platform-with-vc2010).