### PR TITLE
Structure error references in range [C2881, C2910]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2881"
 title: "Compiler Error C2881"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2881"
+ms.date: 11/04/2016
 f1_keywords: ["C2881"]
 helpviewer_keywords: ["C2881"]
-ms.assetid: b49c63c2-b064-4d4b-a75e-ddd2af947522
 ---
 # Compiler Error C2881
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
@@ -10,7 +10,11 @@ ms.assetid: b49c63c2-b064-4d4b-a75e-ddd2af947522
 
 > 'namespace1' : is already used as an alias for 'namespace2'
 
+## Remarks
+
 You cannot use the same name as an alias for two namespaces.
+
+## Example
 
 The following sample generates C2881:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
@@ -8,7 +8,7 @@ ms.assetid: b49c63c2-b064-4d4b-a75e-ddd2af947522
 ---
 # Compiler Error C2881
 
-'namespace1' : is already used as an alias for 'namespace2'
+> 'namespace1' : is already used as an alias for 'namespace2'
 
 You cannot use the same name as an alias for two namespaces.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2881.md
@@ -16,7 +16,7 @@ You cannot use the same name as an alias for two namespaces.
 
 ## Example
 
-The following sample generates C2881:
+The following example generates C2881:
 
 ```cpp
 // C2881.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
@@ -10,7 +10,11 @@ ms.assetid: 617018ee-5a0d-4b8d-9612-77e8ae52679b
 
 > 'name' : illegal use of namespace identifier in expression
 
+## Remarks
+
 You tried to use the name of a namespace in an expression.
+
+## Example
 
 The following sample generates C2882:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2882"
 title: "Compiler Error C2882"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2882"
+ms.date: 11/04/2016
 f1_keywords: ["C2882"]
 helpviewer_keywords: ["C2882"]
-ms.assetid: 617018ee-5a0d-4b8d-9612-77e8ae52679b
 ---
 # Compiler Error C2882
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
@@ -16,7 +16,7 @@ You tried to use the name of a namespace in an expression.
 
 ## Example
 
-The following sample generates C2882:
+The following example generates C2882:
 
 ```cpp
 // C2882.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2882.md
@@ -8,7 +8,7 @@ ms.assetid: 617018ee-5a0d-4b8d-9612-77e8ae52679b
 ---
 # Compiler Error C2882
 
-'name' : illegal use of namespace identifier in expression
+> 'name' : illegal use of namespace identifier in expression
 
 You tried to use the name of a namespace in an expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
@@ -8,7 +8,7 @@ ms.assetid: 5c6d689d-ed42-41ad-b5c0-e9c2e0b8c356
 ---
 # Compiler Error C2883
 
-'name' : function declaration conflicts with 'identifier' introduced by using-declaration
+> 'name' : function declaration conflicts with 'identifier' introduced by using-declaration
 
 You tried to define a function more than once. The first definition was made from a namespace with a **`using`** declaration. The second was a local definition.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2883"
 title: "Compiler Error C2883"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2883"
+ms.date: 11/04/2016
 f1_keywords: ["C2883"]
 helpviewer_keywords: ["C2883"]
-ms.assetid: 5c6d689d-ed42-41ad-b5c0-e9c2e0b8c356
 ---
 # Compiler Error C2883
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
@@ -10,7 +10,11 @@ ms.assetid: 5c6d689d-ed42-41ad-b5c0-e9c2e0b8c356
 
 > 'name' : function declaration conflicts with 'identifier' introduced by using-declaration
 
+## Remarks
+
 You tried to define a function more than once. The first definition was made from a namespace with a **`using`** declaration. The second was a local definition.
+
+## Example
 
 The following sample generates C2883:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2883.md
@@ -16,7 +16,7 @@ You tried to define a function more than once. The first definition was made fro
 
 ## Example
 
