### PR TITLE
Structure error references in range [C3381, C3420]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
@@ -4,7 +4,6 @@ description: "Microsoft C++ compiler error C3381, its causes and how to resolve 
 ms.date: 09/28/2020
 f1_keywords: ["C3381"]
 helpviewer_keywords: ["C3381"]
-ms.assetid: d276c89f-8377-4cb6-a8d4-7770885f06c4
 ---
 # Compiler Error C3381
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
@@ -10,9 +10,9 @@ ms.assetid: d276c89f-8377-4cb6-a8d4-7770885f06c4
 
 > '*identifier*' : assembly access specifiers are only available in code compiled with a /clr option
 
-A type was declared or defined by using an access specifier, which is only permitted in code compiled by using **`/clr`**.
-
 ## Remarks
+
+A type was declared or defined by using an access specifier, which is only permitted in code compiled by using **`/clr`**.
 
 This error may result from a misplaced **`public`**, **`protected`**, or **`private`** keyword, or a missing colon (**`:`**) after an access specifier within a **`class`** or **`struct`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3381.md
@@ -20,7 +20,7 @@ In C++/CLI, native types can be visible outside an assembly, but you can only sp
 
 ## Example
 
-The following sample generates C3381. To fix it, first either remove the **`public`** specifier from the `class A` definition, or compile by using the **`/clr`** option. Next, add a colon after **`private`** to specify access for `class B {} b;`. That's because a nested class can't have an assembly access specifier as part of its declaration.
+The following example generates C3381. To fix it, first either remove the **`public`** specifier from the `class A` definition, or compile by using the **`/clr`** option. Next, add a colon after **`private`** to specify access for `class B {} b;`. That's because a nested class can't have an assembly access specifier as part of its declaration.
 
 ```cpp
 // C3381.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
@@ -24,7 +24,7 @@ For more information, see,
 
 ## Example
 
-The following sample generates C3382.
+The following example generates C3382.
 
 ```cpp
 // C3382.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
@@ -10,6 +10,8 @@ ms.assetid: a7603abd-ac4e-4ae6-a02b-3bdc6d1908a6
 
 > 'sizeof' is not supported with /clr:safe
 
+## Remarks
+
 The output file of a **/clr:safe** compilation is a file that is verifiably type safe, and sizeof is not supported because the return value of the sizeof operator is size_t, whose size varies depending on the operating system.
 
 For more information, see,

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
@@ -8,7 +8,7 @@ ms.assetid: a7603abd-ac4e-4ae6-a02b-3bdc6d1908a6
 ---
 # Compiler Error C3382
 
-'sizeof' is not supported with /clr:safe
+> 'sizeof' is not supported with /clr:safe
 
 The output file of a **/clr:safe** compilation is a file that is verifiably type safe, and sizeof is not supported because the return value of the sizeof operator is size_t, whose size varies depending on the operating system.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3382.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3382"
 title: "Compiler Error C3382"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3382"
+ms.date: 11/04/2016
 f1_keywords: ["C3382"]
 helpviewer_keywords: ["C3382"]
-ms.assetid: a7603abd-ac4e-4ae6-a02b-3bdc6d1908a6
 ---
 # Compiler Error C3382
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
@@ -10,6 +10,8 @@ ms.assetid: ceb7f725-f417-4dc3-8496-0f413bb76687
 
 > 'operator new' is not supported with /clr:safe
 
+## Remarks
+
 The output file of a **/clr:safe** compilation is a file that is verifiably type safe, and pointers are not supported.
 
 For more information, see,

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
@@ -8,7 +8,7 @@ ms.assetid: ceb7f725-f417-4dc3-8496-0f413bb76687
 ---
 # Compiler Error C3383
 
-'operator new' is not supported with /clr:safe
+> 'operator new' is not supported with /clr:safe
 
 The output file of a **/clr:safe** compilation is a file that is verifiably type safe, and pointers are not supported.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3383"
 title: "Compiler Error C3383"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3383"
+ms.date: 11/04/2016
 f1_keywords: ["C3383"]
 helpviewer_keywords: ["C3383"]
-ms.assetid: ceb7f725-f417-4dc3-8496-0f413bb76687
 ---
 # Compiler Error C3383
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3383.md
@@ -22,7 +22,7 @@ For more information, see,
 
 ## Example
 
-The following sample generates C3383.
+The following example generates C3383.
 
 ```cpp
 // C3383.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
@@ -10,6 +10,8 @@ ms.assetid: c9f92c6a-62a9-4333-b2b1-bc55c7f288b6
 
 > 'type_parameter' : the value constraint and the ref constraint are mutually exclusive
 
+## Remarks
+
 You cannot constrain a generic type to both **`value class`** and **`ref class`**.
 
 See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3384"
 title: "Compiler Error C3384"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3384"
+ms.date: 11/04/2016
 f1_keywords: ["C3384"]
 helpviewer_keywords: ["C3384"]
-ms.assetid: c9f92c6a-62a9-4333-b2b1-bc55c7f288b6
 ---
 # Compiler Error C3384
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
@@ -18,7 +18,7 @@ See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constrai
 
 ## Example
 
-The following sample generates C3384.
+The following example generates C3384.
 
 ```cpp
 // C3384.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3384.md
