### PR TITLE
Structure error references in range [C2791, C2820]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
@@ -16,7 +16,7 @@ The keyword [super](../../cpp/super.md) was used within the context of a member 
 
 ## Example
 
-The following sample generates C2791:
+The following example generates C2791:
 
 ```cpp
 // C2791.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
@@ -8,7 +8,7 @@ ms.assetid: 938ad1fb-75d9-4ce2-ad92-83d6249005b5
 ---
 # Compiler Error C2791
 
-illegal use of 'super': 'class' does not have any base classes
+> illegal use of 'super': 'class' does not have any base classes
 
 The keyword [super](../../cpp/super.md) was used within the context of a member function of a class that does not have any base classes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
@@ -10,7 +10,11 @@ ms.assetid: 938ad1fb-75d9-4ce2-ad92-83d6249005b5
 
 > illegal use of 'super': 'class' does not have any base classes
 
+## Remarks
+
 The keyword [super](../../cpp/super.md) was used within the context of a member function of a class that does not have any base classes.
+
+## Example
 
 The following sample generates C2791:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2791.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2791"
 title: "Compiler Error C2791"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2791"
+ms.date: 11/04/2016
 f1_keywords: ["C2791"]
 helpviewer_keywords: ["C2791"]
-ms.assetid: 938ad1fb-75d9-4ce2-ad92-83d6249005b5
 ---
 # Compiler Error C2791
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
@@ -8,7 +8,7 @@ ms.assetid: 392cf748-4f5e-4e62-a364-3118d5658408
 ---
 # Compiler Error C2792
 
-'super' : this keyword must be followed by '::'
+> 'super' : this keyword must be followed by '::'
 
 The only token that can follow the keyword **`__super`** is `::`.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2792"
 title: "Compiler Error C2792"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2792"
+ms.date: 11/04/2016
 f1_keywords: ["C2792"]
 helpviewer_keywords: ["C2792"]
-ms.assetid: 392cf748-4f5e-4e62-a364-3118d5658408
 ---
 # Compiler Error C2792
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
@@ -16,7 +16,7 @@ The only token that can follow the keyword **`__super`** is `::`.
 
 ## Example
 
-The following sample generates C2792:
+The following example generates C2792:
 
 ```cpp
 // C2792.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2792.md
@@ -10,7 +10,11 @@ ms.assetid: 392cf748-4f5e-4e62-a364-3118d5658408
 
 > 'super' : this keyword must be followed by '::'
 
+## Remarks
+
 The only token that can follow the keyword **`__super`** is `::`.
+
+## Example
 
 The following sample generates C2792:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
@@ -16,7 +16,7 @@ The only tokens that can follow `__super::` are an identifier or the keyword **`
 
 ## Example
 
-The following sample generates C2793
+The following example generates C2793
 
 ```cpp
 // C2793.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
@@ -8,7 +8,7 @@ ms.assetid: ce35f4e8-c357-40ca-95c4-15ff001ad69d
 ---
 # Compiler Error C2793
 
-'token' : unexpected token following '::', identifier or keyword 'operator' expected
+> 'token' : unexpected token following '::', identifier or keyword 'operator' expected
 
 The only tokens that can follow `__super::` are an identifier or the keyword **`operator`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2793"
 title: "Compiler Error C2793"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2793"
+ms.date: 11/04/2016
 f1_keywords: ["C2793"]
 helpviewer_keywords: ["C2793"]
-ms.assetid: ce35f4e8-c357-40ca-95c4-15ff001ad69d
 ---
 # Compiler Error C2793
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2793.md
@@ -10,7 +10,11 @@ ms.assetid: ce35f4e8-c357-40ca-95c4-15ff001ad69d
 
 > 'token' : unexpected token following '::', identifier or keyword 'operator' expected
 
+## Remarks
+
 The only tokens that can follow `__super::` are an identifier or the keyword **`operator`**.
+
+## Example
 
 The following sample generates C2793
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
@@ -8,7 +8,7 @@ ms.assetid: d508191c-9044-4c6a-9119-4bca668c0b93
 ---
 # Compiler Error C2794
 
-'function' : is not a member of any direct or indirect base class of 'class'
+> 'function' : is not a member of any direct or indirect base class of 'class'
 
 You tried to use [super](../../cpp/super.md) to call a nonexistent member function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
