### PR TITLE
Structure error references in range [C2911, C2940]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
@@ -8,7 +8,7 @@ ms.assetid: 83c7c01a-ab6a-4179-9fb0-289a9ec8d44e
 ---
 # Compiler Error C2911
 
-'member' : cannot be declared or defined in the current scope
+> 'member' : cannot be declared or defined in the current scope
 
 Inside a namespace, class, or function, you can only define a member of the same namespace, class, or function or a member that is enclosed by the same namespace, class, or function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
@@ -10,7 +10,11 @@ ms.assetid: 83c7c01a-ab6a-4179-9fb0-289a9ec8d44e
 
 > 'member' : cannot be declared or defined in the current scope
 
+## Remarks
+
 Inside a namespace, class, or function, you can only define a member of the same namespace, class, or function or a member that is enclosed by the same namespace, class, or function.
+
+## Example
 
 The following sample generates C2911:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
@@ -16,7 +16,7 @@ Inside a namespace, class, or function, you can only define a member of the same
 
 ## Example
 
-The following sample generates C2911:
+The following example generates C2911:
 
 ```cpp
 // C2911.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2911.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2911"
 title: "Compiler Error C2911"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2911"
+ms.date: 11/04/2016
 f1_keywords: ["C2911"]
 helpviewer_keywords: ["C2911"]
-ms.assetid: 83c7c01a-ab6a-4179-9fb0-289a9ec8d44e
 ---
 # Compiler Error C2911
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2912"
 title: "Compiler Error C2912"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2912"
+ms.date: 11/04/2016
 f1_keywords: ["C2912"]
 helpviewer_keywords: ["C2912"]
-ms.assetid: bd55cecd-ab1a-4636-ab8a-a00393fe7b3d
 ---
 # Compiler Error C2912
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
@@ -16,7 +16,7 @@ You cannot specialize a non-template function.
 
 ## Examples
 
-The following sample generates C2912:
+The following example generates C2912:
 
 ```cpp
 // C2912.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
@@ -8,7 +8,7 @@ ms.assetid: bd55cecd-ab1a-4636-ab8a-a00393fe7b3d
 ---
 # Compiler Error C2912
 
-explicit specialization 'declaration' is not a specialization of a function template
+> explicit specialization 'declaration' is not a specialization of a function template
 
 You cannot specialize a non-template function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2912.md
@@ -10,7 +10,11 @@ ms.assetid: bd55cecd-ab1a-4636-ab8a-a00393fe7b3d
 
 > explicit specialization 'declaration' is not a specialization of a function template
 
+## Remarks
+
 You cannot specialize a non-template function.
+
+## Examples
 
 The following sample generates C2912:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
@@ -10,7 +10,11 @@ ms.assetid: c6cf6090-02e8-49a5-913f-5bc6f864b769
 
 > explicit specialization; 'declaration' is not a specialization of a class template
 
+## Remarks
+
 You cannot specialize a non-template class.
+
+## Example
 
 The following sample generates C2913:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
@@ -16,7 +16,7 @@ You cannot specialize a non-template class.
 
 ## Example
 
-The following sample generates C2913:
+The following example generates C2913:
 
 ```cpp
 // C2913.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2913"
 title: "Compiler Error C2913"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2913"
+ms.date: 11/04/2016
 f1_keywords: ["C2913"]
 helpviewer_keywords: ["C2913"]
-ms.assetid: c6cf6090-02e8-49a5-913f-5bc6f864b769
 ---
 # Compiler Error C2913
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2913.md
@@ -8,7 +8,7 @@ ms.assetid: c6cf6090-02e8-49a5-913f-5bc6f864b769
 ---
 # Compiler Error C2913
 
-explicit specialization; 'declaration' is not a specialization of a class template
+> explicit specialization; 'declaration' is not a specialization of a class template
 
 You cannot specialize a non-template class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
@@ -8,7 +8,7 @@ ms.assetid: fc6a0592-f53e-4f5a-88cb-780bbed4acf2
 ---
 # Compiler Error C2914
 
-'identifier' : cannot deduce type argument as function argument is ambiguous
+> 'identifier' : cannot deduce type argument as function argument is ambiguous
 
 The compiler cannot determine which overloaded functions to use for a generic or template argument.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
@@ -10,7 +10,11 @@ ms.assetid: fc6a0592-f53e-4f5a-88cb-780bbed4acf2
 
 > 'identifier' : cannot deduce type argument as function argument is ambiguous
 
+## Remarks
+
 The compiler cannot determine which overloaded functions to use for a generic or template argument.
+
+## Examples
 
 The following sample generates C2914:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2914"
 title: "Compiler Error C2914"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2914"
+ms.date: 11/04/2016
 f1_keywords: ["C2914"]
 helpviewer_keywords: ["C2914"]
-ms.assetid: fc6a0592-f53e-4f5a-88cb-780bbed4acf2
 ---
 # Compiler Error C2914
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2914.md
@@ -16,7 +16,7 @@ The compiler cannot determine which overloaded functions to use for a generic or
 
 ## Examples
 
-The following sample generates C2914:
+The following example generates C2914:
 
 ```cpp
 // C2914.cpp
