### PR TITLE
Structure error references in range [C2701, C2730]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
@@ -16,7 +16,7 @@ A local class can't have a function template as a `friend` function.
 
 ## Example
 
-The following sample generates C2701:
+The following example generates C2701:
 
 ```cpp
 // C2701.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
@@ -10,7 +10,11 @@ ms.assetid: 31cf2ab7-ced9-4f75-aa51-e169e20407fb
 
 > 'function': a function template cannot be a `friend` of a local class
 
+## Remarks
+
 A local class can't have a function template as a `friend` function.
+
+## Example
 
 The following sample generates C2701:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2701.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2701"
 title: "Compiler Error C2701"
+description: "Learn more about: Compiler Error C2701"
 ms.date: 09/27/2022
 f1_keywords: ["C2701"]
 helpviewer_keywords: ["C2701"]
-ms.assetid: 31cf2ab7-ced9-4f75-aa51-e169e20407fb
 ---
 # Compiler Error C2701
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
@@ -16,7 +16,7 @@ An exception handler (**`__try`**/**`__except`**) cannot be nested inside a **`_
 
 ## Example
 
-The following sample generates C2702:
+The following example generates C2702:
 
 ```cpp
 // C2702.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2702."
 ms.date: 08/25/2020
 f1_keywords: ["C2702"]
 helpviewer_keywords: ["C2702"]
-ms.assetid: 6def15d4-9a8d-43e7-ae35-42d7cb57c27e
 ---
 # Compiler Error C2702
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2702.md
@@ -10,7 +10,11 @@ ms.assetid: 6def15d4-9a8d-43e7-ae35-42d7cb57c27e
 
 > `__except` may not appear in termination block
 
+## Remarks
+
 An exception handler (**`__try`**/**`__except`**) cannot be nested inside a **`__finally`** block.
+
+## Example
 
 The following sample generates C2702:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2703.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2703.md
@@ -16,7 +16,7 @@ A **`__leave`** statement must be inside a **`__try`** block.
 
 ## Example
 
-The following sample generates C2703:
+The following example generates C2703:
 
 ```cpp
 // C2703.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2703.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2703.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2703."
 ms.date: 08/24/2020
 f1_keywords: ["C2703"]
 helpviewer_keywords: ["C2703"]
-ms.assetid: 384295c3-643d-47ae-a9a6-865b3036aa84
 ---
 # Compiler Error C2703
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
@@ -8,6 +8,6 @@ ms.assetid: 185797e2-55b5-4c11-8493-e70eb1d15a94
 ---
 # Compiler Error C2704
 
-'identifier' : __va_start intrinsic only allowed in varargs
+> 'identifier' : __va_start intrinsic only allowed in varargs
 
 The `__va_start` intrinsic is used in a declaration for a function with a fixed number of arguments.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
@@ -10,4 +10,6 @@ ms.assetid: 185797e2-55b5-4c11-8493-e70eb1d15a94
 
 > 'identifier' : __va_start intrinsic only allowed in varargs
 
+## Remarks
+
 The `__va_start` intrinsic is used in a declaration for a function with a fixed number of arguments.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2704.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2704"
 title: "Compiler Error C2704"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2704"
+ms.date: 11/04/2016
 f1_keywords: ["C2704"]
 helpviewer_keywords: ["C2704"]
-ms.assetid: 185797e2-55b5-4c11-8493-e70eb1d15a94
 ---
 # Compiler Error C2704
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2705.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2705.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2705."
 ms.date: 08/25/2020
 f1_keywords: ["C2705"]
 helpviewer_keywords: ["C2705"]
-ms.assetid: 29249ea3-4ea7-4105-944b-bdb83e8d6852
 ---
 # Compiler Error C2705
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2705.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2705.md
@@ -16,7 +16,7 @@ Execution jumps to a label within a **`try`**/**`catch`**, **`__try`**/**`__exce
 
 ## Example
 
-The following sample generates C2705:
+The following example generates C2705:
 
 ```cpp
 // C2705.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
