### PR TITLE
Structure error references in range [C3351, C3380]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3351"
 title: "Compiler Error C3351"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3351"
+ms.date: 11/04/2016
 f1_keywords: ["C3351"]
 helpviewer_keywords: ["C3351"]
-ms.assetid: c021bbbe-1067-4f51-af4f-940d2b792eb5
 ---
 # Compiler Error C3351
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
@@ -16,7 +16,7 @@ The compiler expected the address of a function declared **`static`**.
 
 ## Example
 
-The following sample generates C3351:
+The following example generates C3351:
 
 ```cpp
 // C3351a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
@@ -8,7 +8,7 @@ ms.assetid: c021bbbe-1067-4f51-af4f-940d2b792eb5
 ---
 # Compiler Error C3351
 
-'object' : delegate constructor: second argument must be address of a static member function or global function
+> 'object' : delegate constructor: second argument must be address of a static member function or global function
 
 The compiler expected the address of a function declared **`static`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3351.md
@@ -10,7 +10,11 @@ ms.assetid: c021bbbe-1067-4f51-af4f-940d2b792eb5
 
 > 'object' : delegate constructor: second argument must be address of a static member function or global function
 
+## Remarks
+
 The compiler expected the address of a function declared **`static`**.
+
+## Example
 
 The following sample generates C3351:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
@@ -18,7 +18,7 @@ For more information, see [delegate  (C++ Component Extensions)](../../extension
 
 ## Example
 
-The following sample generates C3352:
+The following example generates C3352:
 
 ```cpp
 // C3352.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
@@ -8,7 +8,7 @@ ms.assetid: f233bed7-474e-425f-aad2-7801578169d4
 ---
 # Compiler Error C3352
 
-'function' : the specified function does not match the delegate type 'type'
+> 'function' : the specified function does not match the delegate type 'type'
 
 The parameter lists for `function` and the delegate do not match.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3352"
 title: "Compiler Error C3352"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3352"
+ms.date: 11/04/2016
 f1_keywords: ["C3352"]
 helpviewer_keywords: ["C3352"]
-ms.assetid: f233bed7-474e-425f-aad2-7801578169d4
 ---
 # Compiler Error C3352
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3352.md
@@ -10,9 +10,13 @@ ms.assetid: f233bed7-474e-425f-aad2-7801578169d4
 
 > 'function' : the specified function does not match the delegate type 'type'
 
