### PR TITLE
Structure error references in range [C2731, C2760]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
@@ -16,7 +16,7 @@ The functions `main`, `WinMain`, `DllMain`, and `LibMain` cannot be overloaded.
 
 ## Example
 
-The following sample generates C2731:
+The following example generates C2731:
 
 ```cpp
 // C2731.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
@@ -8,7 +8,7 @@ ms.assetid: 9b563999-febd-4582-9147-f355083c091e
 ---
 # Compiler Error C2731
 
-'identifier' : function cannot be overloaded
+> 'identifier' : function cannot be overloaded
 
 The functions `main`, `WinMain`, `DllMain`, and `LibMain` cannot be overloaded.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
@@ -10,7 +10,11 @@ ms.assetid: 9b563999-febd-4582-9147-f355083c091e
 
 > 'identifier' : function cannot be overloaded
 
+## Remarks
+
 The functions `main`, `WinMain`, `DllMain`, and `LibMain` cannot be overloaded.
+
+## Example
 
 The following sample generates C2731:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2731.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2731"
 title: "Compiler Error C2731"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2731"
+ms.date: 11/04/2016
 f1_keywords: ["C2731"]
 helpviewer_keywords: ["C2731"]
-ms.assetid: 9b563999-febd-4582-9147-f355083c091e
 ---
 # Compiler Error C2731
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2732"
 title: "Compiler Error C2732"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2732"
+ms.date: 11/04/2016
 f1_keywords: ["C2732"]
 helpviewer_keywords: ["C2732"]
-ms.assetid: 01b7ad2c-93cf-456f-a4c0-c5f2fdc7c07c
 ---
 # Compiler Error C2732
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
@@ -10,6 +10,8 @@ ms.assetid: 01b7ad2c-93cf-456f-a4c0-c5f2fdc7c07c
 
 > linkage specification contradicts earlier specification for 'function'
 
+## Remarks
+
 The function is already declared with a different linkage specifier.
 
 This error can be caused by include files with different linkage specifiers.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
@@ -8,7 +8,7 @@ ms.assetid: 01b7ad2c-93cf-456f-a4c0-c5f2fdc7c07c
 ---
 # Compiler Error C2732
 
-linkage specification contradicts earlier specification for 'function'
+> linkage specification contradicts earlier specification for 'function'
 
 The function is already declared with a different linkage specifier.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2732.md
@@ -20,7 +20,7 @@ To fix this error, change the **`extern`** statements so that the linkages agree
 
 ## Example
 
-The following sample generates C2732:
+The following example generates C2732:
 
 ```cpp
 // C2732.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2733"
 title: "Compiler Error C2733"
+description: "Learn more about: Compiler Error C2733"
 ms.date: 12/02/2021
 f1_keywords: ["C2733"]
 helpviewer_keywords: ["C2733"]
-ms.assetid: 67f83561-c633-407c-a2ee-f9fd16e165bf
 ---
 # Compiler Error C2733
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
@@ -10,6 +10,8 @@ ms.assetid: 67f83561-c633-407c-a2ee-f9fd16e165bf
 
 > you cannot overload a function with 'C' linkage
 
+## Remarks
+
 More than one overloaded function is declared with `extern "C"` linkage. When using `"C"` linkage, only one form of a specified function can be external. Since overloaded functions have the same undecorated name, they can't be used with C programs.
 
 This error may occur after an upgrade because of conformance changes in Visual Studio 2019. Starting in Visual Studio 2019 version 16.3, the [`/Zc:externC-`](../../build/reference/zc-externc.md) compiler option relaxes this check. The option must come after any [`/permissive-`](../../build/reference/permissive-standards-conformance.md) option on the command line.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2733.md
@@ -18,7 +18,7 @@ This error may occur after an upgrade because of conformance changes in Visual S
 
 ## Example
 