@@ -16,7 +16,7 @@ You tried to use [super](../../cpp/super.md) to call a nonexistent member functi
 
 ## Example
 
-The following sample generates C2794
+The following example generates C2794
 
 ```cpp
 // C2794.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2794"
 title: "Compiler Error C2794"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2794"
+ms.date: 11/04/2016
 f1_keywords: ["C2794"]
 helpviewer_keywords: ["C2794"]
-ms.assetid: d508191c-9044-4c6a-9119-4bca668c0b93
 ---
 # Compiler Error C2794
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2794.md
@@ -10,7 +10,11 @@ ms.assetid: d508191c-9044-4c6a-9119-4bca668c0b93
 
 > 'function' : is not a member of any direct or indirect base class of 'class'
 
+## Remarks
+
 You tried to use [super](../../cpp/super.md) to call a nonexistent member function.
+
+## Example
 
 The following sample generates C2794
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
@@ -10,4 +10,6 @@ ms.assetid: 8cd8c7fe-2add-4871-85f7-9a6afe4ac588
 
 > 'super::function' is not a member function
 
+## Remarks
+
 This error message appears whenever you try to use [super](../../cpp/super.md) to access a member other than a member function.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2795"
 title: "Compiler Error C2795"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2795"
+ms.date: 11/04/2016
 f1_keywords: ["C2795"]
 helpviewer_keywords: ["C2795"]
-ms.assetid: 8cd8c7fe-2add-4871-85f7-9a6afe4ac588
 ---
 # Compiler Error C2795
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2795.md
@@ -8,6 +8,6 @@ ms.assetid: 8cd8c7fe-2add-4871-85f7-9a6afe4ac588
 ---
 # Compiler Error C2795
 
-'super::function' is not a member function
+> 'super::function' is not a member function
 
 This error message appears whenever you try to use [super](../../cpp/super.md) to access a member other than a member function.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2797"]
 
 > (Obsolete) List initialization inside member initializer list or non-static data member initializer is not implemented.
 
+## Remarks
+
 This warning is obsolete in Visual Studio 2015. In Visual Studio 2013 and earlier versions, the Microsoft C++ compiler does not implement list initialization inside either a member initializer list or a non-static data member initializer. Before Visual Studio 2013 Update 3, this was silently converted to a function call, which could lead to bad code generation. Visual Studio 2013 Update 3 reports this as an error.
+
+## Examples
 
 This example generates C2797:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2797.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2797"]
 ---
 # Compiler Error C2797
 
-(Obsolete) List initialization inside member initializer list or non-static data member initializer is not implemented.
+> (Obsolete) List initialization inside member initializer list or non-static data member initializer is not implemented.
 
 This warning is obsolete in Visual Studio 2015. In Visual Studio 2013 and earlier versions, the Microsoft C++ compiler does not implement list initialization inside either a member initializer list or a non-static data member initializer. Before Visual Studio 2013 Update 3, this was silently converted to a function call, which could lead to bad code generation. Visual Studio 2013 Update 3 reports this as an error.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
@@ -10,11 +10,15 @@ ms.assetid: fb0cd861-b228-4f81-8090-e28344a727e0
 
 > 'super::member' is ambiguous
 
+## Remarks
+
 Multiple inherited structures contain the member you referenced with [super](../../cpp/super.md). You could fix the error by either:
 
 - Removing B1 or B2 from the inheritance list of D.
 
 - Changing the name of the data member in B1 or B2.
+
+## Example
 
 The following sample generates C2798:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
@@ -20,7 +20,7 @@ Multiple inherited structures contain the member you referenced with [super](../
 
 ## Example
 
-The following sample generates C2798:
+The following example generates C2798:
 
 ```cpp
 // C2798.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2798"
 title: "Compiler Error C2798"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2798"
+ms.date: 11/04/2016
 f1_keywords: ["C2798"]
 helpviewer_keywords: ["C2798"]
-ms.assetid: fb0cd861-b228-4f81-8090-e28344a727e0
 ---
 # Compiler Error C2798
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2798.md
@@ -8,7 +8,7 @@ ms.assetid: fb0cd861-b228-4f81-8090-e28344a727e0
 ---
 # Compiler Error C2798
 
-'super::member' is ambiguous
+> 'super::member' is ambiguous
 
 Multiple inherited structures contain the member you referenced with [super](../../cpp/super.md). You could fix the error by either:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2800"
 title: "Compiler Error C2800"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2800"
