### PR TITLE
Structure error references in range [C2651, C2670]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
@@ -8,6 +8,6 @@ ms.assetid: c3524a89-47d1-43f6-9e20-2cda15f9ae8a
 ---
 # Compiler Error C2651
 
-'data type' : left of 'operator' must be a class, struct or union
+> 'data type' : left of 'operator' must be a class, struct or union
 
 To use a template parameter as if it is a class, specialize the class template with a class instead of an integral type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2651"
 title: "Compiler Error C2651"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2651"
+ms.date: 11/04/2016
 f1_keywords: ["C2651"]
 helpviewer_keywords: ["C2651"]
-ms.assetid: c3524a89-47d1-43f6-9e20-2cda15f9ae8a
 ---
 # Compiler Error C2651
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2651.md
@@ -10,4 +10,6 @@ ms.assetid: c3524a89-47d1-43f6-9e20-2cda15f9ae8a
 
 > 'data type' : left of 'operator' must be a class, struct or union
 
+## Remarks
+
 To use a template parameter as if it is a class, specialize the class template with a class instead of an integral type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
@@ -10,7 +10,11 @@ ms.assetid: 6e3d1a90-a989-4088-8afd-dc82f6a2d66f
 
 > 'identifier' : illegal copy constructor: first parameter must not be an 'identifier'
 
+## Remarks
+
 The first parameter in the copy constructor has the same type as the class, structure, or union for which it is defined. The first parameter can be a reference to the type but not the type itself.
+
+## Example
 
 The following sample generates C2651:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2652"
 title: "Compiler Error C2652"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2652"
+ms.date: 11/04/2016
 f1_keywords: ["C2652"]
 helpviewer_keywords: ["C2652"]
-ms.assetid: 6e3d1a90-a989-4088-8afd-dc82f6a2d66f
 ---
 # Compiler Error C2652
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
@@ -16,7 +16,7 @@ The first parameter in the copy constructor has the same type as the class, stru
 
 ## Example
 
-The following sample generates C2651:
+The following example generates C2651:
 
 ```cpp
 // C2652.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
@@ -8,7 +8,7 @@ ms.assetid: 6e3d1a90-a989-4088-8afd-dc82f6a2d66f
 ---
 # Compiler Error C2652
 
-'identifier' : illegal copy constructor: first parameter must not be an 'identifier'
+> 'identifier' : illegal copy constructor: first parameter must not be an 'identifier'
 
 The first parameter in the copy constructor has the same type as the class, structure, or union for which it is defined. The first parameter can be a reference to the type but not the type itself.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
@@ -19,7 +19,7 @@ C2653 is also possible if you try to define a *compound namespace*, a namespace 
 
 ## Examples
 
-This sample generates C2653 because a scope name is used but not declared. The compiler expects a class, structure, union, or namespace name before a scope operator (::).
+This example generates C2653 because a scope name is used but not declared. The compiler expects a class, structure, union, or namespace name before a scope operator (::).
 
 ```cpp
 // C2653.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2653.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2653"]
 
 > '*identifier*' : is not a class or namespace name
 
+## Remarks
+
 The language syntax requires a class, structure, union, or namespace name here.
 
 This error can occur when you use a name that has not been declared as a class, structure, union, or namespace in front of a scope operator. To fix this issue, declare the name or include the header that declares the name before it is used.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2654"
 title: "Compiler Error C2654"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2654"
+ms.date: 11/04/2016
 f1_keywords: ["C2654"]
 helpviewer_keywords: ["C2654"]
-ms.assetid: ca7de1bd-576b-40bf-96fc-a91984827d20
 ---
 # Compiler Error C2654
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
@@ -8,7 +8,7 @@ ms.assetid: ca7de1bd-576b-40bf-96fc-a91984827d20
 ---
 # Compiler Error C2654
 
-'identifier' : attempt to access member outside a member function
+> 'identifier' : attempt to access member outside a member function
 
 A member is accessed in a declaration. Member data can be accessed only in member functions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2654.md