-The following sample generates C2733:
+The following example generates C2733:
 
 ```cpp
 // C2733.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2734"
 title: "Compiler Error C2734"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2734"
+ms.date: 11/04/2016
 f1_keywords: ["C2734"]
 helpviewer_keywords: ["C2734"]
-ms.assetid: e53a77b7-825c-42d1-a655-90e1c93b833e
 ---
 # Compiler Error C2734
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
@@ -16,7 +16,7 @@ The identifier is declared **`const`** but not initialized or **`extern`**.
 
 ## Example
 
-The following sample generates C2734:
+The following example generates C2734:
 
 ```cpp
 // C2734.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
@@ -10,7 +10,11 @@ ms.assetid: e53a77b7-825c-42d1-a655-90e1c93b833e
 
 > 'identifier' : const object must be initialized if not extern
 
+## Remarks
+
 The identifier is declared **`const`** but not initialized or **`extern`**.
+
+## Example
 
 The following sample generates C2734:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2734.md
@@ -8,7 +8,7 @@ ms.assetid: e53a77b7-825c-42d1-a655-90e1c93b833e
 ---
 # Compiler Error C2734
 
-'identifier' : const object must be initialized if not extern
+> 'identifier' : const object must be initialized if not extern
 
 The identifier is declared **`const`** but not initialized or **`extern`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
@@ -10,7 +10,11 @@ ms.assetid: 6ce45600-7148-4bc0-8699-af0ef137571e
 
 > 'keyword' keyword is not permitted in formal parameter type specifier
 
+## Remarks
+
 The keyword is invalid in this context.
+
+## Example
 
 The following sample generates C2735:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
@@ -16,7 +16,7 @@ The keyword is invalid in this context.
 
 ## Example
 
-The following sample generates C2735:
+The following example generates C2735:
 
 ```cpp
 // C2735.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2735"
 title: "Compiler Error C2735"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2735"
+ms.date: 11/04/2016
 f1_keywords: ["C2735"]
 helpviewer_keywords: ["C2735"]
-ms.assetid: 6ce45600-7148-4bc0-8699-af0ef137571e
 ---
 # Compiler Error C2735
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
@@ -8,7 +8,7 @@ ms.assetid: 6ce45600-7148-4bc0-8699-af0ef137571e
 ---
 # Compiler Error C2735
 
-'keyword' keyword is not permitted in formal parameter type specifier
+> 'keyword' keyword is not permitted in formal parameter type specifier
 
 The keyword is invalid in this context.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
@@ -8,7 +8,7 @@ ms.assetid: 95a6bc28-c0cb-49dc-87e6-e993dbbba881
 ---
 # Compiler Error C2736
 
-'keyword' keyword is not permitted in cast
+> 'keyword' keyword is not permitted in cast
 
 The keyword is invalid in a cast.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2736"
 title: "Compiler Error C2736"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2736"
+ms.date: 11/04/2016
 f1_keywords: ["C2736"]
 helpviewer_keywords: ["C2736"]
-ms.assetid: 95a6bc28-c0cb-49dc-87e6-e993dbbba881
 ---
 # Compiler Error C2736
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
@@ -10,7 +10,11 @@ ms.assetid: 95a6bc28-c0cb-49dc-87e6-e993dbbba881
 
 > 'keyword' keyword is not permitted in cast
 
+## Remarks
+
 The keyword is invalid in a cast.
+
+## Example
 
 The following sample generates C2736:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2736.md
@@ -16,7 +16,7 @@ The keyword is invalid in a cast.
 
 ## Example
 
-The following sample generates C2736:
+The following example generates C2736:
 
 ```cpp
 // C2736.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2738"
 title: "Compiler Error C2738"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2738"
+ms.date: 11/04/2016
 f1_keywords: ["C2738"]
 helpviewer_keywords: ["C2738"]
-ms.assetid: 896b4640-1ee0-4cd8-9910-de3efa30006a
 ---
 # Compiler Error C2738
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
@@ -10,7 +10,11 @@ ms.assetid: 896b4640-1ee0-4cd8-9910-de3efa30006a
 
 > 'declaration' : is ambiguous or is not a member of 'type'
 
