### PR TITLE
Structure error references in range [C2671, C2700]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
@@ -16,7 +16,7 @@ A **`static`** member function tried to access **`this`**.
 
 ## Example
 
-The following sample generates C2671:
+The following example generates C2671:
 
 ```cpp
 // C2671.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2671"
 title: "Compiler Error C2671"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2671"
+ms.date: 11/04/2016
 f1_keywords: ["C2671"]
 helpviewer_keywords: ["C2671"]
-ms.assetid: fc0ee40f-c8f3-408f-b89d-745d149c4169
 ---
 # Compiler Error C2671
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
@@ -10,7 +10,11 @@ ms.assetid: fc0ee40f-c8f3-408f-b89d-745d149c4169
 
 > 'function' : static member functions do not have 'this' pointers
 
+## Remarks
+
 A **`static`** member function tried to access **`this`**.
+
+## Example
 
 The following sample generates C2671:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2671.md
@@ -8,7 +8,7 @@ ms.assetid: fc0ee40f-c8f3-408f-b89d-745d149c4169
 ---
 # Compiler Error C2671
 
-'function' : static member functions do not have 'this' pointers
+> 'function' : static member functions do not have 'this' pointers
 
 A **`static`** member function tried to access **`this`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2672.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2672.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2672"
 title: "Compiler Error C2672"
-ms.date: "10/24/2017"
+description: "Learn more about: Compiler Error C2672"
+ms.date: 10/24/2017
 f1_keywords: ["C2672"]
 helpviewer_keywords: ["C2672"]
-ms.assetid: 7e86338a-2d4b-40fe-9dd2-ac6886f3f31a
 ---
 # Compiler Error C2672
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2672.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2672.md
@@ -10,6 +10,8 @@ ms.assetid: 7e86338a-2d4b-40fe-9dd2-ac6886f3f31a
 
 > '*function*': no matching overloaded function found
 
+## Remarks
+
 The compiler could not find an overloaded function that matches the specified function. No function was found that takes matching parameters, or no matching function has the required accessibility in context.
 
 When used by certain standard library containers or algorithms, your types must provide accessible members or friend functions that satisfy the requirements of the container or algorithm. For example, your iterator types should derive from `std::iterator<>`. Comparison operations or use of other operators on container element types may require the type be considered as both a left-hand and a right-hand operand. Use of the type as a right-hand operand can require implementation of the operator as a non-member function of the type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
@@ -10,7 +10,11 @@ ms.assetid: 780230c0-619b-4a78-b01d-ff5886306741
 
 > 'function' : global functions do not have 'this' pointers
 
+## Remarks
+
 A global function tried to access **`this`**.
+
+## Example
 
 The following sample generates C2673:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2673"
 title: "Compiler Error C2673"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2673"
+ms.date: 11/04/2016
 f1_keywords: ["C2673"]
 helpviewer_keywords: ["C2673"]
-ms.assetid: 780230c0-619b-4a78-b01d-ff5886306741
 ---
 # Compiler Error C2673
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
@@ -16,7 +16,7 @@ A global function tried to access **`this`**.
 
 ## Example
 
-The following sample generates C2673:
+The following example generates C2673:
 
 ```cpp
 // C2673.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2673.md
@@ -8,7 +8,7 @@ ms.assetid: 780230c0-619b-4a78-b01d-ff5886306741
 ---
 # Compiler Error C2673
 
-'function' : global functions do not have 'this' pointers
+> 'function' : global functions do not have 'this' pointers
 
 A global function tried to access **`this`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