@@ -16,7 +16,7 @@ The compiler did not find a closing brace for a **`__try`** block.
 
 ## Example
 
-The following sample generates C2706:
+The following example generates C2706:
 
 ```cpp
 // C2706.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
@@ -10,7 +10,11 @@ ms.assetid: e18da924-c42d-4b09-8e29-f4e0382d7dc6
 
 > illegal `__except` without matching `__try` (missing '}' in `__try` block?)
 
+## Remarks
+
 The compiler did not find a closing brace for a **`__try`** block.
+
+## Example
 
 The following sample generates C2706:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2706.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2706."
 ms.date: 08/25/2020
 f1_keywords: ["C2706"]
 helpviewer_keywords: ["C2706"]
-ms.assetid: e18da924-c42d-4b09-8e29-f4e0382d7dc6
 ---
 # Compiler Error C2706
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
@@ -10,6 +10,8 @@ ms.assetid: 3deaf45c-74da-4c9d-acc6-b82412720b74
 
 > 'identifier' : bad context for intrinsic function
 
+## Remarks
+
 Structured exception-handling intrinsics are invalid in certain contexts:
 
 - `_exception_code()` outside an exception filter or **`__except`** block

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2707"
 title: "Compiler Error C2707"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2707"
+ms.date: 11/04/2016
 f1_keywords: ["C2707"]
 helpviewer_keywords: ["C2707"]
-ms.assetid: 3deaf45c-74da-4c9d-acc6-b82412720b74
 ---
 # Compiler Error C2707
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
@@ -8,7 +8,7 @@ ms.assetid: 3deaf45c-74da-4c9d-acc6-b82412720b74
 ---
 # Compiler Error C2707
 
-'identifier' : bad context for intrinsic function
+> 'identifier' : bad context for intrinsic function
 
 Structured exception-handling intrinsics are invalid in certain contexts:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2707.md
@@ -24,7 +24,7 @@ To resolve the error, be sure that the exception-handling intrinsics are placed 
 
 ## Example
 
-The following sample generates C2707.
+The following example generates C2707.
 
 ```cpp
 // C2707.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
@@ -10,6 +10,8 @@ ms.assetid: d52d3088-1141-42f4-829c-74755a7fcc3a
 
 > 'identifier' : actual parameters length in bytes differs from previous call or reference
 
+## Remarks
+
 A [__stdcall](../../cpp/stdcall.md) function must be preceded by a prototype. Otherwise, the compiler interprets the first call to the function as a prototype and this error occurs when the compiler encounters a call that does not match.
 
 To fix this error add a function prototype.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2708"
 title: "Compiler Error C2708"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2708"
+ms.date: 11/04/2016
 f1_keywords: ["C2708"]
 helpviewer_keywords: ["C2708"]
-ms.assetid: d52d3088-1141-42f4-829c-74755a7fcc3a
 ---
 # Compiler Error C2708
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2708.md
@@ -8,7 +8,7 @@ ms.assetid: d52d3088-1141-42f4-829c-74755a7fcc3a
 ---
 # Compiler Error C2708
 
-'identifier' : actual parameters length in bytes differs from previous call or reference
+> 'identifier' : actual parameters length in bytes differs from previous call or reference
 
 A [__stdcall](../../cpp/stdcall.md) function must be preceded by a prototype. Otherwise, the compiler interprets the first call to the function as a prototype and this error occurs when the compiler encounters a call that does not match.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2709"
 title: "Compiler Error C2709"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2709"
+ms.date: 11/04/2016
 f1_keywords: ["C2709"]
 helpviewer_keywords: ["C2709"]
-ms.assetid: e66fc7e6-0e91-4b99-a6e0-fdb069b09fbc
 ---
 # Compiler Error C2709
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
@@ -10,4 +10,6 @@ ms.assetid: e66fc7e6-0e91-4b99-a6e0-fdb069b09fbc
 
 > 'identifier' : formal parameter's length in bytes differs from previous declaration
 
+## Remarks
+
 The signature in a call to the specified function differs from the prototype.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2709.md