+## Remarks
+
 The parameter lists for `function` and the delegate do not match.
 
 For more information, see [delegate  (C++ Component Extensions)](../../extensions/delegate-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3352:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
@@ -8,7 +8,7 @@ ms.assetid: 5699c04b-d504-46ce-bf71-c200318fed71
 ---
 # Compiler Error C3353
 
-'delegate' : a delegate can only be created from a global function or a member function of a managed or WinRT type
+> 'delegate' : a delegate can only be created from a global function or a member function of a managed or WinRT type
 
 Delegates, declared with the [delegate](../../extensions/delegate-cpp-component-extensions.md) keyword, can only be declared at global scope.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3353"
 title: "Compiler Error C3353"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3353"
+ms.date: 11/04/2016
 f1_keywords: ["C3353"]
 helpviewer_keywords: ["C3353"]
-ms.assetid: 5699c04b-d504-46ce-bf71-c200318fed71
 ---
 # Compiler Error C3353
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
@@ -10,7 +10,11 @@ ms.assetid: 5699c04b-d504-46ce-bf71-c200318fed71
 
 > 'delegate' : a delegate can only be created from a global function or a member function of a managed or WinRT type
 
+## Remarks
+
 Delegates, declared with the [delegate](../../extensions/delegate-cpp-component-extensions.md) keyword, can only be declared at global scope.
+
+## Example
 
 The following sample generates C3353:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3353.md
@@ -16,7 +16,7 @@ Delegates, declared with the [delegate](../../extensions/delegate-cpp-component-
 
 ## Example
 
-The following sample generates C3353:
+The following example generates C3353:
 
 ```cpp
 // C3353.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3354"
 title: "Compiler Error C3354"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3354"
+ms.date: 11/04/2016
 f1_keywords: ["C3354"]
 helpviewer_keywords: ["C3354"]
-ms.assetid: 185de401-231e-4999-a149-172ee4c69d84
 ---
 # Compiler Error C3354
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
@@ -10,6 +10,8 @@ ms.assetid: 185de401-231e-4999-a149-172ee4c69d84
 
 > 'function' : the function used to create a delegate cannot have return type 'type'
 
+## Remarks
+
 The following types are invalid as return types for a **`delegate`**:
 
 - Pointer to function
@@ -21,6 +23,8 @@ The following types are invalid as return types for a **`delegate`**:
 - Reference to function
 
 - Reference to member function
+
+## Example
 
 The following sample generates C3354:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
@@ -26,7 +26,7 @@ The following types are invalid as return types for a **`delegate`**:
 
 ## Example
 
-The following sample generates C3354:
+The following example generates C3354:
 
 ```cpp
 // C3354_2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3354.md
@@ -8,7 +8,7 @@ ms.assetid: 185de401-231e-4999-a149-172ee4c69d84
 ---
 # Compiler Error C3354
 
-'function' : the function used to create a delegate cannot have return type 'type'
+> 'function' : the function used to create a delegate cannot have return type 'type'
 
 The following types are invalid as return types for a **`delegate`**:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
@@ -8,6 +8,6 @@ ms.assetid: 6c1094f6-ac85-480a-b78b-e92fcf38641a
 ---
 # Compiler Error C3356
 
-'attribute': cannot call a multicast attribute with a fully qualified name
+> 'attribute': cannot call a multicast attribute with a fully qualified name
 
 An attribute that is processed by more than one process, for example, the compiler and ATL provider, was specified incorrectly.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
@@ -10,4 +10,6 @@ ms.assetid: 6c1094f6-ac85-480a-b78b-e92fcf38641a
 
 > 'attribute': cannot call a multicast attribute with a fully qualified name
 
+## Remarks
+
 An attribute that is processed by more than one process, for example, the compiler and ATL provider, was specified incorrectly.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3356.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3356"
 title: "Compiler Error C3356"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3356"
+ms.date: 11/04/2016
 f1_keywords: ["C3356"]
 helpviewer_keywords: ["C3356"]
-ms.assetid: 6c1094f6-ac85-480a-b78b-e92fcf38641a
 ---
 # Compiler Error C3356
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
@@ -10,7 +10,11 @@ ms.assetid: 180b93df-e78f-441a-91fb-1594c681f7f0
 
 > 'symbol': symbol not found
 
+## Remarks
+
 The required symbol was not found.
+
+## Example
 
 The following sample generates C3358:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3358"
 title: "Compiler Error C3358"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3358"
+ms.date: 11/04/2016
 f1_keywords: ["C3358"]
 helpviewer_keywords: ["C3358"]
-ms.assetid: 180b93df-e78f-441a-91fb-1594c681f7f0
 ---
 # Compiler Error C3358
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
@@ -8,7 +8,7 @@ ms.assetid: 180b93df-e78f-441a-91fb-1594c681f7f0
 ---
 # Compiler Error C3358
 
-'symbol': symbol not found
+> 'symbol': symbol not found
 
 The required symbol was not found.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3358.md
@@ -16,7 +16,7 @@ The required symbol was not found.
 
 ## Example
 
-The following sample generates C3358:
+The following example generates C3358:
 
 ```cpp
 // C3358.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
@@ -8,7 +8,7 @@ ms.assetid: 6acf983a-dbb6-422b-b045-a34bb4ba6761
 ---
 # Compiler Error C3360
 
-'string': cannot create name
+> 'string': cannot create name
 
 The value that was passed to the [uuid](../../windows/attributes/uuid-cpp-attributes.md) attribute was not valid.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
@@ -10,7 +10,11 @@ ms.assetid: 6acf983a-dbb6-422b-b045-a34bb4ba6761
 
 > 'string': cannot create name
 
+## Remarks
+
 The value that was passed to the [uuid](../../windows/attributes/uuid-cpp-attributes.md) attribute was not valid.
+
+## Example
 
 The following sample generates C3360:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
@@ -16,7 +16,7 @@ The value that was passed to the [uuid](../../windows/attributes/uuid-cpp-attrib
 
 ## Example
 
-The following sample generates C3360:
+The following example generates C3360:
 
 ```cpp
 // C3360.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3360.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3360"
 title: "Compiler Error C3360"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3360"
+ms.date: 11/04/2016
 f1_keywords: ["C3360"]
 helpviewer_keywords: ["C3360"]
-ms.assetid: 6acf983a-dbb6-422b-b045-a34bb4ba6761
 ---
 # Compiler Error C3360
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3363"
 title: "Compiler Error C3363"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3363"
+ms.date: 11/04/2016
 f1_keywords: ["C3363"]
 helpviewer_keywords: ["C3363"]
-ms.assetid: 41aa922f-608e-4f7a-ba66-451fc1161935
 ---
 # Compiler Error C3363
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
@@ -8,7 +8,7 @@ ms.assetid: 41aa922f-608e-4f7a-ba66-451fc1161935
 ---
 # Compiler Error C3363
 
-'type' : 'typeid' can only be applied to a type
+> 'type' : 'typeid' can only be applied to a type
 
 The [typeid](../../extensions/typeid-cpp-component-extensions.md) operator was used incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
@@ -16,7 +16,7 @@ The [typeid](../../extensions/typeid-cpp-component-extensions.md) operator was u
 
 ## Example
 
-The following sample generates C3363.
+The following example generates C3363.
 
 ```cpp
 // C3363.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3363.md
@@ -10,6 +10,8 @@ ms.assetid: 41aa922f-608e-4f7a-ba66-451fc1161935
 
 > 'type' : 'typeid' can only be applied to a type
 
+## Remarks
+
 The [typeid](../../extensions/typeid-cpp-component-extensions.md) operator was used incorrectly.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
@@ -16,7 +16,7 @@ The second parameter of the delegate's constructor takes either the address of a
 
 ## Example
 
-The following sample generates C3364:
+The following example generates C3364:
 
 ```cpp
 // C3364_2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
@@ -8,7 +8,7 @@ ms.assetid: 98654741-60fe-4472-a6af-e580f8c0a6e1
 ---
 # Compiler Error C3364
 
-'delegate': delegate constructor: argument must be pointer to member function of managed class or global function
+> 'delegate': delegate constructor: argument must be pointer to member function of managed class or global function
 
 The second parameter of the delegate's constructor takes either the address of a member function or the address of a static member function of any class. Both are treated as simple addresses.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
@@ -10,7 +10,11 @@ ms.assetid: 98654741-60fe-4472-a6af-e580f8c0a6e1
 
 > 'delegate': delegate constructor: argument must be pointer to member function of managed class or global function
 
+## Remarks
+
 The second parameter of the delegate's constructor takes either the address of a member function or the address of a static member function of any class. Both are treated as simple addresses.
+
+## Example
 
 The following sample generates C3364:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3364.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3364"
 title: "Compiler Error C3364"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3364"
+ms.date: 11/04/2016
 f1_keywords: ["C3364"]
 helpviewer_keywords: ["C3364"]
-ms.assetid: 98654741-60fe-4472-a6af-e580f8c0a6e1
 ---
 # Compiler Error C3364
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
@@ -10,6 +10,8 @@ ms.assetid: 875ec3a4-522c-4e3d-9b67-48808b857f6d
 
 > operator 'operator' : differing operands of type 'type1' and 'type2'
 
+## Remarks
+
 An attempt was made to compose delegates with different types.  See [How to: Define and Use Delegates (C++/CLI)](../../dotnet/how-to-define-and-use-delegates-cpp-cli.md) for more information about delegates.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
@@ -8,7 +8,7 @@ ms.assetid: 875ec3a4-522c-4e3d-9b67-48808b857f6d
 ---
 # Compiler Error C3365
 
-operator 'operator' : differing operands of type 'type1' and 'type2'
+> operator 'operator' : differing operands of type 'type1' and 'type2'
 
 An attempt was made to compose delegates with different types.  See [How to: Define and Use Delegates (C++/CLI)](../../dotnet/how-to-define-and-use-delegates-cpp-cli.md) for more information about delegates.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3365"
 title: "Compiler Error C3365"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3365"
+ms.date: 11/04/2016
 f1_keywords: ["C3365"]
 helpviewer_keywords: ["C3365"]
-ms.assetid: 875ec3a4-522c-4e3d-9b67-48808b857f6d
 ---
 # Compiler Error C3365
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3365.md
@@ -16,7 +16,7 @@ An attempt was made to compose delegates with different types.  See [How to: Def
 
 ## Example
 
-The following sample generates C3365:
+The following example generates C3365:
 
 ```cpp
 // C3365.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
@@ -8,7 +8,7 @@ ms.assetid: efc55bcf-c16d-43c1-a36f-87a6165fa2a8
 ---
 # Compiler Error C3366
 
-'variable' : static data members of managed or WinRTtypes must be defined within the class definition
+> 'variable' : static data members of managed or WinRTtypes must be defined within the class definition
 
 You attempted to reference a static member of a WinRT or .NET class or interface outside the definition of that class or interface.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3366"
 title: "Compiler Error C3366"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3366"
+ms.date: 11/04/2016
 f1_keywords: ["C3366"]
 helpviewer_keywords: ["C3366"]
-ms.assetid: efc55bcf-c16d-43c1-a36f-87a6165fa2a8
 ---
 # Compiler Error C3366
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3366.md
@@ -10,9 +10,13 @@ ms.assetid: efc55bcf-c16d-43c1-a36f-87a6165fa2a8
 
 > 'variable' : static data members of managed or WinRTtypes must be defined within the class definition
 
+## Remarks
+
 You attempted to reference a static member of a WinRT or .NET class or interface outside the definition of that class or interface.
 
 The compiler needs to know the full definition of the class (to emit the meta-data after one pass) and requires static data members to be initialized within the class.
+
+## Example
 
 For example, the following example generates C3366 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
@@ -8,7 +8,7 @@ ms.assetid: e675d42b-f5b0-4d43-aab1-1f5024233102
 ---
 # Compiler Error C3367
 
-'static_member_function' : cannot use static function to create an unbound delegate
+> 'static_member_function' : cannot use static function to create an unbound delegate
 
 When you call an unbound delegate, you must pass an instance of an object. Since a static member function is called through the class name, you can only instantiate an unbound delegate with an instance member function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
@@ -18,7 +18,7 @@ For more information about unbound delegates, see [How to: Define and Use Delega
 
 ## Example
 
-The following sample generates C3367.
+The following example generates C3367.
 
 ```cpp
 // C3367.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
@@ -10,6 +10,8 @@ ms.assetid: e675d42b-f5b0-4d43-aab1-1f5024233102
 
 > 'static_member_function' : cannot use static function to create an unbound delegate
 
+## Remarks
+
 When you call an unbound delegate, you must pass an instance of an object. Since a static member function is called through the class name, you can only instantiate an unbound delegate with an instance member function.
 
 For more information about unbound delegates, see [How to: Define and Use Delegates (C++/CLI)](../../dotnet/how-to-define-and-use-delegates-cpp-cli.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3367.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3367"
 title: "Compiler Error C3367"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3367"
+ms.date: 11/04/2016
 f1_keywords: ["C3367"]
 helpviewer_keywords: ["C3367"]
-ms.assetid: e675d42b-f5b0-4d43-aab1-1f5024233102
 ---
 # Compiler Error C3367
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3368"
 title: "Compiler Error C3368"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3368"
+ms.date: 11/04/2016
 f1_keywords: ["C3368"]
 helpviewer_keywords: ["C3368"]
-ms.assetid: 5bfd5be4-dfa9-4b33-9612-010561b40955
 ---
 # Compiler Error C3368
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
@@ -10,7 +10,11 @@ ms.assetid: 5bfd5be4-dfa9-4b33-9612-010561b40955
 
 > 'function declaration' : invalid calling convention for IDL
 
+## Remarks
+
 You can only use the [__stdcall](../../cpp/stdcall.md) or [__cdecl](../../cpp/cdecl.md) calling conventions in an .idl file.
+
+## Example
 
 The following sample generates C3368:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
@@ -16,7 +16,7 @@ You can only use the [__stdcall](../../cpp/stdcall.md) or [__cdecl](../../cpp/cd
 
 ## Example
 
-The following sample generates C3368:
+The following example generates C3368:
 
 ```cpp
 // C3368.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3368.md
@@ -8,7 +8,7 @@ ms.assetid: 5bfd5be4-dfa9-4b33-9612-010561b40955
 ---
 # Compiler Error C3368
 
-'function declaration' : invalid calling convention for IDL
+> 'function declaration' : invalid calling convention for IDL
 
 You can only use the [__stdcall](../../cpp/stdcall.md) or [__cdecl](../../cpp/cdecl.md) calling conventions in an .idl file.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
@@ -10,7 +10,11 @@ ms.assetid: c6ceb9cb-3df9-4334-9a5c-d16db351d476
 
 > 'module name': idl_module already defined
 
+## Remarks
+
 The [idl_module](../../windows/attributes/idl-module.md) usage where you define the DLL can only occur once in a program.
+
+## Example
 
 The following sample generates C3369:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
@@ -16,7 +16,7 @@ The [idl_module](../../windows/attributes/idl-module.md) usage where you define 
 
 ## Example
 
-The following sample generates C3369:
+The following example generates C3369:
 
 ```cpp
 // C3369.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3369"
 title: "Compiler Error C3369"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3369"
+ms.date: 11/04/2016
 f1_keywords: ["C3369"]
 helpviewer_keywords: ["C3369"]
-ms.assetid: c6ceb9cb-3df9-4334-9a5c-d16db351d476
 ---
 # Compiler Error C3369
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3369.md
@@ -8,7 +8,7 @@ ms.assetid: c6ceb9cb-3df9-4334-9a5c-d16db351d476
 ---
 # Compiler Error C3369
 
-'module name': idl_module already defined
+> 'module name': idl_module already defined
 
 The [idl_module](../../windows/attributes/idl-module.md) usage where you define the DLL can only occur once in a program.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
@@ -16,7 +16,7 @@ Before you can use [idl_module](../../windows/attributes/idl-module.md) to speci
 
 ## Example
 
-The following sample generates C3370:
+The following example generates C3370:
 
 ```cpp
 // C3370.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
@@ -10,7 +10,11 @@ ms.assetid: ee6d4c85-78fc-42b2-836e-5cc491a3b2ba
 
 > 'idl_module name': idl_module not yet defined
 
+## Remarks
+
 Before you can use [idl_module](../../windows/attributes/idl-module.md) to specify an entry point in a DLL, you must first use `idl_module` to specify the DLL name.
+
+## Example
 
 The following sample generates C3370:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3370"
 title: "Compiler Error C3370"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3370"
+ms.date: 11/04/2016
 f1_keywords: ["C3370"]
 helpviewer_keywords: ["C3370"]
-ms.assetid: ee6d4c85-78fc-42b2-836e-5cc491a3b2ba
 ---
 # Compiler Error C3370
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3370.md
@@ -8,7 +8,7 @@ ms.assetid: ee6d4c85-78fc-42b2-836e-5cc491a3b2ba
 ---
 # Compiler Error C3370
 
-'idl_module name': idl_module not yet defined
+> 'idl_module name': idl_module not yet defined
 
 Before you can use [idl_module](../../windows/attributes/idl-module.md) to specify an entry point in a DLL, you must first use `idl_module` to specify the DLL name.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3371"
 title: "Compiler Error C3371"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3371"
+ms.date: 11/04/2016
 f1_keywords: ["C3371"]
 helpviewer_keywords: ["C3371"]
-ms.assetid: f7ecf1aa-ed0a-4f73-81e5-62cf98f88ea1
 ---
 # Compiler Error C3371
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
@@ -8,7 +8,7 @@ ms.assetid: f7ecf1aa-ed0a-4f73-81e5-62cf98f88ea1
 ---
 # Compiler Error C3371
 
-'idl_module': only the 'name' property is allowed here
+> 'idl_module': only the 'name' property is allowed here
 
 [idl_module](../../windows/attributes/idl-module.md) usage directly on a function declaration cannot have any parameters other than name.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
@@ -10,7 +10,11 @@ ms.assetid: f7ecf1aa-ed0a-4f73-81e5-62cf98f88ea1
 
 > 'idl_module': only the 'name' property is allowed here
 
+## Remarks
+
 [idl_module](../../windows/attributes/idl-module.md) usage directly on a function declaration cannot have any parameters other than name.
+
+## Example
 
 The following sample generates C3371:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3371.md
@@ -16,7 +16,7 @@ ms.assetid: f7ecf1aa-ed0a-4f73-81e5-62cf98f88ea1
 
 ## Example
 
-The following sample generates C3371:
+The following example generates C3371:
 
 ```cpp
 // C3371.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
@@ -10,7 +10,11 @@ ms.assetid: 38ee39ed-03ff-4e6d-9104-f1977b96645d
 
 > must specify at least 1 interface for attribute 'source' on a coclass
 
+## Remarks
+
 For certain attributes, you must pass an interface name as a parameter.
+
+## Example
 
 The following sample generates C3372:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
@@ -8,7 +8,7 @@ ms.assetid: 38ee39ed-03ff-4e6d-9104-f1977b96645d
 ---
 # Compiler Error C3372
 
-must specify at least 1 interface for attribute 'source' on a coclass
+> must specify at least 1 interface for attribute 'source' on a coclass
 
 For certain attributes, you must pass an interface name as a parameter.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
@@ -16,7 +16,7 @@ For certain attributes, you must pass an interface name as a parameter.
 
 ## Example
 
-The following sample generates C3372:
+The following example generates C3372:
 
 ```cpp
 // C3372.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3372.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3372"
 title: "Compiler Error C3372"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3372"
+ms.date: 11/04/2016
 f1_keywords: ["C3372"]
 helpviewer_keywords: ["C3372"]
-ms.assetid: 38ee39ed-03ff-4e6d-9104-f1977b96645d
 ---
 # Compiler Error C3372
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
@@ -16,7 +16,7 @@ Some attributes can be applied to more than one C++ construct, but arguments to 
 
 ## Example
 
-The following sample generates C3373:
+The following example generates C3373:
 
 ```cpp
 // C3373.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3373"
 title: "Compiler Error C3373"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3373"
+ms.date: 11/04/2016
 f1_keywords: ["C3373"]
 helpviewer_keywords: ["C3373"]
-ms.assetid: 6e7586c3-1a15-4773-ad20-f90090a400dc
 ---
 # Compiler Error C3373
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
@@ -8,7 +8,7 @@ ms.assetid: 6e7586c3-1a15-4773-ad20-f90090a400dc
 ---
 # Compiler Error C3373
 
-attribute 'attribute' takes no arguments except on a coclass
+> attribute 'attribute' takes no arguments except on a coclass
 
 Some attributes can be applied to more than one C++ construct, but arguments to the attribute may only be allowed on some constructs.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3373.md
@@ -10,7 +10,11 @@ ms.assetid: 6e7586c3-1a15-4773-ad20-f90090a400dc
 
 > attribute 'attribute' takes no arguments except on a coclass
 
+## Remarks
+
 Some attributes can be applied to more than one C++ construct, but arguments to the attribute may only be allowed on some constructs.
+
+## Example
 
 The following sample generates C3373:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
@@ -8,7 +8,7 @@ ms.assetid: 41431299-bd20-47d4-a0c8-1334dd79018b
 ---
 # Compiler Error C3374
 
-can't take address of 'function' unless creating delegate instance
+> can't take address of 'function' unless creating delegate instance
 
 The address of a function was taken in a context other than the creation of a delegate instance.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3374"
 title: "Compiler Error C3374"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3374"
+ms.date: 11/04/2016
 f1_keywords: ["C3374"]
 helpviewer_keywords: ["C3374"]
-ms.assetid: 41431299-bd20-47d4-a0c8-1334dd79018b
 ---
 # Compiler Error C3374
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
@@ -16,7 +16,7 @@ The address of a function was taken in a context other than the creation of a de
 
 ## Example
 
-The following sample generates C3374:
+The following example generates C3374:
 
 ```cpp
 // C3374.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3374.md
@@ -10,7 +10,11 @@ ms.assetid: 41431299-bd20-47d4-a0c8-1334dd79018b
 
 > can't take address of 'function' unless creating delegate instance
 
+## Remarks
+
 The address of a function was taken in a context other than the creation of a delegate instance.
+
+## Example
 
 The following sample generates C3374:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3375"
 title: "Compiler Error C3375"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3375"
+ms.date: 11/04/2016
 f1_keywords: ["C3375"]
 helpviewer_keywords: ["C3375"]
-ms.assetid: f1df78c6-e6ca-48f3-8b29-4e1710002bf3
 ---
 # Compiler Error C3375
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
@@ -8,7 +8,7 @@ ms.assetid: f1df78c6-e6ca-48f3-8b29-4e1710002bf3
 ---
 # Compiler Error C3375
 
-'function' : ambiguous delegate function
+> 'function' : ambiguous delegate function
 
 A delegate instantiation could have been to a static member function, or as an unbound delegate to an instance function, so the compiler issued this error.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
@@ -10,6 +10,8 @@ ms.assetid: f1df78c6-e6ca-48f3-8b29-4e1710002bf3
 
 > 'function' : ambiguous delegate function
 
+## Remarks
+
 A delegate instantiation could have been to a static member function, or as an unbound delegate to an instance function, so the compiler issued this error.
 
 For more information, see [delegate  (C++ Component Extensions)](../../extensions/delegate-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3375.md
@@ -18,7 +18,7 @@ For more information, see [delegate  (C++ Component Extensions)](../../extension
 
 ## Example
 
-The following sample generates C3375.
+The following example generates C3375.
 
 ```cpp
 // C3375.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
@@ -10,9 +10,13 @@ ms.assetid: a66c2c4e-091c-4426-9cde-7c4cfb2ffce1
 
 > 'class' : a nested class cannot have an assembly access specifier as part of its declaration
 
+## Remarks
+
 When applied to a managed type, such as class or struct, the [public](../../cpp/public-cpp.md) and [private](../../cpp/private-cpp.md) keywords indicate whether the class will be exposed through assembly metadata. `public` or `private` cannot be applied to a nested class, which will inherit the assembly access of the enclosing class.
 
 When used with [/clr](../../build/reference/clr-common-language-runtime-compilation.md), the `ref` and `value` keywords indicate that a class is managed (see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md)).
+
+## Example
 
 The following sample generates C3379:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3379"
 title: "Compiler Error C3379"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3379"
+ms.date: 11/04/2016
 f1_keywords: ["C3379"]
 helpviewer_keywords: ["C3379"]
-ms.assetid: a66c2c4e-091c-4426-9cde-7c4cfb2ffce1
 ---
 # Compiler Error C3379
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
@@ -18,7 +18,7 @@ When used with [/clr](../../build/reference/clr-common-language-runtime-compilat
 
 ## Example
 
-The following sample generates C3379:
+The following example generates C3379:
 
 ```cpp
 // C3379a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3379.md
@@ -8,7 +8,7 @@ ms.assetid: a66c2c4e-091c-4426-9cde-7c4cfb2ffce1
 ---
 # Compiler Error C3379
 
-'class' : a nested class cannot have an assembly access specifier as part of its declaration
+> 'class' : a nested class cannot have an assembly access specifier as part of its declaration
 
 When applied to a managed type, such as class or struct, the [public](../../cpp/public-cpp.md) and [private](../../cpp/private-cpp.md) keywords indicate whether the class will be exposed through assembly metadata. `public` or `private` cannot be applied to a nested class, which will inherit the assembly access of the enclosing class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3380"
 title: "Compiler Error C3380"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3380"
+ms.date: 11/04/2016
 f1_keywords: ["C3380"]
 helpviewer_keywords: ["C3380"]
-ms.assetid: 86f1f4ec-4ad8-4a1a-9b6c-2d9b6129df6b
 ---
 # Compiler Error C3380
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
@@ -8,7 +8,7 @@ ms.assetid: 86f1f4ec-4ad8-4a1a-9b6c-2d9b6129df6b
 ---
 # Compiler Error C3380
 
-'class' : invalid assembly access specifier - only 'public' or 'private' are allowed
+> 'class' : invalid assembly access specifier - only 'public' or 'private' are allowed
 
 When applied to a managed class or struct, the [public](../../cpp/public-cpp.md) and [private](../../cpp/private-cpp.md) keywords indicate whether the class will be exposed through assembly metadata. Only `public` or `private` can be applied to a class in a program compiled with [/clr](../../build/reference/clr-common-language-runtime-compilation.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
@@ -10,9 +10,13 @@ ms.assetid: 86f1f4ec-4ad8-4a1a-9b6c-2d9b6129df6b
 
 > 'class' : invalid assembly access specifier - only 'public' or 'private' are allowed
 
+## Remarks
+
 When applied to a managed class or struct, the [public](../../cpp/public-cpp.md) and [private](../../cpp/private-cpp.md) keywords indicate whether the class will be exposed through assembly metadata. Only `public` or `private` can be applied to a class in a program compiled with [/clr](../../build/reference/clr-common-language-runtime-compilation.md).
 
 The `ref` and `value` keywords, when used with [/clr](../../build/reference/clr-common-language-runtime-compilation.md), indicate that a class is managed (see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md)).
+
+## Example
 
 The following sample generates C3380:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3380.md
@@ -18,7 +18,7 @@ The `ref` and `value` keywords, when used with [/clr](../../build/reference/clr-
 
 ## Example
 
-The following sample generates C3380:
+The following example generates C3380:
 
 ```cpp
 // C3380_2.cpp


### PR DESCRIPTION
This is batch 56 that structures error/warning references. See #5465 for more information.