### PR TITLE
Structure error references in range [C2431, C2460]

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
@@ -16,7 +16,7 @@ The ESP register is scaled or used as both index and base register. The SIB enco
 
 ## Example
 
-The following sample generates C2431:
+The following example generates C2431:
 
 ```cpp
 // C2431.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
@@ -8,7 +8,7 @@ ms.assetid: 88a5b648-c89f-47d1-a20e-63231ab4f0f7
 ---
 # Compiler Error C2431
 
-illegal index register in 'identifier'
+> illegal index register in 'identifier'
 
 The ESP register is scaled or used as both index and base register. The SIB encoding for the x86 processor does not allow either.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
@@ -10,7 +10,11 @@ ms.assetid: 88a5b648-c89f-47d1-a20e-63231ab4f0f7
 
 > illegal index register in 'identifier'
 
+## Remarks
+
 The ESP register is scaled or used as both index and base register. The SIB encoding for the x86 processor does not allow either.
+
+## Example
 
 The following sample generates C2431:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2431.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2431"
 title: "Compiler Error C2431"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2431"
+ms.date: 11/04/2016
 f1_keywords: ["C2431"]
 helpviewer_keywords: ["C2431"]
-ms.assetid: 88a5b648-c89f-47d1-a20e-63231ab4f0f7
 ---
 # Compiler Error C2431
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
@@ -10,7 +10,11 @@ ms.assetid: 0e3326e8-cab1-45a5-b48d-61edd33793e8
 
 > illegal reference to 16-bit data in 'identifier'
 
+## Remarks
+
 A 16-bit register is used as an index or base register. The compiler does not support referencing 16-bit data. 16-bit registers cannot be used as index or base registers when compiling for 32-bit code.
+
+## Example
 
 The following sample generates C2432:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
@@ -8,7 +8,7 @@ ms.assetid: 0e3326e8-cab1-45a5-b48d-61edd33793e8
 ---
 # Compiler Error C2432
 
-illegal reference to 16-bit data in 'identifier'
+> illegal reference to 16-bit data in 'identifier'
 
 A 16-bit register is used as an index or base register. The compiler does not support referencing 16-bit data. 16-bit registers cannot be used as index or base registers when compiling for 32-bit code.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
@@ -16,7 +16,7 @@ A 16-bit register is used as an index or base register. The compiler does not su
 
 ## Example
 
-The following sample generates C2432:
+The following example generates C2432:
 
 ```cpp
 // C2432.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2432.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2432"
 title: "Compiler Error C2432"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2432"
+ms.date: 11/04/2016
 f1_keywords: ["C2432"]
 helpviewer_keywords: ["C2432"]
-ms.assetid: 0e3326e8-cab1-45a5-b48d-61edd33793e8
 ---
 # Compiler Error C2432
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2433.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2433.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2433"]
 
 > '*identifier*': '*modifier*' not permitted on data declarations
 
+## Remarks
+
 The **`friend`**, **`virtual`**, and **`inline`** modifiers cannot be used for data declarations.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2434.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2434.md
@@ -18,7 +18,7 @@ It is not possible to dynamically initialize a per-process variable under **/clr
 
 ## Example
 
-The following sample generates C2434. To fix this issue, use constants to initialize `process` variables.
+The following example generates C2434. To fix this issue, use constants to initialize `process` variables.
 
 ```cpp
 // C2434.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2434.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2434.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2434"
 title: "Compiler Error C2434"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2434"
+ms.date: 11/04/2016
 f1_keywords: ["C2434"]
 helpviewer_keywords: ["C2434"]
-ms.assetid: 01329e26-7c74-4219-b74f-69e3a40c9738
 ---
 # Compiler Error C2434
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2435.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2435.md
@@ -20,7 +20,7 @@ For more information, see [appdomain](../../cpp/appdomain.md) and [process](../.
 
 ## Example
 
-The following sample generates C2435:
+The following example generates C2435:
 
 ```cpp
 // C2435.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2435.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2435.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2435"
 title: "Compiler Error C2435"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2435"
