### PR TITLE
Fix error in example and update `_vcprintf_p` reference

### DIFF
--- a/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
+++ b/docs/c-runtime-library/reference/vcprintf-p-vcprintf-p-l-vcwprintf-p-vcwprintf-p-l.md
@@ -101,18 +101,18 @@ For more compatibility information, see [Compatibility](../compatibility.md).
 // An error formatting function that's used to print to the console.
 int eprintf(const char* format, ...)
 {
-   va_list args;
-   va_start(args, format);
-   int result = _vcprintf_p(format, args);
-   va_end(args);
-   return result;
+    va_list args;
+    va_start(args, format);
+    int result = _vcprintf_p(format, args);
+    va_end(args);
+    return result;
 }
 
 int main()
 {
-   int n = eprintf("parameter 2 = %2$d; parameter 1 = %1$s\r\n",
-      "one", 222);
-   _cprintf_s("%d characters printed\r\n", n);
+    int n = eprintf("parameter 2 = %2$d; parameter 1 = %1$s\r\n",
+        "one", 222);
+    _cprintf_s("%d characters printed\r\n", n);
 }
 ```
 


### PR DESCRIPTION
- Add missing integer argument to `_cprintf_s` call in the example
- Add backticks, update "`printf_p` positional parameters" link text (match casing with heading in said topic), and normalize example indent to 4 spaces