### PR TITLE
Structure error references in range [C3481, C3530]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
@@ -10,6 +10,8 @@ ms.assetid: 5d09375a-5ed3-4b61-86ed-45e91fd734c7
 
 > 'var': lambda capture variable not found
 
+## Remarks
+
 The compiler could not find the definition of a variable that you passed to the capture list of a lambda expression.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
@@ -8,7 +8,7 @@ ms.assetid: 5d09375a-5ed3-4b61-86ed-45e91fd734c7
 ---
 # Compiler Error C3481
 
-'var': lambda capture variable not found
+> 'var': lambda capture variable not found
 
 The compiler could not find the definition of a variable that you passed to the capture list of a lambda expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3481.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3481"
 title: "Compiler Error C3481"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3481"
+ms.date: 11/04/2016
 f1_keywords: ["C3481"]
 helpviewer_keywords: ["C3481"]
-ms.assetid: 5d09375a-5ed3-4b61-86ed-45e91fd734c7
 ---
 # Compiler Error C3481
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
@@ -10,6 +10,8 @@ ms.assetid: bf99558e-bef4-421c-bb16-dcd9c54c1011
 
 > 'this' can only be used as a lambda capture within a non-static member function
 
+## Remarks
+
 You cannot pass **`this`** to the capture list of a lambda expression that is declared in a static method or a global function.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3482"
 title: "Compiler Error C3482"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3482"
+ms.date: 11/04/2016
 f1_keywords: ["C3482"]
 helpviewer_keywords: ["C3482"]
-ms.assetid: bf99558e-bef4-421c-bb16-dcd9c54c1011
 ---
 # Compiler Error C3482
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3482.md
@@ -8,7 +8,7 @@ ms.assetid: bf99558e-bef4-421c-bb16-dcd9c54c1011
 ---
 # Compiler Error C3482
 
-'this' can only be used as a lambda capture within a non-static member function
+> 'this' can only be used as a lambda capture within a non-static member function
 
 You cannot pass **`this`** to the capture list of a lambda expression that is declared in a static method or a global function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
@@ -8,7 +8,7 @@ ms.assetid: 18b3a2c5-dfc9-4661-9653-08a5798474cf
 ---
 # Compiler Error C3483
 
-'var' is already part of the lambda capture list
+> 'var' is already part of the lambda capture list
 
 You passed the same variable to the capture list of a lambda expression more than one time.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
@@ -10,6 +10,8 @@ ms.assetid: 18b3a2c5-dfc9-4661-9653-08a5798474cf
 
 > 'var' is already part of the lambda capture list
 
+## Remarks
+
 You passed the same variable to the capture list of a lambda expression more than one time.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3483.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3483"
 title: "Compiler Error C3483"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3483"
+ms.date: 11/04/2016
 f1_keywords: ["C3483"]
 helpviewer_keywords: ["C3483"]
-ms.assetid: 18b3a2c5-dfc9-4661-9653-08a5798474cf
 ---
 # Compiler Error C3483
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3484"
 title: "Compiler Error C3484"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3484"
+ms.date: 11/04/2016
 f1_keywords: ["C3484"]
 helpviewer_keywords: ["C3484"]
-ms.assetid: 2fe847fa-f6ee-4978-bc1d-b6dc6ae906ac
 ---
 # Compiler Error C3484
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
@@ -10,13 +10,15 @@ ms.assetid: 2fe847fa-f6ee-4978-bc1d-b6dc6ae906ac
 
 > expected '->' before the return type
 
+## Remarks
+
 You must provide `->` before the return type of a lambda expression.
 
 ### To correct this error
 
 - Provide `->` before the return type.
 
-## Examples
+## Example
 
 The following example generates C3484:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3484.md
@@ -8,7 +8,7 @@ ms.assetid: 2fe847fa-f6ee-4978-bc1d-b6dc6ae906ac
 ---
 # Compiler Error C3484
 
-expected '->' before the return type
+> expected '->' before the return type
 
 You must provide `->` before the return type of a lambda expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3485.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3485.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3485"
 title: "Compiler Error C3485"
+description: "Learn more about: Compiler Error C3485"
 ms.date: 06/01/2022
 f1_keywords: ["C3485"]
 helpviewer_keywords: ["C3485"]