@@ -8,6 +8,6 @@ ms.assetid: e66fc7e6-0e91-4b99-a6e0-fdb069b09fbc
 ---
 # Compiler Error C2709
 
-'identifier' : formal parameter's length in bytes differs from previous declaration
+> 'identifier' : formal parameter's length in bytes differs from previous declaration
 
 The signature in a call to the specified function differs from the prototype.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
@@ -16,7 +16,7 @@ A function whose return value is a pointer is the only construct to which `modif
 
 ## Example
 
-The following sample generates C2710:
+The following example generates C2710:
 
 ```cpp
 // C2710.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
@@ -10,7 +10,11 @@ ms.assetid: a2a6bb5b-86ad-4a6c-acd0-e2bef8464e0e
 
 > 'construct' : '__declspec(modifier)' can only be applied to a function returning a pointer
 
+## Remarks
+
 A function whose return value is a pointer is the only construct to which `modifier` can be applied.
+
+## Example
 
 The following sample generates C2710:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2710"
 title: "Compiler Error C2710"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2710"
+ms.date: 11/04/2016
 f1_keywords: ["C2710"]
 helpviewer_keywords: ["C2710"]
-ms.assetid: a2a6bb5b-86ad-4a6c-acd0-e2bef8464e0e
 ---
 # Compiler Error C2710
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2710.md
@@ -8,7 +8,7 @@ ms.assetid: a2a6bb5b-86ad-4a6c-acd0-e2bef8464e0e
 ---
 # Compiler Error C2710
 
-'construct' : '__declspec(modifier)' can only be applied to a function returning a pointer
+> 'construct' : '__declspec(modifier)' can only be applied to a function returning a pointer
 
 A function whose return value is a pointer is the only construct to which `modifier` can be applied.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2711"
 title: "Compiler Error C2711"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2711"
+ms.date: 11/04/2016
 f1_keywords: ["C2711"]
 helpviewer_keywords: ["C2711"]
-ms.assetid: 9df9f808-7419-4e63-abdd-e6538ff0871f
 ---
 # Compiler Error C2711
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
@@ -10,7 +10,11 @@ ms.assetid: 9df9f808-7419-4e63-abdd-e6538ff0871f
 
 > 'function' : this function cannot be compiled as managed, consider using #pragma unmanaged
 
+## Remarks
+
 Some instructions will prevent the compiler from generating MSIL for the enclosing function.
+
+## Example
 
 The following sample generates C2711:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
@@ -8,7 +8,7 @@ ms.assetid: 9df9f808-7419-4e63-abdd-e6538ff0871f
 ---
 # Compiler Error C2711
 
-'function' : this function cannot be compiled as managed, consider using #pragma unmanaged
+> 'function' : this function cannot be compiled as managed, consider using #pragma unmanaged
 
 Some instructions will prevent the compiler from generating MSIL for the enclosing function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2711.md
@@ -16,7 +16,7 @@ Some instructions will prevent the compiler from generating MSIL for the enclosi
 
 ## Example
 
-The following sample generates C2711:
+The following example generates C2711:
 
 ```cpp
 // C2711.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2712.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2712.md
@@ -30,7 +30,7 @@ The **`/clr:pure`** and **`/clr:safe`** compiler options are deprecated in Visua
 
 ## Example
 
-The following sample generates C2712 and shows how to fix it.
+The following example generates C2712 and shows how to fix it.
 
 ```cpp
 // C2712.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2712.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2712.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2712."
 ms.date: 08/25/2020
 f1_keywords: ["C2712"]
 helpviewer_keywords: ["C2712"]
-ms.assetid: f7d4ffcc-7ed2-459b-8067-a728ce647071
 ---
 # Compiler Error C2712
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2713.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2713.md
@@ -10,4 +10,6 @@ ms.assetid: bae9bee3-b4b8-4be5-b6a5-02df587a7278
 
 > only one form of exception handling permitted per function
 
+## Remarks
+
 You can't use structured exception handling (**`__try`**/**`__except`**) and C++ exception handling (**`try`**/**`catch`**) in the same function.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2713.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2713.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C/C++ compiler error C2713."
 ms.date: 08/25/2020
 f1_keywords: ["C2713"]
 helpviewer_keywords: ["C2713"]