+ms.date: 11/04/2016
 f1_keywords: ["C2435"]
 helpviewer_keywords: ["C2435"]
-ms.assetid: be6aa8f8-579b-42ea-bdd8-2d01393646ad
 ---
 # Compiler Error C2435
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
@@ -10,7 +10,11 @@ ms.assetid: ca4cc813-bc1d-4c0a-9a2c-3a5fe673d084
 
 > 'identifier' : member function or nested class in constructor initializer list
 
+## Remarks
+
 Member functions or local classes in the constructor initializer list cannot be initialized.
+
+## Example
 
 The following sample generates C2436:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
@@ -8,7 +8,7 @@ ms.assetid: ca4cc813-bc1d-4c0a-9a2c-3a5fe673d084
 ---
 # Compiler Error C2436
 
-'identifier' : member function or nested class in constructor initializer list
+> 'identifier' : member function or nested class in constructor initializer list
 
 Member functions or local classes in the constructor initializer list cannot be initialized.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
@@ -16,7 +16,7 @@ Member functions or local classes in the constructor initializer list cannot be 
 
 ## Example
 
-The following sample generates C2436:
+The following example generates C2436:
 
 ```cpp
 // C2436.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2436.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2436"
 title: "Compiler Error C2436"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2436"
+ms.date: 11/04/2016
 f1_keywords: ["C2436"]
 helpviewer_keywords: ["C2436"]
-ms.assetid: ca4cc813-bc1d-4c0a-9a2c-3a5fe673d084
 ---
 # Compiler Error C2436
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
@@ -8,7 +8,7 @@ ms.assetid: 2d2b3c6c-856a-4b27-ae10-64813b3e5483
 ---
 # Compiler Error C2437
 
-'identifier' : already initialized
+> 'identifier' : already initialized
 
 An object can be initialized only once.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
@@ -10,7 +10,11 @@ ms.assetid: 2d2b3c6c-856a-4b27-ae10-64813b3e5483
 
 > 'identifier' : already initialized
 
+## Remarks
+
 An object can be initialized only once.
+
+## Example
 
 The following sample generates C2437:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2437"
 title: "Compiler Error C2437"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2437"
+ms.date: 11/04/2016
 f1_keywords: ["C2437"]
 helpviewer_keywords: ["C2437"]
-ms.assetid: 2d2b3c6c-856a-4b27-ae10-64813b3e5483
 ---
 # Compiler Error C2437
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2437.md
@@ -16,7 +16,7 @@ An object can be initialized only once.
 
 ## Example
 
-The following sample generates C2437:
+The following example generates C2437:
 
 ```cpp
 // C2437.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
@@ -16,7 +16,7 @@ A constructor is used to initialize a static member of a class. Static members m
 
 ## Example
 