-ms.assetid: d67536f9-67a1-4ad9-9a94-d8bbbca3d0dc
 ---
 # Compiler Error C3485
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
@@ -10,6 +10,8 @@ ms.assetid: 39bda474-4418-4a79-98bf-2b22fa92eaaa
 
 > 'return type': all return expressions must deduce to the same type: previously it was 'return type'
 
+## Remarks
+
 A lambda must specify its return type unless it contains a single return statement. If a lambda contains multiple return statements, they must all have the same type.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
@@ -8,7 +8,7 @@ ms.assetid: 39bda474-4418-4a79-98bf-2b22fa92eaaa
 ---
 # Compiler Error C3487
 
-'return type': all return expressions must deduce to the same type: previously it was 'return type'
+> 'return type': all return expressions must deduce to the same type: previously it was 'return type'
 
 A lambda must specify its return type unless it contains a single return statement. If a lambda contains multiple return statements, they must all have the same type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3487.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3487"
 title: "Compiler Error C3487"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3487"
+ms.date: 11/04/2016
 f1_keywords: ["C3487"]
 helpviewer_keywords: ["C3487"]
-ms.assetid: 39bda474-4418-4a79-98bf-2b22fa92eaaa
 ---
 # Compiler Error C3487
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
@@ -10,6 +10,8 @@ ms.assetid: 0a6fcd76-dd3b-48d7-abb3-22eccda96034
 
 > 'var' is not allowed when the default capture mode is by-reference
 
+## Remarks
+
 When you specify that the default capture mode for a lambda expression is by-reference, you cannot pass a variable by reference to the capture clause of that expression.
 
 ### To correct this error
@@ -22,7 +24,7 @@ When you specify that the default capture mode for a lambda expression is by-ref
 
 - Pass the variable by value to the capture clause. (This might change the behavior of the lambda expression.)
 
-## Examples
+## Example
 
 The following example generates C3488 because a reference to the variable `n` appears in the capture clause of a lambda expression whose default mode is by-reference:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3488"
 title: "Compiler Error C3488"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3488"
+ms.date: 11/04/2016
 f1_keywords: ["C3488"]
 helpviewer_keywords: ["C3488"]
-ms.assetid: 0a6fcd76-dd3b-48d7-abb3-22eccda96034
 ---
 # Compiler Error C3488
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3488.md
@@ -8,7 +8,7 @@ ms.assetid: 0a6fcd76-dd3b-48d7-abb3-22eccda96034
 ---
 # Compiler Error C3488
 
-'var' is not allowed when the default capture mode is by-reference
+> 'var' is not allowed when the default capture mode is by-reference
 
 When you specify that the default capture mode for a lambda expression is by-reference, you cannot pass a variable by reference to the capture clause of that expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3489"
 title: "Compiler Error C3489"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3489"
+ms.date: 11/04/2016
 f1_keywords: ["C3489"]
 helpviewer_keywords: ["C3489"]
-ms.assetid: 47b58d69-459d-4499-abc7-5f0b9303d773
 ---
 # Compiler Error C3489
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
@@ -8,7 +8,7 @@ ms.assetid: 47b58d69-459d-4499-abc7-5f0b9303d773
 ---
 # Compiler Error C3489
 
-'var' is required when the default capture mode is by-value
+> 'var' is required when the default capture mode is by-value
 
 When you specify that the default capture mode for a lambda expression is by-value, you cannot pass a variable by value to the capture clause of that expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3489.md
@@ -10,6 +10,8 @@ ms.assetid: 47b58d69-459d-4499-abc7-5f0b9303d773
 
 > 'var' is required when the default capture mode is by-value
 
+## Remarks
+
 When you specify that the default capture mode for a lambda expression is by-value, you cannot pass a variable by value to the capture clause of that expression.
 
 ### To correct this error
@@ -22,7 +24,7 @@ When you specify that the default capture mode for a lambda expression is by-val
 
 - Pass the variable by reference to the capture clause. (This might change the behavior of the lambda expression.)
 
-## Examples
+## Example
 
 The following example generates C3489 variable `n` appears by value in the capture clause of a lambda expression whose default mode is by-value:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
@@ -10,13 +10,15 @@ ms.assetid: 7638559a-fd06-4527-a9c1-0c8ae68b3123
 
 > 'var' cannot be modified because it is being accessed through a const object
 
+## Remarks
+
 A lambda expression that is declared in a **`const`** method cannot modify non-mutable member data.
 
 ### To correct this error
 
 - Remove the **`const`** modifier from your method declaration.
 
