### PR TITLE
Structure error references in range [C3081, C3130]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3084"
 title: "Compiler Error C3084"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3084"
+ms.date: 11/04/2016
 f1_keywords: ["C3084"]
 helpviewer_keywords: ["C3084"]
-ms.assetid: 0362cb70-e24e-476f-a24d-8f5bb97c3afd
 ---
 # Compiler Error C3084
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
@@ -18,7 +18,7 @@ For example, a destructor should not be marked as sealed.  The destructor will b
 
 ## Example
 
-The following sample generates C3084.
+The following example generates C3084.
 
 ```cpp
 // C3084.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
@@ -10,6 +10,8 @@ ms.assetid: 0362cb70-e24e-476f-a24d-8f5bb97c3afd
 
 > 'function': a finalizer/destructor cannot be 'keyword'
 
+## Remarks
+
 A finalizer or destructor was declared incorrectly.
 
 For example, a destructor should not be marked as sealed.  The destructor will be inaccessible to derived types.  For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md) and [Destructors and finalizers in How to: Define and consume classes and structs (C++/CLI)](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Destructors_and_finalizers).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3084.md
@@ -8,7 +8,7 @@ ms.assetid: 0362cb70-e24e-476f-a24d-8f5bb97c3afd
 ---
 # Compiler Error C3084
 
-'function': a finalizer/destructor cannot be 'keyword'
+> 'function': a finalizer/destructor cannot be 'keyword'
 
 A finalizer or destructor was declared incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
@@ -16,7 +16,7 @@ A constructor was declared incorrectly. See [Override Specifiers](../../extensio
 
 ## Example
 
-The following sample generates C3085.
+The following example generates C3085.
 
 ```cpp
 // C3085.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
@@ -8,7 +8,7 @@ ms.assetid: 1ac40bf2-f63e-439e-8921-47e6dadc8354
 ---
 # Compiler Error C3085
 
