### PR TITLE
Structure error references in range [C2461, C2490]

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2461"
 title: "Compiler Error C2461"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2461"
+ms.date: 11/04/2016
 f1_keywords: ["C2461"]
 helpviewer_keywords: ["C2461"]
-ms.assetid: e64ba651-f441-4fdb-b5cb-4209bbbe4db4
 ---
 # Compiler Error C2461
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
@@ -18,7 +18,7 @@ To fix this issue, add a pair of parentheses after the declaration of *class*::*
 
 ## Example
 
-The following sample shows how to fix C2461:
+The following example shows how to fix C2461:
 
 ```cpp
 // C2461.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2461.md
@@ -10,6 +10,8 @@ ms.assetid: e64ba651-f441-4fdb-b5cb-4209bbbe4db4
 
 > '*class*' : constructor syntax missing formal parameters
 
+## Remarks
+
 The constructor for the class does not specify any formal parameters. The declaration of a constructor must specify a formal parameter list. The list can be empty.
 
 To fix this issue, add a pair of parentheses after the declaration of *class*::**class*.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Error C2462"
 title: "Compiler Error C2462"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2462"
+ms.date: 11/04/2016
 f1_keywords: ["C2462"]
 helpviewer_keywords: ["C2462"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2462"]
 
 > 'identifier' : cannot define a type in a 'new-expression'
 
+## Remarks
+
 You cannot define a type in the operand field of the **`new`** operator. Put the type definition in a separate statement.
+
+## Example
 
 The following sample generates C2462:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2462.md
@@ -15,7 +15,7 @@ You cannot define a type in the operand field of the **`new`** operator. Put the
 
 ## Example
 
-The following sample generates C2462:
+The following example generates C2462:
 
 ```cpp
 // C2462.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2464"
 title: "Compiler Error C2464"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2464"
+ms.date: 11/04/2016
 f1_keywords: ["C2464"]
 helpviewer_keywords: ["C2464"]
-ms.assetid: ace953d6-b414-49ee-bfef-90578a8da00c
 ---
 # Compiler Error C2464
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
@@ -10,7 +10,11 @@ ms.assetid: ace953d6-b414-49ee-bfef-90578a8da00c
 
 > 'identifier' : cannot use 'new' to allocate a reference
 
+## Remarks
+
 A reference identifier was allocated with the **`new`** operator. References are not memory objects, so **`new`** cannot return a pointer to them. Use the standard variable declaration syntax to declare a reference.
+
+## Example
 
 The following sample generates C2464:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
@@ -8,7 +8,7 @@ ms.assetid: ace953d6-b414-49ee-bfef-90578a8da00c
 ---
 # Compiler Error C2464
 
-'identifier' : cannot use 'new' to allocate a reference
+> 'identifier' : cannot use 'new' to allocate a reference
 
 A reference identifier was allocated with the **`new`** operator. References are not memory objects, so **`new`** cannot return a pointer to them. Use the standard variable declaration syntax to declare a reference.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2464.md
@@ -16,7 +16,7 @@ A reference identifier was allocated with the **`new`** operator. References are
 
 ## Example
 
-The following sample generates C2464:
+The following example generates C2464:
 
 ```cpp
 // C2464.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
@@ -10,4 +10,6 @@ ms.assetid: 65ba2a9f-d95e-4af3-b60b-1ac59a1e307c
 
 > cannot define an anonymous type inside parentheses
 
+## Remarks
+
 An anonymous structure, union, or enumerated type is defined inside a parenthetical expression. This is invalid in C++ because the definition is meaningless in function scope.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2465"
 title: "Compiler Error C2465"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2465"
+ms.date: 11/04/2016
 f1_keywords: ["C2465"]
 helpviewer_keywords: ["C2465"]
-ms.assetid: 65ba2a9f-d95e-4af3-b60b-1ac59a1e307c
 ---
 # Compiler Error C2465
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2465.md
@@ -8,6 +8,6 @@ ms.assetid: 65ba2a9f-d95e-4af3-b60b-1ac59a1e307c
 ---
 # Compiler Error C2465
 
-cannot define an anonymous type inside parentheses
+> cannot define an anonymous type inside parentheses
 
 An anonymous structure, union, or enumerated type is defined inside a parenthetical expression. This is invalid in C++ because the definition is meaningless in function scope.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
@@ -15,7 +15,7 @@ An array is allocated or declared with size zero. The constant expression for th
 
 ## Example
 
-The following sample generates C2466:
+The following example generates C2466:
 
 ```cpp
 // C2466.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2466"
 description: "Learn more about: Compiler Error C2466"
