### PR TITLE
Improve C2135 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2135"
 description: "Learn more about: Compiler Error C2135"
-ms.date: 11/04/2016
+ms.date: 08/13/2025
 f1_keywords: ["C2135"]
 helpviewer_keywords: ["C2135"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C2135"]
 
 ## Remarks
 
-The address-of operator (`&`) cannot be applied to a bit field.
+The [address-of operator (`&`)](../../cpp/address-of-operator-amp.md), [unary plus operator (`+`)](../../cpp/unary-plus-and-negation-operators-plus-and.md), [unary negation operator (`-`)](../../cpp/unary-plus-and-negation-operators-plus-and.md), [logical negation operator (`!`)](../../cpp/logical-negation-operator-exclpt.md), [one's complement operator (`~`)](../../cpp/one-s-complement-operator-tilde.md), and [indirection operator (`*`)](../../cpp/indirection-operator-star.md) cannot be applied to a bit-field in this context.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
@@ -19,15 +19,16 @@ The following example generates C2135:
 
 ```cpp
 // C2135.cpp
-struct S {
-   int i : 1;
+
+struct S
+{
+    int bit_field : 1;
+    int integer;
 };
 
-struct T {
-   int j;
-};
-int main() {
-   &S::i;   // C2135 address of a bit field
-   &T::j;   // OK
+int main()
+{
+    &S::bit_field;   // C2135
+    &S::integer;     // OK
 }
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2135"]
 ---
 # Compiler Error C2135
 
-> 'bit operator' : illegal bit field operation
+> '*identifier*': you cannot apply '*operator*' to a bit-field
 
 ## Remarks
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2135.md
@@ -32,3 +32,7 @@ int main()
     &S::integer;     // OK
 }
 ```
+
+## See also
+
+[C2104](compiler-error-c2104.md)


### PR DESCRIPTION
```cpp
// C2135.cpp

struct S
{
    int bit_field : 1;
};

int main()
{
    &S::bit_field;   // C2135
    +S::bit_field;   // C2135
    -S::bit_field;   // C2135
    !S::bit_field;   // C2135
    ~S::bit_field;   // C2135
    *S::bit_field;   // C2135
}
```

```Output
C:\Test>cl C2135.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35214 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2135.cpp
C2135.cpp(10): error C2135: 'bit_field': you cannot apply '&' to a bit-field
C2135.cpp(11): error C2135: 'bit_field': you cannot apply '+' to a bit-field
C2135.cpp(12): error C2135: 'bit_field': you cannot apply '-' to a bit-field
C2135.cpp(13): error C2135: 'bit_field': you cannot apply '!' to a bit-field
C2135.cpp(14): error C2135: 'bit_field': you cannot apply '~' to a bit-field
C2135.cpp(15): error C2135: 'bit_field': you cannot apply '*' to a bit-field
```

## Changes to "Remarks"

- Add 5 more operators that could emit C2135 (from my testing, there doesn't seem to be any other, but I could have missed some)
- Add important "in this context", since the compiler either emits some other error (e.g. C2104 for `S s{}; &s.bit_field;`) or said operator is valid in other contexts

## Changes to "Example"

- Merge `T` into `S` for a terser example
- Remove "address of a bit field" comment as it's a bit more nuanced than that (trying to take the address of a bit-field data member on an instance emits C2104 instead of C2135)
- Use slightly more descriptive identifiers for clarity

## Other changes

- Update the outdated error message
- Add C2104 "See also" link and update `ms.date` metadata