-## Examples
+## Example
 
 The following example generates C3490 because it modifies the member variable `_i` in a **`const`** method:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3490"
 title: "Compiler Error C3490"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3490"
+ms.date: 11/04/2016
 f1_keywords: ["C3490"]
 helpviewer_keywords: ["C3490"]
-ms.assetid: 7638559a-fd06-4527-a9c1-0c8ae68b3123
 ---
 # Compiler Error C3490
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3490.md
@@ -8,7 +8,7 @@ ms.assetid: 7638559a-fd06-4527-a9c1-0c8ae68b3123
 ---
 # Compiler Error C3490
 
-'var' cannot be modified because it is being accessed through a const object
+> 'var' cannot be modified because it is being accessed through a const object
 
 A lambda expression that is declared in a **`const`** method cannot modify non-mutable member data.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
@@ -8,7 +8,7 @@ ms.assetid: 7f0e71b2-46a0-4d25-bd09-6158a280f509
 ---
 # Compiler Error C3491
 
-'var': a by-value capture cannot be modified in a non-mutable lambda
+> 'var': a by-value capture cannot be modified in a non-mutable lambda
 
 A non-mutable lambda expression cannot modify the value of a variable that is captured by value.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
@@ -10,6 +10,8 @@ ms.assetid: 7f0e71b2-46a0-4d25-bd09-6158a280f509
 
 > 'var': a by-value capture cannot be modified in a non-mutable lambda
 
+## Remarks
+
 A non-mutable lambda expression cannot modify the value of a variable that is captured by value.
 
 ### To correct this error
@@ -18,7 +20,7 @@ A non-mutable lambda expression cannot modify the value of a variable that is ca
 
 - Pass the variable by reference to the capture list of the lambda expression.
 
-## Examples
+## Example
 
 The following example generates C3491 because the body of a non-mutable lambda expression modifies the capture variable `m`:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3491.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3491"
 title: "Compiler Error C3491"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3491"
+ms.date: 11/04/2016
 f1_keywords: ["C3491"]
 helpviewer_keywords: ["C3491"]
-ms.assetid: 7f0e71b2-46a0-4d25-bd09-6158a280f509
 ---
 # Compiler Error C3491
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
@@ -10,13 +10,15 @@ ms.assetid: b1dc6342-9133-4b1f-a9c3-e8c65d20d121
 
 > 'var': you cannot capture a member of an anonymous union
 
+## Remarks
+
 You cannot capture a member of an unnamed union.
 
 ### To correct this error
 
 - Give the union a name and pass the complete union structure to the capture list of the lambda expression.
 
-## Examples
+## Example
 
 The following example generates C3492 because it captures a member of an anonymous union:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3492"
 title: "Compiler Error C3492"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3492"
+ms.date: 11/04/2016
 f1_keywords: ["C3492"]
 helpviewer_keywords: ["C3492"]
-ms.assetid: b1dc6342-9133-4b1f-a9c3-e8c65d20d121
 ---
 # Compiler Error C3492
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3492.md
@@ -8,7 +8,7 @@ ms.assetid: b1dc6342-9133-4b1f-a9c3-e8c65d20d121
 ---
 # Compiler Error C3492
 
-'var': you cannot capture a member of an anonymous union
+> 'var': you cannot capture a member of an anonymous union
 
 You cannot capture a member of an unnamed union.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
@@ -8,7 +8,7 @@ ms.assetid: 734b4257-12a3-436f-8488-c8c55ec81634
 ---
 # Compiler Error C3493
 
-'var' cannot be implicitly captured because no default capture mode has been specified
+> 'var' cannot be implicitly captured because no default capture mode has been specified
 
 The empty lambda expression capture, `[]`, specifies that the lambda expression does not explicitly or implicitly capture any variables.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
@@ -10,6 +10,8 @@ ms.assetid: 734b4257-12a3-436f-8488-c8c55ec81634
 
 > 'var' cannot be implicitly captured because no default capture mode has been specified
 
+## Remarks
+
 The empty lambda expression capture, `[]`, specifies that the lambda expression does not explicitly or implicitly capture any variables.
 
 ### To correct this error
@@ -18,7 +20,7 @@ The empty lambda expression capture, `[]`, specifies that the lambda expression 
 
 - Explicitly capture one or more variables.
 