@@ -29,7 +29,7 @@ void h() { g(f); }   // C2914
 // void h() { g<int>(f); }
 ```
 
-C2914 can also occur when using generics.  The following sample generates C2914:
+C2914 can also occur when using generics.  The following example generates C2914:
 
 ```cpp
 // C2914b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2917.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2917.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Example
 
-The following sample generates C2917.
+The following example generates C2917.
 
 ```cpp
 // C2917.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2917.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2917.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2917"
 title: "Compiler Error C2917"
+description: "Learn more about: Compiler Error C2917"
 ms.date: 06/01/2022
 f1_keywords: ["C2917"]
 helpviewer_keywords: ["C2917"]
-ms.assetid: ec9da9ee-0f37-47b3-87dd-19ef5a14dc4c
 ---
 # Compiler Error C2917
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
@@ -10,4 +10,6 @@ ms.assetid: e452f7ef-0590-45e6-9c7c-ee75dc014670
 
 > 'name': Indexed properties cannot be used on the published surface of a WinRT type
 
+## Remarks
+
 Indexed properties are not supported on the published surface of a WinRT type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
@@ -8,6 +8,6 @@ ms.assetid: e452f7ef-0590-45e6-9c7c-ee75dc014670
 ---
 # Compiler Error C2918
 
-'name': Indexed properties cannot be used on the published surface of a WinRT type
+> 'name': Indexed properties cannot be used on the published surface of a WinRT type
 
 Indexed properties are not supported on the published surface of a WinRT type.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2918.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2918"
 title: "Compiler Error C2918"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2918"
+ms.date: 11/04/2016
 f1_keywords: ["C2918"]
 helpviewer_keywords: ["C2918"]
-ms.assetid: e452f7ef-0590-45e6-9c7c-ee75dc014670
 ---
 # Compiler Error C2918
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2919"
 title: "Compiler Error C2919"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2919"
+ms.date: 11/04/2016
 f1_keywords: ["C2919"]
 helpviewer_keywords: ["C2919"]
-ms.assetid: 140a6db9-eb48-4c5e-84a7-a09d2653605b
 ---
 # Compiler Error C2919
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
@@ -10,6 +10,8 @@ ms.assetid: 140a6db9-eb48-4c5e-84a7-a09d2653605b
 
 > 'type': Operators cannot be used on the published surface of a WinRT type
 
+## Remarks
+
 The Windows Runtime type system does not support operator member functions in the published surface of a type. This is because not all languages can consume operator member functions. You can create private or internal operator member functions that can be called from C++ code in the same class or compilation unit.
 
 To fix this issue, remove the operator member function from the public interface, or change it to a named member function. For example, instead of `operator==`, name the member function `Equals`.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2919.md
@@ -8,7 +8,7 @@ ms.assetid: 140a6db9-eb48-4c5e-84a7-a09d2653605b
 ---
 # Compiler Error C2919
 
-'type': Operators cannot be used on the published surface of a WinRT type
+> 'type': Operators cannot be used on the published surface of a WinRT type
 
 The Windows Runtime type system does not support operator member functions in the published surface of a type. This is because not all languages can consume operator member functions. You can create private or internal operator member functions that can be called from C++ code in the same class or compilation unit.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
@@ -8,7 +8,7 @@ ms.assetid: 0a4cb2de-00a0-4209-8160-c7ce6ed7d9ab
 ---
 # Compiler Error C2920
 
-redefinition : 'class' : class template or generic has already been declared as 'type'
+> redefinition : 'class' : class template or generic has already been declared as 'type'
 
 A generic or template class has multiple declarations, which are not equivalent. To fix this error, use different names for different types, or remove the redefinition of the type name.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
@@ -16,7 +16,7 @@ A generic or template class has multiple declarations, which are not equivalent.
 
 ## Examples
 
-The following sample generates C2920 and shows how to fix it:
+The following example generates C2920 and shows how to fix it:
 
 ```cpp
 // C2920.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