-'constructor': a constructor cannot be 'keyword'
+> 'constructor': a constructor cannot be 'keyword'
 
 A constructor was declared incorrectly. See [Override Specifiers](../../extensions/override-specifiers-cpp-component-extensions.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
@@ -10,6 +10,8 @@ ms.assetid: 1ac40bf2-f63e-439e-8921-47e6dadc8354
 
 > 'constructor': a constructor cannot be 'keyword'
 
+## Remarks
+
 A constructor was declared incorrectly. See [Override Specifiers](../../extensions/override-specifiers-cpp-component-extensions.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3085.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3085"
 title: "Compiler Error C3085"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3085"
+ms.date: 11/04/2016
 f1_keywords: ["C3085"]
 helpviewer_keywords: ["C3085"]
-ms.assetid: 1ac40bf2-f63e-439e-8921-47e6dadc8354
 ---
 # Compiler Error C3085
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
@@ -16,7 +16,7 @@ A named argument was specified in the same attribute block as an unnamed argumen
 
 ## Example
 
-The following sample generates C3087.
+The following example generates C3087.
 
 ```cpp
 // C3087.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
@@ -10,6 +10,8 @@ ms.assetid: 4f5bdd52-a853-4f02-b160-6868e9190b9d
 
 > 'named_argument': call of 'attribute' already initializes this member
 
+## Remarks
+
 A named argument was specified in the same attribute block as an unnamed argument for the same value. Specify only a named or unnamed argument.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
@@ -8,7 +8,7 @@ ms.assetid: 4f5bdd52-a853-4f02-b160-6868e9190b9d
 ---
 # Compiler Error C3087
 
-'named_argument': call of 'attribute' already initializes this member
+> 'named_argument': call of 'attribute' already initializes this member
 
 A named argument was specified in the same attribute block as an unnamed argument for the same value. Specify only a named or unnamed argument.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3087.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3087"
 title: "Compiler Error C3087"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3087"
+ms.date: 11/04/2016
 f1_keywords: ["C3087"]
 helpviewer_keywords: ["C3087"]
-ms.assetid: 4f5bdd52-a853-4f02-b160-6868e9190b9d
 ---
 # Compiler Error C3087
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
@@ -8,7 +8,7 @@ ms.assetid: 10da9b7c-e72d-4013-9925-c83e1bb142db
 ---
 # Compiler Error C3094
 
-'attribute': anonymous usage not allowed
+> 'attribute': anonymous usage not allowed
 
 An attribute was not scoped correctly.  For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
@@ -10,6 +10,8 @@ ms.assetid: 10da9b7c-e72d-4013-9925-c83e1bb142db
 
 > 'attribute': anonymous usage not allowed
 
+## Remarks
+
 An attribute was not scoped correctly.  For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
@@ -16,7 +16,7 @@ An attribute was not scoped correctly.  For more information, see [User-Defined 
 
 ## Example
 
-The following sample generates C3094.
+The following example generates C3094.
 
 ```cpp
 // C3094.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3094.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3094"
 title: "Compiler Error C3094"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3094"
+ms.date: 11/04/2016
 f1_keywords: ["C3094"]
 helpviewer_keywords: ["C3094"]
-ms.assetid: 10da9b7c-e72d-4013-9925-c83e1bb142db
 ---
 # Compiler Error C3094
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3095"
 title: "Compiler Error C3095"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3095"
+ms.date: 11/04/2016
 f1_keywords: ["C3095"]
 helpviewer_keywords: ["C3095"]
-ms.assetid: cde725be-0936-40f6-9e57-e1d7d0710f83
 ---
 # Compiler Error C3095
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
@@ -8,7 +8,7 @@ ms.assetid: cde725be-0936-40f6-9e57-e1d7d0710f83
 ---
 # Compiler Error C3095
 
-'attribute': attribute cannot be repeated
+> 'attribute': attribute cannot be repeated
 
 Some attributes are declared such that, multiple occurrences of the attribute cannot be applied to a target.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
@@ -18,7 +18,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3095.
+The following example generates C3095.
 
 ```cpp
 // C3095.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3095.md
@@ -10,6 +10,8 @@ ms.assetid: cde725be-0936-40f6-9e57-e1d7d0710f83
 
 > 'attribute': attribute cannot be repeated
 
+## Remarks
+
 Some attributes are declared such that, multiple occurrences of the attribute cannot be applied to a target.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3096"
 title: "Compiler Error C3096"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3096"
+ms.date: 11/04/2016
 f1_keywords: ["C3096"]
 helpviewer_keywords: ["C3096"]
-ms.assetid: 56353c9a-800c-474f-b428-3e5d2a7afc9a
 ---
 # Compiler Error C3096
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
@@ -10,6 +10,8 @@ ms.assetid: 56353c9a-800c-474f-b428-3e5d2a7afc9a
 
 > 'attribute': attribute is allowed on data members of attribute classes only
 
+## Remarks
+
 An attribute was applied incorrectly.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3096.md
@@ -8,7 +8,7 @@ ms.assetid: 56353c9a-800c-474f-b428-3e5d2a7afc9a
 ---
 # Compiler Error C3096
 
-'attribute': attribute is allowed on data members of attribute classes only
+> 'attribute': attribute is allowed on data members of attribute classes only
 
 An attribute was applied incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3097"
 title: "Compiler Error C3097"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3097"
+ms.date: 11/04/2016
 f1_keywords: ["C3097"]
 helpviewer_keywords: ["C3097"]
-ms.assetid: b24bd8f8-e04f-4fbb-be57-4feb9165572e
 ---
 # Compiler Error C3097
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
@@ -10,6 +10,8 @@ ms.assetid: b24bd8f8-e04f-4fbb-be57-4feb9165572e
 
 > 'attribute': attribute must be scoped with 'assembly:' or 'module:'
 
+## Remarks
+
 A global attribute was used incorrectly.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
@@ -8,7 +8,7 @@ ms.assetid: b24bd8f8-e04f-4fbb-be57-4feb9165572e
 ---
 # Compiler Error C3097
 
-'attribute': attribute must be scoped with 'assembly:' or 'module:'
+> 'attribute': attribute must be scoped with 'assembly:' or 'module:'
 
 A global attribute was used incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3097.md
@@ -18,7 +18,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3097.
+The following example generates C3097.
 
 ```cpp
 // C3097.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
@@ -10,6 +10,8 @@ ms.assetid: b3dded0f-76c9-42c1-991b-532eb8619661
 
 > 'keyword': use [System::AttributeUsageAttribute] for managed attributes; use [Windows::Foundation::Metadata::AttributeUsageAttribute] for WinRT attributes
 
+## Remarks
+
 Use <xref:System.AttributeUsageAttribute> to declare **/clr** attributes. Use `Windows::Foundation::Metadata::AttributeUsageAttribute` to declare Windows Runtime attributes.
 
 For more information about /CLR attributes, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md). For supported attributes in Windows Runtime, see [Windows.Foundation.Metadata namespace](/uwp/api/windows.foundation.metadata)

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
@@ -8,7 +8,7 @@ ms.assetid: b3dded0f-76c9-42c1-991b-532eb8619661
 ---
 # Compiler Error C3099
 
-'keyword': use [System::AttributeUsageAttribute] for managed attributes; use [Windows::Foundation::Metadata::AttributeUsageAttribute] for WinRT attributes
+> 'keyword': use [System::AttributeUsageAttribute] for managed attributes; use [Windows::Foundation::Metadata::AttributeUsageAttribute] for WinRT attributes
 
 Use <xref:System.AttributeUsageAttribute> to declare **/clr** attributes. Use `Windows::Foundation::Metadata::AttributeUsageAttribute` to declare Windows Runtime attributes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3099"
 title: "Compiler Error C3099"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3099"
+ms.date: 11/04/2016
 f1_keywords: ["C3099"]
 helpviewer_keywords: ["C3099"]
-ms.assetid: b3dded0f-76c9-42c1-991b-532eb8619661
 ---
 # Compiler Error C3099
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3099.md
@@ -18,7 +18,7 @@ For more information about /CLR attributes, see [User-Defined Attributes](../../
 
 ## Example
 
-The following sample generates C3099 and shows how to fix it.
+The following example generates C3099 and shows how to fix it.
 
 ```cpp
 // C3099.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
@@ -10,6 +10,8 @@ ms.assetid: 7a9c9eaf-08ef-442d-94a0-e457beee8549
 
 > 'target' : unknown attribute qualifier
 
+## Remarks
+
 An invalid attribute target was specified.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3100"
 title: "Compiler Error C3100"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3100"
+ms.date: 11/04/2016
 f1_keywords: ["C3100"]
 helpviewer_keywords: ["C3100"]
-ms.assetid: 7a9c9eaf-08ef-442d-94a0-e457beee8549
 ---
 # Compiler Error C3100
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
@@ -8,7 +8,7 @@ ms.assetid: 7a9c9eaf-08ef-442d-94a0-e457beee8549
 ---
 # Compiler Error C3100
 
-'target' : unknown attribute qualifier
+> 'target' : unknown attribute qualifier
 
 An invalid attribute target was specified.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3100.md
@@ -18,7 +18,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3100.
+The following example generates C3100.
 
 ```cpp
 // C3100.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
@@ -8,7 +8,7 @@ ms.assetid: 4f673766-d4f7-4632-94a5-d36a83f7f4b5
 ---
 # Compiler Error C3101
 
-illegal expression for named attribute argument 'field'
+> illegal expression for named attribute argument 'field'
 
 When initializing a named attribute argument, the value must be a compile time constant.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
@@ -18,7 +18,7 @@ For more information on attributes, see [User-Defined Attributes](../../extensio
 
 ## Example
 
-The following sample generates C3101.
+The following example generates C3101.
 
 ```cpp
 // C3101.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
@@ -10,6 +10,8 @@ ms.assetid: 4f673766-d4f7-4632-94a5-d36a83f7f4b5
 
 > illegal expression for named attribute argument 'field'
 
+## Remarks
+
 When initializing a named attribute argument, the value must be a compile time constant.
 
 For more information on attributes, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3101.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3101"
 title: "Compiler Error C3101"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3101"
+ms.date: 11/04/2016
 f1_keywords: ["C3101"]
 helpviewer_keywords: ["C3101"]
-ms.assetid: 4f673766-d4f7-4632-94a5-d36a83f7f4b5
 ---
 # Compiler Error C3101
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3103"
 title: "Compiler Error C3103"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3103"
+ms.date: 11/04/2016
 f1_keywords: ["C3103"]
 helpviewer_keywords: ["C3103"]
-ms.assetid: 7984bd3e-d51d-43e4-b6f4-08c1e9fb9704
 ---
 # Compiler Error C3103
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
@@ -18,7 +18,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3103.
+The following example generates C3103.
 
 ```cpp
 // C3103.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
@@ -10,6 +10,8 @@ ms.assetid: 7984bd3e-d51d-43e4-b6f4-08c1e9fb9704
 
 > 'argument': repeated named argument
 
+## Remarks
+
 An attribute can not repeat named arguments.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3103.md
@@ -8,7 +8,7 @@ ms.assetid: 7984bd3e-d51d-43e4-b6f4-08c1e9fb9704
 ---
 # Compiler Error C3103
 
-'argument': repeated named argument
+> 'argument': repeated named argument
 
 An attribute can not repeat named arguments.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3104"
 title: "Compiler Error C3104"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3104"
+ms.date: 11/04/2016
 f1_keywords: ["C3104"]
 helpviewer_keywords: ["C3104"]
-ms.assetid: b5648d47-e5d3-4b45-a3c0-f46e04eae731
 ---
 # Compiler Error C3104
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
@@ -20,7 +20,7 @@ This error can be generated as a result of compiler conformance work that was do
 
 ## Examples
 
-The following sample generates C3104.
+The following example generates C3104.
 
 ```cpp
 // C3104a.cpp
@@ -39,7 +39,7 @@ public ref struct ABC : public Attribute {
 ref struct AStruct{};
 ```
 
-The following sample generates C3104.
+The following example generates C3104.
 
 ```cpp
 // C3104b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
@@ -8,7 +8,7 @@ ms.assetid: b5648d47-e5d3-4b45-a3c0-f46e04eae731
 ---
 # Compiler Error C3104
 
-illegal attribute argument
+> illegal attribute argument
 
 You specified an invalid argument to an attribute.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3104.md
@@ -10,6 +10,8 @@ ms.assetid: b5648d47-e5d3-4b45-a3c0-f46e04eae731
 
 > illegal attribute argument
 
+## Remarks
+
 You specified an invalid argument to an attribute.
 
 See [Attribute Parameter Types](../../extensions/attribute-parameter-types-cpp-component-extensions.md) for more information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3106"
 title: "Compiler Error C3106"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3106"
+ms.date: 11/04/2016
 f1_keywords: ["C3106"]
 helpviewer_keywords: ["C3106"]
-ms.assetid: 39d97a32-0905-4702-87d3-7f8ce473fb93
 ---
 # Compiler Error C3106
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
@@ -10,6 +10,8 @@ ms.assetid: 39d97a32-0905-4702-87d3-7f8ce473fb93
 
 > 'attribute': unnamed arguments must precede named arguments
 
+## Remarks
+
 Unnamed arguments must be passed to an attribute before named arguments.
 
 For more information, see [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
@@ -18,7 +18,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3106.
+The following example generates C3106.
 
 ```cpp
 // C3106.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3106.md
@@ -8,7 +8,7 @@ ms.assetid: 39d97a32-0905-4702-87d3-7f8ce473fb93
 ---
 # Compiler Error C3106
 
-'attribute': unnamed arguments must precede named arguments
+> 'attribute': unnamed arguments must precede named arguments
 
 Unnamed arguments must be passed to an attribute before named arguments.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
@@ -10,6 +10,8 @@ ms.assetid: 821dc71f-896e-4b2d-af0e-aa9932934b7b
 
 > 'function_name' : you cannot overload a COM interface method
 
+## Remarks
+
 An interface that is prefaced by an interface attribute, such as:
 
 - [custom](../../windows/attributes/custom-cpp.md)
@@ -20,7 +22,11 @@ An interface that is prefaced by an interface attribute, such as:
 
 - [object](../../windows/attributes/object-cpp.md)
 
-cannot be overloaded. For example:
+cannot be overloaded.
+
+## Example
+
+For example:
 
 ```cpp
 // C3110.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
@@ -8,7 +8,7 @@ ms.assetid: 821dc71f-896e-4b2d-af0e-aa9932934b7b
 ---
 # Compiler Error C3110
 
-'function_name' : you cannot overload a COM interface method
+> 'function_name' : you cannot overload a COM interface method
 
 An interface that is prefaced by an interface attribute, such as:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3110.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3110"
 title: "Compiler Error C3110"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3110"
+ms.date: 11/04/2016
 f1_keywords: ["C3110"]
 helpviewer_keywords: ["C3110"]
-ms.assetid: 821dc71f-896e-4b2d-af0e-aa9932934b7b
 ---
 # Compiler Error C3110
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
@@ -10,7 +10,11 @@ ms.assetid: 3afdc668-b29e-474e-9ea3-aa027d42db7c
 
 > an 'structure' cannot be a template/generic
 
+## Remarks
+
 You attempted to make a class template or class generic out of an interface or an enum.
+
+## Example
 
 The following sample generates C3113:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
@@ -8,7 +8,7 @@ ms.assetid: 3afdc668-b29e-474e-9ea3-aa027d42db7c
 ---
 # Compiler Error C3113
 
-an 'structure' cannot be a template/generic
+> an 'structure' cannot be a template/generic
 
 You attempted to make a class template or class generic out of an interface or an enum.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
@@ -16,7 +16,7 @@ You attempted to make a class template or class generic out of an interface or a
 
 ## Example
 
-The following sample generates C3113:
+The following example generates C3113:
 
 ```cpp
 // C3113.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3113.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3113"
 title: "Compiler Error C3113"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3113"
+ms.date: 11/04/2016
 f1_keywords: ["C3113"]
 helpviewer_keywords: ["C3113"]
-ms.assetid: 3afdc668-b29e-474e-9ea3-aa027d42db7c
 ---
 # Compiler Error C3113
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
@@ -10,6 +10,8 @@ ms.assetid: b5d2df4f-87d0-4292-9981-25c6a6013c05
 
 > 'argument': not a valid named attribute argument
 
+## Remarks
+
 In order for an attribute class data member to be a valid named argument, it must not be marked **`static`**, **`const`**, or **`literal`**. If a property, the property must not be **`static`** and must have get and set accessors.
 
 For more information, see [property](../../extensions/property-cpp-component-extensions.md) and [User-Defined Attributes](../../extensions/user-defined-attributes-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
@@ -8,7 +8,7 @@ ms.assetid: b5d2df4f-87d0-4292-9981-25c6a6013c05
 ---
 # Compiler Error C3114
 
-'argument': not a valid named attribute argument
+> 'argument': not a valid named attribute argument
 
 In order for an attribute class data member to be a valid named argument, it must not be marked **`static`**, **`const`**, or **`literal`**. If a property, the property must not be **`static`** and must have get and set accessors.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3114"
 title: "Compiler Error C3114"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3114"
+ms.date: 11/04/2016
 f1_keywords: ["C3114"]
 helpviewer_keywords: ["C3114"]
-ms.assetid: b5d2df4f-87d0-4292-9981-25c6a6013c05
 ---
 # Compiler Error C3114
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3114.md
@@ -18,7 +18,7 @@ For more information, see [property](../../extensions/property-cpp-component-ext
 
 ## Example
 
-The following sample generates C3114.
+The following example generates C3114.
 
 ```cpp
 // C3114.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
@@ -16,7 +16,7 @@ An attribute was applied to a construct for which it was not intended.  See [Att
 
 ## Example
 
-The following sample generates C3115.
+The following example generates C3115.
 
 ```cpp
 // C3115.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
@@ -8,7 +8,7 @@ ms.assetid: 51726145-9782-4ec9-84b9-286f366d9cbd
 ---
 # Compiler Error C3115
 
-'attribute': this attribute is not allowed on 'construct'
+> 'attribute': this attribute is not allowed on 'construct'
 
 An attribute was applied to a construct for which it was not intended.  See [Attributes by Usage](../../windows/attributes/attributes-by-usage.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
@@ -10,6 +10,8 @@ ms.assetid: 51726145-9782-4ec9-84b9-286f366d9cbd
 
 > 'attribute': this attribute is not allowed on 'construct'
 
+## Remarks
+
 An attribute was applied to a construct for which it was not intended.  See [Attributes by Usage](../../windows/attributes/attributes-by-usage.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3115.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3115"
 title: "Compiler Error C3115"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3115"
+ms.date: 11/04/2016
 f1_keywords: ["C3115"]
 helpviewer_keywords: ["C3115"]
-ms.assetid: 51726145-9782-4ec9-84b9-286f366d9cbd
 ---
 # Compiler Error C3115
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
@@ -8,7 +8,7 @@ ms.assetid: 597463e1-a5cc-4ed3-a917-eae9a61d3312
 ---
 # Compiler Error C3116
 
-'storage specifier' : invalid storage class for interface method
+> 'storage specifier' : invalid storage class for interface method
 
 You used **`typedef`**, **`register`**, or **`static`** as the storage class for an interface method. These storage classes are not permitted on interface members.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
@@ -16,7 +16,7 @@ You used **`typedef`**, **`register`**, or **`static`** as the storage class for
 
 ## Example
 
-The following sample generates C3116:
+The following example generates C3116:
 
 ```cpp
 // C3116.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3116"
 title: "Compiler Error C3116"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3116"
+ms.date: 11/04/2016
 f1_keywords: ["C3116"]
 helpviewer_keywords: ["C3116"]
-ms.assetid: 597463e1-a5cc-4ed3-a917-eae9a61d3312
 ---
 # Compiler Error C3116
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3116.md
@@ -10,7 +10,11 @@ ms.assetid: 597463e1-a5cc-4ed3-a917-eae9a61d3312
 
 > 'storage specifier' : invalid storage class for interface method
 
+## Remarks
+
 You used **`typedef`**, **`register`**, or **`static`** as the storage class for an interface method. These storage classes are not permitted on interface members.
+
+## Example
 
 The following sample generates C3116:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
@@ -10,7 +10,11 @@ ms.assetid: dceee392-d4c7-4599-b75e-7aaac7c36fdd
 
 > '%$S' : an interface can only have one base class
 
+## Remarks
+
 You declared an interface that inherits from multiple base classes.
+
+## Example
 
 The following sample generates C3117:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
@@ -16,7 +16,7 @@ You declared an interface that inherits from multiple base classes.
 
 ## Example
 
-The following sample generates C3117:
+The following example generates C3117:
 
 ```cpp
 // C3117.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3117"
 title: "Compiler Error C3117"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3117"
+ms.date: 11/04/2016
 f1_keywords: ["C3117"]
 helpviewer_keywords: ["C3117"]
-ms.assetid: dceee392-d4c7-4599-b75e-7aaac7c36fdd
 ---
 # Compiler Error C3117
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3117.md
@@ -8,7 +8,7 @@ ms.assetid: dceee392-d4c7-4599-b75e-7aaac7c36fdd
 ---
 # Compiler Error C3117
 
-'%$S' : an interface can only have one base class
+> '%$S' : an interface can only have one base class
 
 You declared an interface that inherits from multiple base classes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3118"
 title: "Compiler Error C3118"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3118"
+ms.date: 11/04/2016
 f1_keywords: ["C3118"]
 helpviewer_keywords: ["C3118"]
-ms.assetid: 40fbe681-8868-4cb2-a2b2-4db4449319a7
 ---
 # Compiler Error C3118
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
@@ -10,7 +10,13 @@ ms.assetid: 40fbe681-8868-4cb2-a2b2-4db4449319a7
 
 > 'interface' : interfaces do not support virtual inheritance
 
-You tried to virtually inherit from an interface. For example,
+## Remarks
+
+You tried to virtually inherit from an interface.
+
+## Example
+
+For example,
 
 ```cpp
 // C3118.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3118.md
@@ -8,7 +8,7 @@ ms.assetid: 40fbe681-8868-4cb2-a2b2-4db4449319a7
 ---
 # Compiler Error C3118
 
-'interface' : interfaces do not support virtual inheritance
+> 'interface' : interfaces do not support virtual inheritance
 
 You tried to virtually inherit from an interface. For example,
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3120"
 title: "Compiler Error C3120"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3120"
+ms.date: 11/04/2016
 f1_keywords: ["C3120"]
 helpviewer_keywords: ["C3120"]
-ms.assetid: 9b6b210f-9948-4517-a4cc-b4aaadebde68
 ---
 # Compiler Error C3120
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
@@ -10,7 +10,13 @@ ms.assetid: 9b6b210f-9948-4517-a4cc-b4aaadebde68
 
 > 'method_name' : interface methods cannot take a variable argument list
 
-An interface method cannot take a variable argument list. For example, the following interface definition generates C3120:
+## Remarks
+
+An interface method cannot take a variable argument list.
+
+## Example
+
+For example, the following interface definition generates C3120:
 
 ```cpp
 // C3120.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3120.md
@@ -8,7 +8,7 @@ ms.assetid: 9b6b210f-9948-4517-a4cc-b4aaadebde68
 ---
 # Compiler Error C3120
 
-'method_name' : interface methods cannot take a variable argument list
+> 'method_name' : interface methods cannot take a variable argument list
 
 An interface method cannot take a variable argument list. For example, the following interface definition generates C3120:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
@@ -8,7 +8,7 @@ ms.assetid: 1d3c7be4-d42d-4def-8d53-182c0c5cc237
 ---
 # Compiler Error C3121
 
-cannot change GUID for class 'class_name'
+> cannot change GUID for class 'class_name'
 
 You attempted to change the class ID with [__declspec(uuid)](../../cpp/uuid-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
@@ -10,7 +10,11 @@ ms.assetid: 1d3c7be4-d42d-4def-8d53-182c0c5cc237
 
 > cannot change GUID for class 'class_name'
 
+## Remarks
+
 You attempted to change the class ID with [__declspec(uuid)](../../cpp/uuid-cpp.md).
+
+## Example
 
 For example, the following code generates C3121:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3121.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3121"
 title: "Compiler Error C3121"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3121"
+ms.date: 11/04/2016
 f1_keywords: ["C3121"]
 helpviewer_keywords: ["C3121"]
-ms.assetid: 1d3c7be4-d42d-4def-8d53-182c0c5cc237
 ---
 # Compiler Error C3121
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
@@ -8,7 +8,7 @@ ms.assetid: e72658a3-5d85-4a31-89a4-dbc3d475973d
 ---
 # Compiler Error C3126
 
-cannot define a union 'union' inside of managed type 'type'
+> cannot define a union 'union' inside of managed type 'type'
 
 A union cannot be defined inside a managed type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
@@ -16,7 +16,7 @@ A union cannot be defined inside a managed type.
 
 ## Example
 
-The following sample generates C3126:
+The following example generates C3126:
 
 ```cpp
 // C3126_2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
@@ -10,7 +10,11 @@ ms.assetid: e72658a3-5d85-4a31-89a4-dbc3d475973d
 
 > cannot define a union 'union' inside of managed type 'type'
 
+## Remarks
+
 A union cannot be defined inside a managed type.
+
+## Example
 
 The following sample generates C3126:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3126.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3126"
 title: "Compiler Error C3126"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3126"
+ms.date: 11/04/2016
 f1_keywords: ["C3126"]
 helpviewer_keywords: ["C3126"]
-ms.assetid: e72658a3-5d85-4a31-89a4-dbc3d475973d
 ---
 # Compiler Error C3126
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
@@ -10,4 +10,6 @@ ms.assetid: c1462f33-434f-41f0-937e-392864916850
 
 > Internal Compiler Error: failed to write injected code block to PDB
 
+## Remarks
+
 This error occurs if the compiler failed to write an injected code block to the .pdb file. The most common reason for the failure is lack of disk space.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3130"
 title: "Compiler Error C3130"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3130"
+ms.date: 11/04/2016
 f1_keywords: ["C3130"]
 helpviewer_keywords: ["C3130"]
-ms.assetid: c1462f33-434f-41f0-937e-392864916850
 ---
 # Compiler Error C3130
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3130.md
@@ -8,6 +8,6 @@ ms.assetid: c1462f33-434f-41f0-937e-392864916850
 ---
 # Compiler Error C3130
 
-Internal Compiler Error: failed to write injected code block to PDB
+> Internal Compiler Error: failed to write injected code block to PDB
 
 This error occurs if the compiler failed to write an injected code block to the .pdb file. The most common reason for the failure is lack of disk space.


### PR DESCRIPTION
C3083 is skipped due to #5661.

This is batch 49 that structures error/warning references. See #5465 for more information.