+ms.date: 11/04/2016
 f1_keywords: ["C2800"]
 helpviewer_keywords: ["C2800"]
-ms.assetid: a2f1a590-9fe6-44cb-ad09-b4505ef47c6a
 ---
 # Compiler Error C2800
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
@@ -16,7 +16,7 @@ The following operators cannot be overloaded: class member access (`.`), pointer
 
 ## Example
 
-The following sample generates C2800:
+The following example generates C2800:
 
 ```cpp
 // C2800.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
@@ -10,7 +10,11 @@ ms.assetid: a2f1a590-9fe6-44cb-ad09-b4505ef47c6a
 
 > 'operator operator' cannot be overloaded
 
+## Remarks
+
 The following operators cannot be overloaded: class member access (`.`), pointer to member (`.*`), scope resolution (`::`), conditional expression (`? :`), and **`sizeof`**.
+
+## Example
 
 The following sample generates C2800:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2800.md
@@ -8,7 +8,7 @@ ms.assetid: a2f1a590-9fe6-44cb-ad09-b4505ef47c6a
 ---
 # Compiler Error C2800
 
-'operator operator' cannot be overloaded
+> 'operator operator' cannot be overloaded
 
 The following operators cannot be overloaded: class member access (`.`), pointer to member (`.*`), scope resolution (`::`), conditional expression (`? :`), and **`sizeof`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2801"
 title: "Compiler Error C2801"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2801"
+ms.date: 11/04/2016
 f1_keywords: ["C2801"]
 helpviewer_keywords: ["C2801"]
-ms.assetid: 35dfc7ea-9e37-4e30-baa1-944dc61302f5
 ---
 # Compiler Error C2801
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
@@ -8,7 +8,7 @@ ms.assetid: 35dfc7ea-9e37-4e30-baa1-944dc61302f5
 ---
 # Compiler Error C2801
 
-'operator operator' must be a non-static member
+> 'operator operator' must be a non-static member
 
 The following operators can be overloaded only as nonstatic members:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
@@ -30,7 +30,7 @@ Possible C2801 causes:
 
 ## Example
 
-- The following sample generates C2801:
+- The following example generates C2801:
 
 ```cpp
 // C2801.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2801.md
@@ -10,6 +10,8 @@ ms.assetid: 35dfc7ea-9e37-4e30-baa1-944dc61302f5
 
 > 'operator operator' must be a non-static member
 
+## Remarks
+
 The following operators can be overloaded only as nonstatic members:
 
 - Assignment `=`
@@ -25,6 +27,8 @@ Possible C2801 causes:
 - Overloaded operator is not a class, structure, or union member.
 
 - Overloaded operator is declared **`static`**.
+
+## Example
 
 - The following sample generates C2801:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2802"
 title: "Compiler Error C2802"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2802"
+ms.date: 11/04/2016
 f1_keywords: ["C2802"]
 helpviewer_keywords: ["C2802"]
-ms.assetid: 08b68c0e-9382-40ac-8949-39a7a2749e05
 ---
 # Compiler Error C2802
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
@@ -16,7 +16,7 @@ An operator declared by a **`static`** member function must have at least one pa
 
 ## Example
 
-The following sample generates C2802:
+The following example generates C2802:
 
 ```cpp
 // C2802.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
@@ -8,7 +8,7 @@ ms.assetid: 08b68c0e-9382-40ac-8949-39a7a2749e05
 ---
 # Compiler Error C2802
 
-static member 'operator operator' has no formal parameters
+> static member 'operator operator' has no formal parameters
 
 An operator declared by a **`static`** member function must have at least one parameter.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2802.md
@@ -10,7 +10,11 @@ ms.assetid: 08b68c0e-9382-40ac-8949-39a7a2749e05
 
 > static member 'operator operator' has no formal parameters
 
+## Remarks
+
 An operator declared by a **`static`** member function must have at least one parameter.
+
+## Example
 
 The following sample generates C2802:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
@@ -8,7 +8,7 @@ ms.assetid: 2cdbe374-8cc4-4c4e-ba15-062a7479e937
 ---
 # Compiler Error C2803
 
-'operator operator' must have at least one formal parameter of class type
+> 'operator operator' must have at least one formal parameter of class type
 
 The overloaded operator lacks a parameter of class type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
@@ -10,11 +10,15 @@ ms.assetid: 2cdbe374-8cc4-4c4e-ba15-062a7479e937
 
 > 'operator operator' must have at least one formal parameter of class type
 
+## Remarks
+
 The overloaded operator lacks a parameter of class type.
 
 You need to pass at least one parameter by reference (not using pointers, but references) or by value to be able to write "a < b" (a and b being of type class A).
 
 If both parameters are pointers it will be a pure comparison of pointer addresses and will not use the user-defined conversion.
+
+## Example
 
 The following sample generates C2803:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
@@ -20,7 +20,7 @@ If both parameters are pointers it will be a pure comparison of pointer addresse
 
 ## Example
 
-The following sample generates C2803:
+The following example generates C2803:
 
 ```cpp
 // C2803.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2803.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2803"
 title: "Compiler Error C2803"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2803"