@@ -8,7 +8,7 @@ ms.assetid: c9f92c6a-62a9-4333-b2b1-bc55c7f288b6
 ---
 # Compiler Error C3384
 
-'type_parameter' : the value constraint and the ref constraint are mutually exclusive
+> 'type_parameter' : the value constraint and the ref constraint are mutually exclusive
 
 You cannot constrain a generic type to both **`value class`** and **`ref class`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3385"
 title: "Compiler Error C3385"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3385"
+ms.date: 11/04/2016
 f1_keywords: ["C3385"]
 helpviewer_keywords: ["C3385"]
-ms.assetid: 5f1838c1-986e-47db-8dbc-e06976b83cf3
 ---
 # Compiler Error C3385
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
@@ -16,7 +16,7 @@ A function defined as being in a .dll file specified with the `DllImport` attrib
 
 ## Example
 
-The following sample generates C3385:
+The following example generates C3385:
 
 ```cpp
 // C3385.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
@@ -8,7 +8,7 @@ ms.assetid: 5f1838c1-986e-47db-8dbc-e06976b83cf3
 ---
 # Compiler Error C3385
 
-'class::function' : a function that has a DllImport Custom attribute cannot return an instance of a class
+> 'class::function' : a function that has a DllImport Custom attribute cannot return an instance of a class
 
 A function defined as being in a .dll file specified with the `DllImport` attribute cannot return an instance of a class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3385.md
@@ -10,7 +10,11 @@ ms.assetid: 5f1838c1-986e-47db-8dbc-e06976b83cf3
 
 > 'class::function' : a function that has a DllImport Custom attribute cannot return an instance of a class
 
+## Remarks
+
 A function defined as being in a .dll file specified with the `DllImport` attribute cannot return an instance of a class.
+
+## Example
 
 The following sample generates C3385:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
@@ -16,7 +16,7 @@ The [`dllimport`](../../cpp/dllexport-dllimport.md) and [`dllexport`](../../cpp/
 
 ## Example
 
-The following sample generates C3386 and shows how to fix it:
+The following example generates C3386 and shows how to fix it:
 
 ```cpp
 // C3386.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3386"
 title: "Compiler Error C3386"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3386"
+ms.date: 11/04/2016
 f1_keywords: ["C3386"]
 helpviewer_keywords: ["C3386"]
-ms.assetid: 93fa8c33-0f10-402b-8eec-b0a217a1f8dc
 ---
 # Compiler Error C3386
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3386.md
@@ -10,7 +10,11 @@ ms.assetid: 93fa8c33-0f10-402b-8eec-b0a217a1f8dc
 
 > '*type-name*' : `__declspec(dllexport)`/`__declspec(dllimport)` cannot be applied to a managed or WinRT type
 
+## Remarks
+
 The [`dllimport`](../../cpp/dllexport-dllimport.md) and [`dllexport`](../../cpp/dllexport-dllimport.md) **`__declspec`** modifiers aren't valid on a managed or Windows Runtime type.
+
+## Example
 
 The following sample generates C3386 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
@@ -8,7 +8,7 @@ ms.assetid: c54d9925-ed14-4976-b8db-e8d4dc84e536
 ---
 # Compiler Error C3387
 
-'member' : __declspec(dllexport)/\__declspec(dllimport) cannot be applied to a member of a managed or WinRT type
+> 'member' : __declspec(dllexport)/\__declspec(dllimport) cannot be applied to a member of a managed or WinRT type
 
 The `dllimport` and [dllexport](../../cpp/dllexport-dllimport.md) **`__declspec`** modifiers are not valid on members of a managed or Windows Runtime type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
@@ -16,7 +16,7 @@ The `dllimport` and [dllexport](../../cpp/dllexport-dllimport.md) **`__declspec`
 
 ## Example
 