-The following sample generates C2883:
+The following example generates C2883:
 
 ```cpp
 // C2883.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2884"
 title: "Compiler Error C2884"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2884"
+ms.date: 11/04/2016
 f1_keywords: ["C2884"]
 helpviewer_keywords: ["C2884"]
-ms.assetid: 8b4d43e3-3fb5-4360-86c8-de59d8736d4f
 ---
 # Compiler Error C2884
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
@@ -10,7 +10,11 @@ ms.assetid: 8b4d43e3-3fb5-4360-86c8-de59d8736d4f
 
 > 'name' : introduced by using-declaration conflicts with local function 'function'
 
+## Remarks
+
 You tried to define a function more than once. The first definition is a local definition. The second is from a namespace with a **`using`** declaration.
+
+## Example
 
 The following sample generates C2884:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
@@ -8,7 +8,7 @@ ms.assetid: 8b4d43e3-3fb5-4360-86c8-de59d8736d4f
 ---
 # Compiler Error C2884
 
-'name' : introduced by using-declaration conflicts with local function 'function'
+> 'name' : introduced by using-declaration conflicts with local function 'function'
 
 You tried to define a function more than once. The first definition is a local definition. The second is from a namespace with a **`using`** declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2884.md
@@ -16,7 +16,7 @@ You tried to define a function more than once. The first definition is a local d
 
 ## Example
 
-The following sample generates C2884:
+The following example generates C2884:
 
 ```cpp
 // C2884.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2885"
 title: "Compiler Error C2885"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2885"
+ms.date: 11/04/2016
 f1_keywords: ["C2885"]
 helpviewer_keywords: ["C2885"]
-ms.assetid: 7743e5f3-a034-44b4-9ee8-5a6254c27f8c
 ---
 # Compiler Error C2885
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
@@ -18,7 +18,7 @@ This error can be generated as a result of compiler conformance work that was do
 
 ## Examples
 
-The following sample generates C2885.
+The following example generates C2885.
 
 ```cpp
 // C2885.cpp
@@ -49,7 +49,7 @@ int main () {
 
 If you use the **`using`** keyword with a class member, C++ requires you to define that member inside another class (a derived class).
 
-The following sample generates C2885.
+The following example generates C2885.
 
 ```cpp
 // C2885_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
@@ -10,6 +10,8 @@ ms.assetid: 7743e5f3-a034-44b4-9ee8-5a6254c27f8c
 
 > 'class::identifier' : not a valid using-declaration at non-class scope
 
+## Remarks
+
 You used a [using](../../cpp/using-declaration.md) declaration incorrectly.
 
 This error can be generated as a result of compiler conformance work that was done for Visual Studio 2005: it is no longer valid to have a **`using`** declaration to a nested type; you must explicitly qualify each reference you make to the nested type, put the type in a namespace, or create a typedef.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2885.md
@@ -8,7 +8,7 @@ ms.assetid: 7743e5f3-a034-44b4-9ee8-5a6254c27f8c
 ---
 # Compiler Error C2885
 
-'class::identifier' : not a valid using-declaration at non-class scope
+> 'class::identifier' : not a valid using-declaration at non-class scope
 
 You used a [using](../../cpp/using-declaration.md) declaration incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2886"
 title: "Compiler Error C2886"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2886"
+ms.date: 11/04/2016
 f1_keywords: ["C2886"]
 helpviewer_keywords: ["C2886"]
-ms.assetid: c01588a1-484c-4dc9-a3f1-f900c6e44543
 ---
 # Compiler Error C2886
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
@@ -8,7 +8,7 @@ ms.assetid: c01588a1-484c-4dc9-a3f1-f900c6e44543
 ---
 # Compiler Error C2886
 
-'class::identifier' : symbol cannot be used in a member using-declaration
+> 'class::identifier' : symbol cannot be used in a member using-declaration
 
 A **`using`** declaration uses a symbol, such as a namespace name. A **`using`** declaration is for declaring base class members.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
@@ -16,7 +16,7 @@ A **`using`** declaration uses a symbol, such as a namespace name. A **`using`**
 
 ## Example
 