+ms.date: 11/04/2016
 f1_keywords: ["C2803"]
 helpviewer_keywords: ["C2803"]
-ms.assetid: 2cdbe374-8cc4-4c4e-ba15-062a7479e937
 ---
 # Compiler Error C2803
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2804"
 title: "Compiler Error C2804"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2804"
+ms.date: 11/04/2016
 f1_keywords: ["C2804"]
 helpviewer_keywords: ["C2804"]
-ms.assetid: b066e563-cca4-450c-8ba7-3b0d7a89f3ea
 ---
 # Compiler Error C2804
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
@@ -10,6 +10,8 @@ ms.assetid: b066e563-cca4-450c-8ba7-3b0d7a89f3ea
 
 > binary 'operator operator' has too many parameters
 
+## Remarks
+
 The overloaded binary operator member function is declared with more than one parameter. The first operand parameter of a binary operator member function, whose type is the operator's enclosing type, is implied.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
@@ -8,7 +8,7 @@ ms.assetid: b066e563-cca4-450c-8ba7-3b0d7a89f3ea
 ---
 # Compiler Error C2804
 
-binary 'operator operator' has too many parameters
+> binary 'operator operator' has too many parameters
 
 The overloaded binary operator member function is declared with more than one parameter. The first operand parameter of a binary operator member function, whose type is the operator's enclosing type, is implied.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2804.md
@@ -16,7 +16,7 @@ The overloaded binary operator member function is declared with more than one pa
 
 ## Examples
 
-The following sample generates C2804 and shows how to fix it.
+The following example generates C2804 and shows how to fix it.
 
 ```cpp
 // C2804.cpp
@@ -33,7 +33,7 @@ int main() {
 }
 ```
 
-The following sample generates C2804 and shows how to fix it.
+The following example generates C2804 and shows how to fix it.
 
 ```cpp
 // C2804_2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2805"
 title: "Compiler Error C2805"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2805"
+ms.date: 11/04/2016
 f1_keywords: ["C2805"]
 helpviewer_keywords: ["C2805"]
-ms.assetid: c997dc56-e199-442f-b94e-ac551ec9b015
 ---
 # Compiler Error C2805
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
@@ -16,7 +16,7 @@ The binary operator has no parameters.
 
 ## Example
 
-The following sample generates C2805:
+The following example generates C2805:
 
 ```cpp
 // C2805.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
@@ -10,7 +10,11 @@ ms.assetid: c997dc56-e199-442f-b94e-ac551ec9b015
 
 > binary 'operator operator' has too few parameters
 
+## Remarks
+
 The binary operator has no parameters.
+
+## Example
 
 The following sample generates C2805:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2805.md
@@ -8,7 +8,7 @@ ms.assetid: c997dc56-e199-442f-b94e-ac551ec9b015
 ---
 # Compiler Error C2805
 
-binary 'operator operator' has too few parameters
+> binary 'operator operator' has too few parameters
 
 The binary operator has no parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
@@ -10,7 +10,11 @@ ms.assetid: 7c9ff1f4-1590-4c47-991d-b1075a173b48
 
 > 'operator operator' has too many formal parameters
 
+## Remarks
+
 An overloaded operator has too many parameters.
+
+## Example
 
 The following sample generates C2806:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
@@ -8,7 +8,7 @@ ms.assetid: 7c9ff1f4-1590-4c47-991d-b1075a173b48
 ---
 # Compiler Error C2806
 