@@ -10,6 +10,8 @@ ms.assetid: ca7de1bd-576b-40bf-96fc-a91984827d20
 
 > 'identifier' : attempt to access member outside a member function
 
+## Remarks
+
 A member is accessed in a declaration. Member data can be accessed only in member functions.
 
 This error can be caused when trying to initialize variables in a declaration. Use a constructor for this purpose.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
@@ -8,7 +8,7 @@ ms.assetid: beaefa6e-51b3-4df9-9150-960f3fbf40e0
 ---
 # Compiler Error C2655
 
-'identifier' : definition or redeclaration illegal in current scope
+> 'identifier' : definition or redeclaration illegal in current scope
 
 An identifier can be redeclared only at global scope.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2655"
 title: "Compiler Error C2655"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2655"
+ms.date: 11/04/2016
 f1_keywords: ["C2655"]
 helpviewer_keywords: ["C2655"]
-ms.assetid: beaefa6e-51b3-4df9-9150-960f3fbf40e0
 ---
 # Compiler Error C2655
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
@@ -16,7 +16,7 @@ An identifier can be redeclared only at global scope.
 
 ## Example
 
-The following sample generates C2655:
+The following example generates C2655:
 
 ```cpp
 // C2655.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2655.md
@@ -10,7 +10,11 @@ ms.assetid: beaefa6e-51b3-4df9-9150-960f3fbf40e0
 
 > 'identifier' : definition or redeclaration illegal in current scope
 
+## Remarks
+
 An identifier can be redeclared only at global scope.
+
+## Example
 
 The following sample generates C2655:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
@@ -10,6 +10,8 @@ ms.assetid: 1ec91186-0735-4904-859b-59da9af2d426
 
 > 'function' : function not allowed as a bit field
 
+## Remarks
+
 A function is declared as a member of a bit field.
 
 This error can be caused by a syntax error in a constructor initializer list.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
@@ -8,7 +8,7 @@ ms.assetid: 1ec91186-0735-4904-859b-59da9af2d426
 ---
 # Compiler Error C2656
 
-'function' : function not allowed as a bit field
+> 'function' : function not allowed as a bit field
 
 A function is declared as a member of a bit field.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2656.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2656"
 title: "Compiler Error C2656"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2656"
+ms.date: 11/04/2016
 f1_keywords: ["C2656"]
 helpviewer_keywords: ["C2656"]
-ms.assetid: 1ec91186-0735-4904-859b-59da9af2d426
 ---
 # Compiler Error C2656
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2657"
 title: "Compiler Error C2657"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2657"
+ms.date: 11/04/2016
 f1_keywords: ["C2657"]
 helpviewer_keywords: ["C2657"]
-ms.assetid: f7cf29a9-684a-4605-9469-ecfee9ba4b03
 ---
 # Compiler Error C2657
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
@@ -10,9 +10,13 @@ ms.assetid: f7cf29a9-684a-4605-9469-ecfee9ba4b03
 
 > 'class::*' found at the start of a statement (did you forget to specify a type?)
 
+## Remarks
+
 The line began with a pointer-to-member identifier.
 
 This error can be caused by a missing type specifier in the declaration of a pointer to a member.
+
+## Example
 
 The following sample generates C2657:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
@@ -8,7 +8,7 @@ ms.assetid: f7cf29a9-684a-4605-9469-ecfee9ba4b03
 ---
 # Compiler Error C2657
 
-'class::*' found at the start of a statement (did you forget to specify a type?)
+> 'class::*' found at the start of a statement (did you forget to specify a type?)
 
 The line began with a pointer-to-member identifier.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2657.md
@@ -18,7 +18,7 @@ This error can be caused by a missing type specifier in the declaration of a poi
 
 ## Example
 
-The following sample generates C2657:
+The following example generates C2657:
 
 ```cpp
 // C2657.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
@@ -10,7 +10,11 @@ ms.assetid: 638368e8-7893-4a14-abec-13c768a9543a
 
 > 'member': redefinition in anonymous struct/union
 
+## Remarks
+
 Two anonymous structures or unions contained member declarations with the same identifier but with different types. Under [/Za](../../build/reference/za-ze-disable-language-extensions.md), you will also get this error for members with the same identifier and type.