@@ -10,7 +10,11 @@ ms.assetid: 0a4cb2de-00a0-4209-8160-c7ce6ed7d9ab
 
 > redefinition : 'class' : class template or generic has already been declared as 'type'
 
+## Remarks
+
 A generic or template class has multiple declarations, which are not equivalent. To fix this error, use different names for different types, or remove the redefinition of the type name.
+
+## Examples
 
 The following sample generates C2920 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2920.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2920"
 title: "Compiler Error C2920"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2920"
+ms.date: 11/04/2016
 f1_keywords: ["C2920"]
 helpviewer_keywords: ["C2920"]
-ms.assetid: 0a4cb2de-00a0-4209-8160-c7ce6ed7d9ab
 ---
 # Compiler Error C2920
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
@@ -8,7 +8,7 @@ ms.assetid: 323642a0-bfc4-4942-9f41-c3adf5c54296
 ---
 # Compiler Error C2921
 
-redefinition : 'class' : class template or generic is being redeclared as 'type'
+> redefinition : 'class' : class template or generic is being redeclared as 'type'
 
 A generic or template class has multiple declarations that are not equivalent. To fix this error, use different names for different types, or remove the redefinition of the type name.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
@@ -10,7 +10,11 @@ ms.assetid: 323642a0-bfc4-4942-9f41-c3adf5c54296
 
 > redefinition : 'class' : class template or generic is being redeclared as 'type'
 
+## Remarks
+
 A generic or template class has multiple declarations that are not equivalent. To fix this error, use different names for different types, or remove the redefinition of the type name.
+
+## Examples
 
 The following sample generates C2921:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
@@ -16,7 +16,7 @@ A generic or template class has multiple declarations that are not equivalent. T
 
 ## Examples
 
-The following sample generates C2921:
+The following example generates C2921:
 
 ```cpp
 // C2921.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2921.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2921"
 title: "Compiler Error C2921"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2921"
+ms.date: 11/04/2016
 f1_keywords: ["C2921"]
 helpviewer_keywords: ["C2921"]
-ms.assetid: 323642a0-bfc4-4942-9f41-c3adf5c54296
 ---
 # Compiler Error C2921
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2923"
 title: "Compiler Error C2923"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2923"
+ms.date: 11/04/2016
 f1_keywords: ["C2923"]
 helpviewer_keywords: ["C2923"]
-ms.assetid: 6b92933b-13ef-4124-99d9-b89f9fdae030
 ---
 # Compiler Error C2923
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
@@ -10,7 +10,11 @@ ms.assetid: 6b92933b-13ef-4124-99d9-b89f9fdae030
 
 > 'type' : 'identifier' is not a valid template type argument for parameter 'param'
 
+## Remarks
+
 The argument list is missing a type needed to instantiate the template or generic. Check the template or generic declaration.
+
+## Examples
 
 The following sample generates C2923:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
@@ -16,7 +16,7 @@ The argument list is missing a type needed to instantiate the template or generi
 
 ## Examples
 
-The following sample generates C2923:
+The following example generates C2923:
 
 ```cpp
 // C2923.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2923.md
@@ -8,7 +8,7 @@ ms.assetid: 6b92933b-13ef-4124-99d9-b89f9fdae030
 ---
 # Compiler Error C2923
 
-'type' : 'identifier' is not a valid template type argument for parameter 'param'
+> 'type' : 'identifier' is not a valid template type argument for parameter 'param'
 
 The argument list is missing a type needed to instantiate the template or generic. Check the template or generic declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2927"
 title: "Compiler Error C2927"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2927"
+ms.date: 11/04/2016
 f1_keywords: ["C2927"]
 helpviewer_keywords: ["C2927"]