-The following sample generates C2886:
+The following example generates C2886:
 
 ```cpp
 // C2886.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2886.md
@@ -10,7 +10,11 @@ ms.assetid: c01588a1-484c-4dc9-a3f1-f900c6e44543
 
 > 'class::identifier' : symbol cannot be used in a member using-declaration
 
+## Remarks
+
 A **`using`** declaration uses a symbol, such as a namespace name. A **`using`** declaration is for declaring base class members.
+
+## Example
 
 The following sample generates C2886:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C2888"]
 
 > 'identifier' : symbol cannot be defined within namespace 'namespace'
 
+## Remarks
+
 A symbol belonging to namespace A must be defined in a namespace that encloses A.
+
+## Example
 
 The following sample generates C2888:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2888"]
 ---
 # Compiler Error C2888
 
-'identifier' : symbol cannot be defined within namespace 'namespace'
+> 'identifier' : symbol cannot be defined within namespace 'namespace'
 
 A symbol belonging to namespace A must be defined in a namespace that encloses A.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2888.md
@@ -15,7 +15,7 @@ A symbol belonging to namespace A must be defined in a namespace that encloses A
 
 ## Example
 
-The following sample generates C2888:
+The following example generates C2888:
 
 ```cpp
 // C2888.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2890"
 title: "Compiler Error C2890"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2890"
+ms.date: 11/04/2016
 f1_keywords: ["C2890"]
 helpviewer_keywords: ["C2890"]
-ms.assetid: 49147375-182c-42b1-b170-f475cd436d47
 ---
 # Compiler Error C2890
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
@@ -16,7 +16,7 @@ A reference class can only have one base class.
 
 ## Example
 
-The following sample generates C2890:
+The following example generates C2890:
 
 ```cpp
 // C2890.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
@@ -10,7 +10,11 @@ ms.assetid: 49147375-182c-42b1-b170-f475cd436d47
 
 > 'class' : a ref class can only have one non-interface base class
 
+## Remarks
+
 A reference class can only have one base class.
+
+## Example
 
 The following sample generates C2890:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2890.md
@@ -8,7 +8,7 @@ ms.assetid: 49147375-182c-42b1-b170-f475cd436d47
 ---
 # Compiler Error C2890
 
-'class' : a ref class can only have one non-interface base class
+> 'class' : a ref class can only have one non-interface base class
 
 A reference class can only have one base class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2891"]
 ---
 # Compiler Error C2891
 
-'parameter' : cannot take the address of a template parameter
+> 'parameter' : cannot take the address of a template parameter
 
 You can't take the address of a template parameter unless it is an lvalue. Type parameters are not lvalues because they have no address. Non-type values in template parameter lists that are not lvalues also do not have an address. This is an example of code that causes Compiler Error C2891, because the value passed as the template parameter is a compiler-generated copy of the template argument.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2891.md
@@ -9,7 +9,13 @@ helpviewer_keywords: ["C2891"]
 
 > 'parameter' : cannot take the address of a template parameter
 
-You can't take the address of a template parameter unless it is an lvalue. Type parameters are not lvalues because they have no address. Non-type values in template parameter lists that are not lvalues also do not have an address. This is an example of code that causes Compiler Error C2891, because the value passed as the template parameter is a compiler-generated copy of the template argument.
+## Remarks
+
+You can't take the address of a template parameter unless it is an lvalue. Type parameters are not lvalues because they have no address. Non-type values in template parameter lists that are not lvalues also do not have an address.
+
+## Example
+
+This is an example of code that causes Compiler Error C2891, because the value passed as the template parameter is a compiler-generated copy of the template argument.
 
 ```cpp
 template <int i> int* f() { return &i; }

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
@@ -8,7 +8,7 @@ ms.assetid: c22a5084-2f50-42c2-a56b-6dfe5442edc9
 ---
 # Compiler Error C2892
 