+
+## Example
 
 The following sample generates C2658:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
@@ -16,7 +16,7 @@ Two anonymous structures or unions contained member declarations with the same i
 
 ## Example
 
-The following sample generates C2658:
+The following example generates C2658:
 
 ```cpp
 // C2658.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2658"
 title: "Compiler Error C2658"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2658"
+ms.date: 11/04/2016
 f1_keywords: ["C2658"]
 helpviewer_keywords: ["C2658"]
-ms.assetid: 638368e8-7893-4a14-abec-13c768a9543a
 ---
 # Compiler Error C2658
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2658.md
@@ -8,7 +8,7 @@ ms.assetid: 638368e8-7893-4a14-abec-13c768a9543a
 ---
 # Compiler Error C2658
 
-'member': redefinition in anonymous struct/union
+> 'member': redefinition in anonymous struct/union
 
 Two anonymous structures or unions contained member declarations with the same identifier but with different types. Under [/Za](../../build/reference/za-ze-disable-language-extensions.md), you will also get this error for members with the same identifier and type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
@@ -10,7 +10,13 @@ ms.assetid: b0883600-4d27-4ca7-a931-8ca6bd48654d
 
 > 'operator' : function as left operand
 
-A function was on the left side of the specified operator. The most common reason for this error is that the compiler has parsed the identifier on the left side of the operator as a function when the developer intended it to be a variable. For more information, see Wikipedia article [Most vexing parse](https://en.wikipedia.org/wiki/Most_vexing_parse). This example shows a function declaration and a variable definition that are easily confused:
+## Remarks
+
+A function was on the left side of the specified operator. The most common reason for this error is that the compiler has parsed the identifier on the left side of the operator as a function when the developer intended it to be a variable. For more information, see Wikipedia article [Most vexing parse](https://en.wikipedia.org/wiki/Most_vexing_parse).
+
+## Examples
+
+This example shows a function declaration and a variable definition that are easily confused:
 
 ```cpp
 // C2659a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
@@ -8,7 +8,7 @@ ms.assetid: b0883600-4d27-4ca7-a931-8ca6bd48654d
 ---
 # Compiler Error C2659
 