-ms.assetid: 3f75beec-ff5c-44e1-9085-990ecd55198d
 ---
 # Compiler Error C2927
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
@@ -8,6 +8,6 @@ ms.assetid: 3f75beec-ff5c-44e1-9085-990ecd55198d
 ---
 # Compiler Error C2927
 
-'function' : a function template must be called with at least one argument
+> 'function' : a function template must be called with at least one argument
 
 You cannot call a function template without arguments. The type of the template arguments determines what version of the function to generate.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2927.md
@@ -10,4 +10,6 @@ ms.assetid: 3f75beec-ff5c-44e1-9085-990ecd55198d
 
 > 'function' : a function template must be called with at least one argument
 
+## Remarks
+
 You cannot call a function template without arguments. The type of the template arguments determines what version of the function to generate.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2928.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2928.md
@@ -10,4 +10,6 @@ ms.assetid: 869e57f4-7024-4cbe-b47b-6e1e2a6005c5
 
 > explicit instantiation; '*identifier*' is not a function or static data member of template-class '*class-name*'
 
+## Remarks
+
 You cannot explicitly instantiate a member of *class-name* that is not a function or **`static`** variable.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2928.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2928.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2928"
 title: "Compiler Error C2928"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2928"
+ms.date: 11/04/2016
 f1_keywords: ["C2928"]
 helpviewer_keywords: ["C2928"]
-ms.assetid: 869e57f4-7024-4cbe-b47b-6e1e2a6005c5
 ---
 # Compiler Error C2928
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2929"
 title: "Compiler Error C2929"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2929"
+ms.date: 11/04/2016
 f1_keywords: ["C2929"]
 helpviewer_keywords: ["C2929"]
-ms.assetid: 11134027-6adc-4733-b6bd-b94486bd1933
 ---
 # Compiler Error C2929
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
@@ -8,7 +8,7 @@ ms.assetid: 11134027-6adc-4733-b6bd-b94486bd1933
 ---
 # Compiler Error C2929
 
-'identifier' : explicit instantiation; cannot explicitly force and suppress instantiation of template-class member
+> 'identifier' : explicit instantiation; cannot explicitly force and suppress instantiation of template-class member
 
 You cannot explicitly instantiate an identifier while preventing it from being instantiated.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
@@ -10,7 +10,11 @@ ms.assetid: 11134027-6adc-4733-b6bd-b94486bd1933
 
 > 'identifier' : explicit instantiation; cannot explicitly force and suppress instantiation of template-class member
 
+## Remarks
+
 You cannot explicitly instantiate an identifier while preventing it from being instantiated.
+
+## Example
 
 The following sample generates C2929:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2929.md
@@ -16,7 +16,7 @@ You cannot explicitly instantiate an identifier while preventing it from being i
 
 ## Example
 
-The following sample generates C2929:
+The following example generates C2929:
 
 ```cpp
 // C2929.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
@@ -10,9 +10,13 @@ ms.assetid: f07eecd1-e5d1-4518-bd89-b1fd2a003a17
 
 > 'class' : type-class-id redefined as an enumerator of 'enum identifier'
 
+## Remarks
+
 You cannot use a generic or template class as a member of an enumeration.
 
 This error can be caused if braces are improperly matched.
+
+## Examples
 
 The following sample generates C2930:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2930"
 title: "Compiler Error C2930"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2930"
+ms.date: 11/04/2016
 f1_keywords: ["C2930"]
 helpviewer_keywords: ["C2930"]
-ms.assetid: f07eecd1-e5d1-4518-bd89-b1fd2a003a17
 ---
 # Compiler Error C2930
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
@@ -8,7 +8,7 @@ ms.assetid: f07eecd1-e5d1-4518-bd89-b1fd2a003a17
 ---
 # Compiler Error C2930
 
-'class' : type-class-id redefined as an enumerator of 'enum identifier'
+> 'class' : type-class-id redefined as an enumerator of 'enum identifier'
 
 You cannot use a generic or template class as a member of an enumeration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2930.md
@@ -18,7 +18,7 @@ This error can be caused if braces are improperly matched.
 
 ## Examples
 
-The following sample generates C2930:
+The following example generates C2930:
 
 ```cpp
 // C2930.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
@@ -8,7 +8,7 @@ ms.assetid: 33430407-b149-4ba3-baf8-b0dae1ea3a5d
 ---
 # Compiler Error C2931
 
