### PR TITLE
Structure error references in range [C3161, C3190]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3161"
 title: "Compiler Error C3161"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3161"
+ms.date: 11/04/2016
 f1_keywords: ["C3161"]
 helpviewer_keywords: ["C3161"]
-ms.assetid: 1fe2be85-a343-487b-8476-bf9e257eb29d
 ---
 # Compiler Error C3161
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
@@ -8,7 +8,7 @@ ms.assetid: 1fe2be85-a343-487b-8476-bf9e257eb29d
 ---
 # Compiler Error C3161
 
-'interface' : nesting class, struct, union or interface in an interface is illegal; nesting interface in a class, struct or union is illegal
+> 'interface' : nesting class, struct, union or interface in an interface is illegal; nesting interface in a class, struct or union is illegal
 
 An [__interface](../../cpp/interface.md) can only appear at global scope or within a namespace. A class, struct, or union cannot appear in an interface.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
@@ -16,7 +16,7 @@ An [__interface](../../cpp/interface.md) can only appear at global scope or with
 
 ## Example
 
-The following sample generates C3161.
+The following example generates C3161.
 
 ```cpp
 // C3161.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3161.md
@@ -10,6 +10,8 @@ ms.assetid: 1fe2be85-a343-487b-8476-bf9e257eb29d
 
 > 'interface' : nesting class, struct, union or interface in an interface is illegal; nesting interface in a class, struct or union is illegal
 
+## Remarks
+
 An [__interface](../../cpp/interface.md) can only appear at global scope or within a namespace. A class, struct, or union cannot appear in an interface.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3162"
 title: "Compiler Error C3162"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3162"
+ms.date: 11/04/2016
 f1_keywords: ["C3162"]
 helpviewer_keywords: ["C3162"]
-ms.assetid: 0d4c4a24-1456-4191-b7d8-c38cb7b17c32
 ---
 # Compiler Error C3162
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
@@ -24,7 +24,7 @@ For more information, see,
 
 ## Example
 
-The following sample generates C3162.
+The following example generates C3162.
 
 ```cpp
 // C3162.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
@@ -10,6 +10,8 @@ ms.assetid: 0d4c4a24-1456-4191-b7d8-c38cb7b17c32
 
 > 'type' : a reference type which has a destructor cannot be used as the type of static data member 'member'
 
+## Remarks
+
 The common language runtime cannot know when to run a user-defined destructor when the class also contains static member function.
 
 A destructor will never be run unless the object is deleted explicitly.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3162.md
@@ -8,7 +8,7 @@ ms.assetid: 0d4c4a24-1456-4191-b7d8-c38cb7b17c32
 ---
 # Compiler Error C3162
 
-'type' : a reference type which has a destructor cannot be used as the type of static data member 'member'
+> 'type' : a reference type which has a destructor cannot be used as the type of static data member 'member'
 
 The common language runtime cannot know when to run a user-defined destructor when the class also contains static member function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
@@ -10,6 +10,8 @@ ms.assetid: 17dcafa3-f416-4e04-a232-f9569218ba75
 
 > '*construct*': attributes inconsistent with previous declaration
 
+## Remarks
+
 The attribute(s) that are applied to a definition conflict with the attribute(s) that are applied to a declaration.
 
 One way to resolve C3163 is to eliminate attributes on the forward declaration. Any attributes on a forward declaration should be less than the attributes on the definition or, at most, equal to them.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3163"
 title: "Compiler Error C3163"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3163"
+ms.date: 11/04/2016
 f1_keywords: ["C3163"]
 helpviewer_keywords: ["C3163"]
-ms.assetid: 17dcafa3-f416-4e04-a232-f9569218ba75
 ---
 # Compiler Error C3163
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3163.md
@@ -20,7 +20,7 @@ A possible cause of the C3163 error involves the Microsoft source code annotatio
 
 ## Example
 
