### PR TITLE
Structure error references in range [C3281, C3350]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
@@ -8,7 +8,7 @@ ms.assetid: bac2ac89-c360-4c24-bb81-c20c62ece9ba
 ---
 # Compiler Error C3282
 
-generic parameter lists can only appear on managed or WinRTclasses, structs, or functions
+> generic parameter lists can only appear on managed or WinRTclasses, structs, or functions
 
 A generic parameter list was used incorrectly.  For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
@@ -16,7 +16,7 @@ A generic parameter list was used incorrectly.  For more information, see [Gener
 
 ## Example
 
-The following sample generates C3282 and shows how to fix it.
+The following example generates C3282 and shows how to fix it.
 
 ```cpp
 // C3282.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3282"
 title: "Compiler Error C3282"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3282"
+ms.date: 11/04/2016
 f1_keywords: ["C3282"]
 helpviewer_keywords: ["C3282"]
-ms.assetid: bac2ac89-c360-4c24-bb81-c20c62ece9ba
 ---
 # Compiler Error C3282
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3282.md
@@ -10,6 +10,8 @@ ms.assetid: bac2ac89-c360-4c24-bb81-c20c62ece9ba
 
 > generic parameter lists can only appear on managed or WinRTclasses, structs, or functions
 
+## Remarks
+
 A generic parameter list was used incorrectly.  For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
@@ -10,7 +10,11 @@ ms.assetid: c51d912c-cde3-4928-904e-26734c8954ce
 
 > 'type' : an interface cannot have an instance constructor
 
+## Remarks
+
 A CLR [interface](../../extensions/interface-class-cpp-component-extensions.md) cannot have an instance constructor.  A static constructor is allowed.
+
+## Example
 
 The following sample generates C3283:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
@@ -8,7 +8,7 @@ ms.assetid: c51d912c-cde3-4928-904e-26734c8954ce
 ---
 # Compiler Error C3283
 
-'type' : an interface cannot have an instance constructor
+> 'type' : an interface cannot have an instance constructor
 
 A CLR [interface](../../extensions/interface-class-cpp-component-extensions.md) cannot have an instance constructor.  A static constructor is allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
@@ -16,7 +16,7 @@ A CLR [interface](../../extensions/interface-class-cpp-component-extensions.md) 
 
 ## Example
 
-The following sample generates C3283:
+The following example generates C3283:
 
 ```cpp
 // C3283.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3283.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3283"
 title: "Compiler Error C3283"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3283"
+ms.date: 11/04/2016
 f1_keywords: ["C3283"]
 helpviewer_keywords: ["C3283"]
-ms.assetid: c51d912c-cde3-4928-904e-26734c8954ce
 ---
 # Compiler Error C3283
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
@@ -10,7 +10,11 @@ ms.assetid: e582f316-e9db-4d27-9c70-fdfa737a9d5f
 
 > the constraints for generic parameter 'parameter' of function 'function' must match the constraints for generic parameter 'parameter' of function 'function'
 
+## Remarks
+
 A virtual generic function must use the same constraints as a virtual function with the same name and set of arguments in the base class.
+
+## Example
 
 The following sample generates C3284:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3284"
 title: "Compiler Error C3284"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3284"
+ms.date: 11/04/2016
 f1_keywords: ["C3284"]
 helpviewer_keywords: ["C3284"]
-ms.assetid: e582f316-e9db-4d27-9c70-fdfa737a9d5f
 ---
 # Compiler Error C3284
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
@@ -8,7 +8,7 @@ ms.assetid: e582f316-e9db-4d27-9c70-fdfa737a9d5f
 ---
 # Compiler Error C3284
 
-the constraints for generic parameter 'parameter' of function 'function' must match the constraints for generic parameter 'parameter' of function 'function'
+> the constraints for generic parameter 'parameter' of function 'function' must match the constraints for generic parameter 'parameter' of function 'function'
 
 A virtual generic function must use the same constraints as a virtual function with the same name and set of arguments in the base class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3284.md
@@ -16,7 +16,7 @@ A virtual generic function must use the same constraints as a virtual function w
 
 ## Example
 
-The following sample generates C3284:
+The following example generates C3284:
 
 ```cpp
 // C3284.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3285"
 title: "Compiler Error C3285"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3285"
+ms.date: 11/04/2016
 f1_keywords: ["C3285"]
 helpviewer_keywords: ["C3285"]
-ms.assetid: 04e8f210-d67e-4810-b153-e1efe2986c8f
 ---
 # Compiler Error C3285
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
@@ -8,7 +8,7 @@ ms.assetid: 04e8f210-d67e-4810-b153-e1efe2986c8f
 ---
 # Compiler Error C3285
 
-for each statement cannot operate on variables of type 'type'
+> for each statement cannot operate on variables of type 'type'
 
 The `for each` statement repeats a group of embedded statements for each element in an array or an object collection.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
@@ -18,7 +18,7 @@ See [for each, in](../../dotnet/for-each-in.md) for more information.
 
 ## Example
 
-The following sample generates C3285.
+The following example generates C3285.
 
 ```cpp
 // C3285.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3285.md
@@ -10,6 +10,8 @@ ms.assetid: 04e8f210-d67e-4810-b153-e1efe2986c8f
 
 > for each statement cannot operate on variables of type 'type'
 
+## Remarks
+
 The `for each` statement repeats a group of embedded statements for each element in an array or an object collection.
 
 See [for each, in](../../dotnet/for-each-in.md) for more information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
@@ -10,6 +10,8 @@ ms.assetid: 554328c8-cf44-4f7d-a8d2-def74d28ecdd
 
 > '*specifier*': an iteration variable cannot have any storage-class specifiers
 
+## Remarks
+
 A storage class can't be specified on an iteration variable. For more information, see [Storage classes (C++)](../../cpp/storage-classes-cpp.md) and [for each, in](../../dotnet/for-each-in.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
@@ -16,7 +16,7 @@ A storage class can't be specified on an iteration variable. For more informatio
 
 ## Example
 
-The following sample generates C3286, and also shows correct usage.
+The following example generates C3286, and also shows correct usage.
 
 ```cpp
 // C3286.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3286.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3286"
 title: "Compiler Error C3286"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3286"
+ms.date: 11/04/2016
 f1_keywords: ["C3286"]
 helpviewer_keywords: ["C3286"]
-ms.assetid: 554328c8-cf44-4f7d-a8d2-def74d28ecdd
 ---
 # Compiler Error C3286
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3287.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3287.md
@@ -18,7 +18,7 @@ For more information, see [for each, in](../../dotnet/for-each-in.md).
 
 ## Example
 
-The following sample generates C3287.
+The following example generates C3287.
 
 ```cpp
 // C3287.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3287.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3287.md
@@ -4,7 +4,6 @@ description: "Describes Microsoft C++ compiler error C3287."
 ms.date: 09/25/2020
 f1_keywords: ["C3287"]
 helpviewer_keywords: ["C3287"]
-ms.assetid: c1fa73d2-2c82-4136-a7da-0e75e3b420ad
 ---
 # Compiler Error C3287
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3288"
 title: "Compiler Error C3288"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3288"
+ms.date: 11/04/2016
 f1_keywords: ["C3288"]
 helpviewer_keywords: ["C3288"]
-ms.assetid: ed08a540-9751-46e1-9cbe-c51d6a49ffab
 ---
 # Compiler Error C3288
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
@@ -10,6 +10,8 @@ ms.assetid: ed08a540-9751-46e1-9cbe-c51d6a49ffab
 
 > 'type' : illegal dereference of a handle type
 
+## Remarks
+
 The compiler detected an illegal dereference of a handle type. You can dereference a handle type and assign it to a reference. For more information, see [Tracking Reference Operator](../../extensions/tracking-reference-operator-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
@@ -16,7 +16,7 @@ The compiler detected an illegal dereference of a handle type. You can dereferen
 
 ## Example
 
-The following sample generates C3288.
+The following example generates C3288.
 
 ```cpp
 // C3288.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3288.md
@@ -8,7 +8,7 @@ ms.assetid: ed08a540-9751-46e1-9cbe-c51d6a49ffab
 ---
 # Compiler Error C3288
 
-'type' : illegal dereference of a handle type
+> 'type' : illegal dereference of a handle type
 
 The compiler detected an illegal dereference of a handle type. You can dereference a handle type and assign it to a reference. For more information, see [Tracking Reference Operator](../../extensions/tracking-reference-operator-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
@@ -10,6 +10,8 @@ ms.assetid: 3c1c623b-7fcf-43ab-a89a-8722532a8d29
 
 > 'property' : a trivial property cannot be indexed
 
+## Remarks
+
 A property was declared incorrectly. Accessors must be defined for an indexed property. See [property](../../extensions/property-cpp-component-extensions.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3289"
 title: "Compiler Error C3289"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3289"
+ms.date: 11/04/2016
 f1_keywords: ["C3289"]
 helpviewer_keywords: ["C3289"]
-ms.assetid: 3c1c623b-7fcf-43ab-a89a-8722532a8d29
 ---
 # Compiler Error C3289
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
@@ -16,7 +16,7 @@ A property was declared incorrectly. Accessors must be defined for an indexed pr
 
 ## Example
 
-The following sample generates C3289.
+The following example generates C3289.
 
 ```cpp
 // C3289.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3289.md
@@ -8,7 +8,7 @@ ms.assetid: 3c1c623b-7fcf-43ab-a89a-8722532a8d29
 ---
 # Compiler Error C3289
 
-'property' : a trivial property cannot be indexed
+> 'property' : a trivial property cannot be indexed
 
 A property was declared incorrectly. Accessors must be defined for an indexed property. See [property](../../extensions/property-cpp-component-extensions.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
@@ -8,7 +8,7 @@ ms.assetid: 0baf684b-1143-4953-ac99-a2fa267d8017
 ---
 # Compiler Error C3290
 
-'type' : a trivial property cannot have reference type
+> 'type' : a trivial property cannot have reference type
 
 A property was declared incorrectly. When you declare a trivial property, the compiler creates a variable that the property will update, and it is not possible to have a tracking reference variable in a class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3290"
 title: "Compiler Error C3290"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3290"
+ms.date: 11/04/2016
 f1_keywords: ["C3290"]
 helpviewer_keywords: ["C3290"]
-ms.assetid: 0baf684b-1143-4953-ac99-a2fa267d8017
 ---
 # Compiler Error C3290
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
@@ -18,7 +18,7 @@ See [property](../../extensions/property-cpp-component-extensions.md) and [Track
 
 ## Example
 
-The following sample generates C3290.
+The following example generates C3290.
 
 ```cpp
 // C3290.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3290.md
@@ -10,6 +10,8 @@ ms.assetid: 0baf684b-1143-4953-ac99-a2fa267d8017
 
 > 'type' : a trivial property cannot have reference type
 
+## Remarks
+
 A property was declared incorrectly. When you declare a trivial property, the compiler creates a variable that the property will update, and it is not possible to have a tracking reference variable in a class.
 
 See [property](../../extensions/property-cpp-component-extensions.md) and [Tracking Reference Operator](../../extensions/tracking-reference-operator-cpp-component-extensions.md) for more information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
@@ -10,6 +10,8 @@ ms.assetid: ed2e9f89-8dbc-4387-bc26-cc955e840858
 
 > 'default' : cannot be the name of a trivial property
 
+## Remarks
+
 A trivial property cannot be named **`default`**. See [property](../../extensions/property-cpp-component-extensions.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
@@ -8,7 +8,7 @@ ms.assetid: ed2e9f89-8dbc-4387-bc26-cc955e840858
 ---
 # Compiler Error C3291
 
-'default' : cannot be the name of a trivial property
+> 'default' : cannot be the name of a trivial property
 
 A trivial property cannot be named **`default`**. See [property](../../extensions/property-cpp-component-extensions.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
@@ -16,7 +16,7 @@ A trivial property cannot be named **`default`**. See [property](../../extension
 
 ## Example
 
-The following sample generates C3291.
+The following example generates C3291.
 
 ```cpp
 // C3291.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3291.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3291"
 title: "Compiler Error C3291"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3291"
+ms.date: 11/04/2016
 f1_keywords: ["C3291"]
 helpviewer_keywords: ["C3291"]
-ms.assetid: ed2e9f89-8dbc-4387-bc26-cc955e840858
 ---
 # Compiler Error C3291
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
@@ -16,7 +16,7 @@ The cli namespace cannot be declared in your code.  For more information, see [P
 
 ## Example
 
-The following sample generates C3292.
+The following example generates C3292.
 
 ```cpp
 // C3292.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3292"
 title: "Compiler Error C3292"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3292"
+ms.date: 11/04/2016
 f1_keywords: ["C3292"]
 helpviewer_keywords: ["C3292"]
-ms.assetid: ead485cc-5471-4e10-b361-300589ff5b70
 ---
 # Compiler Error C3292
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
@@ -8,7 +8,7 @@ ms.assetid: ead485cc-5471-4e10-b361-300589ff5b70
 ---
 # Compiler Error C3292
 
-the cli namespace cannot be reopened
+> the cli namespace cannot be reopened
 
 The cli namespace cannot be declared in your code.  For more information, see [Platform, default, and cli Namespaces](../../extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3292.md
@@ -10,6 +10,8 @@ ms.assetid: ead485cc-5471-4e10-b361-300589ff5b70
 
 > the cli namespace cannot be reopened
 
+## Remarks
+
 The cli namespace cannot be declared in your code.  For more information, see [Platform, default, and cli Namespaces](../../extensions/platform-default-and-cli-namespaces-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
@@ -10,6 +10,8 @@ ms.assetid: b772cf98-52e0-4e24-be23-1f5d87d999ac
 
 > 'accessor': use 'default' to access the default property (indexer) for class 'type'
 
+## Remarks
+
 An indexed property was accessed incorrectly.  See [How to: Use Properties in C++/CLI](../../dotnet/how-to-use-properties-in-cpp-cli.md) for more information.
 
 **Visual Studio 2017 and later**: In Visual Studio 2015 and earlier, the compiler in some cases misidentified a default property as a default indexer. It was possible to work around the issue by using the identifier "default" to access the property. The workaround itself became problematic after default was introduced as a keyword in C++11. Therefore, in Visual Studio 2017 the bugs that required the workaround were fixed, and the compiler now raises an error when "default" is used to access the default property for a class.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
@@ -8,7 +8,7 @@ ms.assetid: b772cf98-52e0-4e24-be23-1f5d87d999ac
 ---
 # Compiler Error C3293
 
-'accessor': use 'default' to access the default property (indexer) for class 'type'
+> 'accessor': use 'default' to access the default property (indexer) for class 'type'
 
 An indexed property was accessed incorrectly.  See [How to: Use Properties in C++/CLI](../../dotnet/how-to-use-properties-in-cpp-cli.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3293"
 title: "Compiler Error C3293"
-ms.date: "07/21/2017"
+description: "Learn more about: Compiler Error C3293"
+ms.date: 07/21/2017
 f1_keywords: ["C3293"]
 helpviewer_keywords: ["C3293"]
-ms.assetid: b772cf98-52e0-4e24-be23-1f5d87d999ac
 ---
 # Compiler Error C3293
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3293.md
@@ -18,7 +18,7 @@ An indexed property was accessed incorrectly.  See [How to: Use Properties in C+
 
 ## Example
 
-The following sample generates C3293 in Visual Studio 2015 and earlier.
+The following example generates C3293 in Visual Studio 2015 and earlier.
 
 ```cpp
 // C3293.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
@@ -10,6 +10,8 @@ ms.assetid: fc4c9dcd-16cf-4eee-a1ac-c43e7c29e443
 
 > 'property' : a property with this name already exists
 
+## Remarks
+
 The compiler encountered more than one property with the same name. Each property in a type must have a unique name.
 
 For more information, see [property](../../extensions/property-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3296"
 title: "Compiler Error C3296"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3296"
+ms.date: 11/04/2016
 f1_keywords: ["C3296"]
 helpviewer_keywords: ["C3296"]
-ms.assetid: fc4c9dcd-16cf-4eee-a1ac-c43e7c29e443
 ---
 # Compiler Error C3296
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
@@ -8,7 +8,7 @@ ms.assetid: fc4c9dcd-16cf-4eee-a1ac-c43e7c29e443
 ---
 # Compiler Error C3296
 
-'property' : a property with this name already exists
+> 'property' : a property with this name already exists
 
 The compiler encountered more than one property with the same name. Each property in a type must have a unique name.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3296.md
@@ -18,7 +18,7 @@ For more information, see [property](../../extensions/property-cpp-component-ext
 
 ## Example
 
-The following sample generates C3296.
+The following example generates C3296.
 
 ```cpp
 // C3296.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
@@ -8,7 +8,7 @@ ms.assetid: 2a718b4c-6cdb-4418-92c0-fc3a259431c4
 ---
 # Compiler Error C3297
 
-'constraint_2' : cannot use 'constraint_1' as a constraint because 'constraint_1' has the value constraint
+> 'constraint_2' : cannot use 'constraint_1' as a constraint because 'constraint_1' has the value constraint
 
 Value classes are sealed. If a constraint is a value class, another constraint can never derive from it.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
@@ -18,7 +18,7 @@ For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../
 
 ## Example
 
-The following sample generates C3297.
+The following example generates C3297.
 
 ```cpp
 // C3297.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
@@ -10,6 +10,8 @@ ms.assetid: 2a718b4c-6cdb-4418-92c0-fc3a259431c4
 
 > 'constraint_2' : cannot use 'constraint_1' as a constraint because 'constraint_1' has the value constraint
 
+## Remarks
+
 Value classes are sealed. If a constraint is a value class, another constraint can never derive from it.
 
 For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3297.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3297"
 title: "Compiler Error C3297"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3297"
+ms.date: 11/04/2016
 f1_keywords: ["C3297"]
 helpviewer_keywords: ["C3297"]
-ms.assetid: 2a718b4c-6cdb-4418-92c0-fc3a259431c4
 ---
 # Compiler Error C3297
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
@@ -10,6 +10,8 @@ ms.assetid: 458c2680-95bb-4d5e-895f-ce4115844193
 
 > 'constraint_1' : cannot use 'constraint_2' as a constraint because 'constraint_2' has the ref constraint and 'constraint_1' has the value constraint
 
+## Remarks
+
 You cannot specify mutually exclusive characteristics for a constraint. For example, a generic type parameter cannot be constrained to both a value type and a reference type.
 
 For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
@@ -8,7 +8,7 @@ ms.assetid: 458c2680-95bb-4d5e-895f-ce4115844193
 ---
 # Compiler Error C3298
 
-'constraint_1' : cannot use 'constraint_2' as a constraint because 'constraint_2' has the ref constraint and 'constraint_1' has the value constraint
+> 'constraint_1' : cannot use 'constraint_2' as a constraint because 'constraint_2' has the ref constraint and 'constraint_1' has the value constraint
 
 You cannot specify mutually exclusive characteristics for a constraint. For example, a generic type parameter cannot be constrained to both a value type and a reference type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
@@ -18,7 +18,7 @@ For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../
 
 ## Example
 
-The following sample generates C3298.
+The following example generates C3298.
 
 ```cpp
 // C3298.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3298.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3298"
 title: "Compiler Error C3298"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3298"
+ms.date: 11/04/2016
 f1_keywords: ["C3298"]
 helpviewer_keywords: ["C3298"]
-ms.assetid: 458c2680-95bb-4d5e-895f-ce4115844193
 ---
 # Compiler Error C3298
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
@@ -20,7 +20,7 @@ For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../
 
 ## Example
 
-The following sample generates C3299.
+The following example generates C3299.
 
 ```cpp
 // C3299.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
@@ -8,7 +8,7 @@ ms.assetid: 7cabdf01-bceb-404f-9401-cdd9c7fc1641
 ---
 # Compiler Error C3299
 
-'member_function' : cannot specify constraints, they are inherited from the base method
+> 'member_function' : cannot specify constraints, they are inherited from the base method
 
 When overriding a generic member function, you cannot specify constraint clauses (repeating the constraints implies that the constraints are not inherited).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3299"
 title: "Compiler Error C3299"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3299"
+ms.date: 11/04/2016
 f1_keywords: ["C3299"]
 helpviewer_keywords: ["C3299"]
-ms.assetid: 7cabdf01-bceb-404f-9401-cdd9c7fc1641
 ---
 # Compiler Error C3299
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3299.md
@@ -10,6 +10,8 @@ ms.assetid: 7cabdf01-bceb-404f-9401-cdd9c7fc1641
 
 > 'member_function' : cannot specify constraints, they are inherited from the base method
 
+## Remarks
+
 When overriding a generic member function, you cannot specify constraint clauses (repeating the constraints implies that the constraints are not inherited).
 
 The constraint clauses on the generic function you are overriding will be inherited.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
@@ -8,6 +8,6 @@ ms.assetid: c6f6ea3d-f6b7-4401-8bbb-f283a2c05540
 ---
 # Compiler Error C3303
 
-'attribute': attribute can only be used on 'usage'
+> 'attribute': attribute can only be used on 'usage'
 
 An attempt was made to use an attribute where it is not valid.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
@@ -10,4 +10,6 @@ ms.assetid: c6f6ea3d-f6b7-4401-8bbb-f283a2c05540
 
 > 'attribute': attribute can only be used on 'usage'
 
+## Remarks
+
 An attempt was made to use an attribute where it is not valid.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3303.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3303"
 title: "Compiler Error C3303"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3303"
+ms.date: 11/04/2016
 f1_keywords: ["C3303"]
 helpviewer_keywords: ["C3303"]
-ms.assetid: c6f6ea3d-f6b7-4401-8bbb-f283a2c05540
 ---
 # Compiler Error C3303
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3309"
 title: "Compiler Error C3309"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3309"
+ms.date: 11/04/2016
 f1_keywords: ["C3309"]
 helpviewer_keywords: ["C3309"]
-ms.assetid: 75ee16e3-7d4e-4c41-b3cb-64e9849c3aab
 ---
 # Compiler Error C3309
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
@@ -16,7 +16,7 @@ The value that you pass to the name property of the module attribute cannot be a
 
 ## Example
 
-The following sample generates C3309:
+The following example generates C3309:
 
 ```cpp
 // C3309.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
@@ -10,7 +10,11 @@ ms.assetid: 75ee16e3-7d4e-4c41-b3cb-64e9849c3aab
 
 > 'macro_name': module name cannot be a macro or a keyword
 
+## Remarks
+
 The value that you pass to the name property of the module attribute cannot be a symbol for the preprocessor to expand; it must be a string literal.
+
+## Example
 
 The following sample generates C3309:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3309.md
@@ -8,7 +8,7 @@ ms.assetid: 75ee16e3-7d4e-4c41-b3cb-64e9849c3aab
 ---
 # Compiler Error C3309
 
-'macro_name': module name cannot be a macro or a keyword
+> 'macro_name': module name cannot be a macro or a keyword
 
 The value that you pass to the name property of the module attribute cannot be a symbol for the preprocessor to expand; it must be a string literal.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
@@ -8,7 +8,7 @@ ms.assetid: 2ef72d9a-1f1d-4b2e-b244-9fd3f3e70cb6
 ---
 # Compiler Error C3320
 
-'type': type cannot have the same name as the module 'name' property
+> 'type': type cannot have the same name as the module 'name' property
 
 An exported user-defined type (UDT), which could be a struct, class, enum, or union, cannot have the same name as the parameter passed to the [module](../../windows/attributes/module-cpp.md) attribute's name property.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3320"
 title: "Compiler Error C3320"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3320"
+ms.date: 11/04/2016
 f1_keywords: ["C3320"]
 helpviewer_keywords: ["C3320"]
-ms.assetid: 2ef72d9a-1f1d-4b2e-b244-9fd3f3e70cb6
 ---
 # Compiler Error C3320
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
@@ -10,6 +10,8 @@ ms.assetid: 2ef72d9a-1f1d-4b2e-b244-9fd3f3e70cb6
 
 > 'type': type cannot have the same name as the module 'name' property
 
+## Remarks
+
 An exported user-defined type (UDT), which could be a struct, class, enum, or union, cannot have the same name as the parameter passed to the [module](../../windows/attributes/module-cpp.md) attribute's name property.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3320.md
@@ -16,7 +16,7 @@ An exported user-defined type (UDT), which could be a struct, class, enum, or un
 
 ## Example
 
-The following sample generates C3320:
+The following example generates C3320:
 
 ```cpp
 // C3320.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3322"
 title: "Compiler Error C3322"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3322"
+ms.date: 11/04/2016
 f1_keywords: ["C3322"]
 helpviewer_keywords: ["C3322"]
-ms.assetid: d8a0ad95-30df-4337-b0c8-4747de0bef50
 ---
 # Compiler Error C3322
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
@@ -8,6 +8,6 @@ ms.assetid: d8a0ad95-30df-4337-b0c8-4747de0bef50
 ---
 # Compiler Error C3322
 
-'property': is not a valid property for attribute 'attribute'
+> 'property': is not a valid property for attribute 'attribute'
 
 An invalid or unrecognized property (or parameter) was passed to an attribute. Check the documentation for the attribute.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3322.md
@@ -10,4 +10,6 @@ ms.assetid: d8a0ad95-30df-4337-b0c8-4747de0bef50
 
 > 'property': is not a valid property for attribute 'attribute'
 
+## Remarks
+
 An invalid or unrecognized property (or parameter) was passed to an attribute. Check the documentation for the attribute.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
@@ -10,4 +10,6 @@ ms.assetid: 51693978-fba6-435a-a696-74735cc875de
 
 > 'type library': cannot #import corrupt type library
 
+## Remarks
+
 The type library specified in the `#import` statement is unreadable by the compiler. You may want to either regenerate the type library, if possible, or request a new type library from your supplier. You may want to use the OLE Viewer, supplied with Visual C++, to view the type library file to see what is the matter with it.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3333"
 title: "Compiler Error C3333"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3333"
+ms.date: 11/04/2016
 f1_keywords: ["C3333"]
 helpviewer_keywords: ["C3333"]
-ms.assetid: 51693978-fba6-435a-a696-74735cc875de
 ---
 # Compiler Error C3333
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3333.md
@@ -8,6 +8,6 @@ ms.assetid: 51693978-fba6-435a-a696-74735cc875de
 ---
 # Compiler Error C3333
 
-'type library': cannot #import corrupt type library
+> 'type library': cannot #import corrupt type library
 
 The type library specified in the `#import` statement is unreadable by the compiler. You may want to either regenerate the type library, if possible, or request a new type library from your supplier. You may want to use the OLE Viewer, supplied with Visual C++, to view the type library file to see what is the matter with it.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
@@ -8,7 +8,7 @@ ms.assetid: e972c625-77e7-4022-8aba-e1db01d7a0d7
 ---
 # Compiler Error C3334
 
-cannot #import corrupt type library
+> cannot #import corrupt type library
 
 The library file in a `#import` statement is corrupt and can't be consumed by the compiler.  Corruption can come from bad generation of the module, disk corruption, or if the binary file was somehow edited and modified.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
@@ -10,6 +10,8 @@ ms.assetid: e972c625-77e7-4022-8aba-e1db01d7a0d7
 
 > cannot #import corrupt type library
 
+## Remarks
+
 The library file in a `#import` statement is corrupt and can't be consumed by the compiler.  Corruption can come from bad generation of the module, disk corruption, or if the binary file was somehow edited and modified.
 
 For more information, see [#import Directive](../../preprocessor/hash-import-directive-cpp.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3334.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3334"
 title: "Compiler Error C3334"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3334"
+ms.date: 11/04/2016
 f1_keywords: ["C3334"]
 helpviewer_keywords: ["C3334"]
-ms.assetid: e972c625-77e7-4022-8aba-e1db01d7a0d7
 ---
 # Compiler Error C3334
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
@@ -10,7 +10,11 @@ ms.assetid: 23b12298-b92a-4717-8380-f165c998cb8a
 
 > 'interface': interface cannot be both 'restricted' and 'default' in coclass 'class'
 
+## Remarks
+
 The [restricted](../../windows/attributes/restricted.md) attribute and the [default](../../windows/attributes/default-cpp.md) attribute are mutually exclusive.
+
+## Example
 
 The following sample generates C3340:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
@@ -8,7 +8,7 @@ ms.assetid: 23b12298-b92a-4717-8380-f165c998cb8a
 ---
 # Compiler Error C3340
 
-'interface': interface cannot be both 'restricted' and 'default' in coclass 'class'
+> 'interface': interface cannot be both 'restricted' and 'default' in coclass 'class'
 
 The [restricted](../../windows/attributes/restricted.md) attribute and the [default](../../windows/attributes/default-cpp.md) attribute are mutually exclusive.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3340"
 title: "Compiler Error C3340"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3340"
+ms.date: 11/04/2016
 f1_keywords: ["C3340"]
 helpviewer_keywords: ["C3340"]
-ms.assetid: 23b12298-b92a-4717-8380-f165c998cb8a
 ---
 # Compiler Error C3340
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3340.md
@@ -16,7 +16,7 @@ The [restricted](../../windows/attributes/restricted.md) attribute and the [defa
 
 ## Example
 
-The following sample generates C3340:
+The following example generates C3340:
 
 ```cpp
 // C3340.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
@@ -10,6 +10,8 @@ ms.assetid: 5c6d784f-bebe-4f7e-8615-44ca6f78bfba
 
 > 'attribute': ambiguous attribute
 
+## Remarks
+
 The compiler found more than one definition of an attribute.
 
 An attribute was defined more than once.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3342"
 title: "Compiler Error C3342"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3342"
+ms.date: 11/04/2016
 f1_keywords: ["C3342"]
 helpviewer_keywords: ["C3342"]
-ms.assetid: 5c6d784f-bebe-4f7e-8615-44ca6f78bfba
 ---
 # Compiler Error C3342
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
@@ -20,7 +20,7 @@ For more information, see [User-Defined Attributes](../../extensions/user-define
 
 ## Example
 
-The following sample generates C3342.
+The following example generates C3342.
 
 ```cpp
 // C3342.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3342.md
@@ -8,7 +8,7 @@ ms.assetid: 5c6d784f-bebe-4f7e-8615-44ca6f78bfba
 ---
 # Compiler Error C3342
 
-'attribute': ambiguous attribute
+> 'attribute': ambiguous attribute
 
 The compiler found more than one definition of an attribute.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3345"
 title: "Compiler Error C3345"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3345"
+ms.date: 11/04/2016
 f1_keywords: ["C3345"]
 helpviewer_keywords: ["C3345"]
-ms.assetid: 1dda4c79-73bb-441b-b939-746154c3afba
 ---
 # Compiler Error C3345
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
@@ -10,6 +10,8 @@ ms.assetid: 1dda4c79-73bb-441b-b939-746154c3afba
 
 > 'identifier': invalid identifier for module name
 
+## Remarks
+
 The *identifier* for a module contains one or more unacceptable characters. An identifier is valid if the first character is an alphabetical, underscore, or high ANSI (0x80-FF) character, and any subsequent character is an alphanumeric, underscore, or high ANSI character.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3345.md
@@ -8,7 +8,7 @@ ms.assetid: 1dda4c79-73bb-441b-b939-746154c3afba
 ---
 # Compiler Error C3345
 
-'identifier': invalid identifier for module name
+> 'identifier': invalid identifier for module name
 
 The *identifier* for a module contains one or more unacceptable characters. An identifier is valid if the first character is an alphabetical, underscore, or high ANSI (0x80-FF) character, and any subsequent character is an alphanumeric, underscore, or high ANSI character.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
@@ -16,7 +16,7 @@ A required argument was not passed to the [idl_module](../../windows/attributes/
 
 ## Example
 
-The following sample generates C3347:
+The following example generates C3347:
 
 ```cpp
 // C3347.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3347"
 title: "Compiler Error C3347"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3347"
+ms.date: 11/04/2016
 f1_keywords: ["C3347"]
 helpviewer_keywords: ["C3347"]
-ms.assetid: e939ad29-0b78-4681-9618-9bdae5675cee
 ---
 # Compiler Error C3347
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
@@ -8,7 +8,7 @@ ms.assetid: e939ad29-0b78-4681-9618-9bdae5675cee
 ---
 # Compiler Error C3347
 
-'arg': required argument is not specified in attribute idl_module
+> 'arg': required argument is not specified in attribute idl_module
 
 A required argument was not passed to the [idl_module](../../windows/attributes/idl-module.md) attribute.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3347.md
@@ -10,7 +10,11 @@ ms.assetid: e939ad29-0b78-4681-9618-9bdae5675cee
 
 > 'arg': required argument is not specified in attribute idl_module
 
+## Remarks
+
 A required argument was not passed to the [idl_module](../../windows/attributes/idl-module.md) attribute.
+
+## Example
 
 The following sample generates C3347:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
@@ -16,7 +16,7 @@ When you create an instance of a delegate, you must pass two arguments, an insta
 
 ## Example
 
-The following sample generates C3350:
+The following example generates C3350:
 
 ```cpp
 // C3350.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
@@ -8,7 +8,7 @@ ms.assetid: cfbbc338-92b5-4f34-999e-aa2d2376bc70
 ---
 # Compiler Error C3350
 
-'delegate' : a delegate constructor expects number argument(s)
+> 'delegate' : a delegate constructor expects number argument(s)
 
 When you create an instance of a delegate, you must pass two arguments, an instance of the type containing the delegate function, and the function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3350"
 title: "Compiler Error C3350"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3350"
+ms.date: 11/04/2016
 f1_keywords: ["C3350"]
 helpviewer_keywords: ["C3350"]
-ms.assetid: cfbbc338-92b5-4f34-999e-aa2d2376bc70
 ---
 # Compiler Error C3350
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3350.md
@@ -10,7 +10,11 @@ ms.assetid: cfbbc338-92b5-4f34-999e-aa2d2376bc70
 
 > 'delegate' : a delegate constructor expects number argument(s)
 
+## Remarks
+
 When you create an instance of a delegate, you must pass two arguments, an instance of the type containing the delegate function, and the function.
+
+## Example
 
 The following sample generates C3350:
 


### PR DESCRIPTION
C3295 is skipped to prevent potential merge conflicts with #5630. A separate PR will be issued once that is merged.

This is batch 55 that structures error/warning references. See #5465 for more information.