-'operator operator' has too many formal parameters
+> 'operator operator' has too many formal parameters
 
 An overloaded operator has too many parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2806"
 title: "Compiler Error C2806"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2806"
+ms.date: 11/04/2016
 f1_keywords: ["C2806"]
 helpviewer_keywords: ["C2806"]
-ms.assetid: 7c9ff1f4-1590-4c47-991d-b1075a173b48
 ---
 # Compiler Error C2806
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2806.md
@@ -16,7 +16,7 @@ An overloaded operator has too many parameters.
 
 ## Example
 
-The following sample generates C2806:
+The following example generates C2806:
 
 ```cpp
 // C2806.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
@@ -16,7 +16,7 @@ The second parameter to a postfix operator has the wrong type.
 
 ## Example
 
-The following sample generates C2807:
+The following example generates C2807:
 
 ```cpp
 // C2807.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
@@ -8,7 +8,7 @@ ms.assetid: bd7a207a-f379-4de6-8ee8-c7cab78b3480
 ---
 # Compiler Error C2807
 
-the second formal parameter to postfix 'operator operator' must be 'int'
+> the second formal parameter to postfix 'operator operator' must be 'int'
 
 The second parameter to a postfix operator has the wrong type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2807"
 title: "Compiler Error C2807"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2807"
+ms.date: 11/04/2016
 f1_keywords: ["C2807"]
 helpviewer_keywords: ["C2807"]
-ms.assetid: bd7a207a-f379-4de6-8ee8-c7cab78b3480
 ---
 # Compiler Error C2807
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2807.md
@@ -10,7 +10,11 @@ ms.assetid: bd7a207a-f379-4de6-8ee8-c7cab78b3480
 
 > the second formal parameter to postfix 'operator operator' must be 'int'
 
+## Remarks
+
 The second parameter to a postfix operator has the wrong type.
+
+## Example
 
 The following sample generates C2807:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
@@ -16,7 +16,7 @@ The unary operator has a nonvoid parameter list.
 
 ## Example
 
-The following sample generates C2808:
+The following example generates C2808:
 
 ```cpp
 // C2808.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2808"
 title: "Compiler Error C2808"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2808"
+ms.date: 11/04/2016
 f1_keywords: ["C2808"]
 helpviewer_keywords: ["C2808"]
-ms.assetid: 3d745102-d3b3-4735-a7d2-ad42d5bf3cfa
 ---
 # Compiler Error C2808
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
@@ -10,7 +10,11 @@ ms.assetid: 3d745102-d3b3-4735-a7d2-ad42d5bf3cfa
 
 > unary 'operator operator' has too many formal parameters
 
+## Remarks
+
 The unary operator has a nonvoid parameter list.
+
+## Example
 
 The following sample generates C2808:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2808.md
@@ -8,7 +8,7 @@ ms.assetid: 3d745102-d3b3-4735-a7d2-ad42d5bf3cfa
 ---
 # Compiler Error C2808
 
-unary 'operator operator' has too many formal parameters
+> unary 'operator operator' has too many formal parameters
 
 The unary operator has a nonvoid parameter list.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2809"
 title: "Compiler Error C2809"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2809"
+ms.date: 11/04/2016
 f1_keywords: ["C2809"]
 helpviewer_keywords: ["C2809"]
-ms.assetid: ce796b8e-1a8c-4074-995d-1ad09afd0e93
 ---
 # Compiler Error C2809
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
@@ -10,7 +10,11 @@ ms.assetid: ce796b8e-1a8c-4074-995d-1ad09afd0e93
 
 > 'operator operator' has no formal parameters
 
+## Remarks
+
 The operator lacks required parameters.
+
+## Example
 
 The following sample generates C2809:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
@@ -8,7 +8,7 @@ ms.assetid: ce796b8e-1a8c-4074-995d-1ad09afd0e93
 ---
 # Compiler Error C2809
 
-'operator operator' has no formal parameters
+> 'operator operator' has no formal parameters
 
 The operator lacks required parameters.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2809.md
@@ -16,7 +16,7 @@ The operator lacks required parameters.
 
 ## Example
 
-The following sample generates C2809:
+The following example generates C2809:
 
 ```cpp
 // C2809.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
@@ -10,7 +10,11 @@ ms.assetid: f63e8f24-d7f6-42ac-904f-72ff49592ba6
 
 > 'interface' : an interface can only inherit from another interface
 