-local class shall not have member templates
+> local class shall not have member templates
 
 Templated member functions are not valid in a class that is defined in a function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2892"
 title: "Compiler Error C2892"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2892"
+ms.date: 11/04/2016
 f1_keywords: ["C2892"]
 helpviewer_keywords: ["C2892"]
-ms.assetid: c22a5084-2f50-42c2-a56b-6dfe5442edc9
 ---
 # Compiler Error C2892
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
@@ -10,7 +10,11 @@ ms.assetid: c22a5084-2f50-42c2-a56b-6dfe5442edc9
 
 > local class shall not have member templates
 
+## Remarks
+
 Templated member functions are not valid in a class that is defined in a function.
+
+## Example
 
 The following sample generates C2892:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2892.md
@@ -16,7 +16,7 @@ Templated member functions are not valid in a class that is defined in a functio
 
 ## Example
 
-The following sample generates C2892:
+The following example generates C2892:
 
 ```cpp
 // C2892.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2893"]
 ---
 # Compiler Error C2893
 
-Failed to specialize function template 'template name'
+> Failed to specialize function template 'template name'
 
 The compiler failed to specialize a function template. There can be many causes for this error.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2893"
 description: "Learn more about: Compiler Error C2893"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["C2893"]
 helpviewer_keywords: ["C2893"]
 ---

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C2893"]
 
 > Failed to specialize function template 'template name'
 
+## Remarks
+
 The compiler failed to specialize a function template. There can be many causes for this error.
 
 In general, the way to resolve a C2893 error is to review the function's signature and make sure you can instantiate every type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2893.md
@@ -17,7 +17,7 @@ In general, the way to resolve a C2893 error is to review the function's signatu
 
 ## Example
 
-C2893 occurs because `f`'s template parameter `T` is deduced to be `std::map<int,int>`, but `std::map<int,int>` has no member `data_type` (`T::data_type` can not be instantiated with `T = std::map<int,int>`.). The following sample generates C2893.
+C2893 occurs because `f`'s template parameter `T` is deduced to be `std::map<int,int>`, but `std::map<int,int>` has no member `data_type` (`T::data_type` can not be instantiated with `T = std::map<int,int>`.). The following example generates C2893.
 
 ```cpp
 // C2893.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2894"
 title: "Compiler Error C2894"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2894"
+ms.date: 11/04/2016
 f1_keywords: ["C2894"]
 helpviewer_keywords: ["C2894"]
-ms.assetid: 4e250579-2b59-4993-a6f4-49273e7ecf06
 ---
 # Compiler Error C2894
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
@@ -16,7 +16,7 @@ This error can be caused by a template defined inside an `extern "C"` block.
 
 ## Examples
 
-The following sample generates C2894:
+The following example generates C2894:
 
 ```cpp
 // C2894.cpp
@@ -27,7 +27,7 @@ extern "C" {
 }
 ```
 
-The following sample generates C2894:
+The following example generates C2894:
 
 ```cpp
 // C2894b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
@@ -10,7 +10,11 @@ ms.assetid: 4e250579-2b59-4993-a6f4-49273e7ecf06
 
 > templates cannot be declared to have 'C' linkage
 
+## Remarks
+
 This error can be caused by a template defined inside an `extern "C"` block.
+
+## Examples
 
 The following sample generates C2894:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2894.md
@@ -8,7 +8,7 @@ ms.assetid: 4e250579-2b59-4993-a6f4-49273e7ecf06
 ---
 # Compiler Error C2894
 
-templates cannot be declared to have 'C' linkage
+> templates cannot be declared to have 'C' linkage
 
 This error can be caused by a template defined inside an `extern "C"` block.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
@@ -10,9 +10,13 @@ ms.assetid: b600407b-cb05-42e3-9069-2aa6960f0eaa
 
 > '*function1*' : cannot use function template '*function2*' as argument
 
+## Remarks
+
 A function template can't be an argument to another function template.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2896:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2896"
 title: "Compiler Error C2896"
+description: "Learn more about: Compiler Error C2896"
 ms.date: 06/01/2022
 f1_keywords: ["C2896"]
 helpviewer_keywords: ["C2896"]
-ms.assetid: b600407b-cb05-42e3-9069-2aa6960f0eaa
 ---
 # Compiler Error C2896
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2896.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2896:
+The following example generates C2896:
 
 ```cpp
 // C2896.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