+## Remarks
+
 A function was declared incorrectly.
+
+## Example
 
 The following sample generates C2738:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
@@ -16,7 +16,7 @@ A function was declared incorrectly.
 
 ## Example
 
-The following sample generates C2738:
+The following example generates C2738:
 
 ```cpp
 // C2738.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2738.md
@@ -8,7 +8,7 @@ ms.assetid: 896b4640-1ee0-4cd8-9910-de3efa30006a
 ---
 # Compiler Error C2738
 
-'declaration' : is ambiguous or is not a member of 'type'
+> 'declaration' : is ambiguous or is not a member of 'type'
 
 A function was declared incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
@@ -10,7 +10,11 @@ ms.assetid: 5b63e435-7631-43d7-805e-f2adefb7e517
 
 > 'number' : explicit managed or WinRT array dimensions must be between 1 and 32
 
+## Remarks
+
 An array dimension was not between 1 and 32.
+
+## Example
 
 The following sample generates C2739 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
@@ -8,7 +8,7 @@ ms.assetid: 5b63e435-7631-43d7-805e-f2adefb7e517
 ---
 # Compiler Error C2739
 
-'number' : explicit managed or WinRT array dimensions must be between 1 and 32
+> 'number' : explicit managed or WinRT array dimensions must be between 1 and 32
 
 An array dimension was not between 1 and 32.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2739"
 title: "Compiler Error C2739"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2739"
+ms.date: 11/04/2016
 f1_keywords: ["C2739"]
 helpviewer_keywords: ["C2739"]
-ms.assetid: 5b63e435-7631-43d7-805e-f2adefb7e517
 ---
 # Compiler Error C2739
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2739.md
@@ -16,7 +16,7 @@ An array dimension was not between 1 and 32.
 
 ## Example
 
-The following sample generates C2739 and shows how to fix it:
+The following example generates C2739 and shows how to fix it:
 
 ```cpp
 // C2739.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
@@ -10,6 +10,8 @@ ms.assetid: 644cd444-21d2-471d-a176-f5f52c5a0b73
 
 > 'type' : cannot catch a native type with __clrcall destructor or copy constructor
 
+## Remarks
+
 A module compiled with **/clr** attempted to catch an exception of native type and where the type's destructor or copy constructor uses `__clrcall` calling convention.
 
 When compiled with **/clr**, exception handling expects the member functions in a native type to be [__cdecl](../../cpp/cdecl.md) and not [__clrcall](../../cpp/clrcall.md). Native types with member functions using `__clrcall` calling convention cannot be caught in a module compiled with **/clr**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
@@ -8,7 +8,7 @@ ms.assetid: 644cd444-21d2-471d-a176-f5f52c5a0b73
 ---
 # Compiler Error C2743
 
-'type' : cannot catch a native type with __clrcall destructor or copy constructor
+> 'type' : cannot catch a native type with __clrcall destructor or copy constructor
 
 A module compiled with **/clr** attempted to catch an exception of native type and where the type's destructor or copy constructor uses `__clrcall` calling convention.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
