### PR TITLE
Fix and update "C++ Conformance improvements, behavior changes, and bug fixes in Visual Studio 2019"

### DIFF
--- a/docs/overview/cpp-conformance-improvements-2019.md
+++ b/docs/overview/cpp-conformance-improvements-2019.md
@@ -579,8 +579,8 @@ int main()
     // The conversion from 'E' to the fixed underlying type 'unsigned char' is better than the
     // conversion from 'E' to the promoted type 'unsigned int'.
     f(e);
-  
-    // Error C2666. This call is ambiguous, but previously called f(unsigned int, const B&). 
+
+    // Error C2666. This call is ambiguous, but previously called f(unsigned int, const B&).
     f(e, B{});
 }
 ```
@@ -885,7 +885,7 @@ The non-standard headers \<stdexcpt.h> and \<typeinfo.h> have been removed. Code
 
 Two-phase name lookup requires that non-dependent names used in template bodies must be visible to the template at definition time. Previously, such names may have been found when the template is instantiated. This change makes it easier to write portable and conforming code in MSVC under the [`/permissive-`](../build/reference/permissive-standards-conformance.md) flag.
 
-In Visual Studio 2019 version 16.4 with the **`/permissive-`**  flag set, the following example produces an error, because `N::f` isn't visible when the `f<T>` template is defined:
+In Visual Studio 2019 version 16.4 with the **`/permissive-`** flag set, the following example produces an error, because `N::f` isn't visible when the `f<T>` template is defined:
 
 ```cpp
 template <class T>
@@ -1424,7 +1424,7 @@ In Visual Studio 2019 version 16.6 and later, the behavior of **`typedef`** decl
 
 The same restrictions are applied recursively to each nested class. The restriction is meant to ensure the simplicity of structs that have **`typedef`** names for linkage purposes. They must be simple enough that no linkage calculations are necessary before the compiler gets to the **`typedef`** name for linkage.
 
-This change affects all standards modes of the compiler. In default (**`/std:c++14`**) and  **`/std:c++17`** modes, the compiler emits warning C5208 for non-conforming code. If **`/permissive-`** is specified, the compiler emits warning C5208 as an error under **`/std:c++14`** and emits error C7626 under **`/std:c++17`**. The compiler emits error C7626 for non-conforming code when **`/std:c++20`** or **`/std:c++latest`** is specified.
+This change affects all standards modes of the compiler. In default (**`/std:c++14`**) and **`/std:c++17`** modes, the compiler emits warning C5208 for non-conforming code. If **`/permissive-`** is specified, the compiler emits warning C5208 as an error under **`/std:c++14`** and emits error C7626 under **`/std:c++17`**. The compiler emits error C7626 for non-conforming code when **`/std:c++20`** or **`/std:c++latest`** is specified.
 
 The following sample shows the constructs that are no longer allowed in unnamed structs. Depending on the standards mode specified, C5208 or C7626 errors or warnings are emitted:
 
@@ -2101,7 +2101,7 @@ The update may change program behavior that relied on an introduced temporary:
 int func() {
     int i1 = 13;
     int i2 = 23;
-    
+
     int* iptr = &i1;
     int const * const&  iptrcref = iptr;
 
@@ -2110,7 +2110,7 @@ int func() {
     {
         return 1;
     }
-    
+
     // Now change what iptr points to.
 
     // Prior to CWG 2352 iptrcref should be bound to a temporary and still points to the value 13.
@@ -2151,7 +2151,7 @@ class B {
 
 template <typename T>
 B<T>::~B() { /* ... */ } // Before: no diagnostic.
-// Now diagnoses a definition mismatch. To fix, define the implementation by 
+// Now diagnoses a definition mismatch. To fix, define the implementation by
 // using the same noexcept-specifier. For example,
 // B<T>::~B() noexcept { /* ... */ }
 ```
@@ -2254,7 +2254,7 @@ Earlier versions of the compiler would incorrectly convert the argument of `f` f
 This change can also correct the chosen overload in some other situations:
 
 ```cpp
-struct Base 
+struct Base
 {
     operator char *();
 };


### PR DESCRIPTION
- Remove rogue semicolon in LWG 2729 link text
- Fix wrong error code in "Effect of defining spaceship operator on `==` and `!=`" subsection
- Add missing period character and format note alert
- Clean up double and trailing spaces