-The following sample generates C3163.
+The following example generates C3163.
 
 ```cpp
 // C3163.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3166.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3166.md
@@ -10,6 +10,8 @@ ms.assetid: ec3e330d-c15d-4158-8268-09101486c566
 
 > 'pointer' : cannot declare a pointer to an interior __gc pointer as a member of 'type'
 
+## Remarks
+
 The compiler found an invalid pointer declaration (a **`__nogc`** pointer to a **`__gc`** pointer.).
 
 C3166 is only reachable using the obsolete compiler option **`/clr:oldSyntax`**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3166.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3166.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3166"
 title: "Compiler Error C3166"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3166"
+ms.date: 11/04/2016
 f1_keywords: ["C3166"]
 helpviewer_keywords: ["C3166"]
-ms.assetid: ec3e330d-c15d-4158-8268-09101486c566
 ---
 # Compiler Error C3166
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
@@ -8,6 +8,6 @@ ms.assetid: 58c25fe7-8562-4a18-ad3f-487f081ff173
 ---
 # Compiler Error C3167
 
-Unable to initialize .NET Framework: make sure it is installed
+> Unable to initialize .NET Framework: make sure it is installed
 
 The .NET Framework is not installed on this computer; install the .NET Framework.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
@@ -10,4 +10,6 @@ ms.assetid: 58c25fe7-8562-4a18-ad3f-487f081ff173
 
 > Unable to initialize .NET Framework: make sure it is installed
 
+## Remarks
+
 The .NET Framework is not installed on this computer; install the .NET Framework.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3167.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3167"
 title: "Compiler Error C3167"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3167"
+ms.date: 11/04/2016
 f1_keywords: ["C3167"]
 helpviewer_keywords: ["C3167"]
-ms.assetid: 58c25fe7-8562-4a18-ad3f-487f081ff173
 ---
 # Compiler Error C3167
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3168"
 title: "Compiler Error C3168"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3168"
+ms.date: 11/04/2016
 f1_keywords: ["C3168"]
 helpviewer_keywords: ["C3168"]
-ms.assetid: 4c36fcfb-c351-48ff-b4eb-78d2aa1b4d55
 ---
 # Compiler Error C3168
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
@@ -16,7 +16,7 @@ The underlying type you specified for the **`enum`** type was not valid. The und
 
 ## Example
 
-The following sample generates C3168:
+The following example generates C3168:
 
 ```cpp
 // C3168.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
@@ -8,7 +8,7 @@ ms.assetid: 4c36fcfb-c351-48ff-b4eb-78d2aa1b4d55
 ---
 # Compiler Error C3168
 
-'type' : illegal underlying type for enum
+> 'type' : illegal underlying type for enum
 
 The underlying type you specified for the **`enum`** type was not valid. The underlying type must be an integral C++ type or a corresponding CLR type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3168.md
@@ -10,7 +10,11 @@ ms.assetid: 4c36fcfb-c351-48ff-b4eb-78d2aa1b4d55
 
 > 'type' : illegal underlying type for enum
 
+## Remarks
+
 The underlying type you specified for the **`enum`** type was not valid. The underlying type must be an integral C++ type or a corresponding CLR type.
+
+## Example
 
 The following sample generates C3168:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3170"
 title: "Compiler Error C3170"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3170"
+ms.date: 11/04/2016
 f1_keywords: ["C3170"]
 helpviewer_keywords: ["C3170"]
-ms.assetid: ca9a59d6-7df3-42f0-b028-c09d0af3ac2a
 ---
 # Compiler Error C3170
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
@@ -8,7 +8,7 @@ ms.assetid: ca9a59d6-7df3-42f0-b028-c09d0af3ac2a
 ---
 # Compiler Error C3170
 
-cannot have different module identifiers in a project
+> cannot have different module identifiers in a project
 
 [module](../../windows/attributes/module-cpp.md) attributes with different names were found in two of the files in a compilation. Only one unique `module` attribute can be specified per compilation.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3170.md
@@ -10,9 +10,13 @@ ms.assetid: ca9a59d6-7df3-42f0-b028-c09d0af3ac2a
 
 > cannot have different module identifiers in a project
 
+## Remarks
+
 [module](../../windows/attributes/module-cpp.md) attributes with different names were found in two of the files in a compilation. Only one unique `module` attribute can be specified per compilation.
 
 Identical `module` attributes can be specified in more than one source code file.
+
+## Example
 
 For example, if the following module attributes were found:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3171"
 title: "Compiler Error C3171"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3171"
+ms.date: 11/04/2016
 f1_keywords: ["C3171"]
 helpviewer_keywords: ["C3171"]
-ms.assetid: 1ce26997-7ef1-4c9f-84da-003ea1a4251e
 ---
 # Compiler Error C3171
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
@@ -8,7 +8,7 @@ ms.assetid: 1ce26997-7ef1-4c9f-84da-003ea1a4251e
 ---
 # Compiler Error C3171
 