-The following sample generates C3387 and shows how to fix it:
+The following example generates C3387 and shows how to fix it:
 
 ```cpp
 // C3387a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3387"
 title: "Compiler Error C3387"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3387"
+ms.date: 11/04/2016
 f1_keywords: ["C3387"]
 helpviewer_keywords: ["C3387"]
-ms.assetid: c54d9925-ed14-4976-b8db-e8d4dc84e536
 ---
 # Compiler Error C3387
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3387.md
@@ -10,7 +10,11 @@ ms.assetid: c54d9925-ed14-4976-b8db-e8d4dc84e536
 
 > 'member' : __declspec(dllexport)/\__declspec(dllimport) cannot be applied to a member of a managed or WinRT type
 
+## Remarks
+
 The `dllimport` and [dllexport](../../cpp/dllexport-dllimport.md) **`__declspec`** modifiers are not valid on members of a managed or Windows Runtime type.
+
+## Example
 
 The following sample generates C3387 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3388"
 title: "Compiler Error C3388"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3388"
+ms.date: 11/04/2016
 f1_keywords: ["C3388"]
 helpviewer_keywords: ["C3388"]
-ms.assetid: 34336545-ed13-4d81-ab5f-f869799fe4c2
 ---
 # Compiler Error C3388
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
@@ -16,7 +16,7 @@ A constraint was specified on a generic type, but the constraint was not specifi
 
 ## Example
 
-The following sample generates C3388.
+The following example generates C3388.
 
 ```cpp
 // C3388.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
@@ -8,7 +8,7 @@ ms.assetid: 34336545-ed13-4d81-ab5f-f869799fe4c2
 ---
 # Compiler Error C3388
 
-'type' : not allowed as a constraint, assuming 'ref class' to continue parsing
+> 'type' : not allowed as a constraint, assuming 'ref class' to continue parsing
 
 A constraint was specified on a generic type, but the constraint was not specified correctly. See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3388.md
@@ -10,6 +10,8 @@ ms.assetid: 34336545-ed13-4d81-ab5f-f869799fe4c2
 
 > 'type' : not allowed as a constraint, assuming 'ref class' to continue parsing
 
+## Remarks
+
 A constraint was specified on a generic type, but the constraint was not specified correctly. See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3389.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3389.md
@@ -18,7 +18,7 @@ A [`__declspec`](../../cpp/declspec.md) modifier used implies a per-process stat
 
 ## Example
 
-The following sample generates C3389:
+The following example generates C3389:
 
 ```cpp
 // C3389.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3389.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3389.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3389"
 title: "Compiler Error C3389"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3389"
+ms.date: 11/04/2016
 f1_keywords: ["C3389"]
 helpviewer_keywords: ["C3389"]
-ms.assetid: eaaffe17-23f2-413c-b1ad-f7220cfa1334
 ---
 # Compiler Error C3389
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
@@ -4,7 +4,6 @@ description: "Microsoft C++ compiler error C3390, its causes and how to resolve 
 ms.date: 09/26/2020
 f1_keywords: ["C3390"]
 helpviewer_keywords: ["C3390"]
-ms.assetid: 84800a87-c8e6-45aa-82ae-02f816dc8d97
 ---
 # Compiler Error C3390
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
@@ -18,7 +18,7 @@ For more information, see [Generics](../../extensions/generics-cpp-component-ext
 
 ## Example
 
-The first sample uses C# to create a component that contains a generic type. This type has certain constraints that aren't supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
+The first example uses C# to create a component that contains a generic type. This type has certain constraints that aren't supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
 
 ```csharp
 // C3390.cs
@@ -30,7 +30,7 @@ where V : struct
 where N : new() {}
 ```
 
-When the C3390.dll component is available, the following sample generates C3390.
+When the C3390.dll component is available, the following example generates C3390.
 
 ```cpp
 // C3390_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3390.md
@@ -10,9 +10,9 @@ ms.assetid: 84800a87-c8e6-45aa-82ae-02f816dc8d97
 
 > '*type_arg*' : invalid type argument for generic parameter '*param*' of generic '*generic_type*', must be a reference type
 
-A generic type was instantiated incorrectly. Check the type definition.
-
 ## Remarks
+
+A generic type was instantiated incorrectly. Check the type definition.
 
 For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3391"
 title: "Compiler Error C3391"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3391"
+ms.date: 11/04/2016
 f1_keywords: ["C3391"]
 helpviewer_keywords: ["C3391"]
-ms.assetid: c32532b9-7db4-4ccd-84b9-479e5a1a19d1
 ---
 # Compiler Error C3391
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
@@ -16,7 +16,7 @@ A generic type was instantiated incorrectly. Check the type definition. For more
 
 ## Example
 
-The following sample uses C# to create a component that contains a generic type that has certain constraints that are not supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
+The following example uses C# to create a component that contains a generic type that has certain constraints that are not supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
 
 ```csharp
 // C3391.cs
@@ -26,7 +26,7 @@ public class GR<N>
 where N : struct {}
 ```
 