@@ -20,7 +20,7 @@ For more information, see [/clr (Common Language Runtime Compilation)](../../bui
 
 ## Example
 
-The following sample generates C2743.
+The following example generates C2743.
 
 ```cpp
 // C2743.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2743.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2743"
 title: "Compiler Error C2743"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2743"
+ms.date: 11/04/2016
 f1_keywords: ["C2743"]
 helpviewer_keywords: ["C2743"]
-ms.assetid: 644cd444-21d2-471d-a176-f5f52c5a0b73
 ---
 # Compiler Error C2743
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
@@ -16,7 +16,7 @@ Identifiers must be comprised of legal characters.
 
 ## Example
 
-The following sample generates C2745:
+The following example generates C2745:
 
 ```cpp
 // C2745.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2745"
 title: "Compiler Error C2745"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2745"
+ms.date: 11/04/2016
 f1_keywords: ["C2745"]
 helpviewer_keywords: ["C2745"]
-ms.assetid: a1c45f13-7667-4678-aa16-265304a449a1
 ---
 # Compiler Error C2745
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
@@ -8,7 +8,7 @@ ms.assetid: a1c45f13-7667-4678-aa16-265304a449a1
 ---
 # Compiler Error C2745
 
-'token' : this token cannot be converted to an identifier
+> 'token' : this token cannot be converted to an identifier
 
 Identifiers must be comprised of legal characters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2745.md
@@ -10,7 +10,11 @@ ms.assetid: a1c45f13-7667-4678-aa16-265304a449a1
 
 > 'token' : this token cannot be converted to an identifier
 
+## Remarks
+
 Identifiers must be comprised of legal characters.
+
+## Example
 
 The following sample generates C2745:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
@@ -8,7 +8,7 @@ ms.assetid: b63ac78b-a200-499c-afea-15af1a1e819e
 ---
 # Compiler Error C2748
 
-managed or WinRT array creation must have array size or array initializer
+> managed or WinRT array creation must have array size or array initializer
 
 A managed or WinRT array was ill formed. For more information, see [array](../../extensions/arrays-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2748"
 title: "Compiler Error C2748"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2748"
+ms.date: 11/04/2016
 f1_keywords: ["C2748"]
 helpviewer_keywords: ["C2748"]
-ms.assetid: b63ac78b-a200-499c-afea-15af1a1e819e
 ---
 # Compiler Error C2748
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
@@ -16,7 +16,7 @@ A managed or WinRT array was ill formed. For more information, see [array](../..
 
 ## Example
 
-The following sample generates C2748 and shows how to fix it:
+The following example generates C2748 and shows how to fix it:
 
 ```cpp
 // C2748.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2748.md
@@ -10,7 +10,11 @@ ms.assetid: b63ac78b-a200-499c-afea-15af1a1e819e
 
 > managed or WinRT array creation must have array size or array initializer
 
+## Remarks
+
 A managed or WinRT array was ill formed. For more information, see [array](../../extensions/arrays-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C2748 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
@@ -8,7 +8,7 @@ ms.assetid: a81aef36-cdca-4d78-89d5-b72eff2500b2
 ---
 # Compiler Error C2749
 
-'type' : can only throw or catch handle to a managed class with /clr:safe
+> 'type' : can only throw or catch handle to a managed class with /clr:safe
 
 When using **/clr:safe**, you can only throw or catch a reference type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2749"
 title: "Compiler Error C2749"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2749"
+ms.date: 11/04/2016
 f1_keywords: ["C2749"]
 helpviewer_keywords: ["C2749"]
-ms.assetid: a81aef36-cdca-4d78-89d5-b72eff2500b2
 ---
 # Compiler Error C2749
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
@@ -18,7 +18,7 @@ For more information, see [/clr (Common Language Runtime Compilation)](../../bui
 
 ## Example
 
-The following sample generates C2749:
+The following example generates C2749:
 
 ```cpp
 // C2749.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2749.md
@@ -10,6 +10,8 @@ ms.assetid: a81aef36-cdca-4d78-89d5-b72eff2500b2
 
 > 'type' : can only throw or catch handle to a managed class with /clr:safe
 
+## Remarks
+
 When using **/clr:safe**, you can only throw or catch a reference type.
 
 For more information, see [/clr (Common Language Runtime Compilation)](../../build/reference/clr-common-language-runtime-compilation.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
@@ -8,7 +8,7 @@ ms.assetid: 30450034-feb5-448c-9655-b8c5f3639695
 ---
 # Compiler Error C2750
 
-'type' : cannot use 'new' on the reference type; use 'gcnew' instead
+> 'type' : cannot use 'new' on the reference type; use 'gcnew' instead
 
 To create an instance of a CLR type, which causes the instance to be placed on the garbage-collected heap, you must use [gcnew](../../extensions/ref-new-gcnew-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
@@ -10,7 +10,11 @@ ms.assetid: 30450034-feb5-448c-9655-b8c5f3639695
 
 > 'type' : cannot use 'new' on the reference type; use 'gcnew' instead
 
+## Remarks
+
 To create an instance of a CLR type, which causes the instance to be placed on the garbage-collected heap, you must use [gcnew](../../extensions/ref-new-gcnew-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C2750:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
@@ -16,7 +16,7 @@ To create an instance of a CLR type, which causes the instance to be placed on t
 
 ## Example
 
-The following sample generates C2750:
+The following example generates C2750:
 
 ```cpp
 // C2750.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2750.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2750"
 title: "Compiler Error C2750"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2750"
+ms.date: 11/04/2016
 f1_keywords: ["C2750"]
 helpviewer_keywords: ["C2750"]
-ms.assetid: 30450034-feb5-448c-9655-b8c5f3639695
 ---
 # Compiler Error C2750
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2751"]
 
 > 'parameter' : the name of a function parameter cannot be qualified
 
+## Remarks
+
 You cannot use a qualified name as a function parameter.
+
+## Example
 
 The following sample generates C2751:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
@@ -15,7 +15,7 @@ You cannot use a qualified name as a function parameter.
 
 ## Example
 
-The following sample generates C2751:
+The following example generates C2751:
 
 ```cpp
 // C2751.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2751"]
 ---
 # Compiler Error C2751
 
-'parameter' : the name of a function parameter cannot be qualified
+> 'parameter' : the name of a function parameter cannot be qualified
 
 You cannot use a qualified name as a function parameter.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2751.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Error C2751"
 title: "Compiler Error C2751"
-ms.date: "03/11/2024"
+description: "Learn more about: Compiler Error C2751"
+ms.date: 03/11/2024
 f1_keywords: ["C2751"]
 helpviewer_keywords: ["C2751"]
 ---

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2752"
 title: "Compiler Error C2752"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2752"
+ms.date: 11/04/2016
 f1_keywords: ["C2752"]
 helpviewer_keywords: ["C2752"]
-ms.assetid: ae42b3ec-84a9-4e9d-8d59-3d208132d0b2
 ---
 # Compiler Error C2752
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
@@ -16,7 +16,7 @@ An instantiation was ambiguous.
 
 ## Example
 
-The following sample generates C2752:
+The following example generates C2752:
 
 ```cpp
 // C2752.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
@@ -8,7 +8,7 @@ ms.assetid: ae42b3ec-84a9-4e9d-8d59-3d208132d0b2
 ---
 # Compiler Error C2752
 
-'template' : more than one partial specialization matches the template argument list
+> 'template' : more than one partial specialization matches the template argument list
 
 An instantiation was ambiguous.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2752.md
@@ -10,7 +10,11 @@ ms.assetid: ae42b3ec-84a9-4e9d-8d59-3d208132d0b2
 
 > 'template' : more than one partial specialization matches the template argument list
 
+## Remarks
+
 An instantiation was ambiguous.
+
+## Example
 
 The following sample generates C2752:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
@@ -8,7 +8,7 @@ ms.assetid: 92bfeeac-524a-4a8e-9a4f-fb8269055826
 ---
 # Compiler Error C2753
 
-'*template*' : partial specialization cannot match argument list for primary template
+> '*template*' : partial specialization cannot match argument list for primary template
 
 If the template argument list matches the parameter list, the compiler treats it as the same template. Defining the same template twice is not allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2753"
 title: "Compiler Error C2753"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2753"
+ms.date: 11/04/2016
 f1_keywords: ["C2753"]
 helpviewer_keywords: ["C2753"]
-ms.assetid: 92bfeeac-524a-4a8e-9a4f-fb8269055826
 ---
 # Compiler Error C2753
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
@@ -16,7 +16,7 @@ If the template argument list matches the parameter list, the compiler treats it
 
 ## Example
 
-The following sample generates C2753 and shows a way to fix it:
+The following example generates C2753 and shows a way to fix it:
 
 ```cpp
 // C2753.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2753.md
@@ -10,6 +10,8 @@ ms.assetid: 92bfeeac-524a-4a8e-9a4f-fb8269055826
 
 > '*template*' : partial specialization cannot match argument list for primary template
 
+## Remarks
+
 If the template argument list matches the parameter list, the compiler treats it as the same template. Defining the same template twice is not allowed.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
@@ -16,7 +16,7 @@ An attempt was made to partially specialize a template class that has a dependen
 
 ## Example
 
-The following sample generates C2754:
+The following example generates C2754:
 
 ```cpp
 // C2754.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
@@ -10,7 +10,11 @@ ms.assetid: 1cab66c5-da9d-4b81-b7fb-9cdc48ff1ccc
 
 > 'specialization' : a partial specialization cannot have a dependent non-type template parameter
 
+## Remarks
+
 An attempt was made to partially specialize a template class that has a dependent non-type template parameter. This is not allowed.
+
+## Example
 
 The following sample generates C2754:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
@@ -8,7 +8,7 @@ ms.assetid: 1cab66c5-da9d-4b81-b7fb-9cdc48ff1ccc
 ---
 # Compiler Error C2754
 
-'specialization' : a partial specialization cannot have a dependent non-type template parameter
+> 'specialization' : a partial specialization cannot have a dependent non-type template parameter
 
 An attempt was made to partially specialize a template class that has a dependent non-type template parameter. This is not allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2754.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2754"
 title: "Compiler Error C2754"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2754"
+ms.date: 11/04/2016
 f1_keywords: ["C2754"]
 helpviewer_keywords: ["C2754"]
-ms.assetid: 1cab66c5-da9d-4b81-b7fb-9cdc48ff1ccc
 ---
 # Compiler Error C2754
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
@@ -16,7 +16,7 @@ The non-type parameter needs to be a simple identifier, something the compiler c
 
 ## Example
 
-The following sample generates C2755:
+The following example generates C2755:
 
 ```cpp
 // C2755.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2755"
 title: "Compiler Error C2755"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2755"
+ms.date: 11/04/2016
 f1_keywords: ["C2755"]
 helpviewer_keywords: ["C2755"]
-ms.assetid: 8ee4eeb6-4757-4efe-9100-38ff4a96f1de
 ---
 # Compiler Error C2755
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
@@ -8,7 +8,7 @@ ms.assetid: 8ee4eeb6-4757-4efe-9100-38ff4a96f1de
 ---
 # Compiler Error C2755
 
-'param' : non-type parameter of a partial specialization must be a simple identifier
+> 'param' : non-type parameter of a partial specialization must be a simple identifier
 
 The non-type parameter needs to be a simple identifier, something the compiler can resolve at compile time to a single identifier or a constant value.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2755.md
@@ -10,7 +10,11 @@ ms.assetid: 8ee4eeb6-4757-4efe-9100-38ff4a96f1de
 
 > 'param' : non-type parameter of a partial specialization must be a simple identifier
 
+## Remarks
+
 The non-type parameter needs to be a simple identifier, something the compiler can resolve at compile time to a single identifier or a constant value.
+
+## Example
 
 The following sample generates C2755:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
@@ -16,7 +16,7 @@ The template for a partial specialization may not contain a default argument.
 
 ## Example
 
-The following sample generates C2756 and shows how to fix it:
+The following example generates C2756 and shows how to fix it:
 
 ```cpp
 // C2756.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2756"
 title: "Compiler Error C2756"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2756"
+ms.date: 11/04/2016
 f1_keywords: ["C2756"]
 helpviewer_keywords: ["C2756"]
-ms.assetid: 42eb988d-4043-4dee-8fd4-596949f69a55
 ---
 # Compiler Error C2756
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
@@ -10,7 +10,11 @@ ms.assetid: 42eb988d-4043-4dee-8fd4-596949f69a55
 
 > 'template type' : default template arguments not allowed on a partial specialization
 
+## Remarks
+
 The template for a partial specialization may not contain a default argument.
+
+## Example
 
 The following sample generates C2756 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2756.md
@@ -8,7 +8,7 @@ ms.assetid: 42eb988d-4043-4dee-8fd4-596949f69a55
 ---
 # Compiler Error C2756
 
-'template type' : default template arguments not allowed on a partial specialization
+> 'template type' : default template arguments not allowed on a partial specialization
 
 The template for a partial specialization may not contain a default argument.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2757"
 title: "Compiler Error C2757"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2757"
+ms.date: 11/04/2016
 f1_keywords: ["C2757"]
 helpviewer_keywords: ["C2757"]
-ms.assetid: 421f102f-8a32-4d47-a109-811ddf2c909d
 ---
 # Compiler Error C2757
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
@@ -16,7 +16,7 @@ A symbol used in the current compilation as a namespace identifier is already be
 
 ## Example
 
-The following sample generates C2757:
+The following example generates C2757:
 
 ```cpp
 // C2757a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
@@ -10,7 +10,11 @@ ms.assetid: 421f102f-8a32-4d47-a109-811ddf2c909d
 
 > 'symbol' : a symbol with this name already exists and therefore this name cannot be used as a namespace name
 
+## Remarks
+
 A symbol used in the current compilation as a namespace identifier is already being used in a referenced assembly.
+
+## Example
 
 The following sample generates C2757:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2757.md
@@ -8,7 +8,7 @@ ms.assetid: 421f102f-8a32-4d47-a109-811ddf2c909d
 ---
 # Compiler Error C2757
 
-'symbol' : a symbol with this name already exists and therefore this name cannot be used as a namespace name
+> 'symbol' : a symbol with this name already exists and therefore this name cannot be used as a namespace name
 
 A symbol used in the current compilation as a namespace identifier is already being used in a referenced assembly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2758"]
 
 > 'member': a member of reference type must be initialized
 
+## Remarks
+
 Compiler error C2758 is caused when the constructor does not initialize a member of reference type in an initializer list. The compiler leaves the member undefined. Reference member variables must initialized when declared or be given a value in the initialization list of the constructor.
+
+## Example
 
 The following sample generates C2758:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
@@ -15,7 +15,7 @@ Compiler error C2758 is caused when the constructor does not initialize a member
 
 ## Example
 
-The following sample generates C2758:
+The following example generates C2758:
 
 ```cpp
 // C2758.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2758.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2758"]
 ---
 # Compiler Error C2758
 
-'member': a member of reference type must be initialized
+> 'member': a member of reference type must be initialized
 
 Compiler error C2758 is caused when the constructor does not initialize a member of reference type in an initializer list. The compiler leaves the member undefined. Reference member variables must initialized when declared or be given a value in the initialization list of the constructor.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2760"
 title: "Compiler Error C2760"
+description: "Learn more about: Compiler Error C2760"
 ms.date: 08/12/2021
 f1_keywords: ["C2760"]
 helpviewer_keywords: ["C2760"]
-ms.assetid: 585757fd-d519-43f3-94e5-50316ac8b90b
 ---
 # Compiler Error C2760
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
@@ -18,7 +18,7 @@ There are several ways to cause this error. Usually, it's caused by a token sequ
 
 ## Examples
 
-In this sample, a casting operator is used with an invalid operator.
+In this example, a casting operator is used with an invalid operator.
 
 ```cpp
 // C2760.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2760.md
@@ -16,7 +16,7 @@ ms.assetid: 585757fd-d519-43f3-94e5-50316ac8b90b
 
 There are several ways to cause this error. Usually, it's caused by a token sequence that the compiler can't make sense of.
 
-## Example
+## Examples
 
 In this sample, a casting operator is used with an invalid operator.
 


### PR DESCRIPTION
This is batch 37 that structures error/warning references. See #5465 for more information.