-'*class*' : type-class-id redefined as a member function of '*identifier*'
+> '*class*' : type-class-id redefined as a member function of '*identifier*'
 
 You can't use a generic or template class as a member function of another class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2931"
 title: "Compiler Error C2931"
+description: "Learn more about: Compiler Error C2931"
 ms.date: 06/01/2022
 f1_keywords: ["C2931"]
 helpviewer_keywords: ["C2931"]
-ms.assetid: 33430407-b149-4ba3-baf8-b0dae1ea3a5d
 ---
 # Compiler Error C2931
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
@@ -10,11 +10,15 @@ ms.assetid: 33430407-b149-4ba3-baf8-b0dae1ea3a5d
 
 > '*class*' : type-class-id redefined as a member function of '*identifier*'
 
+## Remarks
+
 You can't use a generic or template class as a member function of another class.
 
 This error is obsolete in Visual Studio 2022 and later versions.
 
 This error can be caused if braces are improperly matched.
+
+## Examples
 
 The following sample generates C2931:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2931.md
@@ -20,7 +20,7 @@ This error can be caused if braces are improperly matched.
 
 ## Examples
 
-The following sample generates C2931:
+The following example generates C2931:
 
 ```cpp
 // C2931.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2932:
+The following example generates C2932:
 
 ```cpp
 // C2932.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2932"
 title: "Compiler Error C2932"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C2932"
+ms.date: 11/04/2016
 f1_keywords: ["C2932"]
 helpviewer_keywords: ["C2932"]
-ms.assetid: c28e88d9-e654-4367-bfb4-13c780bca9bd
 ---
 # Compiler Error C2932
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2932.md
@@ -10,9 +10,13 @@ ms.assetid: c28e88d9-e654-4367-bfb4-13c780bca9bd
 
 > '*class*' : type-class-id redefined as a data member of '*identifier*'
 
+## Remarks
+
 You can't use a generic or template class as a data member.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2932:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2933:
+The following example generates C2933:
 
 ```cpp
 // C2933.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
@@ -10,9 +10,13 @@ ms.assetid: 394891e3-6b52-4b61-83d2-a1c5125d9bd5
 
 > '*class*' : type-class-id redefined as a typedef member of '*identifier*'
 
+## Remarks
+
 You can't use a generic or template class as a **`typedef`** member.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2933:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2933.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2933"
 title: "Compiler Error C2933"
+description: "Learn more about: Compiler Error C2933"
 ms.date: 06/01/2022
 f1_keywords: ["C2933"]
 helpviewer_keywords: ["C2933"]
-ms.assetid: 394891e3-6b52-4b61-83d2-a1c5125d9bd5
 ---
 # Compiler Error C2933
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
@@ -8,7 +8,7 @@ ms.assetid: b7f7e7aa-2d4c-4e17-8564-2c005ab81fd5
 ---
 # Compiler Error C2934
 
-'*class*' : type-class-id redefined as a nested 'item' of '*identifier*'
+> '*class*' : type-class-id redefined as a nested 'item' of '*identifier*'
 
 You can't use a generic or template class as a nested item.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
@@ -10,6 +10,8 @@ ms.assetid: b7f7e7aa-2d4c-4e17-8564-2c005ab81fd5
 
 > '*class*' : type-class-id redefined as a nested 'item' of '*identifier*'
 
+## Remarks
+
 You can't use a generic or template class as a nested item.
 
 This error is obsolete in Visual Studio 2022 and later versions.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2934.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2934"
 title: "Compiler Error C2934"
+description: "Learn more about: Compiler Error C2934"
 ms.date: 06/01/2022
 f1_keywords: ["C2934"]
 helpviewer_keywords: ["C2934"]
-ms.assetid: b7f7e7aa-2d4c-4e17-8564-2c005ab81fd5
 ---
 # Compiler Error C2934
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
@@ -20,7 +20,7 @@ This error can be caused if braces are improperly matched.
 
 ## Examples
 
-The following sample generates C2935:
+The following example generates C2935:
 
 ```cpp
 // C2935.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
@@ -10,11 +10,15 @@ ms.assetid: e11ef90d-0756-4e43-8a09-4974c6aa72a3
 
 > '*class*' : type-class-id redefined as a global function
 
