### PR TITLE
Improve `<system_error>` header reference

### DIFF
--- a/docs/standard-library/system-error.md
+++ b/docs/standard-library/system-error.md
@@ -23,16 +23,16 @@ Include the header `<system_error>` to define the exception class `system_error`
 |Name|Description|
 |-|-|
 |[`generic_category`](system-error-functions.md#generic_category)|Represents the category for generic errors.|
-|[`is_error_code_enum_v`](system-error-functions.md#is_error_code_enum_v)||
-|[`is_error_condition_enum_v`](system-error-functions.md#is_error_condition_enum_v)||
-|[`system_category`](system-error-functions.md#system_category)|Represents the category for errors caused by low-level system overflows.|
+|[`is_error_code_enum_v`](system-error-functions.md#is_error_code_enum_v)|A helper variable template for the [`is_error_code_enum`](is-error-code-enum-class.md) value.|
+|[`is_error_condition_enum_v`](system-error-functions.md#is_error_condition_enum_v)|A helper variable template for the [`is_error_condition_enum`](is-error-condition-enum-class.md) value.|
+|[`system_category`](system-error-functions.md#system_category)|Represents the category for operating system errors.|
 
 ### Functions
 
 |Name|Description|
 |-|-|
-|[`make_error_code`](system-error-functions.md#make_error_code)|Creates an `error_code` object.|
-|[`make_error_condition`](system-error-functions.md#make_error_condition)|Creates an `error_condition` object.|
+|[`make_error_code`](system-error-functions.md#make_error_code)|Creates an [`error_code`](error-code-class.md) object.|
+|[`make_error_condition`](system-error-functions.md#make_error_condition)|Creates an [`error_condition`](error-condition-class.md) object.|
 
 ### Operators
 
@@ -41,7 +41,7 @@ Include the header `<system_error>` to define the exception class `system_error`
 |[`operator==`](system-error-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
 |[`operator!=`](system-error-operators.md#op_neq)|Tests if the object on the left side of the operator is not equal to the object on the right side.|
 |[`operator<`](system-error-operators.md#op_lt)|Tests if an object is less than the object passed in for comparison.|
-|[`operator<<`](system-error-operators.md#op_ostream)||
+|[`operator<<`](system-error-operators.md#op_ostream)|Inserts an [`error_code`](error-code-class.md) object into the output stream.|
 
 ### Enums
 
@@ -56,10 +56,10 @@ Include the header `<system_error>` to define the exception class `system_error`
 |[`error_category`](error-category-class.md)|Represents the abstract, common base for objects that describes a category of error codes.|
 |[`error_code`](error-code-class.md)|Represents low-level system errors that are implementation-specific.|
 |[`error_condition`](error-condition-class.md)|Represents user-defined error codes.|
-|[`hash`](hash-structure.md#system_error)||
-|[`is_error_code_enum`](is-error-code-enum-class.md)|Represents a type predicate that tests for the [`error_code` Class](error-code-class.md) enumeration.|
-|[`is_error_condition_enum`](is-error-condition-enum-class.md)|Represents a type predicate that tests for the [`error_condition` Class](error-condition-class.md) enumeration.|
-|[`system_error`](system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system overflow.|
+|[`hash`](hash-structure.md#system_error)|Template specializations of [`std::hash`](hash-class.md) for [`error_code`](error-code-class.md) and [`error_condition`](error-condition-class.md).|
+|[`is_error_code_enum`](is-error-code-enum-class.md)|Represents a type predicate that tests for the [`error_code`](error-code-class.md) enumeration.|
+|[`is_error_condition_enum`](is-error-condition-enum-class.md)|Represents a type predicate that tests for the [`error_condition`](error-condition-class.md) enumeration.|
+|[`system_error`](system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system error.|
 
 ## See also
 

--- a/docs/standard-library/system-error.md
+++ b/docs/standard-library/system-error.md
@@ -8,13 +8,13 @@ ms.assetid: 5e046c6e-48d9-4740-8c8a-05f3727c1215
 ---
 # `<system_error>`
 
-Include the header \<system_error> to define the exception class `system_error` and related templates for processing low-level system errors.
+Include the header `<system_error>` to define the exception class `system_error` and related templates for processing low-level system errors.
 
 ## Requirements
 
-**Header:** \<system_error>
+**Header:** `<system_error>`
 
-**Namespace:** std
+**Namespace:** `std`
 
 ## Members
 
@@ -22,44 +22,44 @@ Include the header \<system_error> to define the exception class `system_error` 
 
 |Name|Description|
 |-|-|
-|[generic_category](../standard-library/system-error-functions.md#generic_category)|Represents the category for generic errors.|
-|[is_error_code_enum_v](../standard-library/system-error-functions.md#is_error_code_enum_v)||
-|[is_error_condition_enum_v](../standard-library/system-error-functions.md#is_error_condition_enum_v)||
-|[system_category](../standard-library/system-error-functions.md#system_category)|Represents the category for errors caused by low-level system overflows.|
+|[`generic_category`](../standard-library/system-error-functions.md#generic_category)|Represents the category for generic errors.|
+|[`is_error_code_enum_v`](../standard-library/system-error-functions.md#is_error_code_enum_v)||
+|[`is_error_condition_enum_v`](../standard-library/system-error-functions.md#is_error_condition_enum_v)||
+|[`system_category`](../standard-library/system-error-functions.md#system_category)|Represents the category for errors caused by low-level system overflows.|
 
 ### Functions
 
 |Name|Description|
 |-|-|
-|[make_error_code](../standard-library/system-error-functions.md#make_error_code)|Creates an `error_code` object.|
-|[make_error_condition](../standard-library/system-error-functions.md#make_error_condition)|Creates an `error_condition` object.|
+|[`make_error_code`](../standard-library/system-error-functions.md#make_error_code)|Creates an `error_code` object.|
+|[`make_error_condition`](../standard-library/system-error-functions.md#make_error_condition)|Creates an `error_condition` object.|
 
 ### Operators
 
 |Name|Description|
 |-|-|
-|[operator==](../standard-library/system-error-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
-|[operator!=](../standard-library/system-error-operators.md#op_neq)|Tests if the object on the left side of the operator is not equal to the object on the right side.|
-|[operator<](../standard-library/system-error-operators.md#op_lt)|Tests if an object is less than the object passed in for comparison.|
-|[operator<<](../standard-library/system-error-operators.md#op_ostream)||
+|[`operator==`](../standard-library/system-error-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
+|[`operator!=`](../standard-library/system-error-operators.md#op_neq)|Tests if the object on the left side of the operator is not equal to the object on the right side.|
+|[`operator<`](../standard-library/system-error-operators.md#op_lt)|Tests if an object is less than the object passed in for comparison.|
+|[`operator<<`](../standard-library/system-error-operators.md#op_ostream)||
 
 ### Enums
 
 |Name|Description|
 |-|-|
-|[errc](../standard-library/system-error-enums.md#errc)|Provides symbolic names for all the error-code macros defined by POSIX in `<errno.h>`.|
+|[`errc`](../standard-library/system-error-enums.md#errc)|Provides symbolic names for all the error-code macros defined by POSIX in `<errno.h>`.|
 
 ### Classes and Structs
 
 |Name|Description|
 |-|-|
-|[error_category](../standard-library/error-category-class.md)|Represents the abstract, common base for objects that describes a category of error codes.|
-|[error_code](../standard-library/error-code-class.md)|Represents low-level system errors that are implementation-specific.|
-|[error_condition](../standard-library/error-condition-class.md)|Represents user-defined error codes.|
-|[hash](../standard-library/hash-structure.md#system_error)||
-|[is_error_code_enum](../standard-library/is-error-code-enum-class.md)|Represents a type predicate that tests for the [error_code Class](../standard-library/error-code-class.md) enumeration.|
-|[is_error_condition_enum](../standard-library/is-error-condition-enum-class.md)|Represents a type predicate that tests for the [error_condition Class](../standard-library/error-condition-class.md) enumeration.|
-|[system_error](../standard-library/system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system overflow.|
+|[`error_category`](../standard-library/error-category-class.md)|Represents the abstract, common base for objects that describes a category of error codes.|
+|[`error_code`](../standard-library/error-code-class.md)|Represents low-level system errors that are implementation-specific.|
+|[`error_condition`](../standard-library/error-condition-class.md)|Represents user-defined error codes.|
+|[`hash`](../standard-library/hash-structure.md#system_error)||
+|[`is_error_code_enum`](../standard-library/is-error-code-enum-class.md)|Represents a type predicate that tests for the [`error_code` Class](../standard-library/error-code-class.md) enumeration.|
+|[`is_error_condition_enum`](../standard-library/is-error-condition-enum-class.md)|Represents a type predicate that tests for the [`error_condition` Class](../standard-library/error-condition-class.md) enumeration.|
+|[`system_error`](../standard-library/system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system overflow.|
 
 ## See also
 

--- a/docs/standard-library/system-error.md
+++ b/docs/standard-library/system-error.md
@@ -22,45 +22,45 @@ Include the header `<system_error>` to define the exception class `system_error`
 
 |Name|Description|
 |-|-|
-|[`generic_category`](../standard-library/system-error-functions.md#generic_category)|Represents the category for generic errors.|
-|[`is_error_code_enum_v`](../standard-library/system-error-functions.md#is_error_code_enum_v)||
-|[`is_error_condition_enum_v`](../standard-library/system-error-functions.md#is_error_condition_enum_v)||
-|[`system_category`](../standard-library/system-error-functions.md#system_category)|Represents the category for errors caused by low-level system overflows.|
+|[`generic_category`](system-error-functions.md#generic_category)|Represents the category for generic errors.|
+|[`is_error_code_enum_v`](system-error-functions.md#is_error_code_enum_v)||
+|[`is_error_condition_enum_v`](system-error-functions.md#is_error_condition_enum_v)||
+|[`system_category`](system-error-functions.md#system_category)|Represents the category for errors caused by low-level system overflows.|
 
 ### Functions
 
 |Name|Description|
 |-|-|
-|[`make_error_code`](../standard-library/system-error-functions.md#make_error_code)|Creates an `error_code` object.|
-|[`make_error_condition`](../standard-library/system-error-functions.md#make_error_condition)|Creates an `error_condition` object.|
+|[`make_error_code`](system-error-functions.md#make_error_code)|Creates an `error_code` object.|
+|[`make_error_condition`](system-error-functions.md#make_error_condition)|Creates an `error_condition` object.|
 
 ### Operators
 
 |Name|Description|
 |-|-|
-|[`operator==`](../standard-library/system-error-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
-|[`operator!=`](../standard-library/system-error-operators.md#op_neq)|Tests if the object on the left side of the operator is not equal to the object on the right side.|
-|[`operator<`](../standard-library/system-error-operators.md#op_lt)|Tests if an object is less than the object passed in for comparison.|
-|[`operator<<`](../standard-library/system-error-operators.md#op_ostream)||
+|[`operator==`](system-error-operators.md#op_eq_eq)|Tests if the object on the left side of the operator is equal to the object on the right side.|
+|[`operator!=`](system-error-operators.md#op_neq)|Tests if the object on the left side of the operator is not equal to the object on the right side.|
+|[`operator<`](system-error-operators.md#op_lt)|Tests if an object is less than the object passed in for comparison.|
+|[`operator<<`](system-error-operators.md#op_ostream)||
 
 ### Enums
 
 |Name|Description|
 |-|-|
-|[`errc`](../standard-library/system-error-enums.md#errc)|Provides symbolic names for all the error-code macros defined by POSIX in `<errno.h>`.|
+|[`errc`](system-error-enums.md#errc)|Provides symbolic names for all the error-code macros defined by POSIX in `<errno.h>`.|
 
 ### Classes and Structs
 
 |Name|Description|
 |-|-|
-|[`error_category`](../standard-library/error-category-class.md)|Represents the abstract, common base for objects that describes a category of error codes.|
-|[`error_code`](../standard-library/error-code-class.md)|Represents low-level system errors that are implementation-specific.|
-|[`error_condition`](../standard-library/error-condition-class.md)|Represents user-defined error codes.|
-|[`hash`](../standard-library/hash-structure.md#system_error)||
-|[`is_error_code_enum`](../standard-library/is-error-code-enum-class.md)|Represents a type predicate that tests for the [`error_code` Class](../standard-library/error-code-class.md) enumeration.|
-|[`is_error_condition_enum`](../standard-library/is-error-condition-enum-class.md)|Represents a type predicate that tests for the [`error_condition` Class](../standard-library/error-condition-class.md) enumeration.|
-|[`system_error`](../standard-library/system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system overflow.|
+|[`error_category`](error-category-class.md)|Represents the abstract, common base for objects that describes a category of error codes.|
+|[`error_code`](error-code-class.md)|Represents low-level system errors that are implementation-specific.|
+|[`error_condition`](error-condition-class.md)|Represents user-defined error codes.|
+|[`hash`](hash-structure.md#system_error)||
+|[`is_error_code_enum`](is-error-code-enum-class.md)|Represents a type predicate that tests for the [`error_code` Class](error-code-class.md) enumeration.|
+|[`is_error_condition_enum`](is-error-condition-enum-class.md)|Represents a type predicate that tests for the [`error_condition` Class](error-condition-class.md) enumeration.|
+|[`system_error`](system-error-class.md)|Represents the base class for all exceptions thrown to report a low-level system overflow.|
 
 ## See also
 
-[Header Files Reference](../standard-library/cpp-standard-library-header-files.md)
+[Header Files Reference](cpp-standard-library-header-files.md)

--- a/docs/standard-library/system-error.md
+++ b/docs/standard-library/system-error.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: <system_error>"
 title: "<system_error>"
-ms.date: "03/15/2019"
+description: "Learn more about: <system_error>"
+ms.date: 03/15/2019
 f1_keywords: ["<system_error>"]
 helpviewer_keywords: ["system_error header"]
-ms.assetid: 5e046c6e-48d9-4740-8c8a-05f3727c1215
 ---
 # `<system_error>`
 


### PR DESCRIPTION
- Add backticks, simplify redundant relative links, and update metadata
- Add missing descriptions and update some existing ones to match those in the respective topics

Continues work done in #5238, #5239, and #5243.