-'module': cannot specify different module attributes in a project
+> 'module': cannot specify different module attributes in a project
 
 [module](../../windows/attributes/module-cpp.md) attributes with different parameter lists were found in two of the files in a compilation. Only one unique `module` attribute can be specified per compilation.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3171.md
@@ -10,9 +10,13 @@ ms.assetid: 1ce26997-7ef1-4c9f-84da-003ea1a4251e
 
 > 'module': cannot specify different module attributes in a project
 
+## Remarks
+
 [module](../../windows/attributes/module-cpp.md) attributes with different parameter lists were found in two of the files in a compilation. Only one unique `module` attribute can be specified per compilation.
 
 Identical `module` attributes can be specified in more than one source code file.
+
+## Example
 
 For example, if the following `module` attributes were found:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
@@ -10,9 +10,13 @@ ms.assetid: 1834e2fd-6036-4c33-aff2-b51bc7c99441
 
 > 'module_name': cannot specify different idl_module attributes in a project
 
+## Remarks
+
 [idl_module](../../windows/attributes/idl-module.md) attributes with the same name but different `dllname` or `version` parameters were found in two of the files in a compilation. Only one unique `idl_module` attribute can be specified per compilation.
 
 Identical `idl_module` attributes can be specified in more than one source code file.
+
+## Example
 
 For example, if the following `idl_module` attributes were found:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3172"
 title: "Compiler Error C3172"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3172"
+ms.date: 11/04/2016
 f1_keywords: ["C3172"]
 helpviewer_keywords: ["C3172"]
-ms.assetid: 1834e2fd-6036-4c33-aff2-b51bc7c99441
 ---
 # Compiler Error C3172
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3172.md
@@ -8,7 +8,7 @@ ms.assetid: 1834e2fd-6036-4c33-aff2-b51bc7c99441
 ---
 # Compiler Error C3172
 
-'module_name': cannot specify different idl_module attributes in a project
+> 'module_name': cannot specify different idl_module attributes in a project
 
 [idl_module](../../windows/attributes/idl-module.md) attributes with the same name but different `dllname` or `version` parameters were found in two of the files in a compilation. Only one unique `idl_module` attribute can be specified per compilation.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
@@ -10,6 +10,8 @@ ms.assetid: edf79e10-e8cf-4f76-8d33-ab9d05e974e9
 
 > version mismatch in idl merge
 
+## Remarks
+
 This error occurs when an object file contains embedded idl that was generated with a previous version of the compiler. The compiler encodes a version number to ensure that the same compiler used to generate the idl content that is embedded in the .obj files is also the same compiler used to merge the embedded idl.
 
 Update your Visual C++ installation so that all tools are from the latest released version.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
@@ -8,7 +8,7 @@ ms.assetid: edf79e10-e8cf-4f76-8d33-ab9d05e974e9
 ---
 # Compiler Error C3173
 
-version mismatch in idl merge
+> version mismatch in idl merge
 
 This error occurs when an object file contains embedded idl that was generated with a previous version of the compiler. The compiler encodes a version number to ensure that the same compiler used to generate the idl content that is embedded in the .obj files is also the same compiler used to merge the embedded idl.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3173.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3173"
 title: "Compiler Error C3173"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3173"
+ms.date: 11/04/2016
 f1_keywords: ["C3173"]
 helpviewer_keywords: ["C3173"]
