### PR TITLE
Structure error references in range [C3531, C3620]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3531"
 title: "Compiler Error C3531"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3531"
+ms.date: 11/04/2016
 f1_keywords: ["C3531"]
 helpviewer_keywords: ["C3531"]
-ms.assetid: 2bdb9fdc-9ddf-403e-8b92-02763d434487
 ---
 # Compiler Error C3531
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
@@ -8,7 +8,7 @@ ms.assetid: 2bdb9fdc-9ddf-403e-8b92-02763d434487
 ---
 # Compiler Error C3531
 
-'symbol': a symbol whose type contains 'auto' must have an initializer
+> 'symbol': a symbol whose type contains 'auto' must have an initializer
 
 The specified variable does not have an initializer expression.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3531.md
@@ -10,6 +10,8 @@ ms.assetid: 2bdb9fdc-9ddf-403e-8b92-02763d434487
 
 > 'symbol': a symbol whose type contains 'auto' must have an initializer
 
+## Remarks
+
 The specified variable does not have an initializer expression.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3532"
 title: "Compiler Error C3532"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3532"
+ms.date: 11/04/2016
 f1_keywords: ["C3532"]
 helpviewer_keywords: ["C3532"]
-ms.assetid: 51067853-eda8-4f59-86e8-8924e16d3a95
 ---
 # Compiler Error C3532
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
@@ -8,7 +8,7 @@ ms.assetid: 51067853-eda8-4f59-86e8-8924e16d3a95
 ---
 # Compiler Error C3532
 
-'type': incorrect usage of 'auto'
+> 'type': incorrect usage of 'auto'
 
 The indicated type cannot be declared with the **`auto`** keyword. For example, you cannot use the **`auto`** keyword to declare an array or a method return type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3532.md
@@ -10,6 +10,8 @@ ms.assetid: 51067853-eda8-4f59-86e8-8924e16d3a95
 
 > 'type': incorrect usage of 'auto'
 
+## Remarks
+
 The indicated type cannot be declared with the **`auto`** keyword. For example, you cannot use the **`auto`** keyword to declare an array or a method return type.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
@@ -8,7 +8,7 @@ ms.assetid: a68b1ba5-466e-4190-a1a4-505ccfe548b7
 ---
 # Compiler Error C3533
 
-'type': a parameter cannot have a type that contains 'auto'
+> 'type': a parameter cannot have a type that contains 'auto'
 
 A method or template parameter cannot be declared with the **`auto`** keyword if the default [/Zc:auto](../../build/reference/zc-auto-deduce-variable-type.md) compiler option is in effect.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3533"
 title: "Compiler Error C3533"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3533"
+ms.date: 11/04/2016
 f1_keywords: ["C3533"]
 helpviewer_keywords: ["C3533"]
-ms.assetid: a68b1ba5-466e-4190-a1a4-505ccfe548b7
 ---
 # Compiler Error C3533
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3533.md
@@ -10,6 +10,8 @@ ms.assetid: a68b1ba5-466e-4190-a1a4-505ccfe548b7
 
 > 'type': a parameter cannot have a type that contains 'auto'
 
+## Remarks
+
 A method or template parameter cannot be declared with the **`auto`** keyword if the default [/Zc:auto](../../build/reference/zc-auto-deduce-variable-type.md) compiler option is in effect.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
@@ -8,7 +8,7 @@ ms.assetid: 24449c98-f681-484d-a00b-32533dca3a88
 ---
 # Compiler Error C3535
 
-cannot deduce type for 'type1' from 'type2'
+> cannot deduce type for 'type1' from 'type2'
 
 The type of the variable declared by the **`auto`** keyword cannot be deduced from the type of the initialization expression. For example, this error occurs if the initialization expression evaluates to **`void`**, which is not a type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
@@ -10,6 +10,8 @@ ms.assetid: 24449c98-f681-484d-a00b-32533dca3a88
 
 > cannot deduce type for 'type1' from 'type2'
 
