### PR TITLE
Tweak C2190 and C2191 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C2190"]
 
 ## Remarks
 
-A C function was declared a second time with a shorter parameter list. C does not support overloaded functions.
+A C function was declared a second time with a shorter parameter list. C does not support overloaded functions. Without [`/Za`](../../build/reference/za-ze-disable-language-extensions.md), the compiler emits [Compiler Warning (level 1) C4030](../compiler-warnings/compiler-warning-level-1-c4030.md) instead.
 
 ## Example
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
@@ -20,7 +20,9 @@ The following example generates C2190:
 ```c
 // C2190.c
 // compile with: /Za /c
-void func( int, float );
-void func( int  );   // C2190, different parameter list
-void func2( int  );   // OK
+
+void func1(int, float);
+void func1(int);   // C2190, shorter parameter list
+
+void func2(int);   // OK
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2190"
 description: "Learn more about: Compiler Error C2190"
-ms.date: 11/04/2016
+ms.date: 08/22/2025
 f1_keywords: ["C2190"]
 helpviewer_keywords: ["C2190"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2190.md
@@ -26,3 +26,7 @@ void func1(int);   // C2190, shorter parameter list
 
 void func2(int);   // OK
 ```
+
+## See also
+
+[Compiler Error C2191](compiler-error-c2191.md)

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
@@ -20,7 +20,9 @@ The following example generates C2191:
 ```c
 // C2191.c
 // compile with: /Za /c
-void func( int );
-void func( int, float );   // C2191 different parameter list
-void func2( int, float );   // OK
+
+void func1(int);
+void func1(int, float);   // C2191, longer parameter list
+
+void func2(int, float);   // OK
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2191"
 description: "Learn more about: Compiler Error C2191"
-ms.date: 11/04/2016
+ms.date: 08/22/2025
 f1_keywords: ["C2191"]
 helpviewer_keywords: ["C2191"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
@@ -26,3 +26,7 @@ void func1(int, float);   // C2191, longer parameter list
 
 void func2(int, float);   // OK
 ```
+
+## See also
+
+[Compiler Error C2190](compiler-error-c2190.md)

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2191.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C2191"]
 
 ## Remarks
 
-A C function was declared a second time with a longer parameter list. C does not support overloaded functions.
+A C function was declared a second time with a longer parameter list. C does not support overloaded functions. Without [`/Za`](../../build/reference/za-ze-disable-language-extensions.md), the compiler emits [Compiler Warning (level 1) C4031](../compiler-warnings/compiler-warning-level-1-c4031.md) instead.
 
 ## Example
 


### PR DESCRIPTION
- Augment remarks with what happens without `/Za` flag
- Tweak and format examples
  - Rename `func` to `func1` for alignment
  - Tighten wording in comments
  - Remove superfluous spaces and add newline
- Add each other as "See also" link since they are analogs
- Update `ms.date` metadata