@@ -16,7 +16,7 @@ Destructors or finalizers cannot be overloaded, so declaring a destructor as a t
 
 ## Examples
 
-The following sample generates C2897.
+The following example generates C2897.
 
 ```cpp
 // C2897.cpp
@@ -27,7 +27,7 @@ public:
 };
 ```
 
-The following sample generates C2897.
+The following example generates C2897.
 
 ```cpp
 // C2897_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
@@ -8,7 +8,7 @@ ms.assetid: a88349e2-823f-42a0-8660-0653b677afa4
 ---
 # Compiler Error C2897
 
-a destructor/finalizer cannot be a function template
+> a destructor/finalizer cannot be a function template
 
 Destructors or finalizers cannot be overloaded, so declaring a destructor as a template (which would define a set of destructors) is not allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
@@ -10,6 +10,8 @@ ms.assetid: a88349e2-823f-42a0-8660-0653b677afa4
 
 > a destructor/finalizer cannot be a function template
 
+## Remarks
+
 Destructors or finalizers cannot be overloaded, so declaring a destructor as a template (which would define a set of destructors) is not allowed.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2897.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2897"
 title: "Compiler Error C2897"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2897"
+ms.date: 11/04/2016
 f1_keywords: ["C2897"]
 helpviewer_keywords: ["C2897"]
-ms.assetid: a88349e2-823f-42a0-8660-0653b677afa4
 ---
 # Compiler Error C2897
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
@@ -8,7 +8,7 @@ ms.assetid: 68466e11-2541-4f6b-b772-13a642f30dfb
 ---
 # Compiler Error C2898
 
-'declaration' : member function templates cannot be virtual
+> 'declaration' : member function templates cannot be virtual
 
 The following sample generates C2898:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
@@ -10,6 +10,8 @@ ms.assetid: 68466e11-2541-4f6b-b772-13a642f30dfb
 
 > 'declaration' : member function templates cannot be virtual
 
+## Example
+
 The following sample generates C2898:
 
 ```cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2898"
 title: "Compiler Error C2898"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2898"
+ms.date: 11/04/2016
 f1_keywords: ["C2898"]
 helpviewer_keywords: ["C2898"]
-ms.assetid: 68466e11-2541-4f6b-b772-13a642f30dfb
 ---
 # Compiler Error C2898
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2898.md
@@ -12,7 +12,7 @@ ms.assetid: 68466e11-2541-4f6b-b772-13a642f30dfb
 
 ## Example
 
-The following sample generates C2898:
+The following example generates C2898:
 
 ```cpp
 // C2898.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
@@ -10,9 +10,13 @@ ms.assetid: 89d78d0e-78e5-4c2c-a0f9-a60110e9395e
 
 > '*token*' : unexpected token following '*template*', identifier expected
 
+## Remarks
+
 The token following the keyword **`template`** was not an identifier.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2902:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2902"
 title: "Compiler Error C2902"
+description: "Learn more about: Compiler Error C2902"
 ms.date: 06/01/2022
 f1_keywords: ["C2902"]
 helpviewer_keywords: ["C2902"]
-ms.assetid: 89d78d0e-78e5-4c2c-a0f9-a60110e9395e
 ---
 # Compiler Error C2902
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2902.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2902:
+The following example generates C2902:
 
 ```cpp
 // C2902.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
@@ -10,7 +10,11 @@ ms.assetid: bf6b223f-4921-48c7-82b9-ff318b42c801
 
 > 'identifier' : symbol is neither a class template nor a function template
 
+## Remarks
+
 Code attempts explicit instantiation of something that is not a template.