-ms.assetid: bae9bee3-b4b8-4be5-b6a5-02df587a7278
 ---
 # Compiler Error C2713
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
@@ -10,9 +10,9 @@ ms.assetid: 401a5a42-660c-4bad-9d63-1a2d092bc489
 
 > `alignof(void)` is not allowed
 
-An invalid value was passed to an operator.
-
 ## Remarks
+
+An invalid value was passed to an operator.
 
 See [`alignof` operator](../../cpp/alignof-operator.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
@@ -18,7 +18,7 @@ See [`alignof` operator](../../cpp/alignof-operator.md) for more information.
 
 ## Example
 
-The following sample generates C2714.
+The following example generates C2714.
 
 ```cpp
 // C2714.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2714.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2714"
 title: "Compiler Error C2714"
+description: "Learn more about: Compiler Error C2714"
 ms.date: 07/22/2020
 f1_keywords: ["C2714"]
 helpviewer_keywords: ["C2714"]
-ms.assetid: 401a5a42-660c-4bad-9d63-1a2d092bc489
 ---
 # Compiler Error C2714
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2715"
 title: "Compiler Error C2715"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2715"
+ms.date: 11/04/2016
 f1_keywords: ["C2715"]
 helpviewer_keywords: ["C2715"]
-ms.assetid: c81567a7-5b65-468f-aaf9-835f91e468e4
 ---
 # Compiler Error C2715
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
@@ -8,7 +8,7 @@ ms.assetid: c81567a7-5b65-468f-aaf9-835f91e468e4
 ---
 # Compiler Error C2715
 
-'type' : cannot throw or catch this type
+> 'type' : cannot throw or catch this type
 
 Value types are not valid arguments when using exception handling in managed code (see [Exception Handling](../../extensions/exception-handling-cpp-component-extensions.md) for more information).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
@@ -10,7 +10,11 @@ ms.assetid: c81567a7-5b65-468f-aaf9-835f91e468e4
 
 > 'type' : cannot throw or catch this type
 
+## Remarks
+
 Value types are not valid arguments when using exception handling in managed code (see [Exception Handling](../../extensions/exception-handling-cpp-component-extensions.md) for more information).
+
+## Example
 
 ```cpp
 // C2715a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
@@ -15,6 +15,8 @@ Value types are not valid arguments when using exception handling in managed cod
 
 ## Example
 
+The following example generates C2715:
+
 ```cpp
 // C2715a.cpp
 // compile with: /clr

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2715.md
@@ -15,7 +15,7 @@ Value types are not valid arguments when using exception handling in managed cod
 
 ## Example
 
-The following example generates C2715:
+The following example generates C2715 and shows how to fix it:
 
 ```cpp
 // C2715a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
@@ -16,7 +16,7 @@ The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted o
 
 ## Example
 
-The following sample generates C2718:
+The following example generates C2718:
 
 ```cpp
 // C2718.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
@@ -8,7 +8,7 @@ ms.assetid: 78cc71f8-c142-46fc-9aed-970635d74f0c
 ---
 # Compiler Error C2718
 
-'parameter': actual parameter with __declspec(align('#')) won't be aligned
+> 'parameter': actual parameter with __declspec(align('#')) won't be aligned
 
 The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted on function parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2718"
 title: "Compiler Error C2718"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2718"
+ms.date: 11/04/2016
 f1_keywords: ["C2718"]
 helpviewer_keywords: ["C2718"]
-ms.assetid: 78cc71f8-c142-46fc-9aed-970635d74f0c
 ---
 # Compiler Error C2718
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2718.md
@@ -10,7 +10,11 @@ ms.assetid: 78cc71f8-c142-46fc-9aed-970635d74f0c
 
 > 'parameter': actual parameter with __declspec(align('#')) won't be aligned
 
+## Remarks
+
 The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted on function parameters.
+
+## Example
 
 The following sample generates C2718:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
@@ -8,7 +8,7 @@ ms.assetid: ea6236d3-8286-45cc-9478-c84ad3dd3c8e
 ---
 # Compiler Error C2719
 
-'parameter': formal parameter with __declspec(align('#')) won't be aligned
+> 'parameter': formal parameter with __declspec(align('#')) won't be aligned
 
 The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted on function parameters. Function parameter alignment is controlled by the calling convention used. For more information, see [Calling Conventions](../../cpp/calling-conventions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2719"
 title: "Compiler Error C2719"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2719"
+ms.date: 11/04/2016
 f1_keywords: ["C2719"]
 helpviewer_keywords: ["C2719"]
-ms.assetid: ea6236d3-8286-45cc-9478-c84ad3dd3c8e
 ---
 # Compiler Error C2719
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
@@ -16,7 +16,7 @@ The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted o
 
 ## Example
 
-The following sample generates C2719 and shows how to fix it:
+The following example generates C2719 and shows how to fix it:
 
 ```cpp
 // C2719.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2719.md
@@ -10,7 +10,11 @@ ms.assetid: ea6236d3-8286-45cc-9478-c84ad3dd3c8e
 
 > 'parameter': formal parameter with __declspec(align('#')) won't be aligned
 
+## Remarks
+
 The [align](../../cpp/align-cpp.md) **`__declspec`** modifier is not permitted on function parameters. Function parameter alignment is controlled by the calling convention used. For more information, see [Calling Conventions](../../cpp/calling-conventions.md).
+
+## Example
 
 The following sample generates C2719 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
@@ -16,7 +16,7 @@ The storage class cannot be used on class members outside the declaration. To fi
 
 ## Example
 
-The following sample generates C2720 and shows how to fix it:
+The following example generates C2720 and shows how to fix it:
 
 ```cpp
 // C2720.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
@@ -10,6 +10,8 @@ ms.assetid: 9ee3aab7-711b-4f5a-b2f1-cb62b130f1ce
 
 > '*identifier*' : '*specifier*' storage-class specifier illegal on members
 
+## Remarks
+
 The storage class cannot be used on class members outside the declaration. To fix this error, remove the unneeded [storage class](../../cpp/storage-classes-cpp.md) specifier from the definition of the member outside the class declaration.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2720.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2720"
 title: "Compiler Error C2720"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2720"
+ms.date: 11/04/2016
 f1_keywords: ["C2720"]
 helpviewer_keywords: ["C2720"]
-ms.assetid: 9ee3aab7-711b-4f5a-b2f1-cb62b130f1ce
 ---
 # Compiler Error C2720
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2721"
 title: "Compiler Error C2721"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2721"
+ms.date: 11/04/2016
 f1_keywords: ["C2721"]
 helpviewer_keywords: ["C2721"]
-ms.assetid: 7a97823c-3ce1-4112-8253-fc1448685235
 ---
 # Compiler Error C2721
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
@@ -8,6 +8,6 @@ ms.assetid: 7a97823c-3ce1-4112-8253-fc1448685235
 ---
 # Compiler Error C2721
 
-'specifier' : storage-class specifier illegal between operator keyword and type
+> 'specifier' : storage-class specifier illegal between operator keyword and type
 
 User-defined type conversions apply to all storage classes, so you cannot specify a storage class in a type conversion.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2721.md
@@ -10,4 +10,6 @@ ms.assetid: 7a97823c-3ce1-4112-8253-fc1448685235
 
 > 'specifier' : storage-class specifier illegal between operator keyword and type
 
+## Remarks
+
 User-defined type conversions apply to all storage classes, so you cannot specify a storage class in a type conversion.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
@@ -10,4 +10,6 @@ ms.assetid: 4cc2c7fa-cb12-4bcf-9df1-6d627ef62973
 
 > '::operator' : illegal following operator command; use 'operator operator'
 
+## Remarks
+
 An `operator` statement redefines `::new` or `::delete`. The `new` and `delete` operators are global, so the scope resolution operator (`::`) is meaningless. Remove the `::` operator.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2722"
 title: "Compiler Error C2722"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2722"
+ms.date: 11/04/2016
 f1_keywords: ["C2722"]
 helpviewer_keywords: ["C2722"]
-ms.assetid: 4cc2c7fa-cb12-4bcf-9df1-6d627ef62973
 ---
 # Compiler Error C2722
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2722.md
@@ -8,6 +8,6 @@ ms.assetid: 4cc2c7fa-cb12-4bcf-9df1-6d627ef62973
 ---
 # Compiler Error C2722
 
-'::operator' : illegal following operator command; use 'operator operator'
+> '::operator' : illegal following operator command; use 'operator operator'
 
 An `operator` statement redefines `::new` or `::delete`. The `new` and `delete` operators are global, so the scope resolution operator (`::`) is meaningless. Remove the `::` operator.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
@@ -8,7 +8,7 @@ ms.assetid: 86925601-2297-4cfd-94e2-2caf27c474c4
 ---
 # Compiler Error C2723
 
-'function' : 'specifier' specifier illegal on function definition
+> 'function' : 'specifier' specifier illegal on function definition
 
 The specifier cannot appear with a function definition outside of a class declaration. The **`virtual`** specifier can be specified only on a member function declaration within a class declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
@@ -16,7 +16,7 @@ The specifier cannot appear with a function definition outside of a class declar
 
 ## Example
 
-The following sample generates C2723 and shows how to fix it:
+The following example generates C2723 and shows how to fix it:
 
 ```cpp
 // C2723.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2723"
 title: "Compiler Error C2723"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2723"
+ms.date: 11/04/2016
 f1_keywords: ["C2723"]
 helpviewer_keywords: ["C2723"]
-ms.assetid: 86925601-2297-4cfd-94e2-2caf27c474c4
 ---
 # Compiler Error C2723
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2723.md
@@ -10,7 +10,11 @@ ms.assetid: 86925601-2297-4cfd-94e2-2caf27c474c4
 
 > 'function' : 'specifier' specifier illegal on function definition
 
+## Remarks
+
 The specifier cannot appear with a function definition outside of a class declaration. The **`virtual`** specifier can be specified only on a member function declaration within a class declaration.
+
+## Example
 
 The following sample generates C2723 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
@@ -15,7 +15,7 @@ Static member functions should be declared with external linkage.
 
 ## Example
 
-The following sample generates C2724:
+The following example generates C2724:
 
 ```cpp
 // C2724.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2724"]
 ---
 # Compiler Error C2724
 
-'identifier' : 'static' should not be used on member functions defined at file scope
+> 'identifier' : 'static' should not be used on member functions defined at file scope
 
 Static member functions should be declared with external linkage.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2724.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2724"]
 
 > 'identifier' : 'static' should not be used on member functions defined at file scope
 
+## Remarks
+
 Static member functions should be declared with external linkage.
+
+## Example
 
 The following sample generates C2724:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
@@ -10,6 +10,8 @@ ms.assetid: 13cd5b1b-e906-4cd8-9b2b-510d587c665a
 
 > 'exception' : unable to throw or catch a managed or WinRT object by value or reference
 
+## Remarks
+
 The type of a managed or WinRT exception was not correct.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
@@ -16,7 +16,7 @@ The type of a managed or WinRT exception was not correct.
 
 ## Examples
 
-The following sample generates C2725 and shows how to fix it.
+The following example generates C2725 and shows how to fix it.
 
 ```cpp
 // C2725.cpp
@@ -35,7 +35,7 @@ int main() {
 }
 ```
 
-The following sample generates C2725 and shows how to fix it.
+The following example generates C2725 and shows how to fix it.
 
 ```cpp
 // C2725b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2725"
 title: "Compiler Error C2725"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2725"
+ms.date: 11/04/2016
 f1_keywords: ["C2725"]
 helpviewer_keywords: ["C2725"]
-ms.assetid: 13cd5b1b-e906-4cd8-9b2b-510d587c665a
 ---
 # Compiler Error C2725
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2725.md
@@ -8,7 +8,7 @@ ms.assetid: 13cd5b1b-e906-4cd8-9b2b-510d587c665a
 ---
 # Compiler Error C2725
 
-'exception' : unable to throw or catch a managed or WinRT object by value or reference
+> 'exception' : unable to throw or catch a managed or WinRT object by value or reference
 
 The type of a managed or WinRT exception was not correct.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
@@ -10,7 +10,11 @@ ms.assetid: f0191bb7-c175-450b-bf09-a3213db96d09
 
 > 'gcnew' may only be used to create an object with managed or WinRT type
 
+## Remarks
+
 You cannot create an instance of a native type on the garbage-collected heap.
+
+## Example
 
 The following sample generates C2726 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2726"
 title: "Compiler Error C2726"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2726"
+ms.date: 11/04/2016
 f1_keywords: ["C2726"]
 helpviewer_keywords: ["C2726"]
-ms.assetid: f0191bb7-c175-450b-bf09-a3213db96d09
 ---
 # Compiler Error C2726
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
@@ -16,7 +16,7 @@ You cannot create an instance of a native type on the garbage-collected heap.
 
 ## Example
 
-The following sample generates C2726 and shows how to fix it:
+The following example generates C2726 and shows how to fix it:
 
 ```cpp
 // C2726.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2726.md
@@ -8,7 +8,7 @@ ms.assetid: f0191bb7-c175-450b-bf09-a3213db96d09
 ---
 # Compiler Error C2726
 
-'gcnew' may only be used to create an object with managed or WinRT type
+> 'gcnew' may only be used to create an object with managed or WinRT type
 
 You cannot create an instance of a native type on the garbage-collected heap.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2728"
 title: "Compiler Error C2728"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2728"
+ms.date: 11/04/2016
 f1_keywords: ["C2728"]
 helpviewer_keywords: ["C2728"]
-ms.assetid: 65635f91-1cd1-46e4-9ad7-14726d0546af
 ---
 # Compiler Error C2728
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
@@ -10,9 +10,13 @@ ms.assetid: 65635f91-1cd1-46e4-9ad7-14726d0546af
 
 > 'type' : a native array cannot contain this type
 
+## Remarks
+
 Array creation syntax was used to create an array of managed or WinRT objects. You cannot create an array of managed or WinRT objects using native array syntax.
 
 For more information, see [array](../../extensions/arrays-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C2728 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
@@ -8,7 +8,7 @@ ms.assetid: 65635f91-1cd1-46e4-9ad7-14726d0546af
 ---
 # Compiler Error C2728
 
-'type' : a native array cannot contain this type
+> 'type' : a native array cannot contain this type
 
 Array creation syntax was used to create an array of managed or WinRT objects. You cannot create an array of managed or WinRT objects using native array syntax.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2728.md
@@ -18,7 +18,7 @@ For more information, see [array](../../extensions/arrays-cpp-component-extensio
 
 ## Example
 
-The following sample generates C2728 and shows how to fix it:
+The following example generates C2728 and shows how to fix it:
 
 ```cpp
 // C2728.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2730"
 title: "Compiler Error C2730"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2730"
+ms.date: 11/04/2016
 f1_keywords: ["C2730"]
 helpviewer_keywords: ["C2730"]
-ms.assetid: 07f0b17a-bc8e-4d79-af5a-07a07af3687b
 ---
 # Compiler Error C2730
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
@@ -8,6 +8,6 @@ ms.assetid: 07f0b17a-bc8e-4d79-af5a-07a07af3687b
 ---
 # Compiler Error C2730
 
-'class' : cannot be a base class of itself
+> 'class' : cannot be a base class of itself
 
 Recursive base classes are invalid. Specify another class as the base class.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2730.md
@@ -10,4 +10,6 @@ ms.assetid: 07f0b17a-bc8e-4d79-af5a-07a07af3687b
 
 > 'class' : cannot be a base class of itself
 
+## Remarks
+
 Recursive base classes are invalid. Specify another class as the base class.


### PR DESCRIPTION
This is batch 36 that structures error/warning references. See #5465 for more information.