### PR TITLE
Update C2182 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2182.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2182.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2182"
 description: "Learn more about: Compiler Error C2182"
-ms.date: 11/04/2016
+ms.date: 08/22/2025
 f1_keywords: ["C2182"]
 helpviewer_keywords: ["C2182"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
+++ b/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler errors C2100 through C2199"
 description: "Learn more about: Compiler errors C2100 through C2199"
-ms.date: "04/21/2019"
+ms.date: 04/21/2019
 f1_keywords: ["C2119", "C2123", "C2125", "C2126", "C2127", "C2136", "C2176", "C2187", "C2189"]
 helpviewer_keywords: ["C2119", "C2123", "C2125", "C2126", "C2127", "C2136", "C2176", "C2187", "C2189"]
 ---


### PR DESCRIPTION
- Update error message to the new one (introduced in MSVC v19.32 VS17.2 as per [godbolt](https://godbolt.org/z/q8zqWE1vr) & [image](https://github.com/user-attachments/assets/2ee717a9-db57-4b0c-afc3-7d777d4e49c5))
- Augment the remarks by mentioning `void` arrays and pointers to `void`
- Fix example as the old one no longer emits C2182 (it now emits the newer C7683 for reference to `void`)
- Update metadata