+
+## Examples
 
 The following sample generates C2903:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
@@ -8,7 +8,7 @@ ms.assetid: bf6b223f-4921-48c7-82b9-ff318b42c801
 ---
 # Compiler Error C2903
 
-'identifier' : symbol is neither a class template nor a function template
+> 'identifier' : symbol is neither a class template nor a function template
 
 Code attempts explicit instantiation of something that is not a template.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
@@ -16,7 +16,7 @@ Code attempts explicit instantiation of something that is not a template.
 
 ## Examples
 
-The following sample generates C2903:
+The following example generates C2903:
 
 ```cpp
 // C2903.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2903.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2903"
 title: "Compiler Error C2903"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2903"
+ms.date: 11/04/2016
 f1_keywords: ["C2903"]
 helpviewer_keywords: ["C2903"]
-ms.assetid: bf6b223f-4921-48c7-82b9-ff318b42c801
 ---
 # Compiler Error C2903
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
@@ -10,7 +10,11 @@ ms.assetid: d5802f2e-d3fc-473d-aa04-36957b4eaca5
 
 > 'identifier' : name already used for a template in the current scope
 
+## Remarks
+
 Check the code for duplicate names.
+
+## Example
 
 The following sample generates C2904:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
@@ -16,7 +16,7 @@ Check the code for duplicate names.
 
 ## Example
 
-The following sample generates C2904:
+The following example generates C2904:
 
 ```cpp
 // C2904.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
@@ -8,7 +8,7 @@ ms.assetid: d5802f2e-d3fc-473d-aa04-36957b4eaca5
 ---
 # Compiler Error C2904
 
-'identifier' : name already used for a template in the current scope
+> 'identifier' : name already used for a template in the current scope
 
 Check the code for duplicate names.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2904.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2904"
 title: "Compiler Error C2904"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2904"
+ms.date: 11/04/2016
 f1_keywords: ["C2904"]
 helpviewer_keywords: ["C2904"]
-ms.assetid: d5802f2e-d3fc-473d-aa04-36957b4eaca5
 ---
 # Compiler Error C2904
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
@@ -16,7 +16,7 @@ You must use the new syntax for explicit specialization of templates.
 
 ## Example
 
-The following sample generates C2906:
+The following example generates C2906:
 
 ```cpp
 // C2906.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2906"
 title: "Compiler Error C2906"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2906"
+ms.date: 11/04/2016
 f1_keywords: ["C2906"]
 helpviewer_keywords: ["C2906"]
-ms.assetid: 30f652f1-6af6-4a2f-a69e-a1a4876cc8c6
 ---
 # Compiler Error C2906
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
@@ -8,7 +8,7 @@ ms.assetid: 30f652f1-6af6-4a2f-a69e-a1a4876cc8c6
 ---
 # Compiler Error C2906
 
-'specialization' : explicit specialization requires 'template <>'
+> 'specialization' : explicit specialization requires 'template <>'
 
 You must use the new syntax for explicit specialization of templates.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2906.md
@@ -10,7 +10,11 @@ ms.assetid: 30f652f1-6af6-4a2f-a69e-a1a4876cc8c6
 
 > 'specialization' : explicit specialization requires 'template <>'
 
+## Remarks
+
 You must use the new syntax for explicit specialization of templates.
+
+## Example
 
 The following sample generates C2906:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
@@ -16,7 +16,7 @@ A specialization of the primary template occurs before the explicit specializati
 
 ## Example
 
-The following sample generates C2908:
+The following example generates C2908:
 
 ```cpp
 // C2908.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
@@ -8,7 +8,7 @@ ms.assetid: 49cd2a21-cad8-4ba0-9a0b-3a0190d9344c
 ---
 # Compiler Error C2908
 
-explicit specialization; 'template' has already been instantiated
+> explicit specialization; 'template' has already been instantiated
 
 A specialization of the primary template occurs before the explicit specialization.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2908"
 title: "Compiler Error C2908"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2908"
