### PR TITLE
Structure error references in range [C3621, C3660]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
@@ -8,7 +8,7 @@ ms.assetid: 02836f78-0cf2-4947-b87e-710187d81014
 ---
 # Compiler Error C3622
 
-'class' : a class declared as 'keyword' cannot be instantiated
+> 'class' : a class declared as 'keyword' cannot be instantiated
 
 An attempt was made to instantiate a class marked as [abstract](../../extensions/abstract-cpp-component-extensions.md). A class marked as **`abstract`** can be a base class, but it cannot be instantiated.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3622"
 title: "Compiler Error C3622"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3622"
+ms.date: 11/04/2016
 f1_keywords: ["C3622"]
 helpviewer_keywords: ["C3622"]
-ms.assetid: 02836f78-0cf2-4947-b87e-710187d81014
 ---
 # Compiler Error C3622
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
@@ -10,6 +10,8 @@ ms.assetid: 02836f78-0cf2-4947-b87e-710187d81014
 
 > 'class' : a class declared as 'keyword' cannot be instantiated
 
+## Remarks
+
 An attempt was made to instantiate a class marked as [abstract](../../extensions/abstract-cpp-component-extensions.md). A class marked as **`abstract`** can be a base class, but it cannot be instantiated.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3622.md
@@ -16,7 +16,7 @@ An attempt was made to instantiate a class marked as [abstract](../../extensions
 
 ## Example
 
-The following sample generates C3622.
+The following example generates C3622.
 
 ```cpp
 // C3622.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
@@ -16,7 +16,7 @@ The use of bit fields is not permitted on variables in a managed or WinRT class.
 
 ## Example
 
-The following sample generates C3623:
+The following example generates C3623:
 
 ```cpp
 // C3623.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
@@ -10,7 +10,11 @@ ms.assetid: a0341b45-062a-4f67-beb9-ba74201ed1ed
 
 > 'variable': bit fields are not supported in managed or WinRT types
 
+## Remarks
+
 The use of bit fields is not permitted on variables in a managed or WinRT class.
+
+## Example
 
 The following sample generates C3623:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
@@ -8,7 +8,7 @@ ms.assetid: a0341b45-062a-4f67-beb9-ba74201ed1ed
 ---
 # Compiler Error C3623
 
-'variable': bit fields are not supported in managed or WinRT types
+> 'variable': bit fields are not supported in managed or WinRT types
 
 The use of bit fields is not permitted on variables in a managed or WinRT class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3623.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3623"
 title: "Compiler Error C3623"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3623"
+ms.date: 11/04/2016
 f1_keywords: ["C3623"]
 helpviewer_keywords: ["C3623"]
-ms.assetid: a0341b45-062a-4f67-beb9-ba74201ed1ed
 ---
 # Compiler Error C3623
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
@@ -16,7 +16,7 @@ An assembly (reference) needed to compile your code was not specified; pass the 
 
 ## Example
 
-The following sample generates C3624:
+The following example generates C3624:
 
 ```cpp
 // C3624.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3624"
 title: "Compiler Error C3624"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3624"
+ms.date: 11/04/2016
 f1_keywords: ["C3624"]
 helpviewer_keywords: ["C3624"]
-ms.assetid: eaac6a4f-eb11-4e4d-ab12-124ba995c5cf
 ---
 # Compiler Error C3624
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
@@ -8,7 +8,7 @@ ms.assetid: eaac6a4f-eb11-4e4d-ab12-124ba995c5cf
 ---
 # Compiler Error C3624
 
-'type': use of this type requires a reference to assembly 'assembly'
+> 'type': use of this type requires a reference to assembly 'assembly'
 
 An assembly (reference) needed to compile your code was not specified; pass the assembly to the [#using](../../preprocessor/hash-using-directive-cpp.md) directive.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3624.md
@@ -10,6 +10,8 @@ ms.assetid: eaac6a4f-eb11-4e4d-ab12-124ba995c5cf
 
 > 'type': use of this type requires a reference to assembly 'assembly'
 
+## Remarks
+
 An assembly (reference) needed to compile your code was not specified; pass the assembly to the [#using](../../preprocessor/hash-using-directive-cpp.md) directive.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
@@ -8,7 +8,7 @@ ms.assetid: fdf49f21-d6b1-42f4-9eec-23b04ae8b4aa
 ---
 # Compiler Error C3625
 
-'native_type': a native type cannot derive from a managed or WinRT type 'type'
+> 'native_type': a native type cannot derive from a managed or WinRT type 'type'
 
 A native class cannot inherit from a managed or WinRT class. For more information, see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3625"
 title: "Compiler Error C3625"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3625"
+ms.date: 11/04/2016
 f1_keywords: ["C3625"]
 helpviewer_keywords: ["C3625"]
-ms.assetid: fdf49f21-d6b1-42f4-9eec-23b04ae8b4aa
 ---
 # Compiler Error C3625
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
@@ -10,6 +10,8 @@ ms.assetid: fdf49f21-d6b1-42f4-9eec-23b04ae8b4aa
 
 > 'native_type': a native type cannot derive from a managed or WinRT type 'type'
 
+## Remarks
+
 A native class cannot inherit from a managed or WinRT class. For more information, see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3625.md
@@ -16,7 +16,7 @@ A native class cannot inherit from a managed or WinRT class. For more informatio
 
 ## Example
 
-The following sample generates C3625:
+The following example generates C3625:
 
 ```cpp
 // C3625.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3626"
 title: "Compiler Error C3626"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3626"
+ms.date: 11/04/2016
 f1_keywords: ["C3626"]
 helpviewer_keywords: ["C3626"]
-ms.assetid: 43926e2b-1ba9-4a43-9343-c58449cbb336
 ---
 # Compiler Error C3626
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
@@ -8,7 +8,7 @@ ms.assetid: 43926e2b-1ba9-4a43-9343-c58449cbb336
 ---
 # Compiler Error C3626
 
-'keyword': '__event' keyword can only be used on COM interfaces, member functions and data members that are pointers to delegates
+> 'keyword': '__event' keyword can only be used on COM interfaces, member functions and data members that are pointers to delegates
 
 A keyword was used incorrectly.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
@@ -10,7 +10,11 @@ ms.assetid: 43926e2b-1ba9-4a43-9343-c58449cbb336
 
 > 'keyword': '__event' keyword can only be used on COM interfaces, member functions and data members that are pointers to delegates
 
+## Remarks
+
 A keyword was used incorrectly.
+
+## Example
 
 The following sample generates C3626:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3626.md
@@ -16,7 +16,7 @@ A keyword was used incorrectly.
 
 ## Example
 
-The following sample generates C3626:
+The following example generates C3626:
 
 ```cpp
 // C3626.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3627"
 title: "Compiler Error C3627"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3627"
+ms.date: 11/04/2016
 f1_keywords: ["C3627"]
 helpviewer_keywords: ["C3627"]
-ms.assetid: 905ad0a0-8c49-4187-b66e-b375f5a1fae5
 ---
 # Compiler Error C3627
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
@@ -10,4 +10,6 @@ ms.assetid: 905ad0a0-8c49-4187-b66e-b375f5a1fae5
 
 > Only a value type can be boxed
 
+## Remarks
+
 Only value classes can be boxed.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3627.md
@@ -8,6 +8,6 @@ ms.assetid: 905ad0a0-8c49-4187-b66e-b375f5a1fae5
 ---
 # Compiler Error C3627
 
-Only a value type can be boxed
+> Only a value type can be boxed
 
 Only value classes can be boxed.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
@@ -10,7 +10,11 @@ ms.assetid: 0ff5a4a4-fcc9-47a0-a4d8-8af9cf2815f6
 
 > 'base class' : managed or WinRTclasses only support public inheritance
 
+## Remarks
+
 An attempt was made to use a managed or WinRT class as a [private](../../cpp/private-cpp.md) or [protected](../../cpp/protected-cpp.md) base class. A managed or WinRT class can only be used as a base class with [public](../../cpp/public-cpp.md) access.
+
+## Example
 
 The following sample generates C3628 and shows how to fix it:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
@@ -16,7 +16,7 @@ An attempt was made to use a managed or WinRT class as a [private](../../cpp/pri
 
 ## Example
 
-The following sample generates C3628 and shows how to fix it:
+The following example generates C3628 and shows how to fix it:
 
 ```cpp
 // C3628a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3628"
 title: "Compiler Error C3628"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3628"
+ms.date: 11/04/2016
 f1_keywords: ["C3628"]
 helpviewer_keywords: ["C3628"]
-ms.assetid: 0ff5a4a4-fcc9-47a0-a4d8-8af9cf2815f6
 ---
 # Compiler Error C3628
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3628.md
@@ -8,7 +8,7 @@ ms.assetid: 0ff5a4a4-fcc9-47a0-a4d8-8af9cf2815f6
 ---
 # Compiler Error C3628
 
-'base class' : managed or WinRTclasses only support public inheritance
+> 'base class' : managed or WinRTclasses only support public inheritance
 
 An attempt was made to use a managed or WinRT class as a [private](../../cpp/private-cpp.md) or [protected](../../cpp/protected-cpp.md) base class. A managed or WinRT class can only be used as a base class with [public](../../cpp/public-cpp.md) access.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3630.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3630.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3630"
 title: "Compiler Error C3630"
+description: "Learn more about: Compiler Error C3630"
 ms.date: 05/25/2022
 f1_keywords: ["C3630"]
 helpviewer_keywords: ["C3630"]
-ms.assetid: 865626a9-98cc-465d-acde-44d4574c019a
 ---
 # Compiler Error C3630
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3630.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3630.md
@@ -10,4 +10,6 @@ ms.assetid: 865626a9-98cc-465d-acde-44d4574c019a
 
 > error when processing the token '*token*'
 
+## Remarks
+
 A token in source code couldn't be processed. This error is obsolete in Visual Studio 2022.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
@@ -8,7 +8,7 @@ ms.assetid: 88cbd2d5-6fef-4940-be34-d8cbe816d3da
 ---
 # Compiler Error C3631
 
-'function': cannot overload managed or WinRT events
+> 'function': cannot overload managed or WinRT events
 
 A managed or WinRT event cannot be overloaded.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
@@ -10,6 +10,8 @@ ms.assetid: 88cbd2d5-6fef-4940-be34-d8cbe816d3da
 
 > 'function': cannot overload managed or WinRT events
 
+## Remarks
+
 A managed or WinRT event cannot be overloaded.
 
 C3631 is only reachable using the obsolete compiler option **/clr:oldSyntax**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3631.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3631"
 title: "Compiler Error C3631"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3631"
+ms.date: 11/04/2016
 f1_keywords: ["C3631"]
 helpviewer_keywords: ["C3631"]
-ms.assetid: 88cbd2d5-6fef-4940-be34-d8cbe816d3da
 ---
 # Compiler Error C3631
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3632"
 title: "Compiler Error C3632"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3632"
+ms.date: 11/04/2016
 f1_keywords: ["C3632"]
 helpviewer_keywords: ["C3632"]
-ms.assetid: a04e3217-f5a1-4461-a1db-d69fd096d468
 ---
 # Compiler Error C3632
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
@@ -8,7 +8,7 @@ ms.assetid: a04e3217-f5a1-4461-a1db-d69fd096d468
 ---
 # Compiler Error C3632
 
-'event': illegal style of event for construct
+> 'event': illegal style of event for construct
 
 [__event](../../cpp/event.md) declarations are not valid in all constructs.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3632.md
@@ -10,6 +10,8 @@ ms.assetid: a04e3217-f5a1-4461-a1db-d69fd096d468
 
 > 'event': illegal style of event for construct
 
+## Remarks
+
 [__event](../../cpp/event.md) declarations are not valid in all constructs.
 
 C3632 is only reachable using the obsolete compiler option **/clr:oldSyntax**.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
@@ -10,6 +10,8 @@ ms.assetid: 7d65babf-2191-4d67-a69f-f5c4c2ddf946
 
 > cannot define 'member' as a member of managed 'type'
 
+## Remarks
+
 CLR reference class data members cannot be of a non-POD C++ type.  You can only instantiate a POD native type in a CLR type.  For example, a POD type cannot contain a copy constructor or an assignment operator.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
@@ -16,7 +16,7 @@ CLR reference class data members cannot be of a non-POD C++ type.  You can only 
 
 ## Example
 
-The following sample generates C3633.
+The following example generates C3633.
 
 ```cpp
 // C3633.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
@@ -8,7 +8,7 @@ ms.assetid: 7d65babf-2191-4d67-a69f-f5c4c2ddf946
 ---
 # Compiler Error C3633
 
-cannot define 'member' as a member of managed 'type'
+> cannot define 'member' as a member of managed 'type'
 
 CLR reference class data members cannot be of a non-POD C++ type.  You can only instantiate a POD native type in a CLR type.  For example, a POD type cannot contain a copy constructor or an assignment operator.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3633.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3633"
 title: "Compiler Error C3633"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3633"
+ms.date: 11/04/2016
 f1_keywords: ["C3633"]
 helpviewer_keywords: ["C3633"]
-ms.assetid: 7d65babf-2191-4d67-a69f-f5c4c2ddf946
 ---
 # Compiler Error C3633
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3634"
 title: "Compiler Error C3634"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3634"
+ms.date: 11/04/2016
 f1_keywords: ["C3634"]
 helpviewer_keywords: ["C3634"]
-ms.assetid: fd09f10c-f863-483b-9756-71c16b760b02
 ---
 # Compiler Error C3634
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
@@ -8,7 +8,7 @@ ms.assetid: fd09f10c-f863-483b-9756-71c16b760b02
 ---
 # Compiler Error C3634
 
-'function' : cannot define an abstract method of a managed or WinRTclass
+> 'function' : cannot define an abstract method of a managed or WinRTclass
 
 An abstract method can be declared in a managed or WinRT class, but it cannot be defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
@@ -16,7 +16,7 @@ An abstract method can be declared in a managed or WinRT class, but it cannot be
 
 ## Example
 
-The following sample generates C3634:
+The following example generates C3634:
 
 ```cpp
 // C3634.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3634.md
@@ -10,6 +10,8 @@ ms.assetid: fd09f10c-f863-483b-9756-71c16b760b02
 
 > 'function' : cannot define an abstract method of a managed or WinRTclass
 
+## Remarks
+
 An abstract method can be declared in a managed or WinRT class, but it cannot be defined.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
@@ -8,7 +8,7 @@ ms.assetid: 72391377-8519-43d9-870a-73a6423deb74
 ---
 # Compiler Error C3637
 
-'function' : a friend function definition cannot be a specialization of a function type
+> 'function' : a friend function definition cannot be a specialization of a function type
 
 A friend function was defined incorrectly for a template or generic.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
@@ -16,7 +16,7 @@ A friend function was defined incorrectly for a template or generic.
 
 ## Examples
 
-The following sample generates C3637:
+The following example generates C3637:
 
 ```cpp
 // C3637.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3637"
 title: "Compiler Error C3637"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3637"
+ms.date: 11/04/2016
 f1_keywords: ["C3637"]
 helpviewer_keywords: ["C3637"]
-ms.assetid: 72391377-8519-43d9-870a-73a6423deb74
 ---
 # Compiler Error C3637
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3637.md
@@ -10,7 +10,11 @@ ms.assetid: 72391377-8519-43d9-870a-73a6423deb74
 
 > 'function' : a friend function definition cannot be a specialization of a function type
 
+## Remarks
+
 A friend function was defined incorrectly for a template or generic.
+
+## Examples
 
 The following sample generates C3637:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3638"
 title: "Compiler Error C3638"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3638"
+ms.date: 11/04/2016
 f1_keywords: ["C3638"]
 helpviewer_keywords: ["C3638"]
-ms.assetid: 8d8bc5ca-75aa-480e-b6b6-3178fab51b1d
 ---
 # Compiler Error C3638
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
@@ -8,7 +8,7 @@ ms.assetid: 8d8bc5ca-75aa-480e-b6b6-3178fab51b1d
 ---
 # Compiler Error C3638
 
-'operator' : the standard boxing and unboxing conversion operators cannot be redefined
+> 'operator' : the standard boxing and unboxing conversion operators cannot be redefined
 
 The compiler defines a conversion operator for each managed class to support implicit boxing. This operator cannot be redefined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
@@ -18,7 +18,7 @@ For more information, see [Implicit Boxing](../../extensions/boxing-cpp-componen
 
 ## Example
 
-The following sample generates C3638:
+The following example generates C3638:
 
 ```cpp
 // C3638.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3638.md
@@ -10,9 +10,13 @@ ms.assetid: 8d8bc5ca-75aa-480e-b6b6-3178fab51b1d
 
 > 'operator' : the standard boxing and unboxing conversion operators cannot be redefined
 
+## Remarks
+
 The compiler defines a conversion operator for each managed class to support implicit boxing. This operator cannot be redefined.
 
 For more information, see [Implicit Boxing](../../extensions/boxing-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3638:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3640"
 title: "Compiler Error C3640"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3640"
+ms.date: 11/04/2016
 f1_keywords: ["C3640"]
 helpviewer_keywords: ["C3640"]
-ms.assetid: fcc56894-0f98-48af-8561-3bf7c7b2b93f
 ---
 # Compiler Error C3640
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
@@ -8,7 +8,7 @@ ms.assetid: fcc56894-0f98-48af-8561-3bf7c7b2b93f
 ---
 # Compiler Error C3640
 
-'member' : a referenced or virtual member function of a local class must be defined
+> 'member' : a referenced or virtual member function of a local class must be defined
 
 The compiler requires certain functions to be defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
@@ -10,7 +10,11 @@ ms.assetid: fcc56894-0f98-48af-8561-3bf7c7b2b93f
 
 > 'member' : a referenced or virtual member function of a local class must be defined
 
+## Remarks
+
 The compiler requires certain functions to be defined.
+
+## Example
 
 The following sample generates C3640:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3640.md
@@ -16,7 +16,7 @@ The compiler requires certain functions to be defined.
 
 ## Example
 
-The following sample generates C3640:
+The following example generates C3640:
 
 ```cpp
 // C3640.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3641.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3641.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3641"
 title: "Compiler Error C3641"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3641"
+ms.date: 11/04/2016
 f1_keywords: ["C3641"]
 helpviewer_keywords: ["C3641"]
-ms.assetid: e8d3613e-5e8d-46fe-a516-eb7d1de7cd21
 ---
 # Compiler Error C3641
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3641.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3641.md
@@ -18,7 +18,7 @@ Only [__clrcall](../../cpp/clrcall.md) calling convention is allowed with [/clr:
 
 ## Example
 
-The following sample generates C3641:
+The following example generates C3641:
 
 ```cpp
 // C3641.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
@@ -20,7 +20,7 @@ To call a managed function from a native context, you can add a "wrapper" functi
 
 ## Example
 
-The following sample generates C3642:
+The following example generates C3642:
 
 ```cpp
 // C3642.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3642"
 title: "Compiler Error C3642"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3642"
+ms.date: 11/04/2016
 f1_keywords: ["C3642"]
 helpviewer_keywords: ["C3642"]
-ms.assetid: 429790c2-9614-4d85-b31c-687c8d8f83ff
 ---
 # Compiler Error C3642
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
@@ -8,7 +8,7 @@ ms.assetid: 429790c2-9614-4d85-b31c-687c8d8f83ff
 ---
 # Compiler Error C3642
 
-'return_type/args' : cannot call a function with __clrcall calling convention from native code
+> 'return_type/args' : cannot call a function with __clrcall calling convention from native code
 
 A function that is marked with the [__clrcall](../../cpp/clrcall.md) calling convention cannot be called from native (unmanaged) code.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3642.md
@@ -10,11 +10,15 @@ ms.assetid: 429790c2-9614-4d85-b31c-687c8d8f83ff
 
 > 'return_type/args' : cannot call a function with __clrcall calling convention from native code
 
+## Remarks
+
 A function that is marked with the [__clrcall](../../cpp/clrcall.md) calling convention cannot be called from native (unmanaged) code.
 
 *return_type/args* is either the name of the function or the type of the `__clrcall` function you are trying to call.  A type is used when you're calling through a function-pointer.
 
 To call a managed function from a native context, you can add a "wrapper" function that will call the `__clrcall` function. Or, you can use the CLR marshalling mechanism; see [How to: Marshal Function Pointers Using PInvoke](../../dotnet/how-to-marshal-function-pointers-using-pinvoke.md) for more information.
+
+## Example
 
 The following sample generates C3642:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
@@ -10,7 +10,11 @@ ms.assetid: 2e3f6c41-3ec5-4a01-82bc-f11b61ebe68e
 
 > 'function' : cannot compile the function to generate managed code
 
+## Remarks
+
 The presence of some keywords in a function will cause the function to be compiled to native.
+
+## Example
 
 The following sample generates C3644:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
@@ -16,7 +16,7 @@ The presence of some keywords in a function will cause the function to be compil
 
 ## Example
 
-The following sample generates C3644:
+The following example generates C3644:
 
 ```cpp
 // C3644.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
@@ -8,7 +8,7 @@ ms.assetid: 2e3f6c41-3ec5-4a01-82bc-f11b61ebe68e
 ---
 # Compiler Error C3644
 
-'function' : cannot compile the function to generate managed code
+> 'function' : cannot compile the function to generate managed code
 
 The presence of some keywords in a function will cause the function to be compiled to native.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3644.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3644"
 title: "Compiler Error C3644"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3644"
+ms.date: 11/04/2016
 f1_keywords: ["C3644"]
 helpviewer_keywords: ["C3644"]
-ms.assetid: 2e3f6c41-3ec5-4a01-82bc-f11b61ebe68e
 ---
 # Compiler Error C3644
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
@@ -8,7 +8,7 @@ ms.assetid: 346da528-ae86-4cd0-9654-f41bee26ac0d
 ---
 # Compiler Error C3645
 
-'function' : __clrcall cannot be used on functions compiled to native code
+> 'function' : __clrcall cannot be used on functions compiled to native code
 
 The presence of some keywords in a function will cause the function to be compiled to native.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
@@ -16,7 +16,7 @@ The presence of some keywords in a function will cause the function to be compil
 
 ## Example
 
-The following sample generates C3645.
+The following example generates C3645.
 
 ```cpp
 // C3645.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3645"
 title: "Compiler Error C3645"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3645"
+ms.date: 11/04/2016
 f1_keywords: ["C3645"]
 helpviewer_keywords: ["C3645"]
-ms.assetid: 346da528-ae86-4cd0-9654-f41bee26ac0d
 ---
 # Compiler Error C3645
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3645.md
@@ -10,6 +10,8 @@ ms.assetid: 346da528-ae86-4cd0-9654-f41bee26ac0d
 
 > 'function' : __clrcall cannot be used on functions compiled to native code
 
+## Remarks
+
 The presence of some keywords in a function will cause the function to be compiled to native.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3646.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3646.md
@@ -20,7 +20,7 @@ For more information, see [Override Specifiers](../../extensions/override-specif
 
 ## Example
 
-The following sample generates C3646 and shows a way to fix it:
+The following example generates C3646 and shows a way to fix it:
 
 ```cpp
 // C3646.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3646.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3646.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3646"
 title: "Compiler Error C3646"
-ms.date: "06/14/2018"
+description: "Learn more about: Compiler Error C3646"
+ms.date: 06/14/2018
 f1_keywords: ["C3646"]
 helpviewer_keywords: ["C3646"]
-ms.assetid: 4391ead2-9637-4ca3-aeda-5a991b18d66d
 ---
 # Compiler Error C3646
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
@@ -8,7 +8,7 @@ ms.assetid: 5d042989-41cb-4cd0-aa50-976b70146aaf
 ---
 # Compiler Error C3648
 
-this explicit override syntax requires /clr:oldSyntax
+> this explicit override syntax requires /clr:oldSyntax
 
 When compiling for the latest managed syntax, the compiler found explicit override syntax for previous versions that is no longer supported.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
@@ -10,6 +10,8 @@ ms.assetid: 5d042989-41cb-4cd0-aa50-976b70146aaf
 
 > this explicit override syntax requires /clr:oldSyntax
 
+## Remarks
+
 When compiling for the latest managed syntax, the compiler found explicit override syntax for previous versions that is no longer supported.
 
 For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
@@ -18,7 +18,7 @@ For more information, see [Explicit Overrides](../../extensions/explicit-overrid
 
 ## Example
 
-The following sample generates C3648:
+The following example generates C3648:
 
 ```cpp
 // C3648.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3648.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3648"
 title: "Compiler Error C3648"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3648"
+ms.date: 11/04/2016
 f1_keywords: ["C3648"]
 helpviewer_keywords: ["C3648"]
-ms.assetid: 5d042989-41cb-4cd0-aa50-976b70146aaf
 ---
 # Compiler Error C3648
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
@@ -10,9 +10,13 @@ ms.assetid: ca4d8de4-b027-4d13-9b9f-03ca62905c33
 
 > 'interface_method' : cannot be used as an explicit override, must be a virtual member function of a base class
 
+## Remarks
+
 An attempt was made to perform an explicit override on a member that was not virtual.
 
 For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3650:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
@@ -18,7 +18,7 @@ For more information, see [Explicit Overrides](../../extensions/explicit-overrid
 
 ## Example
 
-The following sample generates C3650:
+The following example generates C3650:
 
 ```cpp
 // C3650.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3650"
 title: "Compiler Error C3650"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3650"
+ms.date: 11/04/2016
 f1_keywords: ["C3650"]
 helpviewer_keywords: ["C3650"]
-ms.assetid: ca4d8de4-b027-4d13-9b9f-03ca62905c33
 ---
 # Compiler Error C3650
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3650.md
@@ -8,7 +8,7 @@ ms.assetid: ca4d8de4-b027-4d13-9b9f-03ca62905c33
 ---
 # Compiler Error C3650
 
-'interface_method' : cannot be used as an explicit override, must be a virtual member function of a base class
+> 'interface_method' : cannot be used as an explicit override, must be a virtual member function of a base class
 
 An attempt was made to perform an explicit override on a member that was not virtual.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
@@ -18,7 +18,7 @@ For more information, see [Explicit Overrides](../../extensions/explicit-overrid
 
 ## Example
 
-The following sample generates C3651:
+The following example generates C3651:
 
 ```cpp
 // C3651.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3651"
 title: "Compiler Error C3651"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3651"
+ms.date: 11/04/2016
 f1_keywords: ["C3651"]
 helpviewer_keywords: ["C3651"]
-ms.assetid: a03e692e-c219-4654-9827-8415cfa5a22d
 ---
 # Compiler Error C3651
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
@@ -8,7 +8,7 @@ ms.assetid: a03e692e-c219-4654-9827-8415cfa5a22d
 ---
 # Compiler Error C3651
 
-'member' : cannot be used as an explicit override, must be a member of a base class
+> 'member' : cannot be used as an explicit override, must be a member of a base class
 
 An explicit override was specified, but the function being overridden was in a type that is not a base type.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3651.md
@@ -10,9 +10,13 @@ ms.assetid: a03e692e-c219-4654-9827-8415cfa5a22d
 
 > 'member' : cannot be used as an explicit override, must be a member of a base class
 
+## Remarks
+
 An explicit override was specified, but the function being overridden was in a type that is not a base type.
 
 For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3651:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
@@ -16,7 +16,7 @@ A function that does an explicit override must be virtual. For more information,
 
 ## Example
 
-The following sample generates C3652:
+The following example generates C3652:
 
 ```cpp
 // C3652.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
@@ -8,7 +8,7 @@ ms.assetid: 15d68737-177e-41f1-80e0-7c3e2afdf0fc
 ---
 # Compiler Error C3652
 
-'override' : a function that explicitly overrides must be virtual
+> 'override' : a function that explicitly overrides must be virtual
 
 A function that does an explicit override must be virtual. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
@@ -10,7 +10,11 @@ ms.assetid: 15d68737-177e-41f1-80e0-7c3e2afdf0fc
 
 > 'override' : a function that explicitly overrides must be virtual
 
+## Remarks
+
 A function that does an explicit override must be virtual. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3652:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3652.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3652"
 title: "Compiler Error C3652"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3652"
+ms.date: 11/04/2016
 f1_keywords: ["C3652"]
 helpviewer_keywords: ["C3652"]
-ms.assetid: 15d68737-177e-41f1-80e0-7c3e2afdf0fc
 ---
 # Compiler Error C3652
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3653"
 title: "Compiler Error C3653"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3653"
+ms.date: 11/04/2016
 f1_keywords: ["C3653"]
 helpviewer_keywords: ["C3653"]
-ms.assetid: 316549d7-f7ef-4578-a2ba-57adc8aac527
 ---
 # Compiler Error C3653
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
@@ -8,7 +8,7 @@ ms.assetid: 316549d7-f7ef-4578-a2ba-57adc8aac527
 ---
 # Compiler Error C3653
 
-'function' : cannot be used as a named override: a function being overridden not found; did you forget to name the function explicitly, using a :: operator?
+> 'function' : cannot be used as a named override: a function being overridden not found; did you forget to name the function explicitly, using a :: operator?
 
 An explicit override specified a function that was not found in any interface. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
@@ -16,7 +16,7 @@ An explicit override specified a function that was not found in any interface. F
 
 ## Example
 
-The following sample generates C3653:
+The following example generates C3653:
 
 ```cpp
 // C3653.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3653.md
@@ -10,7 +10,11 @@ ms.assetid: 316549d7-f7ef-4578-a2ba-57adc8aac527
 
 > 'function' : cannot be used as a named override: a function being overridden not found; did you forget to name the function explicitly, using a :: operator?
 
+## Remarks
+
 An explicit override specified a function that was not found in any interface. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3653:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
@@ -8,7 +8,7 @@ ms.assetid: 57d96e3f-6bbb-4eaa-934b-26c23b4ceb2e
 ---
 # Compiler Error C3654
 
-'text' : syntax error in explicit override
+> 'text' : syntax error in explicit override
 
 An unexpected string was in an explicit override. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
@@ -16,7 +16,7 @@ An unexpected string was in an explicit override. For more information, see [Exp
 
 ## Example
 
-The following sample generates C3654:
+The following example generates C3654:
 
 ```cpp
 // C3654.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3654"
 title: "Compiler Error C3654"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3654"
+ms.date: 11/04/2016
 f1_keywords: ["C3654"]
 helpviewer_keywords: ["C3654"]
-ms.assetid: 57d96e3f-6bbb-4eaa-934b-26c23b4ceb2e
 ---
 # Compiler Error C3654
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3654.md
@@ -10,7 +10,11 @@ ms.assetid: 57d96e3f-6bbb-4eaa-934b-26c23b4ceb2e
 
 > 'text' : syntax error in explicit override
 
+## Remarks
+
 An unexpected string was in an explicit override. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3654:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3655"
 title: "Compiler Error C3655"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3655"
+ms.date: 11/04/2016
 f1_keywords: ["C3655"]
 helpviewer_keywords: ["C3655"]
-ms.assetid: 724919ab-2915-4b61-8794-44648e162d62
 ---
 # Compiler Error C3655
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
@@ -16,7 +16,7 @@ A function can only be explicitly overridden once. For more information, see [Ex
 
 ## Example
 
-The following sample generates C3655:
+The following example generates C3655:
 
 ```cpp
 // C3655.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
@@ -10,7 +10,11 @@ ms.assetid: 724919ab-2915-4b61-8794-44648e162d62
 
 > 'function' : function already explicitly overridden
 
+## Remarks
+
 A function can only be explicitly overridden once. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3655:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3655.md
@@ -8,7 +8,7 @@ ms.assetid: 724919ab-2915-4b61-8794-44648e162d62
 ---
 # Compiler Error C3655
 
-'function' : function already explicitly overridden
+> 'function' : function already explicitly overridden
 
 A function can only be explicitly overridden once. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
@@ -10,7 +10,11 @@ ms.assetid: 88965d85-73b0-4b35-8020-0650c9c94cd8
 
 > 'override' : override specifier cannot be repeated
 
+## Remarks
+
 An explicit override keyword can only be specified once. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C3656:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3656"
 title: "Compiler Error C3656"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3656"
+ms.date: 11/04/2016
 f1_keywords: ["C3656"]
 helpviewer_keywords: ["C3656"]
-ms.assetid: 88965d85-73b0-4b35-8020-0650c9c94cd8
 ---
 # Compiler Error C3656
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
@@ -16,7 +16,7 @@ An explicit override keyword can only be specified once. For more information, s
 
 ## Example
 
-The following sample generates C3656:
+The following example generates C3656:
 
 ```cpp
 // C3656.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3656.md
@@ -8,7 +8,7 @@ ms.assetid: 88965d85-73b0-4b35-8020-0650c9c94cd8
 ---
 # Compiler Error C3656
 
-'override' : override specifier cannot be repeated
+> 'override' : override specifier cannot be repeated
 
 An explicit override keyword can only be specified once. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
@@ -8,7 +8,7 @@ ms.assetid: 89a28a18-4c17-43a1-bda6-deb52c32d203
 ---
 # Compiler Error C3657
 
-destructors cannot explicitly override or be explicitly overridden
+> destructors cannot explicitly override or be explicitly overridden
 
 Destructors or finalizers cannot be explicitly overridden. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
@@ -10,6 +10,8 @@ ms.assetid: 89a28a18-4c17-43a1-bda6-deb52c32d203
 
 > destructors cannot explicitly override or be explicitly overridden
 
+## Remarks
+
 Destructors or finalizers cannot be explicitly overridden. For more information, see [Explicit Overrides](../../extensions/explicit-overrides-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
@@ -16,7 +16,7 @@ Destructors or finalizers cannot be explicitly overridden. For more information,
 
 ## Example
 
-The following sample generates C3657.
+The following example generates C3657.
 
 ```cpp
 // C3657.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3657.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3657"
 title: "Compiler Error C3657"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3657"
+ms.date: 11/04/2016
 f1_keywords: ["C3657"]
 helpviewer_keywords: ["C3657"]
-ms.assetid: 89a28a18-4c17-43a1-bda6-deb52c32d203
 ---
 # Compiler Error C3657
 


### PR DESCRIPTION
This is batch 61 that structures error/warning references. See #5465 for more information.