@@ -16,7 +16,7 @@ A generic was declared incorrectly. For more information, see [Generics](../../e
 
 ## Example
 
-The following sample generates C2674.
+The following example generates C2674.
 
 ```cpp
 // C2674.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2674"
 title: "Compiler Error C2674"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2674"
+ms.date: 11/04/2016
 f1_keywords: ["C2674"]
 helpviewer_keywords: ["C2674"]
-ms.assetid: 7cbd70d8-d992-44d7-a5cb-dd8cf9c759d2
 ---
 # Compiler Error C2674
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
@@ -8,7 +8,7 @@ ms.assetid: 7cbd70d8-d992-44d7-a5cb-dd8cf9c759d2
 ---
 # Compiler Error C2674
 
-a generic declaration is not allowed in this context
+> a generic declaration is not allowed in this context
 
 A generic was declared incorrectly. For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2674.md
@@ -10,6 +10,8 @@ ms.assetid: 7cbd70d8-d992-44d7-a5cb-dd8cf9c759d2
 
 > a generic declaration is not allowed in this context
 
+## Remarks
+
 A generic was declared incorrectly. For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
@@ -16,7 +16,7 @@ C2675 can also occur when using a unary operator, and the type does not define t
 
 ## Example
 
-The following sample generates C2675.
+The following example generates C2675.
 
 ```cpp
 // C2675.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
@@ -8,7 +8,7 @@ ms.assetid: 4b92a12b-bff8-4dd5-a109-620065fc146c
 ---
 # Compiler Error C2675
 
-unary 'operator' : 'type' does not define this operator or a conversion to a type acceptable to the predefined operator
+> unary 'operator' : 'type' does not define this operator or a conversion to a type acceptable to the predefined operator
 
 C2675 can also occur when using a unary operator, and the type does not define the operator or a conversion to a type acceptable to the predefined operator. To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2675"
 title: "Compiler Error C2675"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2675"
+ms.date: 11/04/2016
 f1_keywords: ["C2675"]
 helpviewer_keywords: ["C2675"]
-ms.assetid: 4b92a12b-bff8-4dd5-a109-620065fc146c
 ---
 # Compiler Error C2675
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2675.md
@@ -10,6 +10,8 @@ ms.assetid: 4b92a12b-bff8-4dd5-a109-620065fc146c
 
 > unary 'operator' : 'type' does not define this operator or a conversion to a type acceptable to the predefined operator
 
+## Remarks
+
 C2675 can also occur when using a unary operator, and the type does not define the operator or a conversion to a type acceptable to the predefined operator. To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2676.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2676.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2676"
 title: "Compiler Error C2676"
+description: "Learn more about: Compiler Error C2676"
 ms.date: 06/03/2022
 f1_keywords: ["C2676"]
 helpviewer_keywords: ["C2676"]
-ms.assetid: 838a5e34-c92f-4f65-a597-e150bf8cf737
 ---
 # Compiler Error C2676
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2676.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2676.md
@@ -16,7 +16,7 @@ To use the operator, you must overload it for the specified type or define a con
 
 ## Examples
 
-The following sample generates C2676.
+The following example generates C2676.
 
 ```cpp
 // C2676.cpp
@@ -50,7 +50,7 @@ C2676 can also occur if you attempt to do pointer arithmetic on the **`this`** p
 
 The **`this`** pointer is of type handle in a reference type. For more information, see [Semantics of the `this` pointer](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Semantics_of_the_this_pointer).
 
-The following sample generates C2676.
+The following example generates C2676.
 
 ```cpp
 // C2676_a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2677"
 title: "Compiler Error C2677"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2677"
+ms.date: 11/04/2016
 f1_keywords: ["C2677"]
 helpviewer_keywords: ["C2677"]
-ms.assetid: 76bc0b65-f52a-45a6-b6d6-0555f89da9a8
 ---
 # Compiler Error C2677
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
@@ -8,7 +8,7 @@ ms.assetid: 76bc0b65-f52a-45a6-b6d6-0555f89da9a8
 ---
 # Compiler Error C2677
 
-binary 'operator' : no global operator found which takes type 'type' (or there is no acceptable conversion)
+> binary 'operator' : no global operator found which takes type 'type' (or there is no acceptable conversion)
 
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
@@ -10,7 +10,11 @@ ms.assetid: 76bc0b65-f52a-45a6-b6d6-0555f89da9a8
 
 > binary 'operator' : no global operator found which takes type 'type' (or there is no acceptable conversion)
 
+## Remarks
+
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
+
+## Example
 
 The following sample generates C2677:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2677.md
@@ -16,7 +16,7 @@ To use the operator, you must overload it for the specified type or define a con
 
 ## Example
 
-The following sample generates C2677:
+The following example generates C2677:
 
 ```cpp
 // C2677.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
@@ -10,6 +10,8 @@ ms.assetid: 1f0a4e26-b429-44f5-9f94-cb66441220c8
 
 > binary 'operator' : no operator defined which takes a left-hand operand of type 'type' (or there is no acceptable conversion)
 
+## Remarks
+
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 
 C2678 can occur when the left-hand operand is const-qualified but the operator is defined to take a non-const argument.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
@@ -8,7 +8,7 @@ ms.assetid: 1f0a4e26-b429-44f5-9f94-cb66441220c8
 ---
 # Compiler Error C2678
 
-binary 'operator' : no operator defined which takes a left-hand operand of type 'type' (or there is no acceptable conversion)
+> binary 'operator' : no operator defined which takes a left-hand operand of type 'type' (or there is no acceptable conversion)
 
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2678"
 title: "Compiler Error C2678"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2678"
+ms.date: 11/04/2016
 f1_keywords: ["C2678"]
 helpviewer_keywords: ["C2678"]
-ms.assetid: 1f0a4e26-b429-44f5-9f94-cb66441220c8
 ---
 # Compiler Error C2678
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2678.md
@@ -18,7 +18,7 @@ C2678 can occur when the left-hand operand is const-qualified but the operator i
 
 ## Examples
 
-The following sample generates C2678 and shows how to fix it:
+The following example generates C2678 and shows how to fix it:
 
 ```cpp
 // C2678a.cpp
@@ -44,7 +44,7 @@ int main() {
 
 C2678 can also occur if you do not pin a native member before calling a member function on it.
 
-The following sample generates C2678 and shows how to fix it.
+The following example generates C2678 and shows how to fix it.
 
 ```cpp
 // C2678.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
@@ -16,7 +16,7 @@ To use the operator, you must overload it for the specified type or define a con
 
 ## Example
 
-The following sample generates C2679:
+The following example generates C2679:
 
 ```cpp
 // C2679.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
@@ -8,7 +8,7 @@ ms.assetid: 1a5f9d00-9190-4aa6-bc72-949f68ec136f
 ---
 # Compiler Error C2679
 
-binary 'operator' : no operator found which takes a right-hand operand of type 'type' (or there is no acceptable conversion)
+> binary 'operator' : no operator found which takes a right-hand operand of type 'type' (or there is no acceptable conversion)
 
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
@@ -10,7 +10,11 @@ ms.assetid: 1a5f9d00-9190-4aa6-bc72-949f68ec136f
 
 > binary 'operator' : no operator found which takes a right-hand operand of type 'type' (or there is no acceptable conversion)
 
+## Remarks
+
 To use the operator, you must overload it for the specified type or define a conversion to a type for which the operator is defined.
+
+## Example
 
 The following sample generates C2679:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2679.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2679"
 title: "Compiler Error C2679"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2679"
+ms.date: 11/04/2016
 f1_keywords: ["C2679"]
 helpviewer_keywords: ["C2679"]
-ms.assetid: 1a5f9d00-9190-4aa6-bc72-949f68ec136f
 ---
 # Compiler Error C2679
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2680"
 title: "Compiler Error C2680"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2680"
+ms.date: 11/04/2016
 f1_keywords: ["C2680"]
 helpviewer_keywords: ["C2680"]
-ms.assetid: d6f7129e-dd17-4661-b680-18d6b925b1cc
 ---
 # Compiler Error C2680
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
@@ -16,7 +16,7 @@ A casting operator tried to convert to a type that is not a pointer or reference
 
 ## Examples
 
-The following sample generates C2680:
+The following example generates C2680:
 
 ```cpp
 // C2680.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
@@ -10,7 +10,11 @@ ms.assetid: d6f7129e-dd17-4661-b680-18d6b925b1cc
 
 > 'type' : invalid target type for name
 
+## Remarks
+
 A casting operator tried to convert to a type that is not a pointer or reference. The [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator can be used only for pointers or references.
+
+## Examples
 
 The following sample generates C2680:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2680.md
@@ -8,7 +8,7 @@ ms.assetid: d6f7129e-dd17-4661-b680-18d6b925b1cc
 ---
 # Compiler Error C2680
 
-'type' : invalid target type for name
+> 'type' : invalid target type for name
 
 A casting operator tried to convert to a type that is not a pointer or reference. The [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator can be used only for pointers or references.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
@@ -8,7 +8,7 @@ ms.assetid: eb42da6d-8d2c-43fd-986b-e73e2b004885
 ---
 # Compiler Error C2681
 
-'type' : invalid expression type for name
+> 'type' : invalid expression type for name
 
 A casting operator tried to convert from an invalid type. For example, if you use the [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator to convert an expression to a pointer type, the source expression must be a pointer.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2681"
 title: "Compiler Error C2681"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2681"
+ms.date: 11/04/2016
 f1_keywords: ["C2681"]
 helpviewer_keywords: ["C2681"]
-ms.assetid: eb42da6d-8d2c-43fd-986b-e73e2b004885
 ---
 # Compiler Error C2681
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
@@ -10,7 +10,11 @@ ms.assetid: eb42da6d-8d2c-43fd-986b-e73e2b004885
 
 > 'type' : invalid expression type for name
 
+## Remarks
+
 A casting operator tried to convert from an invalid type. For example, if you use the [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator to convert an expression to a pointer type, the source expression must be a pointer.
+
+## Example
 
 The following sample generates C2681:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2681.md
@@ -16,7 +16,7 @@ A casting operator tried to convert from an invalid type. For example, if you us
 
 ## Example
 
-The following sample generates C2681:
+The following example generates C2681:
 
 ```cpp
 // C2681.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2682"
 title: "Compiler Error C2682"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2682"
+ms.date: 11/04/2016
 f1_keywords: ["C2682"]
 helpviewer_keywords: ["C2682"]
-ms.assetid: 30c6a7c4-f5f7-4fe8-81a8-c48938521ab4
 ---
 # Compiler Error C2682
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
@@ -18,7 +18,7 @@ You can use the **`const_cast`** operator to remove attributes such as **`const`
 
 ## Examples
 
-The following sample generates C2682:
+The following example generates C2682:
 
 ```cpp
 // C2682.cpp
@@ -30,7 +30,7 @@ void g(A* pa) {
 }
 ```
 
-The following sample generates C2682:
+The following example generates C2682:
 
 ```cpp
 // C2682b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
@@ -10,9 +10,13 @@ ms.assetid: 30c6a7c4-f5f7-4fe8-81a8-c48938521ab4
 
 > cannot use casting_operator to convert from 'type1' to 'type2'
 
+## Remarks
+
 A casting operator tried to convert between incompatible types. For example, you cannot use the [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator to convert a pointer to a reference. The **`dynamic_cast`** operator cannot be used to cast away qualifiers. All qualifiers on the types must match.
 
 You can use the **`const_cast`** operator to remove attributes such as **`const`**, **`volatile`**, or **`__unaligned`**.
+
+## Examples
 
 The following sample generates C2682:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2682.md
@@ -8,7 +8,7 @@ ms.assetid: 30c6a7c4-f5f7-4fe8-81a8-c48938521ab4
 ---
 # Compiler Error C2682
 
-cannot use casting_operator to convert from 'type1' to 'type2'
+> cannot use casting_operator to convert from 'type1' to 'type2'
 
 A casting operator tried to convert between incompatible types. For example, you cannot use the [dynamic_cast](../../cpp/dynamic-cast-operator.md) operator to convert a pointer to a reference. The **`dynamic_cast`** operator cannot be used to cast away qualifiers. All qualifiers on the types must match.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
@@ -8,7 +8,7 @@ ms.assetid: db605e4f-601b-4d05-92a1-c43ca24de08d
 ---
 # Compiler Error C2683
 
-'cast' : 'type' is not a polymorphic type
+> 'cast' : 'type' is not a polymorphic type
 
 You cannot use [dynamic_cast](../../cpp/dynamic-cast-operator.md) to convert from a non-polymorphic class (a class with no virtual functions).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2683"
 title: "Compiler Error C2683"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2683"
+ms.date: 11/04/2016
 f1_keywords: ["C2683"]
 helpviewer_keywords: ["C2683"]
-ms.assetid: db605e4f-601b-4d05-92a1-c43ca24de08d
 ---
 # Compiler Error C2683
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
@@ -10,9 +10,13 @@ ms.assetid: db605e4f-601b-4d05-92a1-c43ca24de08d
 
 > 'cast' : 'type' is not a polymorphic type
 
+## Remarks
+
 You cannot use [dynamic_cast](../../cpp/dynamic-cast-operator.md) to convert from a non-polymorphic class (a class with no virtual functions).
 
 You can use [static_cast](../../cpp/static-cast-operator.md) to perform conversions of non-polymorphic types. However, **`static_cast`** does not perform a run-time check.
+
+## Example
 
 The following sample generates C2683:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2683.md
@@ -18,7 +18,7 @@ You can use [static_cast](../../cpp/static-cast-operator.md) to perform conversi
 
 ## Example
 
-The following sample generates C2683:
+The following example generates C2683:
 
 ```cpp
 // C2683.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
@@ -10,7 +10,11 @@ ms.assetid: 1d24b24a-cd0f-41cc-975c-b08dcfb7f402
 
 > 'type' : exception-declaration cannot be 'void' or denote an incomplete type or pointer or reference to an incomplete type
 
+## Remarks
+
 For a type to be part of an exception declaration, it must be defined and not void.
+
+## Example
 
 The following sample generates C2687:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
@@ -8,7 +8,7 @@ ms.assetid: 1d24b24a-cd0f-41cc-975c-b08dcfb7f402
 ---
 # Compiler Error C2687
 
-'type' : exception-declaration cannot be 'void' or denote an incomplete type or pointer or reference to an incomplete type
+> 'type' : exception-declaration cannot be 'void' or denote an incomplete type or pointer or reference to an incomplete type
 
 For a type to be part of an exception declaration, it must be defined and not void.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2687"
 title: "Compiler Error C2687"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2687"
+ms.date: 11/04/2016
 f1_keywords: ["C2687"]
 helpviewer_keywords: ["C2687"]
-ms.assetid: 1d24b24a-cd0f-41cc-975c-b08dcfb7f402
 ---
 # Compiler Error C2687
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2687.md
@@ -16,7 +16,7 @@ For a type to be part of an exception declaration, it must be defined and not vo
 
 ## Example
 
-The following sample generates C2687:
+The following example generates C2687:
 
 ```cpp
 // C2687.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
@@ -10,9 +10,13 @@ ms.assetid: 168c9e9d-8f65-4664-af86-db71d3e6ee46
 
 > 'C2::fgrv' : covariant returns with multiple or virtual inheritance not supported for varargs functions
 
+## Remarks
+
 Covariant return types are not supported in Visual C++ when a function contains variable arguments.
 
 To resolve this error, either define your functions so that they do not use variable arguments or make the return values the same for all virtual functions.
+
+## Example
 
 The following sample generates C2688:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2688"
 title: "Compiler Error C2688"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2688"
+ms.date: 11/04/2016
 f1_keywords: ["C2688"]
 helpviewer_keywords: ["C2688"]
-ms.assetid: 168c9e9d-8f65-4664-af86-db71d3e6ee46
 ---
 # Compiler Error C2688
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
@@ -8,7 +8,7 @@ ms.assetid: 168c9e9d-8f65-4664-af86-db71d3e6ee46
 ---
 # Compiler Error C2688
 
-'C2::fgrv' : covariant returns with multiple or virtual inheritance not supported for varargs functions
+> 'C2::fgrv' : covariant returns with multiple or virtual inheritance not supported for varargs functions
 
 Covariant return types are not supported in Visual C++ when a function contains variable arguments.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2688.md
@@ -18,7 +18,7 @@ To resolve this error, either define your functions so that they do not use vari
 
 ## Example
 
-The following sample generates C2688:
+The following example generates C2688:
 
 ```cpp
 // C2688.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
@@ -10,7 +10,11 @@ ms.assetid: b5216fba-524d-4194-9168-26e9dc5210ce
 
 > 'function' : a friend function cannot be defined within a local class
 
+## Remarks
+
 You can declare but not define a friend function in a local class.
+
+## Example
 
 The following sample generates C2689:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
@@ -8,7 +8,7 @@ ms.assetid: b5216fba-524d-4194-9168-26e9dc5210ce
 ---
 # Compiler Error C2689
 
-'function' : a friend function cannot be defined within a local class
+> 'function' : a friend function cannot be defined within a local class
 
 You can declare but not define a friend function in a local class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2689"
 title: "Compiler Error C2689"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2689"
+ms.date: 11/04/2016
 f1_keywords: ["C2689"]
 helpviewer_keywords: ["C2689"]
-ms.assetid: b5216fba-524d-4194-9168-26e9dc5210ce
 ---
 # Compiler Error C2689
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2689.md
@@ -16,7 +16,7 @@ You can declare but not define a friend function in a local class.
 
 ## Example
 
-The following sample generates C2689:
+The following example generates C2689:
 
 ```cpp
 // C2689.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
@@ -10,4 +10,6 @@ ms.assetid: f165a806-14bd-4942-99b7-8a9fc7dea227
 
 > 'operator' : cannot perform pointer arithmetic on a managed or WinRT array
 
+## Remarks
+
 Pointer arithmetic is not allowed on a managed or WinRT array. Use array index notation to traverse the array.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2690"
 title: "Compiler Error C2690"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2690"
+ms.date: 11/04/2016
 f1_keywords: ["C2690"]
 helpviewer_keywords: ["C2690"]
-ms.assetid: f165a806-14bd-4942-99b7-8a9fc7dea227
 ---
 # Compiler Error C2690
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2690.md
@@ -8,6 +8,6 @@ ms.assetid: f165a806-14bd-4942-99b7-8a9fc7dea227
 ---
 # Compiler Error C2690
 
-'operator' : cannot perform pointer arithmetic on a managed or WinRT array
+> 'operator' : cannot perform pointer arithmetic on a managed or WinRT array
 
 Pointer arithmetic is not allowed on a managed or WinRT array. Use array index notation to traverse the array.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
@@ -16,7 +16,7 @@ The type of a managed or WinRT array element can be a value type or a reference 
 
 ## Example
 
-The following sample generates C2691:
+The following example generates C2691:
 
 ```cpp
 // C2691a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
@@ -8,7 +8,7 @@ ms.assetid: 6925f8f3-ea60-4909-91e6-b781492c645d
 ---
 # Compiler Error C2691
 
-'data type' : a managed or WinRTarray cannot have this element type
+> 'data type' : a managed or WinRTarray cannot have this element type
 
 The type of a managed or WinRT array element can be a value type or a reference type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
@@ -10,7 +10,11 @@ ms.assetid: 6925f8f3-ea60-4909-91e6-b781492c645d
 
 > 'data type' : a managed or WinRTarray cannot have this element type
 
+## Remarks
+
 The type of a managed or WinRT array element can be a value type or a reference type.
+
+## Example
 
 The following sample generates C2691:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2691.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2691"
 title: "Compiler Error C2691"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2691"
+ms.date: 11/04/2016
 f1_keywords: ["C2691"]
 helpviewer_keywords: ["C2691"]
-ms.assetid: 6925f8f3-ea60-4909-91e6-b781492c645d
 ---
 # Compiler Error C2691
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
@@ -8,6 +8,6 @@ ms.assetid: 02ade3b4-b757-448b-b065-d7d71bc3f441
 ---
 # Compiler Error C2692
 
-'function_name' : fully prototyped functions required in C compiler with the '/clr' option
+> 'function_name' : fully prototyped functions required in C compiler with the '/clr' option
 
 When compiling for .NET managed code, the C compiler requires ANSI function declarations. In addition, if a function takes no parameters, it must explicitly declare **`void`** as the parameter type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2692"
 title: "Compiler Error C2692"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2692"
+ms.date: 11/04/2016
 f1_keywords: ["C2692"]
 helpviewer_keywords: ["C2692"]
-ms.assetid: 02ade3b4-b757-448b-b065-d7d71bc3f441
 ---
 # Compiler Error C2692
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2692.md
@@ -10,4 +10,6 @@ ms.assetid: 02ade3b4-b757-448b-b065-d7d71bc3f441
 
 > 'function_name' : fully prototyped functions required in C compiler with the '/clr' option
 
+## Remarks
+
 When compiling for .NET managed code, the C compiler requires ANSI function declarations. In addition, if a function takes no parameters, it must explicitly declare **`void`** as the parameter type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2693"
 title: "Compiler Error C2693"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2693"
+ms.date: 11/04/2016
 f1_keywords: ["C2693"]
 helpviewer_keywords: ["C2693"]
-ms.assetid: b7364ca8-b6be-48c0-97d6-6029787fb171
 ---
 # Compiler Error C2693
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
@@ -10,4 +10,6 @@ ms.assetid: b7364ca8-b6be-48c0-97d6-6029787fb171
 
 > 'operator' : illegal comparison for references to a managed or WinRT array
 
+## Remarks
+
 You cannot test a managed or WinRT array for any kind of inequality. For example, you can test to see if managed arrays are equal but you cannot test to see if one array is greater or less than another array.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2693.md
@@ -8,6 +8,6 @@ ms.assetid: b7364ca8-b6be-48c0-97d6-6029787fb171
 ---
 # Compiler Error C2693
 
-'operator' : illegal comparison for references to a managed or WinRT array
+> 'operator' : illegal comparison for references to a managed or WinRT array
 
 You cannot test a managed or WinRT array for any kind of inequality. For example, you can test to see if managed arrays are equal but you cannot test to see if one array is greater or less than another array.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
@@ -16,7 +16,7 @@ A virtual function was overridden, but under [/Za](../../build/reference/za-ze-d
 
 ## Example
 
-The following sample generates C2694:
+The following example generates C2694:
 
 ```cpp
 // C2694.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2694"
 title: "Compiler Error C2694"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2694"
+ms.date: 11/04/2016
 f1_keywords: ["C2694"]
 helpviewer_keywords: ["C2694"]
-ms.assetid: 8dc2cec2-67ae-4e16-8c0c-374425aca8bc
 ---
 # Compiler Error C2694
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
@@ -8,7 +8,7 @@ ms.assetid: 8dc2cec2-67ae-4e16-8c0c-374425aca8bc
 ---
 # Compiler Error C2694
 
-'override': overriding virtual function has less restrictive exception specification than base class virtual member function 'base'
+> 'override': overriding virtual function has less restrictive exception specification than base class virtual member function 'base'
 
 A virtual function was overridden, but under [/Za](../../build/reference/za-ze-disable-language-extensions.md), the overriding function had a less restrictive [exception specification](../../cpp/exception-specifications-throw-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2694.md
@@ -10,7 +10,11 @@ ms.assetid: 8dc2cec2-67ae-4e16-8c0c-374425aca8bc
 
 > 'override': overriding virtual function has less restrictive exception specification than base class virtual member function 'base'
 
+## Remarks
+
 A virtual function was overridden, but under [/Za](../../build/reference/za-ze-disable-language-extensions.md), the overriding function had a less restrictive [exception specification](../../cpp/exception-specifications-throw-cpp.md).
+
+## Example
 
 The following sample generates C2694:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
@@ -10,7 +10,11 @@ ms.assetid: 3f6f2091-c38b-40ea-ab6c-f1846f5702d7
 
 > 'function1': overriding virtual function differs from 'function2' only by calling convention
 
+## Remarks
+
 The signature of a function in a derived class cannot override a function in a base class and change the calling convention.
+
+## Example
 
 The following sample generates C2695:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
@@ -8,7 +8,7 @@ ms.assetid: 3f6f2091-c38b-40ea-ab6c-f1846f5702d7
 ---
 # Compiler Error C2695
 
-'function1': overriding virtual function differs from 'function2' only by calling convention
+> 'function1': overriding virtual function differs from 'function2' only by calling convention
 
 The signature of a function in a derived class cannot override a function in a base class and change the calling convention.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2695"
 title: "Compiler Error C2695"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2695"
+ms.date: 11/04/2016
 f1_keywords: ["C2695"]
 helpviewer_keywords: ["C2695"]
-ms.assetid: 3f6f2091-c38b-40ea-ab6c-f1846f5702d7
 ---
 # Compiler Error C2695
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2695.md
@@ -16,7 +16,7 @@ The signature of a function in a derived class cannot override a function in a b
 
 ## Example
 
-The following sample generates C2695:
+The following example generates C2695:
 
 ```cpp
 // C2695.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2696"
 title: "Compiler Error C2696"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2696"
+ms.date: 11/04/2016
 f1_keywords: ["C2696"]
 helpviewer_keywords: ["C2696"]
-ms.assetid: 6c6eb7df-1230-4346-9a73-abf14c20785d
 ---
 # Compiler Error C2696
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
@@ -10,6 +10,8 @@ ms.assetid: 6c6eb7df-1230-4346-9a73-abf14c20785d
 
 > Cannot create a temporary object of a managed type 'type'
 
+## Remarks
+
 References to **`const`** in an unmanaged program cause the compiler to call the constructor and create a temporary object on the stack. However, a managed class can never be created on the stack.
 
 C2696 is only reachable using the obsolete compiler option **/clr:oldSyntax**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2696.md
@@ -8,7 +8,7 @@ ms.assetid: 6c6eb7df-1230-4346-9a73-abf14c20785d
 ---
 # Compiler Error C2696
 
-Cannot create a temporary object of a managed type 'type'
+> Cannot create a temporary object of a managed type 'type'
 
 References to **`const`** in an unmanaged program cause the compiler to call the constructor and create a temporary object on the stack. However, a managed class can never be created on the stack.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
@@ -10,7 +10,11 @@ ms.assetid: 3ebfe395-c20b-4c56-9980-ca9ed8653382
 
 > the using-declaration for 'declaration 1' cannot co-exist with the existing using-declaration for 'declaration 2'
 
+## Remarks
+
 Once you have a [using declaration](../../cpp/using-declaration.md) for a data member, any using declaration in the same scope that uses the same name is not permitted, as only functions can be overloaded.
+
+## Example
 
 The following sample generates C2698:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
@@ -8,7 +8,7 @@ ms.assetid: 3ebfe395-c20b-4c56-9980-ca9ed8653382
 ---
 # Compiler Error C2698
 
-the using-declaration for 'declaration 1' cannot co-exist with the existing using-declaration for 'declaration 2'
+> the using-declaration for 'declaration 1' cannot co-exist with the existing using-declaration for 'declaration 2'
 
 Once you have a [using declaration](../../cpp/using-declaration.md) for a data member, any using declaration in the same scope that uses the same name is not permitted, as only functions can be overloaded.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2698"
 title: "Compiler Error C2698"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2698"
+ms.date: 11/04/2016
 f1_keywords: ["C2698"]
 helpviewer_keywords: ["C2698"]
-ms.assetid: 3ebfe395-c20b-4c56-9980-ca9ed8653382
 ---
 # Compiler Error C2698
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2698.md
@@ -16,7 +16,7 @@ Once you have a [using declaration](../../cpp/using-declaration.md) for a data m
 
 ## Example
 
-The following sample generates C2698:
+The following example generates C2698:
 
 ```cpp
 // C2698.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
@@ -10,4 +10,6 @@ ms.assetid: a231eb86-bdae-4b37-a606-06854f47929f
 
 > 'identifier' : cannot be thrown (use /W4 for more info)
 
+## Remarks
+
 The object cannot be thrown. Compile with [/W4](../../build/reference/compiler-option-warning-level.md) for more diagnostic information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
@@ -8,6 +8,6 @@ ms.assetid: a231eb86-bdae-4b37-a606-06854f47929f
 ---
 # Compiler Error C2700
 
-'identifier' : cannot be thrown (use /W4 for more info)
+> 'identifier' : cannot be thrown (use /W4 for more info)
 
 The object cannot be thrown. Compile with [/W4](../../build/reference/compiler-option-warning-level.md) for more diagnostic information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2700.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2700"
 title: "Compiler Error C2700"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2700"
+ms.date: 11/04/2016
 f1_keywords: ["C2700"]
 helpviewer_keywords: ["C2700"]
-ms.assetid: a231eb86-bdae-4b37-a606-06854f47929f
 ---
 # Compiler Error C2700
 


### PR DESCRIPTION
This is batch 35 that structures error/warning references. See #5465 for more information.