-## Examples
+## Example
 
 The following example generates C3493 because it modifies an external variable but specifies the empty capture clause:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3493.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3493"
 title: "Compiler Error C3493"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3493"
+ms.date: 11/04/2016
 f1_keywords: ["C3493"]
 helpviewer_keywords: ["C3493"]
-ms.assetid: 734b4257-12a3-436f-8488-c8c55ec81634
 ---
 # Compiler Error C3493
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
@@ -8,7 +8,7 @@ ms.assetid: 1fd40cb8-8373-403d-b8a8-f08424a50807
 ---
 # Compiler Error C3495
 
-'var': a lambda capture must have automatic storage duration
+> 'var': a lambda capture must have automatic storage duration
 
 You cannot capture a variable that does not have automatic storage duration, such as a variable that is marked **`static`** or **`extern`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
@@ -10,6 +10,8 @@ ms.assetid: 1fd40cb8-8373-403d-b8a8-f08424a50807
 
 > 'var': a lambda capture must have automatic storage duration
 
+## Remarks
+
 You cannot capture a variable that does not have automatic storage duration, such as a variable that is marked **`static`** or **`extern`**.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3495.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3495"
 title: "Compiler Error C3495"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3495"
+ms.date: 11/04/2016
 f1_keywords: ["C3495"]
 helpviewer_keywords: ["C3495"]
-ms.assetid: 1fd40cb8-8373-403d-b8a8-f08424a50807
 ---
 # Compiler Error C3495
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3496"
 title: "Compiler Error C3496"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3496"
+ms.date: 11/04/2016
 f1_keywords: ["C3496"]
 helpviewer_keywords: ["C3496"]
-ms.assetid: e19885f2-677f-4c1e-bc69-e35852262dc3
 ---
 # Compiler Error C3496
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
@@ -10,6 +10,8 @@ ms.assetid: e19885f2-677f-4c1e-bc69-e35852262dc3
 
 > 'this' is always captured by value: '&' ignored
 
+## Remarks
+
 You cannot capture the **`this`** pointer by reference.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3496.md
@@ -8,7 +8,7 @@ ms.assetid: e19885f2-677f-4c1e-bc69-e35852262dc3
 ---
 # Compiler Error C3496
 
-'this' is always captured by value: '&' ignored
+> 'this' is always captured by value: '&' ignored
 
 You cannot capture the **`this`** pointer by reference.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
@@ -8,7 +8,7 @@ ms.assetid: 0a5a7817-0872-4119-83bf-980a19113374
 ---
 # Compiler Error C3498
 
-'var': you cannot capture a variable that has a managed or WinRTtype
+> 'var': you cannot capture a variable that has a managed or WinRTtype
 
 You cannot capture a variable that has a managed type or a Windows Runtime type in a lambda.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3498"
 title: "Compiler Error C3498"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3498"
+ms.date: 11/04/2016
 f1_keywords: ["C3498"]
 helpviewer_keywords: ["C3498"]
-ms.assetid: 0a5a7817-0872-4119-83bf-980a19113374
 ---
 # Compiler Error C3498
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3498.md
@@ -10,13 +10,15 @@ ms.assetid: 0a5a7817-0872-4119-83bf-980a19113374
 
 > 'var': you cannot capture a variable that has a managed or WinRTtype
 
+## Remarks
+
 You cannot capture a variable that has a managed type or a Windows Runtime type in a lambda.
 
 ### To correct this error
 
 - Pass the managed or Windows Runtime variable to the parameter list of the lambda expression.
 
-## Examples
+## Example
 
 The following example generates C3498 because a variable that has a managed type appears in the capture list of a lambda expression:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3499"
 title: "Compiler Error C3499"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3499"
+ms.date: 11/04/2016
 f1_keywords: ["C3499"]
 helpviewer_keywords: ["C3499"]
-ms.assetid: 6717de5c-ae0f-4024-bdf2-b5598009e7b6
 ---
 # Compiler Error C3499
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
@@ -10,6 +10,8 @@ ms.assetid: 6717de5c-ae0f-4024-bdf2-b5598009e7b6
 
 > a lambda that has been specified to have a void return type cannot return a value
 
+## Remarks
+
 The compiler generates this error when a lambda expression that specifies **`void`** as the return type returns a value; or when a lambda expression contains more than one statement and returns a value, but does not specify its return type.
 
 ### To correct this error
