### PR TITLE
Fix erroneous `__Pragma` in link texts

### DIFF
--- a/docs/c-language/c-pragmas.md
+++ b/docs/c-language/c-pragmas.md
@@ -1,9 +1,8 @@
 ---
-description: "Learn more about: C Pragmas"
 title: "C Pragmas"
+description: "Learn more about: C Pragmas"
 ms.date: 07/26/2020
 helpviewer_keywords: ["pragmas, C/C++"]
-ms.assetid: 3d6d36b4-d565-4632-a4cd-e39aeaded5ad
 ---
 # C Pragmas
 

--- a/docs/c-language/c-pragmas.md
+++ b/docs/c-language/c-pragmas.md
@@ -59,7 +59,7 @@ A *pragma* instructs the compiler to perform a particular action at compile time
     :::column-end:::
 :::row-end:::
 
-See [Pragma Directives and the `__Pragma` Keyword](../preprocessor/pragma-directives-and-the-pragma-keyword.md) for a description of the Microsoft C compiler pragmas.
+See [Pragma directives and the `__pragma` and `_Pragma` keywords](../preprocessor/pragma-directives-and-the-pragma-keyword.md) for a description of the Microsoft C compiler pragmas.
 
 **END Microsoft Specific**
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3295.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3295.md
@@ -10,7 +10,7 @@ ms.assetid: 83f0aa4d-0e0a-4905-9f66-fcf9991fc07a
 
 '#pragma pragma' can only be used at global or namespace scope
 
-Some pragmas cannot be used in a function.  See [Pragma Directives and the __Pragma Keyword](../../preprocessor/pragma-directives-and-the-pragma-keyword.md) for more information.
+Some pragmas cannot be used in a function.  See [Pragma directives and the `__pragma` and `_Pragma` keywords](../../preprocessor/pragma-directives-and-the-pragma-keyword.md) for more information.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3295.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3295.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3295"
 title: "Compiler Error C3295"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3295"
+ms.date: 11/04/2016
 f1_keywords: ["C3295"]
 helpviewer_keywords: ["C3295"]
-ms.assetid: 83f0aa4d-0e0a-4905-9f66-fcf9991fc07a
 ---
 # Compiler Error C3295
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4789.md
@@ -32,7 +32,7 @@ Visual C++ might generate this warning for a code path that never executes. You 
 #pragma warning( pop )
 ```
 
-This idiom keeps Visual C++ from generating the warning for that specific block of code. The `#pragma warning(push)` preserves the existing state before `#pragma warning(disable: 4789)` changes it. The `#pragma warning(pop)` restores the pushed state, and removes the effects of the `#pragma warning(disable:4789)`. For more information about the C++ preprocessor directive `#pragma`, see [`warning`](../../preprocessor/warning.md) and [Pragma Directives and the `__Pragma` Keyword](../../preprocessor/pragma-directives-and-the-pragma-keyword.md).
+This idiom keeps Visual C++ from generating the warning for that specific block of code. The `#pragma warning(push)` preserves the existing state before `#pragma warning(disable: 4789)` changes it. The `#pragma warning(pop)` restores the pushed state, and removes the effects of the `#pragma warning(disable:4789)`. For more information about the C++ preprocessor directive `#pragma`, see [`warning`](../../preprocessor/warning.md) and [Pragma directives and the `__pragma` and `_Pragma` keywords](../../preprocessor/pragma-directives-and-the-pragma-keyword.md).
 
 The [`/sdl` (Enable Additional Security Checks)](../../build/reference/sdl-enable-additional-security-checks.md) compiler option elevates this warning to an error.
 


### PR DESCRIPTION
Fix erroneous `__Pragma` (notice the capitalization of "P", should be `__pragma`) in link texts and update metadata. The title for [`docs/preprocessor/pragma-directives-and-the-pragma-keyword.md`](https://github.com/MicrosoftDocs/cpp-docs/blob/d54db331dca46569b595837d43cb2ae79f224613/docs/preprocessor/pragma-directives-and-the-pragma-keyword.md) was rectified in commit https://github.com/MicrosoftDocs/cpp-docs/commit/bf7500f926efda19672de9abd488281b0509f74c, however some old link texts were left behind.