### PR TITLE
Update `/ZW` flag reference topic

### DIFF
--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -32,7 +32,7 @@ When you specify the **`/ZW`** option, the compiler supports these features:
 
 - Automatic reference-counting of Windows Runtime objects, and automatic discarding of an object when its reference count goes to zero.
 
-Because the incremental linker doesn't support the Windows metadata included in .obj files by using the **`/ZW`** option, the deprecated [/Gm (Enable Minimal Rebuild)](gm-enable-minimal-rebuild.md) option is incompatible with **`/ZW`**.
+Because the incremental linker doesn't support the Windows metadata included in `.obj` files by using the **`/ZW`** option, the deprecated [`/Gm` (Enable Minimal Rebuild)](gm-enable-minimal-rebuild.md) option is incompatible with **`/ZW`**.
 
 For more information, see [Visual C++ Language Reference](../../cppcx/visual-c-language-reference-c-cx.md).
 

--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: /ZW (Windows Runtime Compilation)"
 title: "/ZW (Windows Runtime Compilation)"
+description: "Learn more about: /ZW (Windows Runtime Compilation)"
 ms.date: 06/22/2023
 f1_keywords: ["VC.Project.VCCLCompilerTool.CompileAsWinRT", "/zw"]
 helpviewer_keywords: ["/ZW", "-ZW compiler option", "/ZW compiler option", "-ZW", "Windows Runtime compiler option"]

--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -14,7 +14,7 @@ When you use **`/ZW`** to compile, always specify [`/EHsc`](eh-exception-handlin
 
 ## Syntax
 
-```cpp
+```
 /ZW /EHsc
 /ZW:nostdlib /EHsc
 ```

--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -21,7 +21,7 @@ When you use **`/ZW`** to compile, always specify [`/EHsc`](eh-exception-handlin
 
 ## Arguments
 
-**`nostdlib`**\
+*`nostdlib`*\
 Indicates that `Platform.winmd`, `Windows.Foundation.winmd`, and other default Windows metadata (`.winmd`) files aren't automatically included in the compilation. Instead, you must use the [`/FU` (Name Forced #using File)](fu-name-forced-hash-using-file.md) compiler option to explicitly specify Windows metadata files.
 
 ## Remarks
@@ -35,8 +35,6 @@ When you specify the **`/ZW`** option, the compiler supports these features:
 Because the incremental linker doesn't support the Windows metadata included in `.obj` files by using the **`/ZW`** option, the deprecated [`/Gm` (Enable Minimal Rebuild)](gm-enable-minimal-rebuild.md) option is incompatible with **`/ZW`**.
 
 For more information, see [C++/CX Language Reference](../../cppcx/visual-c-language-reference-c-cx.md).
-
-## Requirements
 
 ## See also
 

--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -9,8 +9,8 @@ helpviewer_keywords: ["/ZW", "-ZW compiler option", "/ZW compiler option", "-ZW"
 
 Compiles source code to support Microsoft C++ component extensions C++/CX for the creation of Universal Windows Platform (UWP) apps.
 
-When you use **`/ZW`** to compile, always specify **`/EHsc`** as well.\
-**`/ZW`** isn't compatible with **`/std:c++20`**.
+When you use **`/ZW`** to compile, always specify [`/EHsc`](eh-exception-handling-model.md) as well.\
+**`/ZW`** isn't compatible with [`/std:c++20`](std-specify-language-standard-version.md).
 
 ## Syntax
 
@@ -34,7 +34,7 @@ When you specify the **`/ZW`** option, the compiler supports these features:
 
 Because the incremental linker doesn't support the Windows metadata included in `.obj` files by using the **`/ZW`** option, the deprecated [`/Gm` (Enable Minimal Rebuild)](gm-enable-minimal-rebuild.md) option is incompatible with **`/ZW`**.
 
-For more information, see [Visual C++ Language Reference](../../cppcx/visual-c-language-reference-c-cx.md).
+For more information, see [C++/CX Language Reference](../../cppcx/visual-c-language-reference-c-cx.md).
 
 ## Requirements
 

--- a/docs/build/reference/zw-windows-runtime-compilation.md
+++ b/docs/build/reference/zw-windows-runtime-compilation.md
@@ -10,7 +10,7 @@ helpviewer_keywords: ["/ZW", "-ZW compiler option", "/ZW compiler option", "-ZW"
 Compiles source code to support Microsoft C++ component extensions C++/CX for the creation of Universal Windows Platform (UWP) apps.
 
 When you use **`/ZW`** to compile, always specify [`/EHsc`](eh-exception-handling-model.md) as well.\
-**`/ZW`** isn't compatible with [`/std:c++20`](std-specify-language-standard-version.md).
+**`/ZW`** isn't compatible with [`/std:c++20`](std-specify-language-standard-version.md) or later.
 
 ## Syntax
 


### PR DESCRIPTION
- Add backticks, add and update links, update metadata, and other cleanups
- Remove `cpp` language from syntax code block as it's not C++ code
- Add "or later" after "`/ZW` isn't compatible with `/std:c++20`", since `/std:c++23preview` and `/std:c++latest` also trigger D8016