+## Remarks
+
 The type of the variable declared by the **`auto`** keyword cannot be deduced from the type of the initialization expression. For example, this error occurs if the initialization expression evaluates to **`void`**, which is not a type.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3535.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3535"
 title: "Compiler Error C3535"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3535"
+ms.date: 11/04/2016
 f1_keywords: ["C3535"]
 helpviewer_keywords: ["C3535"]
-ms.assetid: 24449c98-f681-484d-a00b-32533dca3a88
 ---
 # Compiler Error C3535
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3536.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3536.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C3536"]
 
 > 'symbol': cannot be used before it is initialized
 
+## Remarks
+
 The indicated symbol cannot be used before it is initialized. In practice, this means that a variable cannot be used to initialize itself.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3536.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3536.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C3536"]
 ---
 # Compiler Error C3536
 
-'symbol': cannot be used before it is initialized
+> 'symbol': cannot be used before it is initialized
 
 The indicated symbol cannot be used before it is initialized. In practice, this means that a variable cannot be used to initialize itself.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
@@ -10,6 +10,8 @@ ms.assetid: f537ebd1-4fb0-4e09-a453-4f38db2c6881
 
 > 'type': you cannot cast to a type that contains 'auto'
 
+## Remarks
+
 You cannot cast a variable to the indicated type because the type contains the **`auto`** keyword and the default [/Zc:auto](../../build/reference/zc-auto-deduce-variable-type.md) compiler option is in effect.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
@@ -8,7 +8,7 @@ ms.assetid: f537ebd1-4fb0-4e09-a453-4f38db2c6881
 ---
 # Compiler Error C3537
 
-'type': you cannot cast to a type that contains 'auto'
+> 'type': you cannot cast to a type that contains 'auto'
 
 You cannot cast a variable to the indicated type because the type contains the **`auto`** keyword and the default [/Zc:auto](../../build/reference/zc-auto-deduce-variable-type.md) compiler option is in effect.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3537.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3537"
 title: "Compiler Error C3537"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3537"
+ms.date: 11/04/2016
 f1_keywords: ["C3537"]
 helpviewer_keywords: ["C3537"]
-ms.assetid: f537ebd1-4fb0-4e09-a453-4f38db2c6881
 ---
 # Compiler Error C3537
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3538"
 title: "Compiler Error C3538"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3538"
+ms.date: 11/04/2016
 f1_keywords: ["C3538"]
 helpviewer_keywords: ["C3538"]
-ms.assetid: ef3698a5-7356-4c62-b9af-5d3a4baed958
 ---
 # Compiler Error C3538
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
@@ -8,7 +8,7 @@ ms.assetid: ef3698a5-7356-4c62-b9af-5d3a4baed958
 ---
 # Compiler Error C3538
 
-in a declarator-list 'auto' must always deduce to the same type
+> in a declarator-list 'auto' must always deduce to the same type
 
 All the declared variables in a declaration list do not resolve to the same type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3538.md
@@ -10,6 +10,8 @@ ms.assetid: ef3698a5-7356-4c62-b9af-5d3a4baed958
 
 > in a declarator-list 'auto' must always deduce to the same type
 
+## Remarks
+
 All the declared variables in a declaration list do not resolve to the same type.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
@@ -10,6 +10,8 @@ ms.assetid: 34a33a0f-d1b6-498f-b312-ffad2d4799b3
 
 > 'type': a template-argument cannot be a type that contains 'auto'
 
+## Remarks
+
 The indicated template argument type cannot contain a usage of the **`auto`** keyword.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
@@ -8,7 +8,7 @@ ms.assetid: 34a33a0f-d1b6-498f-b312-ffad2d4799b3
 ---
 # Compiler Error C3539
 
-'type': a template-argument cannot be a type that contains 'auto'
+> 'type': a template-argument cannot be a type that contains 'auto'
 
 The indicated template argument type cannot contain a usage of the **`auto`** keyword.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3539.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3539"
 title: "Compiler Error C3539"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3539"