-The following sample generates C2438:
+The following example generates C2438:
 
 ```cpp
 // C2438.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2438"
 title: "Compiler Error C2438"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2438"
+ms.date: 11/04/2016
 f1_keywords: ["C2438"]
 helpviewer_keywords: ["C2438"]
-ms.assetid: 3a0ab3ba-d0e4-4d8f-971d-e503397cc827
 ---
 # Compiler Error C2438
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
@@ -8,7 +8,7 @@ ms.assetid: 3a0ab3ba-d0e4-4d8f-971d-e503397cc827
 ---
 # Compiler Error C2438
 
-'identifier' : cannot initialize static class data via constructor
+> 'identifier' : cannot initialize static class data via constructor
 
 A constructor is used to initialize a static member of a class. Static members must be initialized in a definition outside the class declaration.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2438.md
@@ -10,7 +10,11 @@ ms.assetid: 3a0ab3ba-d0e4-4d8f-971d-e503397cc827
 
 > 'identifier' : cannot initialize static class data via constructor
 
+## Remarks
+
 A constructor is used to initialize a static member of a class. Static members must be initialized in a definition outside the class declaration.
+
+## Example
 
 The following sample generates C2438:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
@@ -10,6 +10,8 @@ ms.assetid: 3c5dbe5c-b7d3-4bb0-8619-92f6e280461e
 
 > 'identifier' : member could not be initialized
 
+## Remarks
+
 A class, structure, or union member cannot be initialized.
 
 ### To fix by checking the following possible causes

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
@@ -8,7 +8,7 @@ ms.assetid: 3c5dbe5c-b7d3-4bb0-8619-92f6e280461e
 ---
 # Compiler Error C2439
 
-'identifier' : member could not be initialized
+> 'identifier' : member could not be initialized
 
 A class, structure, or union member cannot be initialized.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2439.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2439"
 title: "Compiler Error C2439"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2439"
+ms.date: 11/04/2016
 f1_keywords: ["C2439"]
 helpviewer_keywords: ["C2439"]
-ms.assetid: 3c5dbe5c-b7d3-4bb0-8619-92f6e280461e
 ---
 # Compiler Error C2439
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2440.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2440.md
@@ -21,7 +21,7 @@ The compiler generates C2440 when it can't convert from one type to another, eit
 
 ### C++ string literals are `const`
 
-C2440 can be caused if you attempt to initialize a non-const `char*` (or `wchar_t*`) by using a string literal in C++ code, when the compiler conformance option [`/Zc:strictStrings`](../../build/reference/zc-strictstrings-disable-string-literal-type-conversion.md) is set. In C, the type of a string literal is array of **`char`**, but in C++, it's array of `const char`. This sample generates C2440:
+C2440 can be caused if you attempt to initialize a non-const `char*` (or `wchar_t*`) by using a string literal in C++ code, when the compiler conformance option [`/Zc:strictStrings`](../../build/reference/zc-strictstrings-disable-string-literal-type-conversion.md) is set. In C, the type of a string literal is array of **`char`**, but in C++, it's array of `const char`. This example generates C2440:
 
 ```cpp
 // C2440s.cpp
