### PR TITLE
Update `<array>` functions reference

### DIFF
--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -2,12 +2,12 @@
 title: "<array> functions"
 description: "Learn more about: <array> functions"
 ms.date: 11/04/2016
-f1_keywords: ["array/std::array::get", "array/std::get", "array/std::swap"]
-helpviewer_keywords: ["std::array [C++], get", "std::get [C++]", "std::swap [C++]"]
+f1_keywords: ["array/std::array::get", "array/std::get", "array/std::swap", "array/std::to_array"]
+helpviewer_keywords: ["std::array [C++], get", "std::get [C++]", "std::swap [C++]", "std::to_array [C++]"]
 ---
 # `<array>` functions
 
-The `<array>` header includes two non-member functions, `get` and `swap`, that operate on **array** objects.
+The `<array>` header includes three non-member functions, `get`, `swap`, and `to_array` that operate on **array** objects.
 
 ## <a name="get"></a> `get`
 
@@ -148,6 +148,74 @@ int main()
 0 1 2 3
 4 5 6 7
 0 1 2 3
+```
+
+## <a name="to_array"></a> `to_array`
+
+Converts a built-in array to a `std::array` object.
+
+```cpp
+// C++20
+template <class Type, std::size_t Size>
+constexpr std::array<std::remove_cv_t<Type>, Size> to_array(Type (&arr)[Size]);
+
+// C++20
+template <class Type, std::size_t Size>
+constexpr std::array<std::remove_cv_t<Type>, Size> to_array(Type (&&arr)[Size]);
+```
+
+### Template parameters
+
+*`Type`*\
+The type of an element.
+
+*`Size`*\
+The size of the input array.
+
+### Parameters
+
+*`arr`*\
+The input array used for conversion.
+
+### Example
+
+```cpp
+// std_to_array.cpp
+// Requires /std:c++20 or later
+
+#include <array>
+#include <iostream>
+
+int main()
+{
+    int arr1[]{ 1, 2, 3 };
+    std::array<int, 3> arr2 = std::to_array(arr1);
+
+    std::cout << "std::to_array(arr1):\n";
+    for (const auto& i : arr2)
+    {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl;
+
+    // The size is 7 as it includes the null terminator
+    std::array<char, 7> arr3 = std::to_array("string");
+
+    std::cout << "\nstd::to_array(\"string\"):\n";
+    for (const auto& i : arr3)
+    {
+        std::cout << i << " ";
+    }
+    std::cout << std::endl;
+}
+```
+
+```Output
+std::to_array(arr1):
+1 2 3 
+
+std::to_array("string"):
+s t r i n g 
 ```
 
 ## See also

--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -27,7 +27,7 @@ template <std::size_t Index, class Type, std::size_t Size>
 constexpr const T&& get(const std::array<Type, Size>&& arr) noexcept;
 ```
 
-### Parameters
+### Template parameters
 
 *`Index`*\
 The element offset.
@@ -37,6 +37,8 @@ The type of an element.
 
 *`Size`*\
 The number of elements in the array.
+
+### Parameters
 
 *`arr`*\
 The array to select from.
@@ -82,13 +84,15 @@ template <class Type, std::size_t Size>
 void swap(std::array<Type, Size>& left, std::array<Type, Size>& right);
 ```
 
-### Parameters
+### Template parameters
 
 *`Type`*\
 The type of an element.
 
 *`Size`*\
 The size of the array.
+
+### Parameters
 
 *`left`*\
 The first array to swap.

--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -220,4 +220,4 @@ s t r i n g
 
 ## See also
 
-[`<array>`](../standard-library/array.md)
+[`<array>`](array.md)

--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -14,14 +14,17 @@ The `<array>` header includes two non-member functions, `get` and `swap`, that o
 Returns a reference to the specified element of the array.
 
 ```cpp
-template <int Index, class T, size_t N>
-constexpr T& get(array<T, N>& arr) noexcept;
+template <std::size_t Index, class Type, std::size_t Size>
+constexpr T& get(std::array<Type, Size>& arr) noexcept;
 
-template <int Index, class T, size_t N>
-constexpr const T& get(const array<T, N>& arr) noexcept;
+template <std::size_t Index, class Type, std::size_t Size>
+constexpr const T& get(const std::array<Type, Size>& arr) noexcept;
 
-template <int Index, class T, size_t N>
-constexpr T&& get(array<T, N>&& arr) noexcept;
+template <std::size_t Index, class Type, std::size_t Size>
+constexpr T&& get(std::array<Type, Size>&& arr) noexcept;
+
+template <std::size_t Index, class Type, std::size_t Size>
+constexpr const T&& get(const std::array<Type, Size>&& arr) noexcept;
 ```
 
 ### Parameters
@@ -29,10 +32,10 @@ constexpr T&& get(array<T, N>&& arr) noexcept;
 *`Index`*\
 The element offset.
 
-*`T`*\
+*`Type`*\
 The type of an element.
 
-*`N`*\
+*`Size`*\
 The number of elements in the array.
 
 *`arr`*\

--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -78,16 +78,16 @@ int main()
 A non-member template specialization of `std::swap` that swaps two **array** objects.
 
 ```cpp
-template <class Ty, std::size_t N>
-void swap(array<Ty, N>& left, array<Ty, N>& right);
+template <class Type, std::size_t Size>
+void swap(std::array<Type, Size>& left, std::array<Type, Size>& right);
 ```
 
 ### Parameters
 
-*`Ty`*\
+*`Type`*\
 The type of an element.
 
-*`N`*\
+*`Size`*\
 The size of the array.
 
 *`left`*\

--- a/docs/standard-library/array-functions.md
+++ b/docs/standard-library/array-functions.md
@@ -1,7 +1,7 @@
 ---
 title: "<array> functions"
 description: "Learn more about: <array> functions"
-ms.date: 11/04/2016
+ms.date: 08/20/2025
 f1_keywords: ["array/std::array::get", "array/std::get", "array/std::swap", "array/std::to_array"]
 helpviewer_keywords: ["std::array [C++], get", "std::get [C++]", "std::swap [C++]", "std::to_array [C++]"]
 ---

--- a/docs/standard-library/array.md
+++ b/docs/standard-library/array.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: <array>"
 title: "<array>"
-ms.date: "11/04/2016"
+description: "Learn more about: <array>"
+ms.date: 11/04/2016
 f1_keywords: ["<array>"]
 helpviewer_keywords: ["array header"]
 ---

--- a/docs/standard-library/array.md
+++ b/docs/standard-library/array.md
@@ -45,6 +45,7 @@ Defines the container class template **array** and several supporting templates.
 |-|-|
 |[get](../standard-library/array-functions.md#get)|Get specified array element.|
 |[swap](../standard-library/array-functions.md#swap)|Exchanges the contents of one array with the contents of another array.|
+| [`to_array`](array-functions.md#to_array) | Converts a built-in array to a `std::array` object. |
 
 ## See also
 


### PR DESCRIPTION
## Overall changes

- Make template parameter names more readable
- Add bunch of `std::` and "Template parameters" headings
- Simplify single "See also" link and update metadata

## `get`

- Add missing `const&&` overload

| Overload # | [`microsoft/STL`](https://github.com/microsoft/STL) | [`cplusplus/draft`](https://github.com/cplusplus/draft)
| -- | -- | -- |
| 1 | [`stl/inc/array#L852-L853`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L852-L853) | [`source/containers.tex#L6099-L6100`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6099-L6100) |
| 2 | [`stl/inc/array#L866-L867`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L866-L867) | [`source/containers.tex#L6103-L6104`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6103-L6104) |
| 3 | [`stl/inc/array#L876-L877`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L876-L877) | [`source/containers.tex#L6101-L6102`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6101-L6102) |
| 4 | [`stl/inc/array#L890-L891`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L890-L891) | [`source/containers.tex#L6105-L6106`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6105-L6106) |

## `swap`

- For now, I skipped the `noexcept` specification introduced in C++17 as I need more time to think how to best represent it

| Overload # | [`microsoft/STL`](https://github.com/microsoft/STL) | [`cplusplus/draft`](https://github.com/cplusplus/draft)
| -- | -- | -- |
| 1 | [`stl/inc/array#L771-L772`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L771-L772) | [`source/containers.tex#L6083-L6084`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6083-L6084) |

## `to_array`

- Document C++20 `std::to_array` function

| Overload # | [`microsoft/STL`](https://github.com/microsoft/STL) | [`cplusplus/draft`](https://github.com/cplusplus/draft)
| -- | -- | -- |
| 1 | [`stl/inc/array#L828-L829`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L828-L829) | [`source/containers.tex#L6087-L6088`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6087-L6088) |
| 2 | [`stl/inc/array#L837-L838`](https://github.com/microsoft/STL/blob/a2686a066284a6475502730bdba87329bc7e167e/stl/inc/array#L837-L838) | [`source/containers.tex#L6089-L6090`](https://github.com/cplusplus/draft/blob/50b86c51a5d54da29256199061872d575e39ef92/source/containers.tex#L6089-L6090) |