### PR TITLE
Update "Use the Microsoft C++ toolset from the command line" topic

### DIFF
--- a/docs/build/building-on-the-command-line.md
+++ b/docs/build/building-on-the-command-line.md
@@ -3,7 +3,6 @@ title: "Use the Microsoft C++ Build Tools from the command line"
 description: "Use the Microsoft C++ (MSVC) Build Tools from the command line outside of the Visual Studio IDE."
 ms.custom: "conceptual"
 ms.date: 04/07/2022
-ms.custom: "conceptual"
 ms.topic: how-to
 helpviewer_keywords: ["command-line builds [C++]", "compiling source code [C++], command line", "builds [C++], command-line", "command line [C++], building from", "command line [C++], compilers"]
 ---


### PR DESCRIPTION
- Fix Visual Studio year typo
- Add backticks and italics
- Convert single line inline code to code block, which makes the snippet easier to copy
- Clean up `<br/>` and update metadata