-ms.date: "03/19/2025"
+ms.date: 03/19/2025
 f1_keywords: ["C2466"]
 helpviewer_keywords: ["C2466"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2466.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2466"]
 
 > cannot allocate an array of constant size 0
 
+## Remarks
+
 An array is allocated or declared with size zero. The constant expression for the array size must be an integer greater than zero. An array declaration with a zero subscript is legal only for a class, structure, or union member and only with Microsoft extensions ([/Ze](../../build/reference/za-ze-disable-language-extensions.md)).
+
+## Example
 
 The following sample generates C2466:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
@@ -16,7 +16,7 @@ A nested user-defined type was declared. This is an error when compiling C sourc
 
 ## Example
 
-The following sample generates C2467:
+The following example generates C2467:
 
 ```c
 //C2467.c

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2467"
 title: "Compiler Error C2467"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2467"
+ms.date: 11/04/2016
 f1_keywords: ["C2467"]
 helpviewer_keywords: ["C2467"]
-ms.assetid: f9ead270-5d0b-41cc-bdcd-586a647c67a7
 ---
 # Compiler Error C2467
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
@@ -10,7 +10,11 @@ ms.assetid: f9ead270-5d0b-41cc-bdcd-586a647c67a7
 
 > illegal declaration of anonymous 'user-defined-type'
 
+## Remarks
+
 A nested user-defined type was declared. This is an error when compiling C source code with the ANSI compatibility option ([/Za](../../build/reference/za-ze-disable-language-extensions.md)) enabled.
+
+## Example
 
 The following sample generates C2467:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2467.md
@@ -8,7 +8,7 @@ ms.assetid: f9ead270-5d0b-41cc-bdcd-586a647c67a7
 ---
 # Compiler Error C2467
 
-illegal declaration of anonymous 'user-defined-type'
+> illegal declaration of anonymous 'user-defined-type'
 
 A nested user-defined type was declared. This is an error when compiling C source code with the ANSI compatibility option ([/Za](../../build/reference/za-ze-disable-language-extensions.md)) enabled.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2470"]
 
 > '*function*': looks like a function definition, but there is no parameter list; skipping apparent body
 
+## Remarks
+
 A function definition is missing its argument list.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2470.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2470"
 description: "Learn more about: Compiler Error C2470"
-ms.date: "03/29/2025"
+ms.date: 03/29/2025
 f1_keywords: ["C2470"]
 helpviewer_keywords: ["C2470"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
@@ -10,6 +10,8 @@ ms.assetid: a8928b44-20f6-4cbc-9aa5-7e86052a9c6b
 
 > cannot update program database 'file'
 
+## Remarks
+
 The compiler cannot write to the database file.
 
 ### To fix the problem

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2471"
 title: "Compiler Error C2471"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2471"
+ms.date: 11/04/2016
 f1_keywords: ["C2471"]
 helpviewer_keywords: ["C2471"]
-ms.assetid: a8928b44-20f6-4cbc-9aa5-7e86052a9c6b
 ---
 # Compiler Error C2471
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2471.md
@@ -8,7 +8,7 @@ ms.assetid: a8928b44-20f6-4cbc-9aa5-7e86052a9c6b
 ---
 # Compiler Error C2471
 
-cannot update program database 'file'
+> cannot update program database 'file'
 
 The compiler cannot write to the database file.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2472.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2472.md
@@ -18,7 +18,7 @@ The **/clr:pure** and **/clr:safe** compiler options are deprecated in Visual St
 
 ## Example
 
-The following sample generates C2472.
+The following example generates C2472.
 
 ```cpp
 // C2472.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2472.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2472.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2472"
 title: "Compiler Error C2472"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2472"
+ms.date: 11/04/2016
 f1_keywords: ["C2472"]
 helpviewer_keywords: ["C2472"]
-ms.assetid: 3b36bcdc-2ba5-4357-ab88-7545ba0551cd
 ---
 # Compiler Error C2472
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
@@ -8,7 +8,7 @@ ms.assetid: 6bb7dbf5-b198-490f-860e-fd64d0c2a284
 ---
 # Compiler Error C2473
 
-'identifier' : looks like a function definition, but there is no parameter list.
+> 'identifier' : looks like a function definition, but there is no parameter list.
 
 The compiler detected what looked like a function, without the parameter list.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
@@ -10,6 +10,8 @@ ms.assetid: 6bb7dbf5-b198-490f-860e-fd64d0c2a284
 
 > 'identifier' : looks like a function definition, but there is no parameter list.
 
+## Remarks
+
 The compiler detected what looked like a function, without the parameter list.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2473"
 title: "Compiler Error C2473"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2473"
+ms.date: 11/04/2016
 f1_keywords: ["C2473"]
 helpviewer_keywords: ["C2473"]
-ms.assetid: 6bb7dbf5-b198-490f-860e-fd64d0c2a284
 ---
 # Compiler Error C2473
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2473.md
@@ -16,7 +16,7 @@ The compiler detected what looked like a function, without the parameter list.
 
 ## Example
 
-The following sample generates C2473.
+The following example generates C2473.
 
 ```cpp
 // C2473.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
@@ -8,7 +8,7 @@ ms.assetid: 64e6c61e-6e77-480e-bcf0-b30a2fc482ac
 ---
 # Compiler Error C2474
 
-'keyword' : missing an adjacent semicolon, could be either keyword or identifier.
+> 'keyword' : missing an adjacent semicolon, could be either keyword or identifier.
 
 The compiler expected to find a semicolon, and was unable to determine your intent. Add the semicolon to resolve this error.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2474"
 title: "Compiler Error C2474"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2474"
+ms.date: 11/04/2016
 f1_keywords: ["C2474"]
 helpviewer_keywords: ["C2474"]
-ms.assetid: 64e6c61e-6e77-480e-bcf0-b30a2fc482ac
 ---
 # Compiler Error C2474
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
@@ -10,6 +10,8 @@ ms.assetid: 64e6c61e-6e77-480e-bcf0-b30a2fc482ac
 
 > 'keyword' : missing an adjacent semicolon, could be either keyword or identifier.
 
+## Remarks
+
 The compiler expected to find a semicolon, and was unable to determine your intent. Add the semicolon to resolve this error.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2474.md
@@ -16,7 +16,7 @@ The compiler expected to find a semicolon, and was unable to determine your inte
 
 ## Example
 
-The following sample generates C2474.
+The following example generates C2474.
 
 ```cpp
 // C2474.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2477"
 title: "Compiler Error C2477"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2477"
+ms.date: 11/04/2016
 f1_keywords: ["C2477"]
 helpviewer_keywords: ["C2477"]
-ms.assetid: 60bc324b-6605-4833-8099-a291efc712e7
 ---
 # Compiler Error C2477
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
@@ -10,7 +10,11 @@ ms.assetid: 60bc324b-6605-4833-8099-a291efc712e7
 
 > 'member' : static data member cannot be initialized via derived class
 
+## Remarks
+
 A static data member of a template class was initialized incorrectly. This is a breaking change with versions of the Microsoft C++ compiler prior to Visual Studio .NET 2003, in order to conform to the ISO C++ standard.
+
+## Example
 
 The following sample generates C2477:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
@@ -8,7 +8,7 @@ ms.assetid: 60bc324b-6605-4833-8099-a291efc712e7
 ---
 # Compiler Error C2477
 
-'member' : static data member cannot be initialized via derived class
+> 'member' : static data member cannot be initialized via derived class
 
 A static data member of a template class was initialized incorrectly. This is a breaking change with versions of the Microsoft C++ compiler prior to Visual Studio .NET 2003, in order to conform to the ISO C++ standard.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2477.md
@@ -16,7 +16,7 @@ A static data member of a template class was initialized incorrectly. This is a 
 
 ## Example
 
-The following sample generates C2477:
+The following example generates C2477:
 
 ```cpp
 // C2477.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2479"
 title: "Compiler Error C2479"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2479"
+ms.date: 11/04/2016
 f1_keywords: ["C2479"]
 helpviewer_keywords: ["C2479"]
-ms.assetid: c74c7869-e65b-4ca1-b6fa-eb39fed4458a
 ---
 # Compiler Error C2479
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
@@ -16,7 +16,7 @@ The `__declspec( allocate())` syntax can be used for static data only.
 
 ## Example
 
-The following sample generates C2479:
+The following example generates C2479:
 
 ```cpp
 // C2479.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
@@ -10,7 +10,11 @@ ms.assetid: c74c7869-e65b-4ca1-b6fa-eb39fed4458a
 
 > 'identifier' : 'allocate( )' is only valid for data items of static extent
 
+## Remarks
+
 The `__declspec( allocate())` syntax can be used for static data only.
+
+## Example
 
 The following sample generates C2479:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2479.md
@@ -8,7 +8,7 @@ ms.assetid: c74c7869-e65b-4ca1-b6fa-eb39fed4458a
 ---
 # Compiler Error C2479
 
-'identifier' : 'allocate( )' is only valid for data items of static extent
+> 'identifier' : 'allocate( )' is only valid for data items of static extent
 
 The `__declspec( allocate())` syntax can be used for static data only.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
@@ -18,7 +18,7 @@ Use the `thread` attribute for global variables, static data members, and local 
 
 ## Example
 
-The following sample generates C2480:
+The following example generates C2480:
 
 ```cpp
 // C2480.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2480"
 title: "Compiler Error C2480"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2480"
+ms.date: 11/04/2016
 f1_keywords: ["C2480"]
 helpviewer_keywords: ["C2480"]
-ms.assetid: 1a58d1c2-971b-4084-96fa-f94aa51c02f1
 ---
 # Compiler Error C2480
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
@@ -10,9 +10,13 @@ ms.assetid: 1a58d1c2-971b-4084-96fa-f94aa51c02f1
 
 > 'identifier' : 'thread' is only valid for data items of static extent
 
+## Remarks
+
 You cannot use the `thread` attribute with an automatic variable, nonstatic data member, function parameter, or on function declarations or definitions.
 
 Use the `thread` attribute for global variables, static data members, and local static variables only.
+
+## Example
 
 The following sample generates C2480:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2480.md
@@ -8,7 +8,7 @@ ms.assetid: 1a58d1c2-971b-4084-96fa-f94aa51c02f1
 ---
 # Compiler Error C2480
 
-'identifier' : 'thread' is only valid for data items of static extent
+> 'identifier' : 'thread' is only valid for data items of static extent
 
 You cannot use the `thread` attribute with an automatic variable, nonstatic data member, function parameter, or on function declarations or definitions.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2482.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2482.md
@@ -16,7 +16,7 @@ In managed or WinRT code, variables declared by using the [__declspec(thread)](.
 
 ## Example
 
-The following sample generates C2482 in managed (**/clr**) and in WinRT (**/ZW**) code:
+The following example generates C2482 in managed (**/clr**) and in WinRT (**/ZW**) code:
 
 ```cpp
 // C2482.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2482.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2482.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2482"
 title: "Compiler Error C2482"
-ms.date: "09/15/2017"
+description: "Learn more about: Compiler Error C2482"
+ms.date: 09/15/2017
 f1_keywords: ["C2482"]
 helpviewer_keywords: ["C2482"]
-ms.assetid: 98c87da2-625c-4cc2-9bf7-78d15921e779
 ---
 # Compiler Error C2482
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
@@ -10,6 +10,8 @@ ms.assetid: 5762b325-914b-442d-a604-e4617ba04038
 
 >'*identifier*' : object with constructor or destructor cannot be declared 'thread'
 
+## Remarks
+
 This error message is obsolete in Visual Studio 2015 and later versions. In previous versions, variables declared with the `thread` attribute cannot be initialized with a constructor or other expression that requires run-time evaluation. A static expression is required to initialize `thread` data.
 
 ## Example

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2483"
 title: "Compiler Error C2483"
-ms.date: "09/15/2017"
+description: "Learn more about: Compiler Error C2483"
+ms.date: 09/15/2017
 f1_keywords: ["C2483"]
 helpviewer_keywords: ["C2483"]
-ms.assetid: 5762b325-914b-442d-a604-e4617ba04038
 ---
 # Compiler Error C2483
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2483.md
@@ -16,7 +16,7 @@ This error message is obsolete in Visual Studio 2015 and later versions. In prev
 
 ## Example
 
-The following sample generates C2483 in Visual Studio 2013 and earlier versions.
+The following example generates C2483 in Visual Studio 2013 and earlier versions.
 
 ```cpp
 // C2483.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
@@ -8,6 +8,6 @@ ms.assetid: daae3fc1-76cf-4a6f-b2fa-86873fb0929d
 ---
 # Compiler Error C2485
 
-'identifier' : unrecognized extended attribute
+> 'identifier' : unrecognized extended attribute
 
 The declaration attribute is not valid.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
@@ -10,4 +10,6 @@ ms.assetid: daae3fc1-76cf-4a6f-b2fa-86873fb0929d
 
 > 'identifier' : unrecognized extended attribute
 
+## Remarks
+
 The declaration attribute is not valid.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2485.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2485"
 title: "Compiler Error C2485"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2485"
+ms.date: 11/04/2016
 f1_keywords: ["C2485"]
 helpviewer_keywords: ["C2485"]
-ms.assetid: daae3fc1-76cf-4a6f-b2fa-86873fb0929d
 ---
 # Compiler Error C2485
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
@@ -8,7 +8,7 @@ ms.assetid: 436da349-6461-4e32-bfca-4f3e620108e2
 ---
 # Compiler Error C2486
 
-'__LOCAL_SIZE' only allowed in function with the 'naked' attribute
+> '__LOCAL_SIZE' only allowed in function with the 'naked' attribute
 
 In inline assembly functions, the name `__LOCAL_SIZE` is reserved for functions declared with the [naked](../../cpp/naked-cpp.md) attribute.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
@@ -16,7 +16,7 @@ In inline assembly functions, the name `__LOCAL_SIZE` is reserved for functions 
 
 ## Example
 
-The following sample generates C2486:
+The following example generates C2486:
 
 ```cpp
 // C2486.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
@@ -10,7 +10,11 @@ ms.assetid: 436da349-6461-4e32-bfca-4f3e620108e2
 
 > '__LOCAL_SIZE' only allowed in function with the 'naked' attribute
 
+## Remarks
+
 In inline assembly functions, the name `__LOCAL_SIZE` is reserved for functions declared with the [naked](../../cpp/naked-cpp.md) attribute.
+
+## Example
 
 The following sample generates C2486:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2486.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2486"
 title: "Compiler Error C2486"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2486"
+ms.date: 11/04/2016
 f1_keywords: ["C2486"]
 helpviewer_keywords: ["C2486"]
-ms.assetid: 436da349-6461-4e32-bfca-4f3e620108e2
 ---
 # Compiler Error C2486
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Error C2487"
 title: "Compiler Error C2487"
-ms.date: "03/04/2024"
+description: "Learn more about: Compiler Error C2487"
+ms.date: 03/04/2024
 f1_keywords: ["C2487"]
 helpviewer_keywords: ["C2487"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
@@ -15,7 +15,7 @@ You can declare a whole class, or certain members of a non-DLL interface class, 
 
 ## Example
 
-The following sample generates C2487:
+The following example generates C2487:
 
 ```cpp
 // C2487.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2487"]
 
 > 'identifier' : member of dll interface class may not be declared with dll interface
 
+## Remarks
+
 You can declare a whole class, or certain members of a non-DLL interface class, with DLL interface. You cannot declare a class with DLL interface and then declare a member of that class with DLL interface.
+
+## Example
 
 The following sample generates C2487:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2487.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2487"]
 ---
 # Compiler Error C2487
 
-'identifier' : member of dll interface class may not be declared with dll interface
+> 'identifier' : member of dll interface class may not be declared with dll interface
 
 You can declare a whole class, or certain members of a non-DLL interface class, with DLL interface. You cannot declare a class with DLL interface and then declare a member of that class with DLL interface.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
@@ -16,7 +16,7 @@ The [naked](../../cpp/naked-cpp.md) attribute was applied to a function declarat
 
 ## Example
 
-The following sample generates C2488:
+The following example generates C2488:
 
 ```cpp
 // C2488.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2488"
 title: "Compiler Error C2488"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2488"
+ms.date: 11/04/2016
 f1_keywords: ["C2488"]
 helpviewer_keywords: ["C2488"]
-ms.assetid: cd435909-43e4-43c6-a57c-5d02468ef75f
 ---
 # Compiler Error C2488
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
@@ -10,7 +10,11 @@ ms.assetid: cd435909-43e4-43c6-a57c-5d02468ef75f
 
 > 'identifier' : 'naked' can only be applied to non-member function definitions
 
+## Remarks
+
 The [naked](../../cpp/naked-cpp.md) attribute was applied to a function declaration.
+
+## Example
 
 The following sample generates C2488:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2488.md
@@ -8,7 +8,7 @@ ms.assetid: cd435909-43e4-43c6-a57c-5d02468ef75f
 ---
 # Compiler Error C2488
 
-'identifier' : 'naked' can only be applied to non-member function definitions
+> 'identifier' : 'naked' can only be applied to non-member function definitions
 
 The [naked](../../cpp/naked-cpp.md) attribute was applied to a function declaration.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
@@ -10,7 +10,11 @@ ms.assetid: 67d8cd98-db7e-4f7f-86b4-4af7bc89ec8b
 
 > 'identifier' : initialized auto or register variable not allowed at function scope in 'naked' function
 
+## Remarks
+
 For more information, see [naked](../../cpp/naked-cpp.md).
+
+## Example
 
 The following sample generates C2489:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
@@ -8,7 +8,7 @@ ms.assetid: 67d8cd98-db7e-4f7f-86b4-4af7bc89ec8b
 ---
 # Compiler Error C2489
 
-'identifier' : initialized auto or register variable not allowed at function scope in 'naked' function
+> 'identifier' : initialized auto or register variable not allowed at function scope in 'naked' function
 
 For more information, see [naked](../../cpp/naked-cpp.md).
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2489"
 title: "Compiler Error C2489"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2489"
+ms.date: 11/04/2016
 f1_keywords: ["C2489"]
 helpviewer_keywords: ["C2489"]
-ms.assetid: 67d8cd98-db7e-4f7f-86b4-4af7bc89ec8b
 ---
 # Compiler Error C2489
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2489.md
@@ -16,7 +16,7 @@ For more information, see [naked](../../cpp/naked-cpp.md).
 
 ## Example
 
-The following sample generates C2489:
+The following example generates C2489:
 
 ```cpp
 // C2489.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
@@ -16,7 +16,7 @@ A function defined as [naked](../../cpp/naked-cpp.md) cannot use structured exce
 
 ## Example
 
-The following sample generates C2490:
+The following example generates C2490:
 
 ```cpp
 // C2490.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
@@ -8,7 +8,7 @@ ms.assetid: 9de6bddd-b2e2-4ce6-b33b-201a8c2c8c54
 ---
 # Compiler Error C2490
 
-'keyword' not allowed in function with 'naked' attribute
+> 'keyword' not allowed in function with 'naked' attribute
 
 A function defined as [naked](../../cpp/naked-cpp.md) cannot use structured exception handling.
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
@@ -10,7 +10,11 @@ ms.assetid: 9de6bddd-b2e2-4ce6-b33b-201a8c2c8c54
 
 > 'keyword' not allowed in function with 'naked' attribute
 
+## Remarks
+
 A function defined as [naked](../../cpp/naked-cpp.md) cannot use structured exception handling.
+
+## Example
 
 The following sample generates C2490:
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2490.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2490"
 title: "Compiler Error C2490"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2490"
+ms.date: 11/04/2016
 f1_keywords: ["C2490"]
 helpviewer_keywords: ["C2490"]
-ms.assetid: 9de6bddd-b2e2-4ce6-b33b-201a8c2c8c54
 ---
 # Compiler Error C2490
 


### PR DESCRIPTION
C2469 is skipped due to #5573.

This is batch 28 that structures error/warning references. See #5465 for more information.