+ms.date: 11/04/2016
 f1_keywords: ["C2908"]
 helpviewer_keywords: ["C2908"]
-ms.assetid: 49cd2a21-cad8-4ba0-9a0b-3a0190d9344c
 ---
 # Compiler Error C2908
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2908.md
@@ -10,7 +10,11 @@ ms.assetid: 49cd2a21-cad8-4ba0-9a0b-3a0190d9344c
 
 > explicit specialization; 'template' has already been instantiated
 
+## Remarks
+
 A specialization of the primary template occurs before the explicit specialization.
+
+## Example
 
 The following sample generates C2908:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2909"
 title: "Compiler Error C2909"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2909"
+ms.date: 11/04/2016
 f1_keywords: ["C2909"]
 helpviewer_keywords: ["C2909"]
-ms.assetid: 1c9df8ae-925d-4002-a5f8-a71413c45f9e
 ---
 # Compiler Error C2909
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
@@ -8,7 +8,7 @@ ms.assetid: 1c9df8ae-925d-4002-a5f8-a71413c45f9e
 ---
 # Compiler Error C2909
 
-'identifier': explicit instantiation of function template requires return type
+> 'identifier': explicit instantiation of function template requires return type
 
 An explicit instantiation of a function template requires explicit specification of its return type. Implicit return type specification does not work.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
@@ -16,7 +16,7 @@ An explicit instantiation of a function template requires explicit specification
 
 ## Example
 
-The following sample generates C2909:
+The following example generates C2909:
 
 ```cpp
 // C2909.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2909.md
@@ -10,7 +10,11 @@ ms.assetid: 1c9df8ae-925d-4002-a5f8-a71413c45f9e
 
 > 'identifier': explicit instantiation of function template requires return type
 
+## Remarks
+
 An explicit instantiation of a function template requires explicit specification of its return type. Implicit return type specification does not work.
+
+## Example
 
 The following sample generates C2909:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2910"
 title: "Compiler Error C2910"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2910"
+ms.date: 11/04/2016
 f1_keywords: ["C2910"]
 helpviewer_keywords: ["C2910"]
-ms.assetid: 09c50e6a-e099-42f6-8ed6-d80e292a7a36
 ---
 # Compiler Error C2910
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
@@ -8,7 +8,7 @@ ms.assetid: 09c50e6a-e099-42f6-8ed6-d80e292a7a36
 ---
 # Compiler Error C2910
 
-'function' : cannot be explicitly specialized
+> 'function' : cannot be explicitly specialized
 
 The compiler detected an attempt to explicitly specialize a function twice.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
@@ -10,7 +10,11 @@ ms.assetid: 09c50e6a-e099-42f6-8ed6-d80e292a7a36
 
 > 'function' : cannot be explicitly specialized
 
+## Remarks
+
 The compiler detected an attempt to explicitly specialize a function twice.
+
+## Examples
 
 The following sample generates C2910:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2910.md
@@ -16,7 +16,7 @@ The compiler detected an attempt to explicitly specialize a function twice.
 
 ## Examples
 
-The following sample generates C2910:
+The following example generates C2910:
 
 ```cpp
 // C2910.cpp
@@ -30,7 +30,7 @@ template <> void S<int>::f() {}   // C2910 delete this specialization
 
 C2910 can also be generated if you try to explicitly specialize a non-template member. That is, you can only explicitly specialize a function template.
 
-The following sample generates C2910:
+The following example generates C2910:
 
 ```cpp
 // C2910b.cpp
@@ -55,7 +55,7 @@ This error will also be generated as a result of compiler conformance work that 
 
 For code will be valid in the Visual Studio .NET 2003 and Visual Studio .NET versions of Visual C++, remove `template <>`.
 
-The following sample generates C2910:
+The following example generates C2910:
 
 ```cpp
 // C2910c.cpp


### PR DESCRIPTION
This is batch 42 that structures error/warning references. See #5465 for more information.