@@ -20,7 +22,7 @@ The compiler generates this error when a lambda expression that specifies **`voi
 
 - Combine the statements that make up the body of the lambda expression into a single statement.
 
-## Examples
+## Example
 
 The following example generates C3499 because the body of a lambda expression contains multiple statements and returns a value, but the lambda expression does not specify the return type:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3499.md
@@ -8,7 +8,7 @@ ms.assetid: 6717de5c-ae0f-4024-bdf2-b5598009e7b6
 ---
 # Compiler Error C3499
 
-a lambda that has been specified to have a void return type cannot return a value
+> a lambda that has been specified to have a void return type cannot return a value
 
 The compiler generates this error when a lambda expression that specifies **`void`** as the return type returns a value; or when a lambda expression contains more than one statement and returns a value, but does not specify its return type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
@@ -10,4 +10,6 @@ ms.assetid: 77336f16-04f5-4943-bfc0-faba4cd8bb51
 
 > invalid ProgID 'progid'
 
+## Remarks
+
 An invalid progid was specified with the `#import` statement. Check the Windows registry to ensure that you are specifying a valid progid.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3500"
 title: "Compiler Error C3500"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3500"
+ms.date: 11/04/2016
 f1_keywords: ["C3500"]
 helpviewer_keywords: ["C3500"]
-ms.assetid: 77336f16-04f5-4943-bfc0-faba4cd8bb51
 ---
 # Compiler Error C3500
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3500.md
@@ -8,6 +8,6 @@ ms.assetid: 77336f16-04f5-4943-bfc0-faba4cd8bb51
 ---
 # Compiler Error C3500
 
-invalid ProgID 'progid'
+> invalid ProgID 'progid'
 
 An invalid progid was specified with the `#import` statement. Check the Windows registry to ensure that you are specifying a valid progid.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
@@ -8,6 +8,6 @@ ms.assetid: cad69fab-2687-41ac-961f-25dc4c51b167
 ---
 # Compiler Error C3501
 
-there is no typelib registered for ProgID 'progid'
+> there is no typelib registered for ProgID 'progid'
 
 The class ID for a given progid does not have an associated type library. Therefore, you cannot pass this progid to the `#import` statement.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3501"
 title: "Compiler Error C3501"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3501"
+ms.date: 11/04/2016
 f1_keywords: ["C3501"]
 helpviewer_keywords: ["C3501"]
-ms.assetid: cad69fab-2687-41ac-961f-25dc4c51b167
 ---
 # Compiler Error C3501
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3501.md
@@ -10,4 +10,6 @@ ms.assetid: cad69fab-2687-41ac-961f-25dc4c51b167
 
 > there is no typelib registered for ProgID 'progid'
 
+## Remarks
+
 The class ID for a given progid does not have an associated type library. Therefore, you cannot pass this progid to the `#import` statement.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3505.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3505.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3505"
 title: "Compiler Error C3505"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3505"
+ms.date: 11/04/2016
 f1_keywords: ["C3505"]
 helpviewer_keywords: ["C3505"]
-ms.assetid: ed73c99e-93a1-4f3a-bac7-ba7ed5d836e4
 ---
 # Compiler Error C3505
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3505.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3505.md
@@ -10,6 +10,8 @@ ms.assetid: ed73c99e-93a1-4f3a-bac7-ba7ed5d836e4
 
 > cannot load type library '*guid*'
 
+## Remarks
+
 C3505 can be caused if you are running the 32-bit, x86-hosted cross-compiler for 64-bit, x64 targets on a 64-bit machine, because the compiler is running under WOW64 and can only read from the 32-bit registry hive.
 
 You can resolve this error by building both 32-bit and 64-bit versions of the type library you are trying to import, and then register them both.  Or you can use the native 64-bit compiler, which requires you to change your **VC++ Directories** property in the IDE to point to the 64-bit compiler.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3506"
 title: "Compiler Error C3506"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3506"
+ms.date: 11/04/2016
 f1_keywords: ["C3506"]
 helpviewer_keywords: ["C3506"]
-ms.assetid: d382c067-5fad-42ca-acf3-9e6d8cbdb2c5
 ---
 # Compiler Error C3506
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
@@ -10,4 +10,6 @@ ms.assetid: d382c067-5fad-42ca-acf3-9e6d8cbdb2c5
 
 > there is no typelib registered for LIBID 'id'
 
