### PR TITLE
Elide some wrong uses of `/c` flag in C runtime library

### DIFF
--- a/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
+++ b/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: _cprintf, _cprintf_l, _cwprintf, _cwprintf_l"
 title: "_cprintf, _cprintf_l, _cwprintf, _cwprintf_l"
-ms.date: "3/9/2021"
+description: "Learn more about: _cprintf, _cprintf_l, _cwprintf, _cwprintf_l"
+ms.date: 3/9/2021
 api_name: ["_cwprintf_l", "_cprintf_l", "_cwprintf", "_cprintf"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
+++ b/docs/c-runtime-library/reference/cprintf-cprintf-l-cwprintf-cwprintf-l.md
@@ -85,7 +85,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_cprintf.c
-// compile with: /c
 // This program displays some variables to the console.
 
 #include <conio.h>

--- a/docs/c-runtime-library/reference/cprintf-s-cprintf-s-l-cwprintf-s-cwprintf-s-l.md
+++ b/docs/c-runtime-library/reference/cprintf-s-cprintf-s-l-cwprintf-s-cwprintf-s-l.md
@@ -93,7 +93,6 @@ All versions of the [C run-time libraries](../crt-library-features.md).
 
 ```C
 // crt_cprintf_s.c
-// compile with: /c
 // This program displays some variables to the console.
 
 #include <conio.h>

--- a/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
+++ b/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
@@ -92,7 +92,6 @@ All versions of the [C run-time libraries](../crt-library-features.md).
 
 ```C
 // crt_cscanf_s.c
-// compile with: /c
 /* This program prompts for a string
 * and uses _cscanf_s to read in the response.
 * Then _cscanf_s returns the number of items

--- a/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
+++ b/docs/c-runtime-library/reference/cscanf-s-cscanf-s-l-cwscanf-s-cwscanf-s-l.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _cscanf_s, _cscanf_s_l, _cwscanf_s, _cwscanf_s_l"
 title: "_cscanf_s, _cscanf_s_l, _cwscanf_s, _cwscanf_s_l"
-ms.date: "11/04/2016"
+description: "Learn more about: _cscanf_s, _cscanf_s_l, _cwscanf_s, _cwscanf_s_l"
+ms.date: 11/04/2016
 api_name: ["_cwscanf_s_l", "_cwscanf_s", "_cscanf_s", "_cscanf_s_l"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["cscanf_s", "cscanf_s_l", "cwscanf_s", "_cwscanf_s", "_tcscanf_s", "_cscanf_s", "_cwscanf_s_l", "_cscanf_s_l", "cwscanf_s_l", "_tcscanf_s_l", "tcscanf_s", "tcscanf_s_l"]
 helpviewer_keywords: ["cscanf_s function", "_cwscanf_s_l function", "tcscanf_s function", "console [C++], reading from", "_cscanf_s function", "data [C++], reading from the console", "cwscanf_s function", "_tcscanf_s_l function", "_cscanf_s_l function", "cscanf_s_l function", "cwscanf_s_l function", "reading data [C++], from the console", "_cwscanf_s function", "_tcscanf_s function", "tcscanf_s_l function"]
-ms.assetid: 9ccab74d-916f-42a6-93d8-920525efdf4b
 ---
 # `_cscanf_s`, `_cscanf_s_l`, `_cwscanf_s`, `_cwscanf_s_l`
 

--- a/docs/c-runtime-library/reference/cwait.md
+++ b/docs/c-runtime-library/reference/cwait.md
@@ -73,7 +73,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_cwait.c
-// compile with: /c
 // This program launches several processes and waits
 // for a specified process to finish.
 

--- a/docs/c-runtime-library/reference/cwait.md
+++ b/docs/c-runtime-library/reference/cwait.md
@@ -1,14 +1,13 @@
 ---
 title: "_cwait"
 description: "API reference for the Microsoft Visual C runtime `_cwait()` function."
-ms.date: "10/23/2020"
+ms.date: 10/23/2020
 api_name: ["_cwait", "_o__cwait"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-process-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_cwait"]
 helpviewer_keywords: ["cwait function", "_cwait function"]
-ms.assetid: d9b596b5-45f4-4e03-9896-3f383cb922b8
 ---
 # `_cwait`
 

--- a/docs/c-runtime-library/reference/getch-getwch.md
+++ b/docs/c-runtime-library/reference/getch-getwch.md
@@ -54,7 +54,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getch.c
-// compile with: /c
 // This program reads characters from
 // the keyboard until it receives a 'Y' or 'y'.
 

--- a/docs/c-runtime-library/reference/getch-getwch.md
+++ b/docs/c-runtime-library/reference/getch-getwch.md
@@ -1,7 +1,7 @@
 ---
 title: "_getch, _getwch"
 description: "API reference for _getch and _getwch; which get a character from the console without echo."
-ms.date: "3/8/2023"
+ms.date: 3/8/2023
 api_name: ["_getch", "_getwch", "_o__getch", "_o__getwch"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
+++ b/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
@@ -52,7 +52,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getch_nolock.c
-// compile with: /c
 // This program reads characters from
 // the keyboard until it receives a 'Y' or 'y'.
 

--- a/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
+++ b/docs/c-runtime-library/reference/getch-nolock-getwch-nolock.md
@@ -1,7 +1,7 @@
 ---
 title: "_getch_nolock, _getwch_nolock"
 description: "Learn more about: _getch_nolock, _getwch_nolock"
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_getwch_nolock", "_getch_nolock", "_o__getch_nolock", "_o__getwch_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/getche-getwche.md
+++ b/docs/c-runtime-library/reference/getche-getwche.md
@@ -55,7 +55,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getche.c
-// compile with: /c
 // This program reads characters from
 // the keyboard until it receives a 'Y' or 'y'.
 

--- a/docs/c-runtime-library/reference/getche-getwche.md
+++ b/docs/c-runtime-library/reference/getche-getwche.md
@@ -1,14 +1,13 @@
 ---
 title: "_getche, _getwche"
 description: "API reference for _getche and _getwche; which get a character from the console with echo."
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_getwche", "_getche", "_o__getche", "_o__getwche"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["getwche", "_getche", "_getwche"]
 helpviewer_keywords: ["characters, getting from console", "_getwche function", "getche function", "console, reading from", "getwche function", "_getche function"]
-ms.assetid: eac978a8-c43a-4130-938f-54f12e2a0fda
 ---
 # `_getche`, `_getwche`
 

--- a/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
+++ b/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
@@ -52,7 +52,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getche_nolock.c
-// compile with: /c
 // This program reads characters from
 // the keyboard until it receives a 'Y' or 'y'.
 

--- a/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
+++ b/docs/c-runtime-library/reference/getche-nolock-getwche-nolock.md
@@ -1,7 +1,7 @@
 ---
 title: "_getche_nolock, _getwche_nolock"
 description: "Learn more about: _getche_nolock, _getwche_nolock"
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_getche_nolock", "_getwche_nolock", "_o__getche_nolock", "_o__getwche_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/getdiskfree.md
+++ b/docs/c-runtime-library/reference/getdiskfree.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _getdiskfree"
 title: "_getdiskfree"
+description: "Learn more about: _getdiskfree"
 ms.date: 05/11/2022
 api_name: ["_getdiskfree", "_o__getdiskfree"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-filesystem-l1-1-0.dll"]

--- a/docs/c-runtime-library/reference/getdiskfree.md
+++ b/docs/c-runtime-library/reference/getdiskfree.md
@@ -66,7 +66,7 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getdiskfree.c
-// compile with: /c
+
 #include <windows.h>
 #include <direct.h>
 #include <stdio.h>

--- a/docs/c-runtime-library/reference/getdrive.md
+++ b/docs/c-runtime-library/reference/getdrive.md
@@ -43,7 +43,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_getdrive.c
-// compile with: /c
 // Illustrates drive functions including:
 //    _getdrive       _chdrive        _getdcwd
 //

--- a/docs/c-runtime-library/reference/getdrive.md
+++ b/docs/c-runtime-library/reference/getdrive.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _getdrive"
 title: "_getdrive"
-ms.date: "4/2/2020"
+description: "Learn more about: _getdrive"
+ms.date: 4/2/2020
 api_name: ["_getdrive", "_o__getdrive"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-filesystem-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_getdrive", "getdrive"]
 helpviewer_keywords: ["current disk drive", "getdrive function", "disk drives", "_getdrive function"]
-ms.assetid: e40631a0-8f1a-4897-90ac-e1037ff30bca
 ---
 # `_getdrive`
 

--- a/docs/c-runtime-library/reference/kbhit.md
+++ b/docs/c-runtime-library/reference/kbhit.md
@@ -48,7 +48,6 @@ All versions of the [C run-time libraries](../crt-library-features.md).
 
 ```C
 // crt_kbhit.c
-// compile with: /c
 /* This program loops until the user
 * presses a key. If _kbhit returns nonzero, a
 * keystroke is waiting in the buffer. The program

--- a/docs/c-runtime-library/reference/kbhit.md
+++ b/docs/c-runtime-library/reference/kbhit.md
@@ -1,7 +1,7 @@
 ---
 title: "_kbhit"
 description: "Learn more about: _kbhit"
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_kbhit", "_o__kbhit"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-stdio-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/set-error-mode.md
+++ b/docs/c-runtime-library/reference/set-error-mode.md
@@ -61,7 +61,7 @@ When it's used with an [`assert`](assert-macro-assert-wassert.md), **`_set_error
 
 ```C
 // crt_set_error_mode.c
-// compile with: /c
+
 #include <stdlib.h>
 #include <assert.h>
 

--- a/docs/c-runtime-library/reference/set-error-mode.md
+++ b/docs/c-runtime-library/reference/set-error-mode.md
@@ -1,14 +1,13 @@
 ---
-description: "Learn more about: _set_error_mode"
 title: "_set_error_mode"
-ms.date: "11/04/2016"
+description: "Learn more about: _set_error_mode"
+ms.date: 11/04/2016
 api_name: ["_set_error_mode"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-runtime-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["set_error_mode", "_set_error_mode"]
 helpviewer_keywords: ["_set_error_mode function", "set_error_mode function"]
-ms.assetid: f0807be5-73d1-4a32-a701-3c9bdd139c5c
 ---
 # `_set_error_mode`
 

--- a/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
+++ b/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
@@ -70,7 +70,6 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_ungetch.c
-// compile with: /c
 // In this program, a white-space delimited
 // token is read from the keyboard. When the program
 // encounters a delimiter, it uses _ungetch to replace

--- a/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
+++ b/docs/c-runtime-library/reference/ungetch-ungetwch-ungetch-nolock-ungetwch-nolock.md
@@ -1,7 +1,7 @@
 ---
 title: "_ungetch, _ungetwch, _ungetch_nolock, _ungetwch_nolock"
 description: "Learn more about: _ungetch, _ungetwch, _ungetch_nolock, _ungetwch_nolock"
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_ungetch_nolock", "_ungetwch_nolock", "_ungetwch", "_ungetch", "_o__ungetch", "_o__ungetch_nolock", "_o__ungetwch", "_o__ungetwch_nolock"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-conio-l1-1-0.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: _vcprintf_p, _vcprintf_p_l, _vcwprintf_p, _vcwprintf_p_l"
 title: "_vcprintf_p, _vcprintf_p_l, _vcwprintf_p, _vcwprintf_p_l"
-ms.date: "3/9/2021"
+description: "Learn more about: _vcprintf_p, _vcprintf_p_l, _vcwprintf_p, _vcwprintf_p_l"
+ms.date: 3/9/2021
 api_name: ["_vcprintf_p", "_vcwprintf_p_l", "_vcprintf_p_l", "_vcwprintf_p"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll"]
 api_type: ["DLLExport"]

--- a/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
@@ -94,7 +94,7 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```C
 // crt_vcprintf_p.c
-// compile with: /c
+
 #include <conio.h>
 #include <stdarg.h>
 

--- a/docs/c-runtime-library/reference/vcprintf-vcprintf-l-vcwprintf-vcwprintf-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-vcprintf-l-vcwprintf-vcwprintf-l.md
@@ -89,7 +89,7 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 
 ```cpp
 // crt_vcprintf.cpp
-// compile with: /c
+
 #include <conio.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
All of these examples require linking to function, hence the use of `/c` is invalid and needs to be removed.