### PR TITLE
Update `_DEBUG` macro reference

### DIFF
--- a/docs/c-runtime-library/debug.md
+++ b/docs/c-runtime-library/debug.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: _DEBUG"
 title: "_DEBUG"
-ms.date: "11/04/2016"
+description: "Learn more about: _DEBUG"
+ms.date: 11/04/2016
 helpviewer_keywords: ["DEBUG macro", "_DEBUG macro"]
-ms.assetid: a9901568-4846-4731-a404-399d947e2e7a
 ---
 # `_DEBUG`
 


### PR DESCRIPTION
- Mention `/LDd` as it also defines `_DEBUG`, as per:

  https://github.com/MicrosoftDocs/cpp-docs/blob/0ffedaacde5c17bd4e98535b221df1b0e9d2753f/docs/preprocessor/predefined-macros.md?plain=1#L168

  https://github.com/MicrosoftDocs/cpp-docs/blob/0ffedaacde5c17bd4e98535b221df1b0e9d2753f/docs/build/reference/md-mt-ld-use-run-time-library.md?plain=1#L29

- Add link to "Predefined macros" in "See also" section
- Simplify and add some links
- Update metadata