-When the C3391.dll component is available, the following sample generates C3391.
+When the C3391.dll component is available, the following example generates C3391.
 
 ```cpp
 // C3391_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
@@ -10,6 +10,8 @@ ms.assetid: c32532b9-7db4-4ccd-84b9-479e5a1a19d1
 
 > 'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must be a non-nullable value type
 
+## Remarks
+
 A generic type was instantiated incorrectly. Check the type definition. For more information, see <xref:System.Nullable> and [Generics](../../extensions/generics-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3391.md
@@ -8,7 +8,7 @@ ms.assetid: c32532b9-7db4-4ccd-84b9-479e5a1a19d1
 ---
 # Compiler Error C3391
 
-'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must be a non-nullable value type
+> 'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must be a non-nullable value type
 
 A generic type was instantiated incorrectly. Check the type definition. For more information, see <xref:System.Nullable> and [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
@@ -16,7 +16,7 @@ A generic type was instantiated incorrectly. Check the type definition. For more
 
 ## Example
 
-The following sample uses C# to create a component that contains a generic type that has certain constraints that are not supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
+The following example uses C# to create a component that contains a generic type that has certain constraints that are not supported when authoring generic types in C++/CLI. For more information, see [Constraints on Type Parameters](/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).
 
 ```csharp
 // C3392.cs
@@ -28,7 +28,7 @@ where V : struct
 where N : new() {}
 ```
 
-When the C3392.dll component is available, the following sample generates C3392.
+When the C3392.dll component is available, the following example generates C3392.
 
 ```cpp
 // C3392_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
@@ -8,7 +8,7 @@ ms.assetid: e4757596-e2aa-4314-b01e-5c4bfd2110e9
 ---
 # Compiler Error C3392
 