-'operator' : function as left operand
+> 'operator' : function as left operand
 
 A function was on the left side of the specified operator. The most common reason for this error is that the compiler has parsed the identifier on the left side of the operator as a function when the developer intended it to be a variable. For more information, see Wikipedia article [Most vexing parse](https://en.wikipedia.org/wiki/Most_vexing_parse). This example shows a function declaration and a variable definition that are easily confused:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2659.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2659"
 title: "Compiler Error C2659"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2659"
+ms.date: 11/04/2016
 f1_keywords: ["C2659"]
 helpviewer_keywords: ["C2659"]
-ms.assetid: b0883600-4d27-4ca7-a931-8ca6bd48654d
 ---
 # Compiler Error C2659
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2660"
 title: "Compiler Error C2660"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2660"
+ms.date: 11/04/2016
 f1_keywords: ["C2660"]
 helpviewer_keywords: ["C2660"]
-ms.assetid: 2e01a1db-4f00-4df6-a04d-cb6f70a6922b
 ---
 # Compiler Error C2660
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
@@ -10,6 +10,8 @@ ms.assetid: 2e01a1db-4f00-4df6-a04d-cb6f70a6922b
 
 > 'function' : function does not take number parameters
 
+## Remarks
+
 The function is called with an incorrect number of parameters.
 
 C2660 can occur if you accidentally call a Windows API function rather than an MFC member function of the same name. To solve this problem:

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
@@ -22,7 +22,7 @@ C2660 can occur if you accidentally call a Windows API function rather than an M
 
 ## Examples
 
-The following sample generates C2660.
+The following example generates C2660.
 
 ```cpp
 // C2660.cpp
@@ -34,7 +34,7 @@ int main() {
 }
 ```
 
-C2660 can also occur if you attempt to directly call the Dispose method of a managed type. For more information, see [Destructors and finalizers](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Destructors_and_finalizers). The following sample generates C2660.
+C2660 can also occur if you attempt to directly call the Dispose method of a managed type. For more information, see [Destructors and finalizers](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Destructors_and_finalizers). The following example generates C2660.
 
 ```cpp
 // C2660_a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2660.md
@@ -8,7 +8,7 @@ ms.assetid: 2e01a1db-4f00-4df6-a04d-cb6f70a6922b
 ---
 # Compiler Error C2660
 
-'function' : function does not take number parameters
+> 'function' : function does not take number parameters
 
 The function is called with an incorrect number of parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
@@ -20,7 +20,7 @@ Possible causes:
 
 ## Example
 
-The following sample generates C2661:
+The following example generates C2661:
 
 ```cpp
 // C2661.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2661"
 title: "Compiler Error C2661"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2661"
+ms.date: 11/04/2016
 f1_keywords: ["C2661"]
 helpviewer_keywords: ["C2661"]
-ms.assetid: 60021467-71cd-451b-9877-23840c69309f
 ---
 # Compiler Error C2661
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
@@ -8,7 +8,7 @@ ms.assetid: 60021467-71cd-451b-9877-23840c69309f
 ---
 # Compiler Error C2661
 
-'function' : no overloaded function takes number parameters
+> 'function' : no overloaded function takes number parameters
 
 Possible causes:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2661.md
@@ -10,11 +10,15 @@ ms.assetid: 60021467-71cd-451b-9877-23840c69309f
 
 > 'function' : no overloaded function takes number parameters
 
+## Remarks
+
 Possible causes:
 
 1. Incorrect actual parameters in function call.
 
 1. Missing function declaration.
+
+## Example
 
 The following sample generates C2661:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
@@ -10,6 +10,8 @@ ms.assetid: e172c2a4-f29e-4034-8232-e7dc6f83689f
 
 > 'function' : cannot convert 'this' pointer from 'type1' to 'type2'
 
+## Remarks
+
 The compiler could not convert the **`this`** pointer from `type1` to `type2`.
 
 This error can be caused by invoking a non-**`const`** member function on a **`const`** object.  Possible resolutions:
@@ -17,6 +19,8 @@ This error can be caused by invoking a non-**`const`** member function on a **`c
 - Remove the **`const`** from the object declaration.
 
 - Add **`const`** to the member function.
+
+## Examples
 
 The following sample generates C2662:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
@@ -22,7 +22,7 @@ This error can be caused by invoking a non-**`const`** member function on a **`c
 
 ## Examples
 
-The following sample generates C2662:
+The following example generates C2662:
 
 ```cpp
 // C2662.cpp
@@ -64,7 +64,7 @@ ref struct N {
 };
 ```
 
-The following sample generates C2662:
+The following example generates C2662:
 
 ```cpp
 // C2662_c.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
@@ -8,7 +8,7 @@ ms.assetid: e172c2a4-f29e-4034-8232-e7dc6f83689f
 ---
 # Compiler Error C2662
 
-'function' : cannot convert 'this' pointer from 'type1' to 'type2'
+> 'function' : cannot convert 'this' pointer from 'type1' to 'type2'
 
 The compiler could not convert the **`this`** pointer from `type1` to `type2`.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2662.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2662"
 title: "Compiler Error C2662"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2662"
+ms.date: 11/04/2016
 f1_keywords: ["C2662"]
 helpviewer_keywords: ["C2662"]
-ms.assetid: e172c2a4-f29e-4034-8232-e7dc6f83689f
 ---
 # Compiler Error C2662
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
@@ -10,6 +10,8 @@ ms.assetid: 1e93e368-fd52-42bf-9908-9b6df467c8c9
 
 > 'function' : number overloads have no legal conversions for 'this' pointer
 
+## Remarks
+
 The compiler could not convert **`this`** to any of the overloaded versions of the member function.
 
 This error can be caused by invoking a non-**`const`** member function on a **`const`** object.  Possible resolutions:
@@ -17,6 +19,8 @@ This error can be caused by invoking a non-**`const`** member function on a **`c
 1. Remove the **`const`** from the object declaration.
 
 1. Add **`const`** to one of the member function overloads.
+
+## Example
 
 The following sample generates C2663:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
@@ -8,7 +8,7 @@ ms.assetid: 1e93e368-fd52-42bf-9908-9b6df467c8c9
 ---
 # Compiler Error C2663
 
-'function' : number overloads have no legal conversions for 'this' pointer
+> 'function' : number overloads have no legal conversions for 'this' pointer
 
 The compiler could not convert **`this`** to any of the overloaded versions of the member function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
@@ -22,7 +22,7 @@ This error can be caused by invoking a non-**`const`** member function on a **`c
 
 ## Example
 
-The following sample generates C2663:
+The following example generates C2663:
 
 ```cpp
 // C2663.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2663.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2663"
 title: "Compiler Error C2663"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2663"
+ms.date: 11/04/2016
 f1_keywords: ["C2663"]
 helpviewer_keywords: ["C2663"]
-ms.assetid: 1e93e368-fd52-42bf-9908-9b6df467c8c9
 ---
 # Compiler Error C2663
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2664"]
 
 > 'function' : cannot convert argument n from 'type1' to 'type2'
 
+## Remarks
+
 This parameter conversion problem might happen if an instance of a class is created and an implicit conversion is attempted on a constructor marked with the **`explicit`** keyword. For more information about explicit conversions, see [User-Defined Type Conversions](../../cpp/user-defined-type-conversions-cpp.md).
 
 If a temporary object is passed to a function that takes a reference to an object as a parameter, that reference must be a **`const`** reference.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2664"]
 ---
 # Compiler Error C2664
 
-'function' : cannot convert argument n from 'type1' to 'type2'
+> 'function' : cannot convert argument n from 'type1' to 'type2'
 
 This parameter conversion problem might happen if an instance of a class is created and an implicit conversion is attempted on a constructor marked with the **`explicit`** keyword. For more information about explicit conversions, see [User-Defined Type Conversions](../../cpp/user-defined-type-conversions-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2664.md
@@ -29,7 +29,7 @@ For more information, see [How to: Convert System::String to wchar_t* or char\*]
 
 ## Examples
 
-The following sample generates C2664 and shows how to fix it.
+The following example generates C2664 and shows how to fix it.
 
 ```cpp
 // C2664.cpp
@@ -51,7 +51,7 @@ int main() {
 }
 ```
 
-This sample also generates C2664 and shows how to fix it.
+This example also generates C2664 and shows how to fix it.
 
 ```cpp
 // C2664b.cpp
@@ -68,7 +68,7 @@ int main() {
 }
 ```
 
-The next sample demonstrates C2664 by using a string literal to call `Test`, and shows how to fix it. Because the parameter is an `szString` reference, an object must be created by the appropriate constructor. The result is a temporary object that cannot be used to initialize the reference.
+The next example demonstrates C2664 by using a string literal to call `Test`, and shows how to fix it. Because the parameter is an `szString` reference, an object must be created by the appropriate constructor. The result is a temporary object that cannot be used to initialize the reference.
 
 ```cpp
 // C2664c.cpp
@@ -107,7 +107,7 @@ int main() {
 }
 ```
 
-The compiler enforces the C++ standard requirements for applying **`const`**. This sample generates C2664:
+The compiler enforces the C++ standard requirements for applying **`const`**. This example generates C2664:
 
 ```cpp
 // C2664d.cpp
@@ -173,7 +173,7 @@ int main( ) {
 }
 ```
 
-An enum variable is not converted to its underlying type such that a function call will be satisfied. For more information, see [enum class](../../extensions/enum-class-cpp-component-extensions.md). The following sample generates C2664 and shows how to fix it.
+An enum variable is not converted to its underlying type such that a function call will be satisfied. For more information, see [enum class](../../extensions/enum-class-cpp-component-extensions.md). The following example generates C2664 and shows how to fix it.
 
 ```cpp
 // C2664f.cpp
@@ -216,7 +216,7 @@ library myproj1 {
 
 C2664 is also raised by using **`wchar_t`** when porting code from Visual C++ 6.0 to later versions. In Visual C++ 6.0 and earlier, **`wchar_t`** was a **`typedef`** for **`unsigned short`** and was therefore implicitly convertible to that type. After Visual C++ 6.0, **`wchar_t`** is its own built-in type, as specified in the C++ standard, and is no longer implicitly convertible to **`unsigned short`**. See [/Zc:wchar_t (wchar_t Is Native Type)](../../build/reference/zc-wchar-t-wchar-t-is-native-type.md).
 
-The following sample generates C2664 and shows how to fix it.
+The following example generates C2664 and shows how to fix it.
 
 ```cpp
 // C2664h.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2665"
 title: "Compiler Error C2665"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2665"
+ms.date: 11/04/2016
 f1_keywords: ["C2665"]
 helpviewer_keywords: ["C2665"]
-ms.assetid: a7f99b61-2eae-4f2b-ba75-ea68fd1e8312
 ---
 # Compiler Error C2665
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
@@ -20,7 +20,7 @@ A parameter of the overloaded function cannot be converted to the required type.
 
 ## Example
 
-The following sample generates C2665.
+The following example generates C2665.
 
 ```cpp
 // C2665.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
@@ -10,6 +10,8 @@ ms.assetid: a7f99b61-2eae-4f2b-ba75-ea68fd1e8312
 
 > 'function' : none of the number1 overloads can convert parameter number2 from type 'type'
 
+## Remarks
+
 A parameter of the overloaded function cannot be converted to the required type.  Possible resolutions:
 
 - Supply a conversion operator.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2665.md
@@ -8,7 +8,7 @@ ms.assetid: a7f99b61-2eae-4f2b-ba75-ea68fd1e8312
 ---
 # Compiler Error C2665
 
-'function' : none of the number1 overloads can convert parameter number2 from type 'type'
+> 'function' : none of the number1 overloads can convert parameter number2 from type 'type'
 
 A parameter of the overloaded function cannot be converted to the required type.  Possible resolutions:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
@@ -8,7 +8,7 @@ ms.assetid: 78364d15-c6eb-439a-9088-e04a0176692b
 ---
 # Compiler Error C2666
 
-'identifier' : number overloads have similar conversions
+> 'identifier' : number overloads have similar conversions
 
 An overloaded function or operator is ambiguous.   Formal parameter lists may be too similar for the compiler to resolve the ambiguity.  To resolve this error, explicitly cast one or more of the actual parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
@@ -10,6 +10,8 @@ ms.assetid: 78364d15-c6eb-439a-9088-e04a0176692b
 
 > 'identifier' : number overloads have similar conversions
 
+## Remarks
+
 An overloaded function or operator is ambiguous.   Formal parameter lists may be too similar for the compiler to resolve the ambiguity.  To resolve this error, explicitly cast one or more of the actual parameters.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
@@ -16,7 +16,7 @@ An overloaded function or operator is ambiguous.   Formal parameter lists may be
 
 ## Examples
 
-The following sample generates C2666:
+The following example generates C2666:
 
 ```cpp
 // C2666.cpp
@@ -143,7 +143,7 @@ int main()
 }
 ```
 
-The following sample generates C2666
+The following example generates C2666
 
 ```cpp
 // C2666c.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2666.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2666"
 title: "Compiler Error C2666"
+description: "Learn more about: Compiler Error C2666"
 ms.date: 10/18/2021
 f1_keywords: ["C2666"]
 helpviewer_keywords: ["C2666"]
-ms.assetid: 78364d15-c6eb-439a-9088-e04a0176692b
 ---
 # Compiler Error C2666
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
@@ -10,6 +10,8 @@ ms.assetid: 3c91d9d1-18fa-4e0d-a9ba-984d38980ca3
 
 > 'function' : none of number overloads have a best conversion
 
+## Remarks
+
 An overloaded function call is ambiguous and cannot be resolved.
 
 The conversion required to match the actual parameters in the function call to one of the overloaded functions must be strictly better than the conversions required by all the other overloaded functions.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2667"
 title: "Compiler Error C2667"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2667"
+ms.date: 11/04/2016
 f1_keywords: ["C2667"]
 helpviewer_keywords: ["C2667"]
-ms.assetid: 3c91d9d1-18fa-4e0d-a9ba-984d38980ca3
 ---
 # Compiler Error C2667
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2667.md
@@ -8,7 +8,7 @@ ms.assetid: 3c91d9d1-18fa-4e0d-a9ba-984d38980ca3
 ---
 # Compiler Error C2667
 
-'function' : none of number overloads have a best conversion
+> 'function' : none of number overloads have a best conversion
 
 An overloaded function call is ambiguous and cannot be resolved.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
@@ -10,6 +10,8 @@ ms.assetid: 041e9627-1c76-420e-a653-cfc83f933bd3
 
 > 'function' : ambiguous call to overloaded function
 
+## Remarks
+
 The specified overloaded function call couldn't be resolved. You may want to explicitly cast one or more of the actual parameters.
 
 You can also get this error through template use. If, in the same class, you have a regular member function and a templated member function with the same signature, the templated one must come first. This limitation remains in the current implementation of Visual C++.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2668"
 title: "Compiler Error C2668"
+description: "Learn more about: Compiler Error C2668"
 ms.date: 05/03/2021
 f1_keywords: ["C2668"]
 helpviewer_keywords: ["C2668"]
-ms.assetid: 041e9627-1c76-420e-a653-cfc83f933bd3
 ---
 # Compiler Error C2668
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2668.md
@@ -18,7 +18,7 @@ You can also get this error through template use. If, in the same class, you hav
 
 ## Examples
 
-The following sample generates C2668:
+The following example generates C2668:
 
 ```cpp
 // C2668.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
@@ -16,7 +16,7 @@ ms.assetid: f9cb8111-bcdc-484b-a863-2c42e15a0496
 
 ## Example
 
-The following sample generates C2669:
+The following example generates C2669:
 
 ```cpp
 // C2669.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
@@ -8,7 +8,7 @@ ms.assetid: f9cb8111-bcdc-484b-a863-2c42e15a0496
 ---
 # Compiler Error C2669
 
-member function not allowed in anonymous union
+> member function not allowed in anonymous union
 
 [Anonymous unions](../../cpp/unions.md#anonymous_unions) cannot have member functions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2669"
 title: "Compiler Error C2669"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2669"
+ms.date: 11/04/2016
 f1_keywords: ["C2669"]
 helpviewer_keywords: ["C2669"]
-ms.assetid: f9cb8111-bcdc-484b-a863-2c42e15a0496
 ---
 # Compiler Error C2669
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2669.md
@@ -10,6 +10,8 @@ ms.assetid: f9cb8111-bcdc-484b-a863-2c42e15a0496
 
 > member function not allowed in anonymous union
 
+## Remarks
+
 [Anonymous unions](../../cpp/unions.md#anonymous_unions) cannot have member functions.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
@@ -10,6 +10,8 @@ ms.assetid: 4b3b74c7-a750-4b0d-abd3-216d1234461f
 
 > 'identifier' : the function template cannot convert parameter number from type 'type'
 
+## Remarks
+
 A parameter could not be converted to the required type.
 
 This error may be fixed if you create an explicit conversion.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
@@ -8,7 +8,7 @@ ms.assetid: 4b3b74c7-a750-4b0d-abd3-216d1234461f
 ---
 # Compiler Error C2670
 
-'identifier' : the function template cannot convert parameter number from type 'type'
+> 'identifier' : the function template cannot convert parameter number from type 'type'
 
 A parameter could not be converted to the required type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2670.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2670"
 title: "Compiler Error C2670"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2670"
+ms.date: 11/04/2016
 f1_keywords: ["C2670"]
 helpviewer_keywords: ["C2670"]
-ms.assetid: 4b3b74c7-a750-4b0d-abd3-216d1234461f
 ---
 # Compiler Error C2670
 


### PR DESCRIPTION
This is batch 34 that structures error/warning references. See #5465 for more information.