+## Remarks
+
 A typelib was not registered correctly. Use regsvr32.exe to register a type library.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3506.md
@@ -8,6 +8,6 @@ ms.assetid: d382c067-5fad-42ca-acf3-9e6d8cbdb2c5
 ---
 # Compiler Error C3506
 
-there is no typelib registered for LIBID 'id'
+> there is no typelib registered for LIBID 'id'
 
 A typelib was not registered correctly. Use regsvr32.exe to register a type library.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
@@ -16,7 +16,7 @@ The [progid](../../windows/attributes/progid.md) attribute has restrictions on t
 
 ## Example
 
-The following sample generates C3507:
+The following example generates C3507:
 
 ```cpp
 // C3507.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3507"
 title: "Compiler Error C3507"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3507"
+ms.date: 11/04/2016
 f1_keywords: ["C3507"]
 helpviewer_keywords: ["C3507"]
-ms.assetid: 75f89767-f6f9-40f6-9820-81a49e09abdf
 ---
 # Compiler Error C3507
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
@@ -8,7 +8,7 @@ ms.assetid: 75f89767-f6f9-40f6-9820-81a49e09abdf
 ---
 # Compiler Error C3507
 
-a ProgID can have no more than 39 characters 'id'; nor contain any punctuation apart from '.'; nor start with a digit
+> a ProgID can have no more than 39 characters 'id'; nor contain any punctuation apart from '.'; nor start with a digit
 
 The [progid](../../windows/attributes/progid.md) attribute has restrictions on the values that it can take.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3507.md
@@ -10,7 +10,11 @@ ms.assetid: 75f89767-f6f9-40f6-9820-81a49e09abdf
 
 > a ProgID can have no more than 39 characters 'id'; nor contain any punctuation apart from '.'; nor start with a digit
 
+## Remarks
+
 The [progid](../../windows/attributes/progid.md) attribute has restrictions on the values that it can take.
+
+## Example
 
 The following sample generates C3507:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
@@ -8,7 +8,7 @@ ms.assetid: 16d08f89-2f32-44eb-9421-68acecddf49b
 ---
 # Compiler Error C3508
 
-'type': is not a valid Automation type
+> 'type': is not a valid Automation type
 
 An invalid type was specified.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
@@ -10,6 +10,8 @@ ms.assetid: 16d08f89-2f32-44eb-9421-68acecddf49b
 
 > 'type': is not a valid Automation type
 
+## Remarks
+
 An invalid type was specified.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3508"
 title: "Compiler Error C3508"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3508"
+ms.date: 11/04/2016
 f1_keywords: ["C3508"]
 helpviewer_keywords: ["C3508"]
-ms.assetid: 16d08f89-2f32-44eb-9421-68acecddf49b
 ---
 # Compiler Error C3508
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3508.md
@@ -16,7 +16,7 @@ An invalid type was specified.
 
 ## Example
 
-The following sample generates C3508:
+The following example generates C3508:
 
 ```cpp
 // C3508.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
@@ -10,7 +10,11 @@ ms.assetid: cc2db39a-2f98-4e40-b803-496e585494e6
 
 > 'type': invalid Automation return type; when a parameter is marked 'retval', the return type must be 'void', 'HRESULT' or 'SCODE'
 
+## Remarks
+
 A method in a COM interface must return either void or an HRESULT.
+
+## Example
 
 The following sample generates C3509:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3509"
 title: "Compiler Error C3509"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3509"
+ms.date: 11/04/2016
 f1_keywords: ["C3509"]
 helpviewer_keywords: ["C3509"]
-ms.assetid: cc2db39a-2f98-4e40-b803-496e585494e6
 ---
 # Compiler Error C3509
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
@@ -8,7 +8,7 @@ ms.assetid: cc2db39a-2f98-4e40-b803-496e585494e6
 ---
 # Compiler Error C3509
 
-'type': invalid Automation return type; when a parameter is marked 'retval', the return type must be 'void', 'HRESULT' or 'SCODE'
+> 'type': invalid Automation return type; when a parameter is marked 'retval', the return type must be 'void', 'HRESULT' or 'SCODE'
 
 A method in a COM interface must return either void or an HRESULT.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3509.md
@@ -16,7 +16,7 @@ A method in a COM interface must return either void or an HRESULT.
 
 ## Example
 
