### PR TITLE
Resolve invalid type `Int` in syntax references

### DIFF
--- a/docs/cpp/com-ptr-t-relational-operators.md
+++ b/docs/cpp/com-ptr-t-relational-operators.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: _com_ptr_t Relational Operators"
 title: "_com_ptr_t Relational Operators"
-ms.date: "11/04/2016"
+description: "Learn more about: _com_ptr_t Relational Operators"
+ms.date: 11/04/2016
 f1_keywords: ["_com_ptr_t::operator>", "_com_ptr_t::operator>=", "_com_ptr_t::operator<=", "_com_ptr_t::operator==", "_com_ptr_t::operator!=", "_com_ptr_t::operator<"]
 helpviewer_keywords: [">= operator [C++], comparing specific objects", "!= operator", "operator > [C++], pointers", "operator>= [C++], pointers", "operator < [C++], pointers", "operator!= [C++], relational operators", "< operator [C++], comparing specific objects", "operator== [C++], pointers", "operator == [C++], pointers", "<= operator [C++], with specific objects", "relational operators [C++], _com_ptr_t class", "operator >= [C++], pointers", "operator != [C++], relational operators", "operator <= [C++], pointers", "> operator [C++], comparing specific objects", "operator<= [C++], pointers", "operator< [C++], pointers", "== operator [C++], with specific Visual C++ objects"]
-ms.assetid: 5ae4028c-33ee-485d-bbda-88d2604d6d4b
 ---
 # _com_ptr_t Relational Operators
 

--- a/docs/cpp/com-ptr-t-relational-operators.md
+++ b/docs/cpp/com-ptr-t-relational-operators.md
@@ -33,7 +33,7 @@ bool operator==( const _com_ptr_t& p ) throw();
 template<>
 bool operator==( _com_ptr_t& p ) throw();
 
-bool operator==( Int null );
+bool operator==( int null );
 
 template<typename _OtherIID>
 bool operator!=( const _com_ptr_t<_OtherIID>& p );
@@ -44,7 +44,7 @@ bool operator!=( _com_ptr_t<_OtherIID>& p );
 template<typename _InterfaceType>
 bool operator!=( _InterfaceType* p );
 
-bool operator!=( Int null );
+bool operator!=( int null );
 
 template<typename _OtherIID>
 bool operator<( const _com_ptr_t<_OtherIID>& p );

--- a/docs/mfc/reference/cmfcribboncombobox-class.md
+++ b/docs/mfc/reference/cmfcribboncombobox-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: CMFCRibbonComboBox Class"
 title: "CMFCRibbonComboBox Class"
-ms.date: "11/04/2016"
+description: "Learn more about: CMFCRibbonComboBox Class"
+ms.date: 11/04/2016
 f1_keywords: ["CMFCRibbonComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::CMFCRibbonComboBox", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::AddItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::DeleteItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::EnableDropDownListResize", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::FindItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetCount", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetCurSel", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetDropDownHeight", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetIntermediateSize", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::GetItemData", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::HasEditBox", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::IsResizeDropDownList", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::OnSelectItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::RemoveAllItems", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::SelectItem", "AFXRIBBONCOMBOBOX/CMFCRibbonComboBox::SetDropDownHeight"]
 helpviewer_keywords: ["CMFCRibbonComboBox [MFC], CMFCRibbonComboBox", "CMFCRibbonComboBox [MFC], AddItem", "CMFCRibbonComboBox [MFC], DeleteItem", "CMFCRibbonComboBox [MFC], EnableDropDownListResize", "CMFCRibbonComboBox [MFC], FindItem", "CMFCRibbonComboBox [MFC], GetCount", "CMFCRibbonComboBox [MFC], GetCurSel", "CMFCRibbonComboBox [MFC], GetDropDownHeight", "CMFCRibbonComboBox [MFC], GetIntermediateSize", "CMFCRibbonComboBox [MFC], GetItem", "CMFCRibbonComboBox [MFC], GetItemData", "CMFCRibbonComboBox [MFC], HasEditBox", "CMFCRibbonComboBox [MFC], IsResizeDropDownList", "CMFCRibbonComboBox [MFC], OnSelectItem", "CMFCRibbonComboBox [MFC], RemoveAllItems", "CMFCRibbonComboBox [MFC], SelectItem", "CMFCRibbonComboBox [MFC], SetDropDownHeight"]
-ms.assetid: 9b29a6a4-cf17-4152-9b13-0bf90784b30d
 ---
 # CMFCRibbonComboBox Class
 

--- a/docs/mfc/reference/cmfcribboncombobox-class.md
+++ b/docs/mfc/reference/cmfcribboncombobox-class.md
@@ -102,9 +102,9 @@ public:
 CMFCRibbonComboBox(
     UINT nID,
     BOOL bHasEditBox=TRUE,
-    Int nWidth=-1,
+    int nWidth=-1,
     LPCTSTR lpszLabel=NULL,
-    Int nImage=-1);
+    int nImage=-1);
 
 protected:
 CMFCRibbonComboBox();


### PR DESCRIPTION
Resolve invalid type `Int` which will cause syntax errors. Here are the relevant snippets from my local copy of the headers:

## `_com_ptr_t` Relational Operators

`C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\include\comip.h`:

Line 385-393

```cpp
    bool operator==(int null) const
    {
        if (null != 0)
        {
            _com_issue_error(E_POINTER);
        }

        return m_pInterface == nullptr;
    }
```

Line 450-458

```cpp
    bool operator!=(int null) const
    {
        if (null != 0)
        {
            _com_issue_error(E_POINTER);
        }

        return m_pInterface != nullptr;
    }
```

## `CMFCRibbonComboBox`

`C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\atlmfc\include\afxribboncombobox.h`:

Line 42-48

```cpp
// Construction:
public:
	CMFCRibbonComboBox(UINT nID, BOOL bHasEditBox = TRUE, int nWidth = -1, LPCTSTR lpszLabel = NULL, int nImage = -1);
	virtual ~CMFCRibbonComboBox();

protected:
	CMFCRibbonComboBox();
```