+## Remarks
+
 An [interface](../../cpp/interface.md) may only inherit from another interface and may not inherit from a class or struct.
+
+## Example
 
 The following sample generates C2810:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
@@ -8,7 +8,7 @@ ms.assetid: f63e8f24-d7f6-42ac-904f-72ff49592ba6
 ---
 # Compiler Error C2810
 
-'interface' : an interface can only inherit from another interface
+> 'interface' : an interface can only inherit from another interface
 
 An [interface](../../cpp/interface.md) may only inherit from another interface and may not inherit from a class or struct.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2810"
 title: "Compiler Error C2810"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2810"
+ms.date: 11/04/2016
 f1_keywords: ["C2810"]
 helpviewer_keywords: ["C2810"]
-ms.assetid: f63e8f24-d7f6-42ac-904f-72ff49592ba6
 ---
 # Compiler Error C2810
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2810.md
@@ -16,7 +16,7 @@ An [interface](../../cpp/interface.md) may only inherit from another interface a
 
 ## Example
 
-The following sample generates C2810:
+The following example generates C2810:
 
 ```cpp
 // C2810.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2811"
 title: "Compiler Error C2811"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2811"
+ms.date: 11/04/2016
 f1_keywords: ["C2811"]
 helpviewer_keywords: ["C2811"]
-ms.assetid: 6a44b18e-44c1-49d8-9b99-e0545b9a6e7d
 ---
 # Compiler Error C2811
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
@@ -10,7 +10,11 @@ ms.assetid: 6a44b18e-44c1-49d8-9b99-e0545b9a6e7d
 
 > 'type1' : cannot inherit from 'type2', a ref class can only inherit from a ref class or interface class
 
+## Remarks
+
 You attempted to use an unmanaged class as a base class for a managed class.
+
+## Example
 
 The following sample generates C2811:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
@@ -8,7 +8,7 @@ ms.assetid: 6a44b18e-44c1-49d8-9b99-e0545b9a6e7d
 ---
 # Compiler Error C2811
 
-'type1' : cannot inherit from 'type2', a ref class can only inherit from a ref class or interface class
+> 'type1' : cannot inherit from 'type2', a ref class can only inherit from a ref class or interface class
 
 You attempted to use an unmanaged class as a base class for a managed class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2811.md
@@ -16,7 +16,7 @@ You attempted to use an unmanaged class as a base class for a managed class.
 
 ## Example
 
-The following sample generates C2811:
+The following example generates C2811:
 
 ```cpp
 // C2811.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
@@ -18,7 +18,7 @@ The **/clr:pure** and **/clr:safe** compiler options are deprecated in Visual St
 
 ## Example
 
-The following sample generates C2812.
+The following example generates C2812.
 
 ```cpp
 // C2812.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
@@ -8,7 +8,7 @@ ms.assetid: 22aadb8c-7232-489d-a3ad-60662dda30a8
 ---
 # Compiler Error C2812
 
-> \#import is not supported with /clr:pure and /clr:safe
+> #import is not supported with /clr:pure and /clr:safe
 
 ## Remarks
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2812.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2812"
 title: "Compiler Error C2812"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2812"
+ms.date: 11/04/2016
 f1_keywords: ["C2812"]
 helpviewer_keywords: ["C2812"]
-ms.assetid: 22aadb8c-7232-489d-a3ad-60662dda30a8
 ---
 # Compiler Error C2812
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
@@ -18,7 +18,7 @@ This compiler error and the **/MP** compiler option are new in Visual Studio 200
 
 ## Example
 
-The following sample generates C2813. The command line in the "compile with:" comment indicates to the compiler to use the **/MP** and **/c** compiler options to compile several files. At least one of the files contains the [#import](../../preprocessor/hash-import-directive-cpp.md) directive. We use the same file twice for the sake of testing this example.
+The following example generates C2813. The command line in the "compile with:" comment indicates to the compiler to use the **/MP** and **/c** compiler options to compile several files. At least one of the files contains the [#import](../../preprocessor/hash-import-directive-cpp.md) directive. We use the same file twice for the sake of testing this example.
 
 ```cpp
 // C2813.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
@@ -10,6 +10,8 @@ ms.assetid: 6cf2135f-7b82-42d1-909a-5e864308a09c
 
 > #import is not supported with /MP
 
