### PR TITLE
Fix `CSnapInPropertyPageImpl` syntax

### DIFF
--- a/docs/atl/reference/csnapinpropertypageimpl-class.md
+++ b/docs/atl/reference/csnapinpropertypageimpl-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CSnapInPropertyPageImpl Class"
 title: "CSnapInPropertyPageImpl Class"
-ms.date: "11/04/2016"
+description: "Learn more about: CSnapInPropertyPageImpl Class"
+ms.date: 11/04/2016
 f1_keywords: ["CSnapInPropertyPageImpl", "ATLSNAP/ATL::CSnapInPropertyPageImpl", "ATLSNAP/ATL::CSnapInPropertyPageImpl::CSnapInPropertyPageImpl", "ATLSNAP/ATL::CSnapInPropertyPageImpl::CancelToClose", "ATLSNAP/ATL::CSnapInPropertyPageImpl::Create", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnApply", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnHelp", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnKillActive", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnQueryCancel", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnReset", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnSetActive", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnWizardBack", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnWizardFinish", "ATLSNAP/ATL::CSnapInPropertyPageImpl::OnWizardNext", "ATLSNAP/ATL::CSnapInPropertyPageImpl::QuerySiblings", "ATLSNAP/ATL::CSnapInPropertyPageImpl::SetModified", "ATLSNAP/ATL::CSnapInPropertyPageImpl::m_psp"]
 helpviewer_keywords: ["snap-ins, property pages", "snap-ins", "property pages, ATL", "CSnapInPropertyPageImpl class"]
-ms.assetid: 75bdce5a-985e-4166-bd44-493132e023c4
 ---
 # CSnapInPropertyPageImpl Class
 


### PR DESCRIPTION
Found this since it's missing the `class` keyword and template details.