-'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must have a public parameterless constructor
+> 'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must have a public parameterless constructor
 
 A generic type was instantiated incorrectly. Check the type definition. For more information, see  [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
@@ -10,6 +10,8 @@ ms.assetid: e4757596-e2aa-4314-b01e-5c4bfd2110e9
 
 > 'type_arg' : invalid type argument for generic parameter 'param' of generic 'generic_type', must have a public parameterless constructor
 
+## Remarks
+
 A generic type was instantiated incorrectly. Check the type definition. For more information, see  [Generics](../../extensions/generics-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3392.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3392"
 title: "Compiler Error C3392"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3392"
+ms.date: 11/04/2016
 f1_keywords: ["C3392"]
 helpviewer_keywords: ["C3392"]
-ms.assetid: e4757596-e2aa-4314-b01e-5c4bfd2110e9
 ---
 # Compiler Error C3392
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
@@ -8,7 +8,7 @@ ms.assetid: d57f7c69-0a02-4fe3-9e45-bc62644fd77c
 ---
 # Compiler Error C3393
 
-syntax error in constraint clause: 'identifier' is not a type
+> syntax error in constraint clause: 'identifier' is not a type
 
 The identifier passed to a constraint, which must be a type, was not a type.  For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3393"
 title: "Compiler Error C3393"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3393"
+ms.date: 11/04/2016
 f1_keywords: ["C3393"]
 helpviewer_keywords: ["C3393"]
-ms.assetid: d57f7c69-0a02-4fe3-9e45-bc62644fd77c
 ---
 # Compiler Error C3393
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
@@ -16,7 +16,7 @@ The identifier passed to a constraint, which must be a type, was not a type.  Fo
 
 ## Example
 
-The following sample generates C3393:
+The following example generates C3393:
 
 ```cpp
 // C3393.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3393.md
@@ -10,6 +10,8 @@ ms.assetid: d57f7c69-0a02-4fe3-9e45-bc62644fd77c
 
 > syntax error in constraint clause: 'identifier' is not a type
 
+## Remarks
+
 The identifier passed to a constraint, which must be a type, was not a type.  For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
@@ -16,7 +16,7 @@ A constraint was ill formed.  For more information, see [Constraints on Generic 
 
 ## Example
 
-The following sample generates C3394:
+The following example generates C3394:
 
 ```cpp
 // C3394.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3394"
 title: "Compiler Error C3394"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3394"
+ms.date: 11/04/2016
 f1_keywords: ["C3394"]
 helpviewer_keywords: ["C3394"]
-ms.assetid: 4e025d79-27ba-43c8-b0d9-839ecef98126
 ---
 # Compiler Error C3394
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
@@ -10,6 +10,8 @@ ms.assetid: 4e025d79-27ba-43c8-b0d9-839ecef98126
 
 > syntax error in constraint clause: found 'identifier' expected a type
 
+## Remarks
+
 A constraint was ill formed.  For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3394.md
@@ -8,7 +8,7 @@ ms.assetid: 4e025d79-27ba-43c8-b0d9-839ecef98126
 ---
 # Compiler Error C3394
 
-syntax error in constraint clause: found 'identifier' expected a type
+> syntax error in constraint clause: found 'identifier' expected a type
 
 A constraint was ill formed.  For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
@@ -10,7 +10,11 @@ ms.assetid: 26a9ebc9-ed97-47ce-b436-19aa2bcf6e50
 
 > 'function' : __declspec(dllexport) cannot be applied to a function with the \__clrcall calling convention
 
+## Remarks
+
 `__declspec(dllexport)` and [__clrcall](../../cpp/clrcall.md) are not compatible.  For more information, see [dllexport, dllimport](../../cpp/dllexport-dllimport.md).
+
+## Example
 
 The following sample generates C3395:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3395"
 title: "Compiler Error C3395"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3395"
+ms.date: 11/04/2016
 f1_keywords: ["C3395"]
 helpviewer_keywords: ["C3395"]
-ms.assetid: 26a9ebc9-ed97-47ce-b436-19aa2bcf6e50
 ---
 # Compiler Error C3395
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
@@ -16,7 +16,7 @@ ms.assetid: 26a9ebc9-ed97-47ce-b436-19aa2bcf6e50
 
 ## Example
 
-The following sample generates C3395:
+The following example generates C3395:
 
 ```cpp
 // C3395.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3395.md
@@ -8,7 +8,7 @@ ms.assetid: 26a9ebc9-ed97-47ce-b436-19aa2bcf6e50
 ---
 # Compiler Error C3395
 
-'function' : __declspec(dllexport) cannot be applied to a function with the \__clrcall calling convention
+> 'function' : __declspec(dllexport) cannot be applied to a function with the \__clrcall calling convention
 
 `__declspec(dllexport)` and [__clrcall](../../cpp/clrcall.md) are not compatible.  For more information, see [dllexport, dllimport](../../cpp/dllexport-dllimport.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3396"
 title: "Compiler Error C3396"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3396"
+ms.date: 11/04/2016
 f1_keywords: ["C3396"]
 helpviewer_keywords: ["C3396"]
-ms.assetid: e3580e32-72ec-4c3e-8afa-755603ffd25c
 ---
 # Compiler Error C3396
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
@@ -8,6 +8,6 @@ ms.assetid: e3580e32-72ec-4c3e-8afa-755603ffd25c
 ---
 # Compiler Error C3396
 
-'attribute' : custom attribute not found in 'namespace'
+> 'attribute' : custom attribute not found in 'namespace'
 
 C3396 indicates that you are not using an up-to-date common language runtime.  Reinstall your CLR to resolve.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3396.md
@@ -10,4 +10,6 @@ ms.assetid: e3580e32-72ec-4c3e-8afa-755603ffd25c
 
 > 'attribute' : custom attribute not found in 'namespace'
 
+## Remarks
+
 C3396 indicates that you are not using an up-to-date common language runtime.  Reinstall your CLR to resolve.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
@@ -16,7 +16,7 @@ An array was declared incorrectly.  See [Arrays](../../extensions/arrays-cpp-com
 
 ## Example
 
-The following sample generates C3397.
+The following example generates C3397.
 
 ```cpp
 // C3397.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
@@ -10,6 +10,8 @@ ms.assetid: a8536e87-79c4-4ed7-bd96-42704d06391f
 
 > Aggregate initialization is not allowed in default arguments
 
+## Remarks
+
 An array was declared incorrectly.  See [Arrays](../../extensions/arrays-cpp-component-extensions.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
@@ -8,7 +8,7 @@ ms.assetid: a8536e87-79c4-4ed7-bd96-42704d06391f
 ---
 # Compiler Error C3397
 
-Aggregate initialization is not allowed in default arguments
+> Aggregate initialization is not allowed in default arguments
 
 An array was declared incorrectly.  See [Arrays](../../extensions/arrays-cpp-component-extensions.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3397.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3397"
 title: "Compiler Error C3397"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3397"
+ms.date: 11/04/2016
 f1_keywords: ["C3397"]
 helpviewer_keywords: ["C3397"]
-ms.assetid: a8536e87-79c4-4ed7-bd96-42704d06391f
 ---
 # Compiler Error C3397
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
@@ -10,6 +10,8 @@ ms.assetid: 26f8c8a4-526f-415b-8047-155c5cd4f180
 
 > 'operator' : cannot convert from 'function_signature' to 'function_pointer'. Source expression must be a function symbol
 
+## Remarks
+
 When the [__clrcall](../../cpp/clrcall.md) calling convention is not specified when compiling with **/clr**, the compiler generates two entry points (addresses) for each function, a native entry point and a managed entry point.
 
 By default the compiler returns the native entry point, but there are some cases where the managed entry point is desired (for instance when assigning the address to a `__clrcall` function pointer). In order for the compiler to reliably choose the managed entry point in an assignment, the right hand side must be a function symbol.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3398"
 title: "Compiler Error C3398"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3398"
+ms.date: 11/04/2016
 f1_keywords: ["C3398"]
 helpviewer_keywords: ["C3398"]
-ms.assetid: 26f8c8a4-526f-415b-8047-155c5cd4f180
 ---
 # Compiler Error C3398
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3398.md
@@ -8,7 +8,7 @@ ms.assetid: 26f8c8a4-526f-415b-8047-155c5cd4f180
 ---
 # Compiler Error C3398
 
-'operator' : cannot convert from 'function_signature' to 'function_pointer'. Source expression must be a function symbol
+> 'operator' : cannot convert from 'function_signature' to 'function_pointer'. Source expression must be a function symbol
 
 When the [__clrcall](../../cpp/clrcall.md) calling convention is not specified when compiling with **/clr**, the compiler generates two entry points (addresses) for each function, a native entry point and a managed entry point.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
@@ -10,6 +10,8 @@ ms.assetid: 306ad199-d150-4f6c-bcf1-24a7948b93be
 
 > 'type' : cannot provide arguments when creating an instance of a generic parameter
 
+## Remarks
+
 When you specify the `gcnew()` constraint, you specify that the constraint type will have a parameterless constructor. Therefore, it is an error to attempt to instantiate that type and pass a parameter.
 
 See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3399"
 title: "Compiler Error C3399"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3399"
+ms.date: 11/04/2016
 f1_keywords: ["C3399"]
 helpviewer_keywords: ["C3399"]
-ms.assetid: 306ad199-d150-4f6c-bcf1-24a7948b93be
 ---
 # Compiler Error C3399
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
@@ -8,7 +8,7 @@ ms.assetid: 306ad199-d150-4f6c-bcf1-24a7948b93be
 ---
 # Compiler Error C3399
 
-'type' : cannot provide arguments when creating an instance of a generic parameter
+> 'type' : cannot provide arguments when creating an instance of a generic parameter
 
 When you specify the `gcnew()` constraint, you specify that the constraint type will have a parameterless constructor. Therefore, it is an error to attempt to instantiate that type and pass a parameter.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3399.md
@@ -18,7 +18,7 @@ See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constrai
 
 ## Example
 
-The following sample generates C3399.
+The following example generates C3399.
 
 ```cpp
 // C3399.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3400"
 title: "Compiler Error C3400"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3400"
+ms.date: 11/04/2016
 f1_keywords: ["C3400"]
 helpviewer_keywords: ["C3400"]
-ms.assetid: d44169a8-73b6-4766-b406-b3a6c93f2a4d
 ---
 # Compiler Error C3400
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
@@ -8,7 +8,7 @@ ms.assetid: d44169a8-73b6-4766-b406-b3a6c93f2a4d
 ---
 # Compiler Error C3400
 
-circular constraint dependency involving 'constraint_1' and 'constraint_2'
+> circular constraint dependency involving 'constraint_1' and 'constraint_2'
 
 The compiler detected circular constraints.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
@@ -10,6 +10,8 @@ ms.assetid: d44169a8-73b6-4766-b406-b3a6c93f2a4d
 
 > circular constraint dependency involving 'constraint_1' and 'constraint_2'
 
+## Remarks
+
 The compiler detected circular constraints.
 
 For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3400.md
@@ -18,7 +18,7 @@ For more information, see [Constraints on Generic Type Parameters (C++/CLI)](../
 
 ## Example
 
-The following sample generates C3400.
+The following example generates C3400.
 
 ```cpp
 // C3400.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
@@ -10,6 +10,8 @@ ms.assetid: 1f5ea979-fb1e-4214-b310-6fd6ca8249b1
 
 > 'attribute': attribute is not allowed on template definitions
 
+## Remarks
+
 Attributes cannot be applied to template definitions.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
@@ -8,7 +8,7 @@ ms.assetid: 1f5ea979-fb1e-4214-b310-6fd6ca8249b1
 ---
 # Compiler Error C3408
 
-'attribute': attribute is not allowed on template definitions
+> 'attribute': attribute is not allowed on template definitions
 
 Attributes cannot be applied to template definitions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3408"
 title: "Compiler Error C3408"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3408"
+ms.date: 11/04/2016
 f1_keywords: ["C3408"]
 helpviewer_keywords: ["C3408"]
-ms.assetid: 1f5ea979-fb1e-4214-b310-6fd6ca8249b1
 ---
 # Compiler Error C3408
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3408.md
@@ -16,7 +16,7 @@ Attributes cannot be applied to template definitions.
 
 ## Example
 
-The following sample generates C3408.
+The following example generates C3408.
 
 ```cpp
 // C3408.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3409.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3409.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3409"
 title: "Compiler Error C3409"
-ms.date: "11/06/2018"
+description: "Learn more about: Compiler Error C3409"
+ms.date: 11/06/2018
 f1_keywords: ["C3409"]
 helpviewer_keywords: ["C3409"]
-ms.assetid: e372d9fa-230c-4b28-b6d3-6ad81ccf9dbb
 ---
 # Compiler Error C3409
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
@@ -10,9 +10,11 @@ ms.assetid: aa4dd43b-54ce-4cda-85c1-1a77dd6e34fa
 
 > 'template' : cannot specialize template in current scope
 
+## Remarks
+
 A template cannot be specialized at class scope, only in global or namespace scope.
 
-## Examples
+## Example
 
 The following sample generates C3412.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
@@ -8,7 +8,7 @@ ms.assetid: aa4dd43b-54ce-4cda-85c1-1a77dd6e34fa
 ---
 # Compiler Error C3412
 
-'template' : cannot specialize template in current scope
+> 'template' : cannot specialize template in current scope
 
 A template cannot be specialized at class scope, only in global or namespace scope.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3412"
 title: "Compiler Error C3412"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3412"
+ms.date: 11/04/2016
 f1_keywords: ["C3412"]
 helpviewer_keywords: ["C3412"]
-ms.assetid: aa4dd43b-54ce-4cda-85c1-1a77dd6e34fa
 ---
 # Compiler Error C3412
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3412.md
@@ -16,7 +16,7 @@ A template cannot be specialized at class scope, only in global or namespace sco
 
 ## Example
 
-The following sample generates C3412.
+The following example generates C3412.
 
 ```cpp
 // C3412.cpp
@@ -27,7 +27,7 @@ struct S {
 };
 ```
 
-The following sample shows a possible resolution.
+The following example shows a possible resolution.
 
 ```cpp
 // C3412b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
@@ -10,7 +10,11 @@ ms.assetid: de6c9b05-c373-4bd8-8cb0-12c2cd2e5674
 
 > 'name' : invalid explicit instantiation
 
+## Remarks
+
 The compiler detected an ill-formed explicit instantiation.
+
+## Example
 
 The following sample generates C3413:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
@@ -16,7 +16,7 @@ The compiler detected an ill-formed explicit instantiation.
 
 ## Example
 
-The following sample generates C3413:
+The following example generates C3413:
 
 ```cpp
 // C3413.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3413"
 title: "Compiler Error C3413"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3413"
+ms.date: 11/04/2016
 f1_keywords: ["C3413"]
 helpviewer_keywords: ["C3413"]
-ms.assetid: de6c9b05-c373-4bd8-8cb0-12c2cd2e5674
 ---
 # Compiler Error C3413
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3413.md
@@ -8,7 +8,7 @@ ms.assetid: de6c9b05-c373-4bd8-8cb0-12c2cd2e5674
 ---
 # Compiler Error C3413
 
-'name' : invalid explicit instantiation
+> 'name' : invalid explicit instantiation
 
 The compiler detected an ill-formed explicit instantiation.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
@@ -8,7 +8,7 @@ ms.assetid: 715f5432-b509-4f8f-84f5-e1463bac490f
 ---
 # Compiler Error C3414
 
-'member' : imported member function can't be defined
+> 'member' : imported member function can't be defined
 
 A member was defined in code that is also defined in a referenced assembly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
@@ -10,7 +10,11 @@ ms.assetid: 715f5432-b509-4f8f-84f5-e1463bac490f
 
 > 'member' : imported member function can't be defined
 
+## Remarks
+
 A member was defined in code that is also defined in a referenced assembly.
+
+## Example
 
 The following sample generates C3414:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
@@ -16,7 +16,7 @@ A member was defined in code that is also defined in a referenced assembly.
 
 ## Example
 
-The following sample generates C3414:
+The following example generates C3414:
 
 ```cpp
 // C3414a2.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3414.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3414"
 title: "Compiler Error C3414"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3414"
+ms.date: 11/04/2016
 f1_keywords: ["C3414"]
 helpviewer_keywords: ["C3414"]
-ms.assetid: 715f5432-b509-4f8f-84f5-e1463bac490f
 ---
 # Compiler Error C3414
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
@@ -37,7 +37,7 @@ Conflicting values were specified in [section](../../preprocessor/section.md) pr
 
 ## Example
 
-The following sample generates C3415:
+The following example generates C3415:
 
 ```cpp
 // C3415.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
@@ -8,7 +8,7 @@ ms.assetid: fa2db8ab-2820-4ec3-a740-fb5e2adcfb29
 ---
 # Compiler Error C3415
 
-multiple 'section_name' sections found with different attributes ('value')
+> multiple 'section_name' sections found with different attributes ('value')
 
 Conflicting values were specified in [section](../../preprocessor/section.md) pragmas.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3415"
 title: "Compiler Error C3415"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3415"
+ms.date: 11/04/2016
 f1_keywords: ["C3415"]
 helpviewer_keywords: ["C3415"]
-ms.assetid: fa2db8ab-2820-4ec3-a740-fb5e2adcfb29
 ---
 # Compiler Error C3415
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3415.md
@@ -10,6 +10,8 @@ ms.assetid: fa2db8ab-2820-4ec3-a740-fb5e2adcfb29
 
 > multiple 'section_name' sections found with different attributes ('value')
 
+## Remarks
+
 Conflicting values were specified in [section](../../preprocessor/section.md) pragmas.
 
 `value` is the current setting for the section, as specified in ntimage.h. For example:
@@ -32,6 +34,8 @@ Conflicting values were specified in [section](../../preprocessor/section.md) pr
 // Section is writeable.
 #define IMAGE_SCN_MEM_WRITE                  0x80000000
 ```
+
+## Example
 
 The following sample generates C3415:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
@@ -8,7 +8,7 @@ ms.assetid: 3e7869ea-8948-42fb-ba30-6ccafe499c35
 ---
 # Compiler Error C3417
 
-'member' : value types cannot contain user-defined special member functions
+> 'member' : value types cannot contain user-defined special member functions
 
 Value types cannot contain functions such as a default instance constructor, destructor, or copy constructor.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
@@ -16,7 +16,7 @@ Value types cannot contain functions such as a default instance constructor, des
 
 ## Example
 
-The following sample generates C3517:
+The following example generates C3517:
 
 ```cpp
 // C3417.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3417"
 title: "Compiler Error C3417"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3417"
+ms.date: 11/04/2016
 f1_keywords: ["C3417"]
 helpviewer_keywords: ["C3417"]
-ms.assetid: 3e7869ea-8948-42fb-ba30-6ccafe499c35
 ---
 # Compiler Error C3417
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
@@ -10,7 +10,11 @@ ms.assetid: 3e7869ea-8948-42fb-ba30-6ccafe499c35
 
 > 'member' : value types cannot contain user-defined special member functions
 
+## Remarks
+
 Value types cannot contain functions such as a default instance constructor, destructor, or copy constructor.
+
+## Example
 
 The following sample generates C3517:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3417.md
@@ -15,7 +15,7 @@ Value types cannot contain functions such as a default instance constructor, des
 
 ## Example
 
-The following example generates C3517:
+The following example generates C3417:
 
 ```cpp
 // C3417.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
@@ -16,7 +16,7 @@ A CLR access specifier was specified incorrectly.  For more information, see Typ
 
 ## Example
 
-The following sample generates C3418.
+The following example generates C3418.
 
 ```cpp
 // C3418.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3418"
 title: "Compiler Error C3418"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3418"
+ms.date: 11/04/2016
 f1_keywords: ["C3418"]
 helpviewer_keywords: ["C3418"]
-ms.assetid: 54042c04-3c45-41c1-bad7-90f9ee05a21b
 ---
 # Compiler Error C3418
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
@@ -8,7 +8,7 @@ ms.assetid: 54042c04-3c45-41c1-bad7-90f9ee05a21b
 ---
 # Compiler Error C3418
 
-access specifier 'specifier' is not supported
+> access specifier 'specifier' is not supported
 
 A CLR access specifier was specified incorrectly.  For more information, see Type visibility and Member visibility in [How to: Define and Consume Classes and Structs (C++/CLI)](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3418.md
@@ -10,6 +10,8 @@ ms.assetid: 54042c04-3c45-41c1-bad7-90f9ee05a21b
 
 > access specifier 'specifier' is not supported
 
+## Remarks
+
 A CLR access specifier was specified incorrectly.  For more information, see Type visibility and Member visibility in [How to: Define and Consume Classes and Structs (C++/CLI)](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
@@ -18,7 +18,7 @@ For more information, see [Destructors and finalizers in How to: Define and cons
 
 ## Example
 
-The following sample generates C3420.
+The following example generates C3420.
 
 ```cpp
 // C3420.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
@@ -8,7 +8,7 @@ ms.assetid: 99b53c77-f36b-4574-9199-b53111becccb
 ---
 # Compiler Error C3420
 
-'finalizer' : a finalizer cannot be virtual
+> 'finalizer' : a finalizer cannot be virtual
 
 A finalizer can only be called non-virtually from its enclosing type. Therefore, it is an error to declare a virtual finalizer.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
@@ -10,6 +10,8 @@ ms.assetid: 99b53c77-f36b-4574-9199-b53111becccb
 
 > 'finalizer' : a finalizer cannot be virtual
 
+## Remarks
+
 A finalizer can only be called non-virtually from its enclosing type. Therefore, it is an error to declare a virtual finalizer.
 
 For more information, see [Destructors and finalizers in How to: Define and consume classes and structs (C++/CLI)](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Destructors_and_finalizers).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3420.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3420"
 title: "Compiler Error C3420"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3420"
+ms.date: 11/04/2016
 f1_keywords: ["C3420"]
 helpviewer_keywords: ["C3420"]
-ms.assetid: 99b53c77-f36b-4574-9199-b53111becccb
 ---
 # Compiler Error C3420
 


### PR DESCRIPTION
This is batch 57 that structures error/warning references. See #5465 for more information.