### PR TITLE
Fix missing trailing underscore for SAL annotations

### DIFF
--- a/docs/c-runtime-library/sal-annotations.md
+++ b/docs/c-runtime-library/sal-annotations.md
@@ -1,10 +1,9 @@
 ---
 title: "SAL Annotations"
 description: "A brief description of the Microsoft source-code annotation language (SAL)."
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 ms.topic: "concept-article"
 helpviewer_keywords: ["__z annotation", "ref annotation", "_opt annotation", "__checkreturn annotatioin", "__deref_opt annotation", "deref_opt annotation", "__deref annotation", "__in annotation", "annotations [C++]", "z annotation", "_inout annotation", "__ref annotation", "full annotation", "_in annotation", "_ref annotation", "__out annotation", "_ecount annotation", "SAL annotations", "__opt annotation", "inout annotation", "in annotation", "_CA_SHOULD_CHECK_RETURN", "__bcount annotation", "_full annotation", "_bcount annotation", "deref annotation", "part annotation", "_out annotation", "__nz annotation", "__part annotation", "opt annotation", "__full annotation", "_nz annotation", "_z annotation", "out annotation", "__ecount annotation", "__inout annotation", "SAL annotations, _CA_SHOULD_CHECK_RETURN", "_deref_opt annotation", "_deref annotation", "nz annotation", "_part annotation", "ecount annotation", "bcount annotation"]
-ms.assetid: 81893638-010c-41a0-9cb3-666fe360f3e0
 ---
 # SAL annotations
 

--- a/docs/code-quality/annotating-function-parameters-and-return-values.md
+++ b/docs/code-quality/annotating-function-parameters-and-return-values.md
@@ -1,5 +1,5 @@
 ---
-title: Annotating function parameters and return values
+title: "Annotating function parameters and return values"
 description: "Reference guide to function parameter and return value annotations."
 ms.date: 10/15/2019
 ms.topic: "concept-article"
@@ -123,7 +123,6 @@ f1_keywords:
   - "_Scanf_format_string_"
   - "_Scanf_s_format_string_"
   - "_Printf_format_string_"
-ms.assetid: 82826a3d-0c81-421c-8ffe-4072555dca3a
 ---
 # Annotating function parameters and return values
 

--- a/docs/code-quality/c26116.md
+++ b/docs/code-quality/c26116.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26116"
 description: "Learn more about: Warning C26116"
-title: Warning C26116
 ms.date: 11/04/2016
 f1_keywords: ["C26116"]
 helpviewer_keywords: ["C26116"]
-ms.assetid: 43e99d2c-405e-4913-b6bd-47f5858b2877
 ---
 # Warning C26116
 


### PR DESCRIPTION
Fix missing trailing underscore for SAL annotations and update metadata.