-ms.assetid: edf79e10-e8cf-4f76-8d33-ab9d05e974e9
 ---
 # Compiler Error C3173
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
@@ -16,7 +16,7 @@ A program that uses Visual C++ attributes did not also use the [module](../../wi
 
 ## Example
 
-The following sample generates C3174:
+The following example generates C3174:
 
 ```cpp
 // C3174.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3174"
 title: "Compiler Error C3174"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3174"
+ms.date: 11/04/2016
 f1_keywords: ["C3174"]
 helpviewer_keywords: ["C3174"]
-ms.assetid: fe6b3b5a-8196-485f-a45f-0b2e51df4086
 ---
 # Compiler Error C3174
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
@@ -8,7 +8,7 @@ ms.assetid: fe6b3b5a-8196-485f-a45f-0b2e51df4086
 ---
 # Compiler Error C3174
 
-module attribute was not specified
+> module attribute was not specified
 
 A program that uses Visual C++ attributes did not also use the [module](../../windows/attributes/module-cpp.md) attribute, which is required in any program that uses attributes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3174.md
@@ -10,7 +10,11 @@ ms.assetid: fe6b3b5a-8196-485f-a45f-0b2e51df4086
 
 > module attribute was not specified
 
+## Remarks
+
 A program that uses Visual C++ attributes did not also use the [module](../../windows/attributes/module-cpp.md) attribute, which is required in any program that uses attributes.
+
+## Example
 
 The following sample generates C3174:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3175"
 title: "Compiler Error C3175"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3175"
+ms.date: 11/04/2016
 f1_keywords: ["C3175"]
 helpviewer_keywords: ["C3175"]
-ms.assetid: 3f19d513-a05a-4b6c-806f-276fe5c36b90
 ---
 # Compiler Error C3175
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
@@ -16,7 +16,7 @@ Unmanaged functions cannot call member functions of managed classes.
 
 ## Example
 
-The following sample generates C3175:
+The following example generates C3175:
 
 ```cpp
 // C3175_2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
@@ -8,7 +8,7 @@ ms.assetid: 3f19d513-a05a-4b6c-806f-276fe5c36b90
 ---
 # Compiler Error C3175
 
-'function1' : cannot call a method of a managed type from unmanaged function 'function2'
+> 'function1' : cannot call a method of a managed type from unmanaged function 'function2'
 
 Unmanaged functions cannot call member functions of managed classes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3175.md
@@ -10,7 +10,11 @@ ms.assetid: 3f19d513-a05a-4b6c-806f-276fe5c36b90
 
 > 'function1' : cannot call a method of a managed type from unmanaged function 'function2'
 
+## Remarks
+
 Unmanaged functions cannot call member functions of managed classes.
+
+## Example
 
 The following sample generates C3175:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
@@ -8,7 +8,7 @@ ms.assetid: 6cc8d602-8e15-47a7-b1b5-e93e5d50e271
 ---
 # Compiler Error C3176
 
-'type' : cannot declare local value type
+> 'type' : cannot declare local value type
 
 A class can only be declared as a value type at global scope.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
@@ -16,7 +16,7 @@ A class can only be declared as a value type at global scope.
 
 ## Example
 
-The following sample generates C3176.
+The following example generates C3176.
 
 ```cpp
 // C3176.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
@@ -10,6 +10,8 @@ ms.assetid: 6cc8d602-8e15-47a7-b1b5-e93e5d50e271
 
 > 'type' : cannot declare local value type
 
+## Remarks
+
 A class can only be declared as a value type at global scope.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3176.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3176"
 title: "Compiler Error C3176"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3176"
+ms.date: 11/04/2016
 f1_keywords: ["C3176"]
 helpviewer_keywords: ["C3176"]
-ms.assetid: 6cc8d602-8e15-47a7-b1b5-e93e5d50e271
 ---
 # Compiler Error C3176
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
@@ -16,7 +16,7 @@ All CLR and WinRT classes and structs must have names.
 
 ## Example
 
-The following sample generates C3179 and shows how to fix it:
+The following example generates C3179 and shows how to fix it:
 
 ```cpp
 // C3179a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
@@ -8,7 +8,7 @@ ms.assetid: 60d7e41b-25fd-48ac-8b79-830c062f4dcd
 ---
 # Compiler Error C3179
 
-an unnamed managed or WinRT type is not allowed
+> an unnamed managed or WinRT type is not allowed
 
 All CLR and WinRT classes and structs must have names.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3179"
 title: "Compiler Error C3179"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3179"
+ms.date: 11/04/2016
 f1_keywords: ["C3179"]
 helpviewer_keywords: ["C3179"]
-ms.assetid: 60d7e41b-25fd-48ac-8b79-830c062f4dcd
 ---
 # Compiler Error C3179
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3179.md
@@ -10,7 +10,11 @@ ms.assetid: 60d7e41b-25fd-48ac-8b79-830c062f4dcd
 
 > an unnamed managed or WinRT type is not allowed
 
+## Remarks
+
 All CLR and WinRT classes and structs must have names.
+
+## Example
 
 The following sample generates C3179 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
@@ -8,7 +8,7 @@ ms.assetid: 5281f583-7df7-418a-8507-d4da67ed6572
 ---
 # Compiler Error C3180
 
-'type name' : name exceeds meta-data limit of 'limit' characters
+> 'type name' : name exceeds meta-data limit of 'limit' characters
 
 The compiler truncated the name for a managed type in metadata. The truncation will make the type unusable with the `#using` directive (or the equivalent in another language).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
@@ -10,6 +10,8 @@ ms.assetid: 5281f583-7df7-418a-8507-d4da67ed6572
 
 > 'type name' : name exceeds meta-data limit of 'limit' characters
 
+## Remarks
+
 The compiler truncated the name for a managed type in metadata. The truncation will make the type unusable with the `#using` directive (or the equivalent in another language).
 
 The type-name limit includes any namespace qualifications.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3180.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3180"
 title: "Compiler Error C3180"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3180"
+ms.date: 11/04/2016
 f1_keywords: ["C3180"]
 helpviewer_keywords: ["C3180"]
-ms.assetid: 5281f583-7df7-418a-8507-d4da67ed6572
 ---
 # Compiler Error C3180
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3181"
 title: "Compiler Error C3181"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3181"
+ms.date: 11/04/2016
 f1_keywords: ["C3181"]
 helpviewer_keywords: ["C3181"]
-ms.assetid: 5d450f8b-6cef-4452-a0c4-2076e967451d
 ---
 # Compiler Error C3181
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
@@ -10,9 +10,13 @@ ms.assetid: 5d450f8b-6cef-4452-a0c4-2076e967451d
 
 > 'type' : invalid operand for operator
 
+## Remarks
+
 An invalid parameter was passed to the [typeid](../../extensions/typeid-cpp-component-extensions.md) operator. The parameter must be a managed type.
 
 Note that the compiler uses aliases for native types that map to types in the common language runtime.
+
+## Example
 
 The following sample generates C3181:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
@@ -8,7 +8,7 @@ ms.assetid: 5d450f8b-6cef-4452-a0c4-2076e967451d
 ---
 # Compiler Error C3181
 
-'type' : invalid operand for operator
+> 'type' : invalid operand for operator
 
 An invalid parameter was passed to the [typeid](../../extensions/typeid-cpp-component-extensions.md) operator. The parameter must be a managed type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3181.md
@@ -18,7 +18,7 @@ Note that the compiler uses aliases for native types that map to types in the co
 
 ## Example
 
-The following sample generates C3181:
+The following example generates C3181:
 
 ```cpp
 // C3181a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
@@ -16,7 +16,7 @@ A [using](../../cpp/using-declaration.md) declaration is invalid within all form
 
 ## Example
 
-The following sample generates C3182 and shows how to fix it.
+The following example generates C3182 and shows how to fix it.
 
 ```cpp
 // C3182a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3182"
 title: "Compiler Error C3182"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3182"
+ms.date: 11/04/2016
 f1_keywords: ["C3182"]
 helpviewer_keywords: ["C3182"]
-ms.assetid: f3681266-308e-4990-a979-8eef8920e186
 ---
 # Compiler Error C3182
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
@@ -10,7 +10,11 @@ ms.assetid: f3681266-308e-4990-a979-8eef8920e186
 
 > 'class' : a member using-declaration or access declaration is illegal within a managed or WinRTtype
 
+## Remarks
+
 A [using](../../cpp/using-declaration.md) declaration is invalid within all forms of managed classes.
+
+## Example
 
 The following sample generates C3182 and shows how to fix it.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3182.md
@@ -8,7 +8,7 @@ ms.assetid: f3681266-308e-4990-a979-8eef8920e186
 ---
 # Compiler Error C3182
 
-'class' : a member using-declaration or access declaration is illegal within a managed or WinRTtype
+> 'class' : a member using-declaration or access declaration is illegal within a managed or WinRTtype
 
 A [using](../../cpp/using-declaration.md) declaration is invalid within all forms of managed classes.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
@@ -8,7 +8,7 @@ ms.assetid: dbd0f020-c739-43c9-947e-9ce21537331b
 ---
 # Compiler Error C3183
 
-cannot define unnamed class, struct or union inside of managed or WinRT type 'type'
+> cannot define unnamed class, struct or union inside of managed or WinRT type 'type'
 
 A type that is embedded in a managed or WinRT type must be named.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
@@ -10,7 +10,11 @@ ms.assetid: dbd0f020-c739-43c9-947e-9ce21537331b
 
 > cannot define unnamed class, struct or union inside of managed or WinRT type 'type'
 
+## Remarks
+
 A type that is embedded in a managed or WinRT type must be named.
+
+## Example
 
 The following sample generates C3183:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
@@ -16,7 +16,7 @@ A type that is embedded in a managed or WinRT type must be named.
 
 ## Example
 
-The following sample generates C3183:
+The following example generates C3183:
 
 ```cpp
 // C3183a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3183.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3183"
 title: "Compiler Error C3183"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3183"
+ms.date: 11/04/2016
 f1_keywords: ["C3183"]
 helpviewer_keywords: ["C3183"]
-ms.assetid: dbd0f020-c739-43c9-947e-9ce21537331b
 ---
 # Compiler Error C3183
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
@@ -15,7 +15,7 @@ You cannot apply the [typeid](../../cpp/typeid-operator.md) operator to a manage
 
 ## Example
 
-The following sample generates C3185 and shows how to fix it:
+The following example generates C3185 and shows how to fix it:
 
 ```cpp
 // C3185a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C3185"]
 ---
 # Compiler Error C3185
 
-'typeid' used on managed or WinRT type 'type', use 'operator' instead
+> 'typeid' used on managed or WinRT type 'type', use 'operator' instead
 
 You cannot apply the [typeid](../../cpp/typeid-operator.md) operator to a managed or WinRT type; use [typeid](../../extensions/typeid-cpp-component-extensions.md) instead.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3185.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C3185"]
 
 > 'typeid' used on managed or WinRT type 'type', use 'operator' instead
 
+## Remarks
+
 You cannot apply the [typeid](../../cpp/typeid-operator.md) operator to a managed or WinRT type; use [typeid](../../extensions/typeid-cpp-component-extensions.md) instead.
+
+## Example
 
 The following sample generates C3185 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
@@ -18,7 +18,7 @@ This error is obsolete in Visual Studio 2022 and later versions.
 
 ## Example
 
-The following sample generates C3189:
+The following example generates C3189:
 
 ```cpp
 // C3189.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3189"
 title: "Compiler Error C3189"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3189"
+ms.date: 11/04/2016
 f1_keywords: ["C3189"]
 helpviewer_keywords: ["C3189"]
-ms.assetid: b254de79-931e-4a59-a9f4-1c690d90ca5e
 ---
 # Compiler Error C3189
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3189.md
@@ -10,9 +10,13 @@ ms.assetid: b254de79-931e-4a59-a9f4-1c690d90ca5e
 
 > 'typeid\<type abstract declarator>': this syntax is no longer supported, use ::typeid instead
 
+## Remarks
+
 An obsolete form of [typeid](../../extensions/typeid-cpp-component-extensions.md) was used, use the new form.
 
 This error is obsolete in Visual Studio 2022 and later versions.
+
+## Example
 
 The following sample generates C3189:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
@@ -16,7 +16,7 @@ The compiler detected an attempt to make an explicit function instantiation; how
 
 ## Example
 
-The following sample generates C3190:
+The following example generates C3190:
 
 ```cpp
 // C3190.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
@@ -8,7 +8,7 @@ ms.assetid: 7c701afa-85a7-4f7a-8881-0662436ac244
 ---
 # Compiler Error C3190
 
-'instantiation' with the provided template arguments is not the explicit instantiation of any member function of 'type'
+> 'instantiation' with the provided template arguments is not the explicit instantiation of any member function of 'type'
 
 The compiler detected an attempt to make an explicit function instantiation; however, the provided type arguments do not match any of the possible functions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3190"
 title: "Compiler Error C3190"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3190"
+ms.date: 11/04/2016
 f1_keywords: ["C3190"]
 helpviewer_keywords: ["C3190"]
-ms.assetid: 7c701afa-85a7-4f7a-8881-0662436ac244
 ---
 # Compiler Error C3190
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3190.md
@@ -10,7 +10,11 @@ ms.assetid: 7c701afa-85a7-4f7a-8881-0662436ac244
 
 > 'instantiation' with the provided template arguments is not the explicit instantiation of any member function of 'type'
 
+## Remarks
+
 The compiler detected an attempt to make an explicit function instantiation; however, the provided type arguments do not match any of the possible functions.
+
+## Example
 
 The following sample generates C3190:
 


### PR DESCRIPTION
C3187 is skipped due to #5665.

This is batch 51 that structures error/warning references. See #5465 for more information.