+ms.date: 11/04/2016
 f1_keywords: ["C3539"]
 helpviewer_keywords: ["C3539"]
-ms.assetid: 34a33a0f-d1b6-498f-b312-ffad2d4799b3
 ---
 # Compiler Error C3539
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
@@ -8,7 +8,7 @@ ms.assetid: 3c0c959c-e3b7-40eb-b922-ccac44bd9d85
 ---
 # Compiler Error C3540
 
-'type': sizeof cannot be applied to a type that contains 'auto'
+> 'type': sizeof cannot be applied to a type that contains 'auto'
 
 The [sizeof](../../cpp/sizeof-operator.md) operator cannot be applied to the indicated type because it contains the **`auto`** specifier.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
@@ -10,6 +10,8 @@ ms.assetid: 3c0c959c-e3b7-40eb-b922-ccac44bd9d85
 
 > 'type': sizeof cannot be applied to a type that contains 'auto'
 
+## Remarks
+
 The [sizeof](../../cpp/sizeof-operator.md) operator cannot be applied to the indicated type because it contains the **`auto`** specifier.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3540.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3540"
 title: "Compiler Error C3540"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3540"
+ms.date: 11/04/2016
 f1_keywords: ["C3540"]
 helpviewer_keywords: ["C3540"]
-ms.assetid: 3c0c959c-e3b7-40eb-b922-ccac44bd9d85
 ---
 # Compiler Error C3540
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
@@ -10,6 +10,8 @@ ms.assetid: 252cfd4c-5fd2-415e-a17d-6b0c254350db
 
 > 'type': typeid cannot be applied to a type that contains 'auto'
 
+## Remarks
+
 The [typeid](../../extensions/typeid-cpp-component-extensions.md) operator cannot be applied to the indicated type because it contains the **`auto`** specifier.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
@@ -8,7 +8,7 @@ ms.assetid: 252cfd4c-5fd2-415e-a17d-6b0c254350db
 ---
 # Compiler Error C3541
 
-'type': typeid cannot be applied to a type that contains 'auto'
+> 'type': typeid cannot be applied to a type that contains 'auto'
 
 The [typeid](../../extensions/typeid-cpp-component-extensions.md) operator cannot be applied to the indicated type because it contains the **`auto`** specifier.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3541.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3541"
 title: "Compiler Error C3541"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3541"
+ms.date: 11/04/2016
 f1_keywords: ["C3541"]
 helpviewer_keywords: ["C3541"]
-ms.assetid: 252cfd4c-5fd2-415e-a17d-6b0c254350db
 ---
 # Compiler Error C3541
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3550"
 title: "Compiler Error C3550"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3550"
+ms.date: 11/04/2016
 f1_keywords: ["C3550"]
 helpviewer_keywords: ["C3550"]
-ms.assetid: 9f2d5ffc-e429-41a1-89e3-7acc4fd47e14
 ---
 # Compiler Error C3550
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -8,7 +8,7 @@ ms.assetid: 9f2d5ffc-e429-41a1-89e3-7acc4fd47e14
 ---
 # Compiler Error C3550
 