-The following sample generates C3509:
+The following example generates C3509:
 
 ```cpp
 // C3509.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3510"
 title: "Compiler Error C3510"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3510"
+ms.date: 11/04/2016
 f1_keywords: ["C3510"]
 helpviewer_keywords: ["C3510"]
-ms.assetid: c48387bc-0300-4a4d-97f7-3fb90f82a451
 ---
 # Compiler Error C3510
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
@@ -8,7 +8,7 @@ ms.assetid: c48387bc-0300-4a4d-97f7-3fb90f82a451
 ---
 # Compiler Error C3510
 
-cannot locate dependent type library 'type_lib'
+> cannot locate dependent type library 'type_lib'
 
 [no_registry](../../preprocessor/no-registry.md) and [auto_search](../../preprocessor/auto-search.md) were passed to `#import` but the compiler was not able to find a referenced type library.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
@@ -10,9 +10,13 @@ ms.assetid: c48387bc-0300-4a4d-97f7-3fb90f82a451
 
 > cannot locate dependent type library 'type_lib'
 
+## Remarks
+
 [no_registry](../../preprocessor/no-registry.md) and [auto_search](../../preprocessor/auto-search.md) were passed to `#import` but the compiler was not able to find a referenced type library.
 
 To resolve this error, make sure that all type libraries and referenced type libraries are available to the compiler.
+
+## Example
 
 The following sample generates C3510:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3510.md
@@ -18,7 +18,7 @@ To resolve this error, make sure that all type libraries and referenced type lib
 
 ## Example
 
-The following sample generates C3510:
+The following example generates C3510:
 
 Assume that the following two type libraries were built, and that C3510a.tlb was deleted or not on the path.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3519"
 title: "Compiler Error C3519"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3519"
+ms.date: 11/04/2016
 f1_keywords: ["C3519"]
 helpviewer_keywords: ["C3519"]
-ms.assetid: ca24b2bc-7e90-4448-ae84-3fedddf9bca7
 ---
 # Compiler Error C3519
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
@@ -8,7 +8,7 @@ ms.assetid: ca24b2bc-7e90-4448-ae84-3fedddf9bca7
 ---
 # Compiler Error C3519
 
-'invalid_param' : invalid parameter to embedded_idl attribute
+> 'invalid_param' : invalid parameter to embedded_idl attribute
 
 A parameter was passed to the `embedded_idl` attribute of [#import](../../preprocessor/hash-import-directive-cpp.md), but the compiler did not recognize the parameter.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
@@ -18,7 +18,7 @@ The only parameters that are allowed for `embedded_idl` are `emitidl` and `no_em
 
 ## Example
 
-The following sample generates C3519:
+The following example generates C3519:
 
 ```cpp
 // C3519.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3519.md
@@ -10,9 +10,13 @@ ms.assetid: ca24b2bc-7e90-4448-ae84-3fedddf9bca7
 
 > 'invalid_param' : invalid parameter to embedded_idl attribute
 
+## Remarks
+
 A parameter was passed to the `embedded_idl` attribute of [#import](../../preprocessor/hash-import-directive-cpp.md), but the compiler did not recognize the parameter.
 
 The only parameters that are allowed for `embedded_idl` are `emitidl` and `no_emitidl`.
+
+## Example
 
 The following sample generates C3519:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3530"
 title: "Compiler Error C3530"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3530"
+ms.date: 11/04/2016
 f1_keywords: ["C3530"]
 helpviewer_keywords: ["C3530"]
-ms.assetid: 21be81ce-b699-4c74-81bc-80a0c34d2d5a
 ---
 # Compiler Error C3530
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
@@ -8,7 +8,7 @@ ms.assetid: 21be81ce-b699-4c74-81bc-80a0c34d2d5a
 ---
 # Compiler Error C3530
 
-'auto' cannot be combined with any other type-specifier
+> 'auto' cannot be combined with any other type-specifier
 
 A type specifier is used with the **`auto`** keyword.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3530.md
@@ -10,6 +10,8 @@ ms.assetid: 21be81ce-b699-4c74-81bc-80a0c34d2d5a
 
 > 'auto' cannot be combined with any other type-specifier
 
+## Remarks
+
 A type specifier is used with the **`auto`** keyword.
 
 ### To correct this error


### PR DESCRIPTION
This is batch 59 that structures error/warning references. See #5465 for more information.