+## Remarks
+
 C2813 is emitted if in a compiler command you specify the **/MP** compiler option and two or more files to compile, and one or more of the files contains the[#import](../../preprocessor/hash-import-directive-cpp.md) preprocessor directive. The [#import](../../preprocessor/hash-import-directive-cpp.md) directive generates C++ classes from the types in the specified type library, and then writes those classes to two header files. The [#import](../../preprocessor/hash-import-directive-cpp.md) directive is not supported because if multiple compilation units import the same type library, those units conflict when they try to write the same header files at the same time.
 
 This compiler error and the **/MP** compiler option are new in Visual Studio 2008.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2813"
 title: "Compiler Error C2813"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2813"
+ms.date: 11/04/2016
 f1_keywords: ["C2813"]
 helpviewer_keywords: ["C2813"]
-ms.assetid: 6cf2135f-7b82-42d1-909a-5e864308a09c
 ---
 # Compiler Error C2813
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2813.md
@@ -8,7 +8,7 @@ ms.assetid: 6cf2135f-7b82-42d1-909a-5e864308a09c
 ---
 # Compiler Error C2813
 
-\#import is not supported with /MP
+> #import is not supported with /MP
 
 C2813 is emitted if in a compiler command you specify the **/MP** compiler option and two or more files to compile, and one or more of the files contains the[#import](../../preprocessor/hash-import-directive-cpp.md) preprocessor directive. The [#import](../../preprocessor/hash-import-directive-cpp.md) directive generates C++ classes from the types in the specified type library, and then writes those classes to two header files. The [#import](../../preprocessor/hash-import-directive-cpp.md) directive is not supported because if multiple compilation units import the same type library, those units conflict when they try to write the same header files at the same time.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
@@ -8,7 +8,7 @@ ms.assetid: 7d165136-a08b-4497-a76d-60a21bb19404
 ---
 # Compiler Error C2814
 
-'member' : a native type cannot be nested within a managed or WinRT type 'type'
+> 'member' : a native type cannot be nested within a managed or WinRT type 'type'
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2814"
 title: "Compiler Error C2814"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2814"
+ms.date: 11/04/2016
 f1_keywords: ["C2814"]
 helpviewer_keywords: ["C2814"]
-ms.assetid: 7d165136-a08b-4497-a76d-60a21bb19404
 ---
 # Compiler Error C2814
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
@@ -16,7 +16,7 @@ A native type cannot be nested in a CLR or WinRT type.
 
 ## Example
 
-The following sample generates C2814 and shows how to fix it.
+The following example generates C2814 and shows how to fix it.
 
 ```cpp
 // C2814.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2814.md
@@ -10,9 +10,13 @@ ms.assetid: 7d165136-a08b-4497-a76d-60a21bb19404
 
 > 'member' : a native type cannot be nested within a managed or WinRT type 'type'
 
+## Remarks
+
+A native type cannot be nested in a CLR or WinRT type.
+
 ## Example
 
-A native type cannot be nested in a CLR or WinRT type. The following sample generates C2814 and shows how to fix it.
+The following sample generates C2814 and shows how to fix it.
 
 ```cpp
 // C2814.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
@@ -8,7 +8,7 @@ ms.assetid: d0256fd6-0721-4c99-b03c-52d96e77a613
 ---
 # Compiler Error C2815
 
-'operator delete' : first formal parameter must be 'void *', but 'param' was used
+> 'operator delete' : first formal parameter must be 'void *', but 'param' was used
 
 Any user-defined [operator delete](../../standard-library/new-operators.md#op_delete) function must take a first formal parameter of type `void *`.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2815"
 title: "Compiler Error C2815"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2815"
+ms.date: 11/04/2016
 f1_keywords: ["C2815"]
 helpviewer_keywords: ["C2815"]
-ms.assetid: d0256fd6-0721-4c99-b03c-52d96e77a613
 ---
 # Compiler Error C2815
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
@@ -10,7 +10,11 @@ ms.assetid: d0256fd6-0721-4c99-b03c-52d96e77a613
 
 > 'operator delete' : first formal parameter must be 'void *', but 'param' was used
 
+## Remarks
+
 Any user-defined [operator delete](../../standard-library/new-operators.md#op_delete) function must take a first formal parameter of type `void *`.
+
+## Example
 
 The following sample generates C2815:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2815.md
@@ -16,7 +16,7 @@ Any user-defined [operator delete](../../standard-library/new-operators.md#op_de
 
 ## Example
 
-The following sample generates C2815:
+The following example generates C2815:
 
 ```cpp
 // C2815.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
@@ -10,4 +10,6 @@ ms.assetid: bca2e55a-8d86-4ddf-ba2b-4568f3bb776e
 
 > return type for 'operator delete' must be 'void'
 
+## Remarks
+
 An overloaded [operator delete](../../standard-library/new-operators.md#op_delete) function cannot return a value.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2817"
 title: "Compiler Error C2817"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2817"
+ms.date: 11/04/2016
 f1_keywords: ["C2817"]
 helpviewer_keywords: ["C2817"]
-ms.assetid: bca2e55a-8d86-4ddf-ba2b-4568f3bb776e
 ---
 # Compiler Error C2817
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2817.md
@@ -8,6 +8,6 @@ ms.assetid: bca2e55a-8d86-4ddf-ba2b-4568f3bb776e
 ---
 # Compiler Error C2817
 
-return type for 'operator delete' must be 'void'
+> return type for 'operator delete' must be 'void'
 
 An overloaded [operator delete](../../standard-library/new-operators.md#op_delete) function cannot return a value.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2818"
 title: "Compiler Error C2818"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2818"
+ms.date: 11/04/2016
 f1_keywords: ["C2818"]
 helpviewer_keywords: ["C2818"]
-ms.assetid: 715fc7c9-0c6d-452b-b7f5-1682cea5e907
 ---
 # Compiler Error C2818
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
@@ -10,4 +10,6 @@ ms.assetid: 715fc7c9-0c6d-452b-b7f5-1682cea5e907
 
 > application of overloaded 'operator ->' is recursive through type 'type'
 
+## Remarks
+
 A redefinition of the class member access operator contains a recursive **`return`** statement. To redefine the `->` operator with recursion, you must move the recursive routine to a separate function called from the operator override function.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2818.md
@@ -8,6 +8,6 @@ ms.assetid: 715fc7c9-0c6d-452b-b7f5-1682cea5e907
 ---
 # Compiler Error C2818
 
-application of overloaded 'operator ->' is recursive through type 'type'
+> application of overloaded 'operator ->' is recursive through type 'type'
 
 A redefinition of the class member access operator contains a recursive **`return`** statement. To redefine the `->` operator with recursion, you must move the recursive routine to a separate function called from the operator override function.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
@@ -10,7 +10,11 @@ ms.assetid: fcc7762d-cb82-4bb1-a715-0d82da832edf
 
 > type 'type' does not have an overloaded member 'operator ->'
 
+## Remarks
+
 You need to define `operator->()` to use this pointer operation.
+
+## Examples
 
 The following sample generates C2819:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2819"
 title: "Compiler Error C2819"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2819"
+ms.date: 11/04/2016
 f1_keywords: ["C2819"]
 helpviewer_keywords: ["C2819"]
-ms.assetid: fcc7762d-cb82-4bb1-a715-0d82da832edf
 ---
 # Compiler Error C2819
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
@@ -16,7 +16,7 @@ You need to define `operator->()` to use this pointer operation.
 
 ## Examples
 
-The following sample generates C2819:
+The following example generates C2819:
 
 ```cpp
 // C2819.cpp
@@ -46,7 +46,7 @@ void F(D j) {
 }
 ```
 
-C2819 can also occur when using [C++ Stack Semantics for Reference Types](../../dotnet/cpp-stack-semantics-for-reference-types.md). The following sample generates C2819:
+C2819 can also occur when using [C++ Stack Semantics for Reference Types](../../dotnet/cpp-stack-semantics-for-reference-types.md). The following example generates C2819:
 
 ```cpp
 // C2819_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2819.md
@@ -8,7 +8,7 @@ ms.assetid: fcc7762d-cb82-4bb1-a715-0d82da832edf
 ---
 # Compiler Error C2819
 
-type 'type' does not have an overloaded member 'operator ->'
+> type 'type' does not have an overloaded member 'operator ->'
 
 You need to define `operator->()` to use this pointer operation.
 


### PR DESCRIPTION
This is batch 39 that structures error/warning references. See #5465 for more information.