### PR TITLE
Structure error reference C2349

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2349.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2349.md
@@ -9,4 +9,6 @@ helpviewer_keywords: ["C2349"]
 
 > 'function' cannot be compiled as managed: 'reason'; use #pragma unmanaged
 
+## Remarks
+
 For more information, see [Compiler Warning (level 1 and 3) C4793](../../error-messages/compiler-warnings/compiler-warning-level-1-and-3-c4793.md).

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2349.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2349.md
@@ -7,6 +7,6 @@ helpviewer_keywords: ["C2349"]
 ---
 # Compiler Error C2349
 
-'function' cannot be compiled as managed: 'reason'; use #pragma unmanaged
+> 'function' cannot be compiled as managed: 'reason'; use #pragma unmanaged
 
 For more information, see [Compiler Warning (level 1 and 3) C4793](../../error-messages/compiler-warnings/compiler-warning-level-1-and-3-c4793.md).


### PR DESCRIPTION
C2349 was skipped in #5575 to prevent potential merge conflicts with #5564. This PR completes the former PR.