+## Remarks
+
 You can't use a generic or template class as a global function.
 
 This error is obsolete in Visual Studio 2022 and later versions.
 
 This error can be caused if braces are improperly matched.
+
+## Examples
 
 The following sample generates C2935:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2935.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2935"
 title: "Compiler Error C2935"
+description: "Learn more about: Compiler Error C2935"
 ms.date: 06/01/2022
 f1_keywords: ["C2935"]
 helpviewer_keywords: ["C2935"]
-ms.assetid: e11ef90d-0756-4e43-8a09-4974c6aa72a3
 ---
 # Compiler Error C2935
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
@@ -20,7 +20,7 @@ This error can be caused if braces are improperly matched.
 
 ## Examples
 
-The following sample generates C2936:
+The following example generates C2936:
 
 ```cpp
 // C2936.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2936"
 title: "Compiler Error C2936"
+description: "Learn more about: Compiler Error C2936"
 ms.date: 06/01/2022
 f1_keywords: ["C2936"]
 helpviewer_keywords: ["C2936"]
-ms.assetid: 5d1ba0fc-0c78-4a37-a83b-1ef8527763be
 ---
 # Compiler Error C2936
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2936.md
@@ -10,11 +10,15 @@ ms.assetid: 5d1ba0fc-0c78-4a37-a83b-1ef8527763be
 
 > '*class*' : type-class-id redefined as a global data variable
 
+## Remarks
+
 You can't use a generic or template class as a global data variable.
 
 This error is obsolete in Visual Studio 2022 and later versions.
 
 This error can be caused if braces are improperly matched.
+
+## Examples
 
 The following sample generates C2936:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2937"
 title: "Compiler Error C2937"
+description: "Learn more about: Compiler Error C2937"
 ms.date: 06/01/2022
 f1_keywords: ["C2937"]
 helpviewer_keywords: ["C2937"]
-ms.assetid: 95671ca3-79f7-4b56-a5f2-a92296da1629
 ---
 # Compiler Error C2937
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2937:
+The following example generates C2937:
 
 ```cpp
 // C2937.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2937.md
@@ -10,9 +10,13 @@ ms.assetid: 95671ca3-79f7-4b56-a5f2-a92296da1629
 
 > '*class*' : type-class-id redefined as a global typedef
 
+## Remarks
+
 You can't use a generic or template class as a global **`typedef`**.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2937:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
@@ -10,11 +10,15 @@ ms.assetid: 455b050b-f2dc-4b5b-bd6a-e1f81d3d1644
 
 > '*class*' : type-class-id redefined as a local data variable
 
+## Remarks
+
 You can't use a generic or template class as a local data variable.
 
 This error is obsolete in Visual Studio 2022 and later versions.
 
 This error can be caused if braces are improperly matched.
+
+## Examples
 
 The following sample generates C2939:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
@@ -20,7 +20,7 @@ This error can be caused if braces are improperly matched.
 
 ## Examples
 
-The following sample generates C2939:
+The following example generates C2939:
 
 ```cpp
 // C2939.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2939.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2939"
 title: "Compiler Error C2939"
+description: "Learn more about: Compiler Error C2939"
 ms.date: 06/01/2022
 f1_keywords: ["C2939"]
 helpviewer_keywords: ["C2939"]
-ms.assetid: 455b050b-f2dc-4b5b-bd6a-e1f81d3d1644
 ---
 # Compiler Error C2939
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
@@ -10,9 +10,13 @@ ms.assetid: af6bf2bf-8de6-4cfd-bbf0-4c6b32a30edf
 
 > '*class*' : type-class-id redefined as a local typedef
 
+## Remarks
+
 You can't use a generic or template class as a local **`typedef`**.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Examples
 
 The following sample generates C2940:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Examples
 
-The following sample generates C2940:
+The following example generates C2940:
 
 ```cpp
 // C2940.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2940.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C2940"
 title: "Compiler Error C2940"
+description: "Learn more about: Compiler Error C2940"
 ms.date: 06/01/2022
 f1_keywords: ["C2940"]
 helpviewer_keywords: ["C2940"]
-ms.assetid: af6bf2bf-8de6-4cfd-bbf0-4c6b32a30edf
 ---
 # Compiler Error C2940
 


### PR DESCRIPTION
This is batch 43 that structures error/warning references. See #5465 for more information.