-only plain 'decltype(auto)' is allowed in this context
+> only plain 'decltype(auto)' is allowed in this context
 
 If [`decltype(auto)`](../../cpp/decltype-cpp.md#decltype-and-auto) is used as a placeholder for the return type of a function, it must be used by itself. It cannot be used as part of a pointer declaration (`decltype(auto)*`), a reference declaration (`decltype(auto)&`), or any other such qualification.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -10,6 +10,8 @@ ms.assetid: 9f2d5ffc-e429-41a1-89e3-7acc4fd47e14
 
 > only plain 'decltype(auto)' is allowed in this context
 
+## Remarks
+
 If [`decltype(auto)`](../../cpp/decltype-cpp.md#decltype-and-auto) is used as a placeholder for the return type of a function, it must be used by itself. It cannot be used as part of a pointer declaration (`decltype(auto)*`), a reference declaration (`decltype(auto)&`), or any other such qualification.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3550.md
@@ -16,7 +16,7 @@ If [`decltype(auto)`](../../cpp/decltype-cpp.md#decltype-and-auto) is used as a 
 
 ## Example
 
-The following sample generates C3550:
+The following example generates C3550:
 
 ```cpp
 // C3550.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3551"
 title: "Compiler Error C3551"
-ms.date: "10/07/2023"
+description: "Learn more about: Compiler Error C3551"
+ms.date: 10/07/2023
 f1_keywords: ["C3551"]
 helpviewer_keywords: ["C3551"]
-ms.assetid: c8ee23da-6568-40db-93a6-3ddb7ac47712
 ---
 # Compiler Error C3551
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
@@ -8,7 +8,7 @@ ms.assetid: c8ee23da-6568-40db-93a6-3ddb7ac47712
 ---
 # Compiler Error C3551
 
-if a trailing return type is used then the leading return type shall be the single type-specifier 'auto' (not 'type')
+> if a trailing return type is used then the leading return type shall be the single type-specifier 'auto' (not 'type')
 
 The leading return type in [trailing return type](../../cpp/functions-cpp.md#trailing-return-types) syntax must contain only `auto`.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
@@ -15,6 +15,8 @@ The leading return type in [trailing return type](../../cpp/functions-cpp.md#tra
 
 ## Example
 
+The following example generates C3551:
+
 ```cpp
 // C3551.cpp
 // compile with: /c

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3551.md
@@ -10,7 +10,11 @@ ms.assetid: c8ee23da-6568-40db-93a6-3ddb7ac47712
 
 > if a trailing return type is used then the leading return type shall be the single type-specifier 'auto' (not 'type')
 
+## Remarks
+
 The leading return type in [trailing return type](../../cpp/functions-cpp.md#trailing-return-types) syntax must contain only `auto`.
+
+## Example
 
 ```cpp
 // C3551.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
@@ -8,7 +8,7 @@ ms.assetid: 83401524-1bf1-44c0-8aca-a6eb35c4224c
 ---
 # Compiler Error C3552
 
-'typename': a late specified return type cannot contain 'auto'
+> 'typename': a late specified return type cannot contain 'auto'
 
 If you use the **`auto`** keyword as a placeholder for the return type of a function, you must provide a late-specified return type. However, you cannot use another **`auto`** keyword to specify the late-specified return type. For example, the following code fragment yields error C3552.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3552"
 title: "Compiler Error C3552"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3552"
+ms.date: 11/04/2016
 f1_keywords: ["C3552"]
 helpviewer_keywords: ["C3552"]
-ms.assetid: 83401524-1bf1-44c0-8aca-a6eb35c4224c
 ---
 # Compiler Error C3552
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3552.md
@@ -10,6 +10,12 @@ ms.assetid: 83401524-1bf1-44c0-8aca-a6eb35c4224c
 
 > 'typename': a late specified return type cannot contain 'auto'
 
-If you use the **`auto`** keyword as a placeholder for the return type of a function, you must provide a late-specified return type. However, you cannot use another **`auto`** keyword to specify the late-specified return type. For example, the following code fragment yields error C3552.
+## Remarks
+
+If you use the **`auto`** keyword as a placeholder for the return type of a function, you must provide a late-specified return type. However, you cannot use another **`auto`** keyword to specify the late-specified return type.
+
+## Example
+
+For example, the following code fragment yields error C3552.
 
 `auto myFunction->auto; // C3552`

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3553.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3553.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3553"
 title: "Compiler Error C3553"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3553"
+ms.date: 11/04/2016
 f1_keywords: ["C3553"]
 helpviewer_keywords: ["C3553"]
-ms.assetid: 7f84bf37-6419-4ad3-ab30-64266100b930
 ---
 # Compiler Error C3553
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3553.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3553.md
@@ -10,7 +10,13 @@ ms.assetid: 7f84bf37-6419-4ad3-ab30-64266100b930
 
 > decltype expects an expression not a type
 
-The `decltype()` keyword requires an expression as an argument, not the name of a type. For example, the last statement in the following code fragment yields error C3553.
+## Remarks
+
+The `decltype()` keyword requires an expression as an argument, not the name of a type.
+
+## Example
+
+For example, the last statement in the following code fragment yields error C3553.
 
 ```cpp
 int x = 0;

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C3554"]
 ---
 # Compiler Error C3554
 
-'decltype' cannot be combined with any other type-specifier
+> 'decltype' cannot be combined with any other type-specifier
 
 You cannot qualify the `decltype()` keyword with any type specifier. For example, the following code fragment yields error C3554.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3554.md
@@ -9,7 +9,13 @@ helpviewer_keywords: ["C3554"]
 
 > 'decltype' cannot be combined with any other type-specifier
 
-You cannot qualify the `decltype()` keyword with any type specifier. For example, the following code fragment yields error C3554.
+## Remarks
+
+You cannot qualify the `decltype()` keyword with any type specifier.
+
+## Example
+
+For example, the following code fragment yields error C3554.
 
 ```cpp
 int x;

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3555.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3555.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3555"
 title: "Compiler Error C3555"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3555"
+ms.date: 11/04/2016
 f1_keywords: ["C3555"]
 helpviewer_keywords: ["C3555"]
-ms.assetid: b4311bd3-851b-479a-9965-d03f39dd8fd4
 ---
 # Compiler Error C3555
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3555.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3555.md
@@ -10,6 +10,8 @@ ms.assetid: b4311bd3-851b-479a-9965-d03f39dd8fd4
 
 > incorrect argument to 'decltype'
 
+## Remarks
+
 The argument to the `decltype(`*expression*`)` type specifier is not a valid expression.
 
 > [!NOTE]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3556.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3556"
 title: "Compiler Error C3556"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3556"
+ms.date: 11/04/2016
 f1_keywords: ["C3556"]
 helpviewer_keywords: ["C3556"]
-ms.assetid: 9b002dcc-494e-414f-9587-20c2a0a39333
 ---
 # Compiler Error C3556
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3556.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3556.md
@@ -10,6 +10,8 @@ ms.assetid: 9b002dcc-494e-414f-9587-20c2a0a39333
 
 > '*expression*': incorrect argument to 'decltype'
 
+## Remarks
+
 The compiler cannot deduce the type of the expression that is the argument to the `decltype(`*expression*`)` type specifier.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
@@ -8,6 +8,6 @@ ms.assetid: d0cdc7d3-f25a-4242-9ee8-51fe044a9959
 ---
 # Compiler Error C3603
 
-'Symbol' : type 'Type' not yet supported
+> 'Symbol' : type 'Type' not yet supported
 
 You attempted to use a data type that is not yet supported by the .NET runtime in a managed object.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
@@ -10,4 +10,6 @@ ms.assetid: d0cdc7d3-f25a-4242-9ee8-51fe044a9959
 
 > 'Symbol' : type 'Type' not yet supported
 
+## Remarks
+
 You attempted to use a data type that is not yet supported by the .NET runtime in a managed object.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3603.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3603"
 title: "Compiler Error C3603"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3603"
+ms.date: 11/04/2016
 f1_keywords: ["C3603"]
 helpviewer_keywords: ["C3603"]
-ms.assetid: d0cdc7d3-f25a-4242-9ee8-51fe044a9959
 ---
 # Compiler Error C3603
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
@@ -16,7 +16,7 @@ The [sealed](../../extensions/sealed-cpp-component-extensions.md) and [final](..
 
 ## Example
 
-The following sample generates C3609:
+The following example generates C3609:
 
 ```cpp
 // C3609.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
@@ -10,7 +10,11 @@ ms.assetid: 801e7f79-4ac6-4f8f-955f-703cdf095d00
 
 > 'member': a sealed or final function must be virtual
 
+## Remarks
+
 The [sealed](../../extensions/sealed-cpp-component-extensions.md) and [final](../../cpp/final-specifier.md) keywords are only allowed on a class, struct, or member function marked **`virtual`**.
+
+## Example
 
 The following sample generates C3609:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3609"
 title: "Compiler Error C3609"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3609"
+ms.date: 11/04/2016
 f1_keywords: ["C3609"]
 helpviewer_keywords: ["C3609"]
-ms.assetid: 801e7f79-4ac6-4f8f-955f-703cdf095d00
 ---
 # Compiler Error C3609
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3609.md
@@ -8,7 +8,7 @@ ms.assetid: 801e7f79-4ac6-4f8f-955f-703cdf095d00
 ---
 # Compiler Error C3609
 
-'member': a sealed or final function must be virtual
+> 'member': a sealed or final function must be virtual
 
 The [sealed](../../extensions/sealed-cpp-component-extensions.md) and [final](../../cpp/final-specifier.md) keywords are only allowed on a class, struct, or member function marked **`virtual`**.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
@@ -8,7 +8,7 @@ ms.assetid: 9349a348-9d37-4a00-9eab-481039268d31
 ---
 # Compiler Error C3610
 
-'valuetype': value type must be 'boxed' before method 'method' can be called
+> 'valuetype': value type must be 'boxed' before method 'method' can be called
 
 By default, a value type is not on the managed heap. Before you can call methods from .NET runtime classes, such as `Object`, you need to move the value type to the managed heap.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
@@ -10,6 +10,8 @@ ms.assetid: 9349a348-9d37-4a00-9eab-481039268d31
 
 > 'valuetype': value type must be 'boxed' before method 'method' can be called
 
+## Remarks
+
 By default, a value type is not on the managed heap. Before you can call methods from .NET runtime classes, such as `Object`, you need to move the value type to the managed heap.
 
 C3610 is only reachable using the obsolete compiler option **/clr:oldSyntax**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3610.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3610"
 title: "Compiler Error C3610"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3610"
+ms.date: 11/04/2016
 f1_keywords: ["C3610"]
 helpviewer_keywords: ["C3610"]
-ms.assetid: 9349a348-9d37-4a00-9eab-481039268d31
 ---
 # Compiler Error C3610
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3611"
 title: "Compiler Error C3611"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3611"
+ms.date: 11/04/2016
 f1_keywords: ["C3611"]
 helpviewer_keywords: ["C3611"]
-ms.assetid: 42f3e320-41de-420a-bd05-8924cab765aa
 ---
 # Compiler Error C3611
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
@@ -10,6 +10,8 @@ ms.assetid: 42f3e320-41de-420a-bd05-8924cab765aa
 
 > 'function': a sealed function cannot have a pure-specifier
 
+## Remarks
+
 A sealed function was declared incorrectly.  For more information, see [sealed](../../extensions/sealed-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
@@ -16,7 +16,7 @@ A sealed function was declared incorrectly.  For more information, see [sealed](
 
 ## Example
 
-The following sample generates C3611.
+The following example generates C3611.
 
 ```cpp
 // C3611.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3611.md
@@ -8,7 +8,7 @@ ms.assetid: 42f3e320-41de-420a-bd05-8924cab765aa
 ---
 # Compiler Error C3611
 
-'function': a sealed function cannot have a pure-specifier
+> 'function': a sealed function cannot have a pure-specifier
 
 A sealed function was declared incorrectly.  For more information, see [sealed](../../extensions/sealed-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
@@ -8,7 +8,7 @@ ms.assetid: aa6e3a2b-4afa-481c-98c1-1b6d1f82f869
 ---
 # Compiler Error C3612
 
-'type': a sealed class cannot be abstract
+> 'type': a sealed class cannot be abstract
 
 Types defined by using `value` are sealed by default, and a class is abstract unless it implements all methods of its base. A sealed abstract class can neither be a base class nor can it be instantiated.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
@@ -18,7 +18,7 @@ For more information, see [Classes and Structs](../../extensions/classes-and-str
 
 ## Example
 
-The following sample generates C3612:
+The following example generates C3612:
 
 ```cpp
 // C3612.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
@@ -10,6 +10,8 @@ ms.assetid: aa6e3a2b-4afa-481c-98c1-1b6d1f82f869
 
 > 'type': a sealed class cannot be abstract
 
+## Remarks
+
 Types defined by using `value` are sealed by default, and a class is abstract unless it implements all methods of its base. A sealed abstract class can neither be a base class nor can it be instantiated.
 
 For more information, see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3612.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3612"
 title: "Compiler Error C3612"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3612"
+ms.date: 11/04/2016
 f1_keywords: ["C3612"]
 helpviewer_keywords: ["C3612"]
-ms.assetid: aa6e3a2b-4afa-481c-98c1-1b6d1f82f869
 ---
 # Compiler Error C3612
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3615.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3615.md
@@ -10,6 +10,8 @@ ms.assetid: 5ce96ba9-3d31-49f3-9aa8-24e5cdf6dcfc
 
 > constexpr function '*function*' cannot result in a constant expression
 
+## Remarks
+
 The function *function* could not be evaluated as **`constexpr`** at compile time. To be **`constexpr`**, a function can only call other **`constexpr`** functions.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3615.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3615.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3615"
 title: "Compiler Error C3615"
-ms.date: "10/24/2017"
+description: "Learn more about: Compiler Error C3615"
+ms.date: 10/24/2017
 f1_keywords: ["C3615"]
 helpviewer_keywords: ["C3615"]
-ms.assetid: 5ce96ba9-3d31-49f3-9aa8-24e5cdf6dcfc
 ---
 # Compiler Error C3615
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3618"
 title: "Compiler Error C3618"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3618"
+ms.date: 11/04/2016
 f1_keywords: ["C3618"]
 helpviewer_keywords: ["C3618"]
-ms.assetid: cacc105d-4389-4cb8-ae6c-41a3622e9a86
 ---
 # Compiler Error C3618
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
@@ -10,6 +10,8 @@ ms.assetid: cacc105d-4389-4cb8-ae6c-41a3622e9a86
 
 > 'function': a method marked DllImport cannot be defined
 
+## Remarks
+
 A method marked with <xref:System.Runtime.InteropServices.DllImportAttribute> is defined in the specified.DLL.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
@@ -8,7 +8,7 @@ ms.assetid: cacc105d-4389-4cb8-ae6c-41a3622e9a86
 ---
 # Compiler Error C3618
 
-'function': a method marked DllImport cannot be defined
+> 'function': a method marked DllImport cannot be defined
 
 A method marked with <xref:System.Runtime.InteropServices.DllImportAttribute> is defined in the specified.DLL.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3618.md
@@ -16,7 +16,7 @@ A method marked with <xref:System.Runtime.InteropServices.DllImportAttribute> is
 
 ## Example
 
-The following sample generates C3618.
+The following example generates C3618.
 
 ```cpp
 // C3618.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
@@ -10,6 +10,8 @@ ms.assetid: 76ae80d0-9fbe-4297-a1ef-b1503377fdcf
 
 > a template cannot be declared within a managed or WinRT type
 
+## Remarks
+
 Class templates are not allowed in a managed or WinRT class or interface.
 
 C3619 is only reachable using the obsolete compiler option **/clr:oldSyntax**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3619"
 title: "Compiler Error C3619"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3619"
+ms.date: 11/04/2016
 f1_keywords: ["C3619"]
 helpviewer_keywords: ["C3619"]
-ms.assetid: 76ae80d0-9fbe-4297-a1ef-b1503377fdcf
 ---
 # Compiler Error C3619
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3619.md
@@ -8,7 +8,7 @@ ms.assetid: 76ae80d0-9fbe-4297-a1ef-b1503377fdcf
 ---
 # Compiler Error C3619
 
-a template cannot be declared within a managed or WinRT type
+> a template cannot be declared within a managed or WinRT type
 
 Class templates are not allowed in a managed or WinRT class or interface.
 


### PR DESCRIPTION
This is batch 60 that structures error/warning references. See #5465 for more information.