### PR TITLE
Improve C3083 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3083.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3083.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3083"
 title: "Compiler Error C3083"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3083"
+ms.date: 08/14/2025
 f1_keywords: ["C3083"]
 helpviewer_keywords: ["C3083"]
-ms.assetid: 05ff791d-52bb-41eb-9511-3ef89d7f4710
 ---
 # Compiler Error C3083
 


### PR DESCRIPTION
- Update outdated error message and add blockquotes
- Add "Remarks" heading and overhaul its content since "A function was called incorrectly." is too vague
- Fix example as the old one no longer emits C3083
- Update metadata

## Other examples

```cpp
// C3083.cpp

namespace A
{
    void func() {}
}

int main()
{
    A::A::func();   // C3083
}
```

```Output
C:\Test>cl C3083.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35214 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C3083.cpp
C3083.cpp(10): error C2039: 'A': is not a member of 'A'
C3083.cpp(3): note: see declaration of 'A'
C3083.cpp(10): error C3083: 'A': the symbol to the left of a '::' must be a type
```

Another one about missing includes:

```cpp
// C3083.cpp

// #include <chrono>

int main()
{
    auto n = std::chrono::system_clock::now();   // C3083 and many others
}
```

```Output
C:\Test>cl C3083.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35214 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C3083.cpp
C3083.cpp(7): error C2039: 'chrono': is not a member of 'std'
predefined C++ types (compiler internal)(357): note: see declaration of 'std'
C3083.cpp(7): error C2039: 'system_clock': is not a member of 'std'
predefined C++ types (compiler internal)(357): note: see declaration of 'std'
C3083.cpp(7): error C3083: 'chrono': the symbol to the left of a '::' must be a type
C3083.cpp(7): error C3083: 'system_clock': the symbol to the left of a '::' must be a type
C3083.cpp(7): error C2039: 'now': is not a member of 'std'
predefined C++ types (compiler internal)(357): note: see declaration of 'std'
C3083.cpp(7): error C3861: 'now': identifier not found
```