@@ -40,7 +40,7 @@ int main() {
 
 ### C++20 `u8` literals are `const char8_t`
 
-In C++20 or under [`/Zc:char8_t`](../../build/reference/zc-char8-t.md), a UTF-8 literal character or string (such as `u8'a'` or `u8"String"`) is of type `const char8_t` or `const char8_t[N]`, respectively. This sample shows how compiler behavior changes between C++17 and C++20:
+In C++20 or under [`/Zc:char8_t`](../../build/reference/zc-char8-t.md), a UTF-8 literal character or string (such as `u8'a'` or `u8"String"`) is of type `const char8_t` or `const char8_t[N]`, respectively. This example shows how compiler behavior changes between C++17 and C++20:
 
 ```cpp
 // C2440u8.cpp
@@ -60,7 +60,7 @@ int main() {
 
 ### Pointer to member
 
-You may see C2440 if you attempt to convert a pointer to member to `void*`. The next sample generates C2440:
+You may see C2440 if you attempt to convert a pointer to member to `void*`. The next example generates C2440:
 
 ```cpp
 // C2440.cpp
@@ -83,7 +83,7 @@ public:
 
 ### Cast of undefined type
 
-The compiler emits C2440 if you attempt to cast from a type that's only forward declared but not defined. This sample generates C2440:
+The compiler emits C2440 if you attempt to cast from a type that's only forward declared but not defined. This example generates C2440:
 
 ```cpp
 // c2440a.cpp
@@ -98,7 +98,7 @@ Base * func(Derived * d) {
 
 ### Incompatible calling convention
 
-The C2440 errors on lines 15 and 16 of the next sample are qualified with the `Incompatible calling conventions for UDT return value` message. A *UDT* is a user-defined type, such as a class, struct, or union. These kinds of incompatibility errors are caused when the calling convention of a UDT specified in the return type of a forward declaration conflicts with the actual calling convention of the UDT and when a function pointer is involved.
+The C2440 errors on lines 15 and 16 of the next example are qualified with the `Incompatible calling conventions for UDT return value` message. A *UDT* is a user-defined type, such as a class, struct, or union. These kinds of incompatibility errors are caused when the calling convention of a UDT specified in the return type of a forward declaration conflicts with the actual calling convention of the UDT and when a function pointer is involved.
 
 In the example, first there are forward declarations for a struct and for a function that returns the struct. The compiler assumes that the struct uses the C++ calling convention. Next is the struct definition, which uses the C calling convention by default. Because the compiler doesn't know the calling convention of the struct until it finishes reading the entire struct, the calling convention for the struct in the return type of `get_c2` is also assumed to be C++.
 
@@ -163,7 +163,7 @@ int main() {
 
 ### User-defined conversions
 
-C2440 can also occur for an incorrect use of a user-defined conversion. For example, when a conversion operator has been defined as **`explicit`**, the compiler can't use it in an implicit conversion. For more information about user-defined conversions, see [User-Defined Conversions (C++/CLI)](../../dotnet/user-defined-conversions-cpp-cli.md)). This sample generates C2440:
+C2440 can also occur for an incorrect use of a user-defined conversion. For example, when a conversion operator has been defined as **`explicit`**, the compiler can't use it in an implicit conversion. For more information about user-defined conversions, see [User-Defined Conversions (C++/CLI)](../../dotnet/user-defined-conversions-cpp-cli.md)). This example generates C2440:
 
 ```cpp
 // C2440d.cpp
@@ -187,7 +187,7 @@ int main() {
 
 ### `System::Array` creation
 
-C2440 can also occur if you try to create an instance of an array in C++/CLI whose type is a <xref:System.Array>.  For more information, see [Arrays](../../extensions/arrays-cpp-component-extensions.md). The next sample generates C2440:
+C2440 can also occur if you try to create an instance of an array in C++/CLI whose type is a <xref:System.Array>.  For more information, see [Arrays](../../extensions/arrays-cpp-component-extensions.md). The next example generates C2440:
 
 ```cpp
 // C2440e.cpp
@@ -202,7 +202,7 @@ int main() {
 
 ### Attributes
 
-C2440 can also occur because of changes in the attributes feature.  The following sample generates C2440.
+C2440 can also occur because of changes in the attributes feature.  The following example generates C2440.
 
 ```cpp
 // c2440f.cpp
@@ -218,7 +218,7 @@ The Microsoft C++ compiler no longer allows the [`const_cast` operator](../../cp
 
 To resolve this C2440, use the correct cast operator. For more information, see [Casting operators](../../cpp/casting-operators.md).
 
-This sample generates C2440:
+This example generates C2440:
 
 ```cpp
 // c2440g.cpp
@@ -237,7 +237,7 @@ int main() {
 
 C2440 can occur because of conformance changes to the compiler in Visual Studio 2015 Update 3. Previously, the compiler incorrectly treated certain distinct expressions as the same type when identifying a template match for a **`static_cast`** operation. Now the compiler distinguishes the types correctly, and code that relied on the previous **`static_cast`** behavior is broken. To fix this issue, change the template argument to match the template parameter type, or use a **`reinterpret_cast`** or C-style cast.
 
-This sample generates C2440:
+This example generates C2440:
 
 ```cpp
 // c2440h.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2440.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2440.md
@@ -11,9 +11,9 @@ no-loc: ["struct", "const"]
 > '*initializing*' : cannot convert from '*type1*' to '*type2*'\
 > '*conversion*' : cannot convert from '*type1*' to '*type2*'
 
-The compiler can't implicitly convert from *`type1`* to *`type2`*, or can't use the specified cast or conversion operator.
-
 ## Remarks
+
+The compiler can't implicitly convert from *`type1`* to *`type2`*, or can't use the specified cast or conversion operator.
 
 The compiler generates C2440 when it can't convert from one type to another, either implicitly or by using the specified cast or conversion operator. There are many ways to generate this error. We've listed some common ones in the Examples section.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2441.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2441.md
@@ -22,7 +22,7 @@ For more information, see [process](../../cpp/process.md) and [/clr (Common Lang
 
 ## Example
 
-The following sample generates C2441.
+The following example generates C2441.
 
 ```cpp
 // C2441.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2441.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2441.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2441"
 title: "Compiler Error C2441"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2441"
+ms.date: 11/04/2016
 f1_keywords: ["C2441"]
 helpviewer_keywords: ["C2441"]
-ms.assetid: ffbd6573-777a-48dd-892f-5cf4a758dcab
 ---
 # Compiler Error C2441
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
@@ -8,7 +8,7 @@ ms.assetid: 315330d5-24bc-4193-a531-0642095be58f
 ---
 # Compiler Error C2443
 
-operand size conflict
+> operand size conflict
 
 The instruction requires operands to be the same size.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2443"
 title: "Compiler Error C2443"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2443"
+ms.date: 11/04/2016
 f1_keywords: ["C2443"]
 helpviewer_keywords: ["C2443"]
-ms.assetid: 315330d5-24bc-4193-a531-0642095be58f
 ---
 # Compiler Error C2443
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
@@ -16,7 +16,7 @@ The instruction requires operands to be the same size.
 
 ## Example
 
-The following sample generates C2443:
+The following example generates C2443:
 
 ```cpp
 // C2443.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2443.md
@@ -10,7 +10,11 @@ ms.assetid: 315330d5-24bc-4193-a531-0642095be58f
 
 > operand size conflict
 
+## Remarks
+
 The instruction requires operands to be the same size.
+
+## Example
 
 The following sample generates C2443:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2444"
 title: "Compiler Error C2444"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2444"
+ms.date: 11/04/2016
 f1_keywords: ["C2444"]
 helpviewer_keywords: ["C2444"]
-ms.assetid: 6339ed82-caad-45d3-a8ff-6c746589fd03
 ---
 # Compiler Error C2444
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
@@ -10,6 +10,8 @@ ms.assetid: 6339ed82-caad-45d3-a8ff-6c746589fd03
 
 > 'identifier' : used ANSI prototype, found 'type', expected '{' or ';'
 
+## Remarks
+
 The function prototype is followed by a type.
 
 This error can be caused by a missing semicolon or curly brace.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2444.md
@@ -8,7 +8,7 @@ ms.assetid: 6339ed82-caad-45d3-a8ff-6c746589fd03
 ---
 # Compiler Error C2444
 
-'identifier' : used ANSI prototype, found 'type', expected '{' or ';'
+> 'identifier' : used ANSI prototype, found 'type', expected '{' or ';'
 
 The function prototype is followed by a type.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2446"
 title: "Compiler Error C2446"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2446"
+ms.date: 11/04/2016
 f1_keywords: ["C2446"]
 helpviewer_keywords: ["C2446"]
-ms.assetid: 4f70dd11-6baf-4b92-9a08-f88f65ffa199
 ---
 # Compiler Error C2446
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
@@ -10,4 +10,6 @@ ms.assetid: 4f70dd11-6baf-4b92-9a08-f88f65ffa199
 
 > 'operator' : no conversion from 'type1' to 'type2'
 
+## Remarks
+
 The compiler cannot convert `type1` to `type2`. The conversion may not make sense because it violates C/C++ semantics.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2446.md
@@ -8,6 +8,6 @@ ms.assetid: 4f70dd11-6baf-4b92-9a08-f88f65ffa199
 ---
 # Compiler Error C2446
 
-'operator' : no conversion from 'type1' to 'type2'
+> 'operator' : no conversion from 'type1' to 'type2'
 
 The compiler cannot convert `type1` to `type2`. The conversion may not make sense because it violates C/C++ semantics.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2447"
 title: "Compiler Error C2447"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2447"
+ms.date: 11/04/2016
 f1_keywords: ["C2447"]
 helpviewer_keywords: ["C2447"]
-ms.assetid: d1bd6e9a-ee42-4510-ae5e-6b0378f7b931
 ---
 # Compiler Error C2447
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
@@ -8,7 +8,7 @@ ms.assetid: d1bd6e9a-ee42-4510-ae5e-6b0378f7b931
 ---
 # Compiler Error C2447
 
-'{' : missing function header (old-style formal list?)
+> '{' : missing function header (old-style formal list?)
 
 The compiler encountered an unexpected open brace at global scope. In most cases, this is caused by a badly-formed function header, a misplaced declaration, or a stray semi-colon. To resolve this issue, verify that the open brace follows a correctly-formed function header, and is not preceded by a declaration or a stray semi-colon.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
@@ -10,9 +10,13 @@ ms.assetid: d1bd6e9a-ee42-4510-ae5e-6b0378f7b931
 
 > '{' : missing function header (old-style formal list?)
 
+## Remarks
+
 The compiler encountered an unexpected open brace at global scope. In most cases, this is caused by a badly-formed function header, a misplaced declaration, or a stray semi-colon. To resolve this issue, verify that the open brace follows a correctly-formed function header, and is not preceded by a declaration or a stray semi-colon.
 
 This error can also be caused by an old-style C-language formal argument list. To resolve this issue, refactor the argument list to use modern style—that is, enclosed in parentheses.
+
+## Example
 
 The following sample generates C2447:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2447.md
@@ -18,7 +18,7 @@ This error can also be caused by an old-style C-language formal argument list. T
 
 ## Example
 
-The following sample generates C2447:
+The following example generates C2447:
 
 ```cpp
 // C2447.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2448"
 title: "Compiler Error C2448"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2448"
+ms.date: 11/04/2016
 f1_keywords: ["C2448"]
 helpviewer_keywords: ["C2448"]
-ms.assetid: e255df3c-f861-4b4d-a193-8768cef061a5
 ---
 # Compiler Error C2448
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
@@ -18,7 +18,7 @@ This error can be caused by an old-style C-language formal list.
 
 ## Example
 
-The following sample generates C2448:
+The following example generates C2448:
 
 ```cpp
 // C2448.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
@@ -10,9 +10,13 @@ ms.assetid: e255df3c-f861-4b4d-a193-8768cef061a5
 
 > 'identifier' : function-style initializer appears to be a function definition
 
+## Remarks
+
 The function definition is incorrect.
 
 This error can be caused by an old-style C-language formal list.
+
+## Example
 
 The following sample generates C2448:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2448.md
@@ -8,7 +8,7 @@ ms.assetid: e255df3c-f861-4b4d-a193-8768cef061a5
 ---
 # Compiler Error C2448
 
-'identifier' : function-style initializer appears to be a function definition
+> 'identifier' : function-style initializer appears to be a function definition
 
 The function definition is incorrect.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
@@ -8,7 +8,7 @@ ms.assetid: 544bf0b6-daa0-40e8-9f21-8e583d472a2d
 ---
 # Compiler Error C2449
 
-found '{' at file scope (missing function header?)
+> found '{' at file scope (missing function header?)
 
 An open brace occurs at file scope.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2449"
 title: "Compiler Error C2449"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2449"
+ms.date: 11/04/2016
 f1_keywords: ["C2449"]
 helpviewer_keywords: ["C2449"]
-ms.assetid: 544bf0b6-daa0-40e8-9f21-8e583d472a2d
 ---
 # Compiler Error C2449
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
@@ -10,9 +10,13 @@ ms.assetid: 544bf0b6-daa0-40e8-9f21-8e583d472a2d
 
 > found '{' at file scope (missing function header?)
 
+## Remarks
+
 An open brace occurs at file scope.
 
 This error can be caused by a semicolon between a function header and the opening brace of the function definition.
+
+## Example
 
 The following sample generates C2499:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
@@ -18,7 +18,7 @@ This error can be caused by a semicolon between a function header and the openin
 
 ## Example
 
-The following sample generates C2499:
+The following example generates C2499:
 
 ```c
 // C2449.c

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Error C2450"
 title: "Compiler Error C2450"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2450"
+ms.date: 11/04/2016
 f1_keywords: ["C2450"]
 helpviewer_keywords: ["C2450"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2450"]
 
 > switch expression of type 'type' is illegal
 
+## Remarks
+
 The **`switch`** expression evaluates to an invalid type. It must evaluate to an integer type or a class type with unambiguous conversion to an integer type. If it evaluates to a user-defined type, you must supply a conversion operator.
+
+## Example
 
 The following sample generates C2450:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2450"]
 ---
 # Compiler Error C2450
 
-switch expression of type 'type' is illegal
+> switch expression of type 'type' is illegal
 
 The **`switch`** expression evaluates to an invalid type. It must evaluate to an integer type or a class type with unambiguous conversion to an integer type. If it evaluates to a user-defined type, you must supply a conversion operator.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2450.md
@@ -15,7 +15,7 @@ The **`switch`** expression evaluates to an invalid type. It must evaluate to an
 
 ## Example
 
-The following sample generates C2450:
+The following example generates C2450:
 
 ```cpp
 // C2450.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
@@ -10,7 +10,11 @@ ms.assetid: a64c93a5-ab8d-4d39-ae57-9ee7ef803036
 
 > conditional expression of type 'type' is illegal
 
+## Remarks
+
 The conditional expression evaluates to an integer type.
+
+## Example
 
 The following sample generates C2451:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
@@ -8,7 +8,7 @@ ms.assetid: a64c93a5-ab8d-4d39-ae57-9ee7ef803036
 ---
 # Compiler Error C2451
 
-conditional expression of type 'type' is illegal
+> conditional expression of type 'type' is illegal
 
 The conditional expression evaluates to an integer type.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2451"
 title: "Compiler Error C2451"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2451"
+ms.date: 11/04/2016
 f1_keywords: ["C2451"]
 helpviewer_keywords: ["C2451"]
-ms.assetid: a64c93a5-ab8d-4d39-ae57-9ee7ef803036
 ---
 # Compiler Error C2451
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2451.md
@@ -16,7 +16,7 @@ The conditional expression evaluates to an integer type.
 
 ## Example
 
-The following sample generates C2451:
+The following example generates C2451:
 
 ```cpp
 // C2451.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
@@ -8,7 +8,7 @@ ms.assetid: a4ec7642-6660-4c7a-9866-853d1cc67daf
 ---
 # Compiler Error C2452
 
-'type' : invalid source type for safe_cast
+> 'type' : invalid source type for safe_cast
 
 The source type for [safe_cast](../../extensions/safe-cast-cpp-component-extensions.md) was not valid.  For example, all types in a `safe_cast` operation must be CLR types.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2452"
 title: "Compiler Error C2452"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2452"
+ms.date: 11/04/2016
 f1_keywords: ["C2452"]
 helpviewer_keywords: ["C2452"]
-ms.assetid: a4ec7642-6660-4c7a-9866-853d1cc67daf
 ---
 # Compiler Error C2452
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
@@ -10,7 +10,11 @@ ms.assetid: a4ec7642-6660-4c7a-9866-853d1cc67daf
 
 > 'type' : invalid source type for safe_cast
 
+## Remarks
+
 The source type for [safe_cast](../../extensions/safe-cast-cpp-component-extensions.md) was not valid.  For example, all types in a `safe_cast` operation must be CLR types.
+
+## Example
 
 The following sample generates C2452:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2452.md
@@ -16,7 +16,7 @@ The source type for [safe_cast](../../extensions/safe-cast-cpp-component-extensi
 
 ## Example
 
-The following sample generates C2452:
+The following example generates C2452:
 
 ```cpp
 // C2452.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
@@ -16,7 +16,7 @@ You attempted to use a predefined macro, such as [`__FUNCTION__`](../../preproce
 
 ## Example
 
-The following sample generates C2457 and also shows correct usage:
+The following example generates C2457 and also shows correct usage:
 
 ```cpp
 // C2457.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
@@ -10,6 +10,8 @@ ms.assetid: 347e169d-23ad-434f-8836-5b09b53980ff
 
 > '*macro*': predefined macro cannot appear outside of a function body
 
+## Remarks
+
 You attempted to use a predefined macro, such as [`__FUNCTION__`](../../preprocessor/predefined-macros.md), in a global space.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2457.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2457"
 title: "Compiler Error C2457"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2457"
+ms.date: 11/04/2016
 f1_keywords: ["C2457"]
 helpviewer_keywords: ["C2457"]
-ms.assetid: 347e169d-23ad-434f-8836-5b09b53980ff
 ---
 # Compiler Error C2457
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
@@ -8,7 +8,7 @@ ms.assetid: ed21901f-1067-42f5-b275-19b480decf5c
 ---
 # Compiler Error C2458
 
-'identifier' : redefinition within definition
+> 'identifier' : redefinition within definition
 
 A class, structure, union, or enumeration is redefined in its own declaration.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
@@ -16,7 +16,7 @@ A class, structure, union, or enumeration is redefined in its own declaration.
 
 ## Example
 
-The following sample generates C2458:
+The following example generates C2458:
 
 ```cpp
 // C2458.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2458"
 title: "Compiler Error C2458"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2458"
+ms.date: 11/04/2016
 f1_keywords: ["C2458"]
 helpviewer_keywords: ["C2458"]
-ms.assetid: ed21901f-1067-42f5-b275-19b480decf5c
 ---
 # Compiler Error C2458
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2458.md
@@ -10,7 +10,11 @@ ms.assetid: ed21901f-1067-42f5-b275-19b480decf5c
 
 > 'identifier' : redefinition within definition
 
+## Remarks
+
 A class, structure, union, or enumeration is redefined in its own declaration.
+
+## Example
 
 The following sample generates C2458:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2459"
 title: "Compiler Error C2459"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2459"
+ms.date: 11/04/2016
 f1_keywords: ["C2459"]
 helpviewer_keywords: ["C2459"]
-ms.assetid: 81e29f4c-5b60-40fb-9557-1cdc630d77e8
 ---
 # Compiler Error C2459
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
@@ -10,7 +10,11 @@ ms.assetid: 81e29f4c-5b60-40fb-9557-1cdc630d77e8
 
 > 'identifier' : is being defined; cannot add as an anonymous member
 
+## Remarks
+
 A class, structure, or union is redefined in its own scope by a member of an anonymous union.
+
+## Example
 
 The following sample generates C2459:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
@@ -8,7 +8,7 @@ ms.assetid: 81e29f4c-5b60-40fb-9557-1cdc630d77e8
 ---
 # Compiler Error C2459
 
-'identifier' : is being defined; cannot add as an anonymous member
+> 'identifier' : is being defined; cannot add as an anonymous member
 
 A class, structure, or union is redefined in its own scope by a member of an anonymous union.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2459.md
@@ -16,7 +16,7 @@ A class, structure, or union is redefined in its own scope by a member of an ano
 
 ## Example
 
-The following sample generates C2459:
+The following example generates C2459:
 
 ```cpp
 // C2459.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
@@ -16,7 +16,7 @@ A class or structure (`identifier2`) is declared as a member of itself (`identif
 
 ## Example
 
-The following sample generates C2460:
+The following example generates C2460:
 
 ```cpp
 // C2460.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
@@ -8,7 +8,7 @@ ms.assetid: d969fca9-3ac5-4e4e-88fc-df05510e2093
 ---
 # Compiler Error C2460
 
-'identifier1' : uses 'identifier2', which is being defined
+> 'identifier1' : uses 'identifier2', which is being defined
 
 A class or structure (`identifier2`) is declared as a member of itself (`identifier1`). Recursive definitions of classes and structures are not allowed.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
@@ -10,7 +10,11 @@ ms.assetid: d969fca9-3ac5-4e4e-88fc-df05510e2093
 
 > 'identifier1' : uses 'identifier2', which is being defined
 
+## Remarks
+
 A class or structure (`identifier2`) is declared as a member of itself (`identifier1`). Recursive definitions of classes and structures are not allowed.
+
+## Example
 
 The following sample generates C2460:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2460.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2460"
 title: "Compiler Error C2460"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2460"
+ms.date: 11/04/2016
 f1_keywords: ["C2460"]
 helpviewer_keywords: ["C2460"]
-ms.assetid: d969fca9-3ac5-4e4e-88fc-df05510e2093
 ---
 # Compiler Error C2460
 


### PR DESCRIPTION
This is batch 27 that structures error/warning references. See #5465 for more information.