### PR TITLE
Structure error references in range [C3741, C3800]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
@@ -16,7 +16,7 @@ When `layout_dependent=true` for an [event_receiver](../../windows/attributes/ev
 
 ## Example
 
-The following sample generates C3741
+The following example generates C3741
 
 ```cpp
 // C3741.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3741"
 title: "Compiler Error C3741"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3741"
+ms.date: 11/04/2016
 f1_keywords: ["C3741"]
 helpviewer_keywords: ["C3741"]
-ms.assetid: ed311315-cc32-49c9-97fa-01b293d81526
 ---
 # Compiler Error C3741
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
@@ -10,7 +10,11 @@ ms.assetid: ed311315-cc32-49c9-97fa-01b293d81526
 
 > 'class': must be a coclass when the 'layout_dependent' parameter of event_receiver = true
 
+## Remarks
+
 When `layout_dependent=true` for an [event_receiver](../../windows/attributes/event-receiver.md) class, then the class must also have the [coclass](../../windows/attributes/coclass.md) attribute.
+
+## Example
 
 The following sample generates C3741
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3741.md
@@ -8,7 +8,7 @@ ms.assetid: ed311315-cc32-49c9-97fa-01b293d81526
 ---
 # Compiler Error C3741
 
-'class': must be a coclass when the 'layout_dependent' parameter of event_receiver = true
+> 'class': must be a coclass when the 'layout_dependent' parameter of event_receiver = true
 
 When `layout_dependent=true` for an [event_receiver](../../windows/attributes/event-receiver.md) class, then the class must also have the [coclass](../../windows/attributes/coclass.md) attribute.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
@@ -16,7 +16,7 @@ The [__unhook](../../cpp/unhook.md) function varies in the number of parameters 
 
 ## Example
 
-The following sample generates C3743:
+The following example generates C3743:
 
 ```cpp
 // C3743.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
@@ -10,7 +10,11 @@ ms.assetid: 7ca9a76e-7b60-46d1-ab8b-18600cf1a306
 
 > can only hook/unhook an entire interface when the 'layout_dependent' parameter of event_receiver is true
 
+## Remarks
+
 The [__unhook](../../cpp/unhook.md) function varies in the number of parameters that it takes based on the value passed to the `layout_dependent` parameter in the [event_receiver](../../windows/attributes/event-receiver.md) class.
+
+## Example
 
 The following sample generates C3743:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3743"
 title: "Compiler Error C3743"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3743"
+ms.date: 11/04/2016
 f1_keywords: ["C3743"]
 helpviewer_keywords: ["C3743"]
-ms.assetid: 7ca9a76e-7b60-46d1-ab8b-18600cf1a306
 ---
 # Compiler Error C3743
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3743.md
@@ -8,7 +8,7 @@ ms.assetid: 7ca9a76e-7b60-46d1-ab8b-18600cf1a306
 ---
 # Compiler Error C3743
 
-can only hook/unhook an entire interface when the 'layout_dependent' parameter of event_receiver is true
+> can only hook/unhook an entire interface when the 'layout_dependent' parameter of event_receiver is true
 
 The [__unhook](../../cpp/unhook.md) function varies in the number of parameters that it takes based on the value passed to the `layout_dependent` parameter in the [event_receiver](../../windows/attributes/event-receiver.md) class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
@@ -8,7 +8,7 @@ ms.assetid: a447d050-80d1-406a-9a6e-f15c527d717c
 ---
 # Compiler Error C3744
 
-__unhook must have at least 3 arguments for managed events
+> __unhook must have at least 3 arguments for managed events
 
 The [`__unhook`](../../cpp/unhook.md) function must take three parameters when used in a program that is compiled for Managed Extensions for C++.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
@@ -10,6 +10,8 @@ ms.assetid: a447d050-80d1-406a-9a6e-f15c527d717c
 
 > __unhook must have at least 3 arguments for managed events
 
+## Remarks
+
 The [`__unhook`](../../cpp/unhook.md) function must take three parameters when used in a program that is compiled for Managed Extensions for C++.
 
 **`__hook`** and **`__unhook`** are not compatible with **`/clr`** programming. Use the += and -= operators instead.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3744.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3744"
 title: "Compiler Error C3744"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3744"
+ms.date: 11/04/2016
 f1_keywords: ["C3744"]
 helpviewer_keywords: ["C3744"]
-ms.assetid: a447d050-80d1-406a-9a6e-f15c527d717c
 ---
 # Compiler Error C3744
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3745"
 title: "Compiler Error C3745"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3745"
+ms.date: 11/04/2016
 f1_keywords: ["C3745"]
 helpviewer_keywords: ["C3745"]
-ms.assetid: 1e64aec5-7e53-47e5-bc7d-3905230cfc66
 ---
 # Compiler Error C3745
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
@@ -16,7 +16,7 @@ Only a function defined with the [__event](../../cpp/event.md) keyword can be pa
 
 ## Example
 
-The following sample generates C3745:
+The following example generates C3745:
 
 ```cpp
 // C3745.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
@@ -10,7 +10,11 @@ ms.assetid: 1e64aec5-7e53-47e5-bc7d-3905230cfc66
 
 > 'function': only an event can be 'raised'
 
+## Remarks
+
 Only a function defined with the [__event](../../cpp/event.md) keyword can be passed to the [__raise](../../cpp/raise.md) keyword.
+
+## Example
 
 The following sample generates C3745:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3745.md
@@ -8,7 +8,7 @@ ms.assetid: 1e64aec5-7e53-47e5-bc7d-3905230cfc66
 ---
 # Compiler Error C3745
 
-'function': only an event can be 'raised'
+> 'function': only an event can be 'raised'
 
 Only a function defined with the [__event](../../cpp/event.md) keyword can be passed to the [__raise](../../cpp/raise.md) keyword.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
@@ -16,7 +16,7 @@ Generic or template parameters with default values cannot be followed in the par
 
 ## Example
 
-The following sample generates C3747:
+The following example generates C3747:
 
 ```cpp
 // C3747.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
@@ -10,7 +10,11 @@ ms.assetid: a9a4be67-5d9c-4dcc-9ae9-baae46cbecde
 
 > missing default type parameter : parameter param
 
+## Remarks
+
 Generic or template parameters with default values cannot be followed in the parameter list by parameters that do not have default values.
+
+## Example
 
 The following sample generates C3747:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
@@ -8,7 +8,7 @@ ms.assetid: a9a4be67-5d9c-4dcc-9ae9-baae46cbecde
 ---
 # Compiler Error C3747
 
-missing default type parameter : parameter param
+> missing default type parameter : parameter param
 
 Generic or template parameters with default values cannot be followed in the parameter list by parameters that do not have default values.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3747.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3747"
 title: "Compiler Error C3747"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3747"
+ms.date: 11/04/2016
 f1_keywords: ["C3747"]
 helpviewer_keywords: ["C3747"]
-ms.assetid: a9a4be67-5d9c-4dcc-9ae9-baae46cbecde
 ---
 # Compiler Error C3747
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
@@ -16,7 +16,7 @@ The [__event](../../cpp/event.md) keyword cannot appear inside an interface.
 
 ## Example
 
-The following sample generates C3748:
+The following example generates C3748:
 
 ```cpp
 // C3748.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
@@ -8,7 +8,7 @@ ms.assetid: 6fe71a0a-dd93-4ce6-9729-b9616360cf34
 ---
 # Compiler Error C3748
 
-'interface': managed interfaces may not fire events
+> 'interface': managed interfaces may not fire events
 
 The [__event](../../cpp/event.md) keyword cannot appear inside an interface.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
@@ -10,7 +10,11 @@ ms.assetid: 6fe71a0a-dd93-4ce6-9729-b9616360cf34
 
 > 'interface': managed interfaces may not fire events
 
+## Remarks
+
 The [__event](../../cpp/event.md) keyword cannot appear inside an interface.
+
+## Example
 
 The following sample generates C3748:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3748.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3748"
 title: "Compiler Error C3748"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3748"
+ms.date: 11/04/2016
 f1_keywords: ["C3748"]
 helpviewer_keywords: ["C3748"]
-ms.assetid: 6fe71a0a-dd93-4ce6-9729-b9616360cf34
 ---
 # Compiler Error C3748
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
@@ -16,7 +16,7 @@ A custom attribute cannot be used inside a function. For more information on cus
 
 ## Example
 
-The following sample generates C3749:
+The following example generates C3749:
 
 ```cpp
 // C3749a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3749"
 title: "Compiler Error C3749"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3749"
+ms.date: 11/04/2016
 f1_keywords: ["C3749"]
 helpviewer_keywords: ["C3749"]
-ms.assetid: 3d26b468-4757-41b8-b5a2-78022a5295fb
 ---
 # Compiler Error C3749
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
@@ -8,7 +8,7 @@ ms.assetid: 3d26b468-4757-41b8-b5a2-78022a5295fb
 ---
 # Compiler Error C3749
 
-'attribute': a custom attribute may not be used inside a function
+> 'attribute': a custom attribute may not be used inside a function
 
 A custom attribute cannot be used inside a function. For more information on custom attributes, see the topic [attribute](../../windows/attributes/attribute.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3749.md
@@ -10,6 +10,8 @@ ms.assetid: 3d26b468-4757-41b8-b5a2-78022a5295fb
 
 > 'attribute': a custom attribute may not be used inside a function
 
+## Remarks
+
 A custom attribute cannot be used inside a function. For more information on custom attributes, see the topic [attribute](../../windows/attributes/attribute.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3752"
 title: "Compiler Error C3752"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3752"
+ms.date: 11/04/2016
 f1_keywords: ["C3752"]
 helpviewer_keywords: ["C3752"]
-ms.assetid: 1ac81d85-0f5a-4f39-95b6-42fd43cb18d5
 ---
 # Compiler Error C3752
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
@@ -8,6 +8,6 @@ ms.assetid: 1ac81d85-0f5a-4f39-95b6-42fd43cb18d5
 ---
 # Compiler Error C3752
 
-'attribute class': cannot classify attribute; 'keyword' should not be used in this context
+> 'attribute class': cannot classify attribute; 'keyword' should not be used in this context
 
 A user-defined attribute was applied incorrectly.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3752.md
@@ -10,4 +10,6 @@ ms.assetid: 1ac81d85-0f5a-4f39-95b6-42fd43cb18d5
 
 > 'attribute class': cannot classify attribute; 'keyword' should not be used in this context
 
+## Remarks
+
 A user-defined attribute was applied incorrectly.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3753"
 title: "Compiler Error C3753"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3753"
+ms.date: 11/04/2016
 f1_keywords: ["C3753"]
 helpviewer_keywords: ["C3753"]
-ms.assetid: a5b99e28-796c-4107-a673-97c2ae3bb2b9
 ---
 # Compiler Error C3753
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
@@ -8,7 +8,7 @@ ms.assetid: a5b99e28-796c-4107-a673-97c2ae3bb2b9
 ---
 # Compiler Error C3753
 
-a generic property is not allowed
+> a generic property is not allowed
 
 Generic parameter lists can only appear on managed classes, structs, or functions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
@@ -10,6 +10,8 @@ ms.assetid: a5b99e28-796c-4107-a673-97c2ae3bb2b9
 
 > a generic property is not allowed
 
+## Remarks
+
 Generic parameter lists can only appear on managed classes, structs, or functions.
 
 For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md) and [property](../../extensions/property-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3753.md
@@ -18,7 +18,7 @@ For more information, see [Generics](../../extensions/generics-cpp-component-ext
 
 ## Example
 
-The following sample generates C3753.
+The following example generates C3753.
 
 ```cpp
 // C3753.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
@@ -16,7 +16,7 @@ A call was made to a function through a pointer to a type that does not contain 
 
 ## Example
 
-The following sample generates C3754:
+The following example generates C3754:
 
 ```cpp
 // C3754a.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3754"
 title: "Compiler Error C3754"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3754"
+ms.date: 11/04/2016
 f1_keywords: ["C3754"]
 helpviewer_keywords: ["C3754"]
-ms.assetid: 14b877bc-9277-40ec-af1c-196a58b45f10
 ---
 # Compiler Error C3754
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
@@ -10,6 +10,8 @@ ms.assetid: 14b877bc-9277-40ec-af1c-196a58b45f10
 
 > delegate constructor: member function 'function' cannot be called on an instance of type 'type'
 
+## Remarks
+
 A call was made to a function through a pointer to a type that does not contain the function.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3754.md
@@ -8,7 +8,7 @@ ms.assetid: 14b877bc-9277-40ec-af1c-196a58b45f10
 ---
 # Compiler Error C3754
 
-delegate constructor: member function 'function' cannot be called on an instance of type 'type'
+> delegate constructor: member function 'function' cannot be called on an instance of type 'type'
 
 A call was made to a function through a pointer to a type that does not contain the function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
@@ -16,7 +16,7 @@ A [delegate  (C++ Component Extensions)](../../extensions/delegate-cpp-component
 
 ## Examples
 
-The following sample generates C3755.
+The following example generates C3755.
 
 ```cpp
 // C3755.cpp
@@ -24,7 +24,7 @@ The following sample generates C3755.
 delegate void MyDel() {};   // C3755
 ```
 
-C3755 can also occur if you attempt to create a delegate template. The following sample generates C3755.
+C3755 can also occur if you attempt to create a delegate template. The following example generates C3755.
 
 ```cpp
 // C3755_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
@@ -10,6 +10,8 @@ ms.assetid: 9317b55e-a52e-4b87-b915-5a208d6eda38
 
 > 'delegate': a delegate may not be defined
 
+## Remarks
+
 A [delegate  (C++ Component Extensions)](../../extensions/delegate-cpp-component-extensions.md) can be declared but not defined.
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
@@ -8,7 +8,7 @@ ms.assetid: 9317b55e-a52e-4b87-b915-5a208d6eda38
 ---
 # Compiler Error C3755
 
-'delegate': a delegate may not be defined
+> 'delegate': a delegate may not be defined
 
 A [delegate  (C++ Component Extensions)](../../extensions/delegate-cpp-component-extensions.md) can be declared but not defined.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3755.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3755"
 title: "Compiler Error C3755"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3755"
+ms.date: 11/04/2016
 f1_keywords: ["C3755"]
 helpviewer_keywords: ["C3755"]
-ms.assetid: 9317b55e-a52e-4b87-b915-5a208d6eda38
 ---
 # Compiler Error C3755
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3761"
 title: "Compiler Error C3761"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3761"
+ms.date: 11/04/2016
 f1_keywords: ["C3761"]
 helpviewer_keywords: ["C3761"]
-ms.assetid: 0c16f093-7a78-4838-b90b-0c67ef6e9270
 ---
 # Compiler Error C3761
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
@@ -16,7 +16,7 @@ The [retval](../../windows/attributes/retval.md) attribute was used on a functio
 
 ## Example
 
-The following sample generates C3761:
+The following example generates C3761:
 
 ```cpp
 // C3761.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
@@ -10,7 +10,11 @@ ms.assetid: 0c16f093-7a78-4838-b90b-0c67ef6e9270
 
 > 'function': 'retval' can only appear on the last argument of a function
 
+## Remarks
+
 The [retval](../../windows/attributes/retval.md) attribute was used on a function argument that was not the last argument in the list.
+
+## Example
 
 The following sample generates C3761:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3761.md
@@ -8,7 +8,7 @@ ms.assetid: 0c16f093-7a78-4838-b90b-0c67ef6e9270
 ---
 # Compiler Error C3761
 
-'function': 'retval' can only appear on the last argument of a function
+> 'function': 'retval' can only appear on the last argument of a function
 
 The [retval](../../windows/attributes/retval.md) attribute was used on a function argument that was not the last argument in the list.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3762"
 title: "Compiler Error C3762"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3762"
+ms.date: 11/04/2016
 f1_keywords: ["C3762"]
 helpviewer_keywords: ["C3762"]
-ms.assetid: b79b6506-2cea-44a0-855a-5fdcb9fd7ad9
 ---
 # Compiler Error C3762
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
@@ -8,6 +8,6 @@ ms.assetid: b79b6506-2cea-44a0-855a-5fdcb9fd7ad9
 ---
 # Compiler Error C3762
 
-unable to process attribute 'attribute'
+> unable to process attribute 'attribute'
 
 A user-defined attribute that inherits from `System.Security.Permissions.SecurityAttribute` is being used to define a security attribute. Such an attribute cannot be used in the same assembly where it is defined.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3762.md
@@ -10,4 +10,6 @@ ms.assetid: b79b6506-2cea-44a0-855a-5fdcb9fd7ad9
 
 > unable to process attribute 'attribute'
 
+## Remarks
+
 A user-defined attribute that inherits from `System.Security.Permissions.SecurityAttribute` is being used to define a security attribute. Such an attribute cannot be used in the same assembly where it is defined.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3763"
 title: "Compiler Error C3763"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3763"
+ms.date: 11/04/2016
 f1_keywords: ["C3763"]
 helpviewer_keywords: ["C3763"]
-ms.assetid: 58b1f079-cd1d-46e0-9431-ea18210106b7
 ---
 # Compiler Error C3763
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
@@ -16,7 +16,7 @@ The [out](../../windows/attributes/out-cpp.md) or [retval](../../windows/attribu
 
 ## Example
 
-The following sample generates C3763:
+The following example generates C3763:
 
 ```cpp
 // C3763.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
@@ -8,7 +8,7 @@ ms.assetid: 58b1f079-cd1d-46e0-9431-ea18210106b7
 ---
 # Compiler Error C3763
 
-'type': 'retval' and 'out' can only appear on a data-pointer type
+> 'type': 'retval' and 'out' can only appear on a data-pointer type
 
 The [out](../../windows/attributes/out-cpp.md) or [retval](../../windows/attributes/retval.md) attributes can only appear on parameters of type pointer. Either remove the attribute or make the parameter of type pointer.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3763.md
@@ -10,7 +10,11 @@ ms.assetid: 58b1f079-cd1d-46e0-9431-ea18210106b7
 
 > 'type': 'retval' and 'out' can only appear on a data-pointer type
 
+## Remarks
+
 The [out](../../windows/attributes/out-cpp.md) or [retval](../../windows/attributes/retval.md) attributes can only appear on parameters of type pointer. Either remove the attribute or make the parameter of type pointer.
+
+## Example
 
 The following sample generates C3763:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
@@ -16,7 +16,7 @@ The compiler detected an ill-formed override. For example, the base class functi
 
 ## Examples
 
-The following sample generates C3764.
+The following example generates C3764.
 
 ```cpp
 // C3764.cpp
@@ -32,7 +32,7 @@ public ref struct B : A {
 };
 ```
 
-C3764 can also occur when a base class method is both explicitly and named overridden. The following sample generates C3764.
+C3764 can also occur when a base class method is both explicitly and named overridden. The following example generates C3764.
 
 ```cpp
 // C3764_b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
@@ -8,7 +8,7 @@ ms.assetid: af5d254c-8d4a-4dda-aad9-3c5c1257c868
 ---
 # Compiler Error C3764
 
-'override_function': cannot override base class method 'base_class_function'
+> 'override_function': cannot override base class method 'base_class_function'
 
 The compiler detected an ill-formed override. For example, the base class function was not **`virtual`**. For more information, see [override](../../extensions/override-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
@@ -10,6 +10,8 @@ ms.assetid: af5d254c-8d4a-4dda-aad9-3c5c1257c868
 
 > 'override_function': cannot override base class method 'base_class_function'
 
+## Remarks
+
 The compiler detected an ill-formed override. For example, the base class function was not **`virtual`**. For more information, see [override](../../extensions/override-cpp-component-extensions.md).
 
 ## Examples

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3764.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3764"
 title: "Compiler Error C3764"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3764"
+ms.date: 11/04/2016
 f1_keywords: ["C3764"]
 helpviewer_keywords: ["C3764"]
-ms.assetid: af5d254c-8d4a-4dda-aad9-3c5c1257c868
 ---
 # Compiler Error C3764
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
@@ -16,7 +16,7 @@ If a class is marked with the [event_receiver](../../windows/attributes/event-re
 
 ## Example
 
-The following sample generates C3765:
+The following example generates C3765:
 
 ```cpp
 // C3765.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
@@ -8,7 +8,7 @@ ms.assetid: feadee7a-fcfb-402c-af2f-0e656f814a13
 ---
 # Compiler Error C3765
 
-'event': cannot define an event in a class/struct 'type' marked as an event_receiver
+> 'event': cannot define an event in a class/struct 'type' marked as an event_receiver
 
 If a class is marked with the [event_receiver](../../windows/attributes/event-receiver.md) attribute, the class cannot contain an [__event](../../cpp/event.md) declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
@@ -10,7 +10,11 @@ ms.assetid: feadee7a-fcfb-402c-af2f-0e656f814a13
 
 > 'event': cannot define an event in a class/struct 'type' marked as an event_receiver
 
+## Remarks
+
 If a class is marked with the [event_receiver](../../windows/attributes/event-receiver.md) attribute, the class cannot contain an [__event](../../cpp/event.md) declaration.
+
+## Example
 
 The following sample generates C3765:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3765.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3765"
 title: "Compiler Error C3765"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3765"
+ms.date: 11/04/2016
 f1_keywords: ["C3765"]
 helpviewer_keywords: ["C3765"]
-ms.assetid: feadee7a-fcfb-402c-af2f-0e656f814a13
 ---
 # Compiler Error C3765
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3766"
 title: "Compiler Error C3766"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3766"
+ms.date: 11/04/2016
 f1_keywords: ["C3766"]
 helpviewer_keywords: ["C3766"]
-ms.assetid: b5af2089-2e1e-4e45-a41d-495b6c55656e
 ---
 # Compiler Error C3766
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
@@ -10,6 +10,8 @@ ms.assetid: b5af2089-2e1e-4e45-a41d-495b6c55656e
 
 > 'type' must provide an implementation for the interface method 'function'
 
+## Remarks
+
 A class that inherits from an interface must implement the interface members.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
@@ -8,7 +8,7 @@ ms.assetid: b5af2089-2e1e-4e45-a41d-495b6c55656e
 ---
 # Compiler Error C3766
 
-'type' must provide an implementation for the interface method 'function'
+> 'type' must provide an implementation for the interface method 'function'
 
 A class that inherits from an interface must implement the interface members.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3766.md
@@ -16,7 +16,7 @@ A class that inherits from an interface must implement the interface members.
 
 ## Example
 
-The following sample generates C3766.
+The following example generates C3766.
 
 ```cpp
 // C3766.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3767"
 title: "Compiler Error C3767"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3767"
+ms.date: 11/04/2016
 f1_keywords: ["C3767"]
 helpviewer_keywords: ["C3767"]
-ms.assetid: 5247cdcd-639c-4527-bd37-37e74c4e8fab
 ---
 # Compiler Error C3767
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
@@ -8,7 +8,7 @@ ms.assetid: 5247cdcd-639c-4527-bd37-37e74c4e8fab
 ---
 # Compiler Error C3767
 
-'function' candidate function(s) not accessible
+> 'function' candidate function(s) not accessible
 
 A friend function defined in a class is not supposed to be treated as if it were defined and declared in the global namespace scope. It can, however, be found by argument-dependent lookup.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
@@ -18,7 +18,7 @@ C3767 may also be caused by a breaking change: native types are now private by d
 
 ## Examples
 
-The following sample generates C3767:
+The following example generates C3767:
 
 ```cpp
 // C3767a.cpp
@@ -49,7 +49,7 @@ int main() {
 };
 ```
 
-The following sample generates C3767:
+The following example generates C3767:
 
 ```cpp
 // C3767c.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3767.md
@@ -10,11 +10,13 @@ ms.assetid: 5247cdcd-639c-4527-bd37-37e74c4e8fab
 
 > 'function' candidate function(s) not accessible
 
+## Remarks
+
 A friend function defined in a class is not supposed to be treated as if it were defined and declared in the global namespace scope. It can, however, be found by argument-dependent lookup.
 
 C3767 may also be caused by a breaking change: native types are now private by default in a **/clr** compilation; see [Type visibility](../../dotnet/how-to-define-and-consume-classes-and-structs-cpp-cli.md#BKMK_Type_visibility) for more information.
 
-## Example
+## Examples
 
 The following sample generates C3767:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3768.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3768.md
@@ -18,7 +18,7 @@ When compiling with **/clr:pure**, you cannot take the address of a virtual `var
 
 ## Example
 
-The following sample generates C3768:
+The following example generates C3768:
 
 ```cpp
 // C3768.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3768.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3768.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3768"
 title: "Compiler Error C3768"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3768"
+ms.date: 11/04/2016
 f1_keywords: ["C3768"]
 helpviewer_keywords: ["C3768"]
-ms.assetid: 091f0d53-1dff-43fd-813d-5c43c85b6ab0
 ---
 # Compiler Error C3768
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
@@ -8,7 +8,7 @@ ms.assetid: 341675e1-7428-4da6-8275-1b2f0a70dacc
 ---
 # Compiler Error C3769
 
-'type' : a nested class cannot have the same name as the immediately enclosing class
+> 'type' : a nested class cannot have the same name as the immediately enclosing class
 
 A nested class cannot have the same name as the immediately enclosing class.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
@@ -10,6 +10,8 @@ ms.assetid: 341675e1-7428-4da6-8275-1b2f0a70dacc
 
 > 'type' : a nested class cannot have the same name as the immediately enclosing class
 
+## Remarks
+
 A nested class cannot have the same name as the immediately enclosing class.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
@@ -16,7 +16,7 @@ A nested class cannot have the same name as the immediately enclosing class.
 
 ## Example
 
-The following sample generates C3769.
+The following example generates C3769.
 
 ```cpp
 // C3769.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3769.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3769"
 title: "Compiler Error C3769"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3769"
+ms.date: 11/04/2016
 f1_keywords: ["C3769"]
 helpviewer_keywords: ["C3769"]
-ms.assetid: 341675e1-7428-4da6-8275-1b2f0a70dacc
 ---
 # Compiler Error C3769
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C3771"]
 
 > "identifier" : friend declaration cannot be found in the nearest namespace scope
 
+## Remarks
+
 The class template declaration for the specified template *identifier* cannot be found within the current namespace.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3771.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C3771"]
 ---
 # Compiler Error C3771
 
-"identifier" : friend declaration cannot be found in the nearest namespace scope
+> "identifier" : friend declaration cannot be found in the nearest namespace scope
 
 The class template declaration for the specified template *identifier* cannot be found within the current namespace.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3772"
 title: "Compiler Error C3772"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3772"
+ms.date: 11/04/2016
 f1_keywords: ["C3772"]
 helpviewer_keywords: ["C3772"]
-ms.assetid: 63e938d4-088d-41cc-a562-5881a05b5710
 ---
 # Compiler Error C3772
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
@@ -8,7 +8,7 @@ ms.assetid: 63e938d4-088d-41cc-a562-5881a05b5710
 ---
 # Compiler Error C3772
 
-"name" : invalid friend template declaration
+> "name" : invalid friend template declaration
 
 It is invalid to declare a friend of a class template specialization. You cannot declare an explicit or partial specialization of a class template and in the same statement declare a friend of that specialization. The *name* placeholder identifies the invalid declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3772.md
@@ -10,6 +10,8 @@ ms.assetid: 63e938d4-088d-41cc-a562-5881a05b5710
 
 > "name" : invalid friend template declaration
 
+## Remarks
+
 It is invalid to declare a friend of a class template specialization. You cannot declare an explicit or partial specialization of a class template and in the same statement declare a friend of that specialization. The *name* placeholder identifies the invalid declaration.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
@@ -9,13 +9,13 @@ helpviewer_keywords: ["C3779"]
 
 > '*function*': a function that returns '*auto or decltype(auto)*' cannot be used before it is defined
 
-The **`auto`** return type of the specified function call couldn't be deduced. The compiler didn't have enough information at the call site.
-
 ## Remarks
+
+The **`auto`** return type of the specified function call couldn't be deduced. The compiler didn't have enough information at the call site.
 
 This error can occur when you call a forward-declared member function that has an **`auto`** return type but no body or trailing return type. You can also get this error when the compiler can't find a candidate return type when it instantiates a template specialization. A common cause of this error is a missing interface header. The missing type can often be determined from the typename mentioned in a note that follows this error. To resolve this issue, for every type you use, include the header for the namespace the type is in.
 
-## Examples
+## Example
 
 The following C++/WinRT sample generates C3779:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Error C3779"
 title: "Compiler Error C3779"
+description: "Learn more about: Compiler Error C3779"
 ms.date: 05/19/2021
 f1_keywords: ["C3779"]
 helpviewer_keywords: ["C3779"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3779.md
@@ -17,7 +17,7 @@ This error can occur when you call a forward-declared member function that has a
 
 ## Example
 
-The following C++/WinRT sample generates C3779:
+The following C++/WinRT example generates C3779:
 
 ```cpp
 // C3779.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
@@ -18,7 +18,7 @@ For more information, see [event](../../extensions/event-cpp-component-extension
 
 ## Example
 
-The following sample generates C3797.
+The following example generates C3797.
 
 ```cpp
 // C3797.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
@@ -10,6 +10,8 @@ ms.assetid: ab27ff34-8c1d-4297-b004-9e39bd3a4f25
 
 > 'override': event declaration cannot have override specifier (should be placed on event add/remove/raise methods instead)
 
+## Remarks
+
 You cannot override a trivial event (an event without explicitly defined accessor methods) with another trivial event. The overriding event must define its behavior with accessor functions.
 
 For more information, see [event](../../extensions/event-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
@@ -8,7 +8,7 @@ ms.assetid: ab27ff34-8c1d-4297-b004-9e39bd3a4f25
 ---
 # Compiler Error C3797
 
-'override': event declaration cannot have override specifier (should be placed on event add/remove/raise methods instead)
+> 'override': event declaration cannot have override specifier (should be placed on event add/remove/raise methods instead)
 
 You cannot override a trivial event (an event without explicitly defined accessor methods) with another trivial event. The overriding event must define its behavior with accessor functions.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3797.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3797"
 title: "Compiler Error C3797"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3797"
+ms.date: 11/04/2016
 f1_keywords: ["C3797"]
 helpviewer_keywords: ["C3797"]
-ms.assetid: ab27ff34-8c1d-4297-b004-9e39bd3a4f25
 ---
 # Compiler Error C3797
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
@@ -8,7 +8,7 @@ ms.assetid: b2f8b1d8-8812-49b8-a346-28e48f02ba5c
 ---
 # Compiler Error C3798
 
-'specifier': property declaration cannot have override specifier (should be placed on property get/set methods instead)
+> 'specifier': property declaration cannot have override specifier (should be placed on property get/set methods instead)
 
 A property was declared incorrectly. For more information, see
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
@@ -22,7 +22,7 @@ A property was declared incorrectly. For more information, see
 
 ## Example
 
-The following sample generates C3798
+The following example generates C3798
 
 ```cpp
 // C3798.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
@@ -10,6 +10,8 @@ ms.assetid: b2f8b1d8-8812-49b8-a346-28e48f02ba5c
 
 > 'specifier': property declaration cannot have override specifier (should be placed on property get/set methods instead)
 
+## Remarks
+
 A property was declared incorrectly. For more information, see
 
 - [property](../../extensions/property-cpp-component-extensions.md)

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3798.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3798"
 title: "Compiler Error C3798"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3798"
+ms.date: 11/04/2016
 f1_keywords: ["C3798"]
 helpviewer_keywords: ["C3798"]
-ms.assetid: b2f8b1d8-8812-49b8-a346-28e48f02ba5c
 ---
 # Compiler Error C3798
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3799"
 title: "Compiler Error C3799"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3799"
+ms.date: 11/04/2016
 f1_keywords: ["C3799"]
 helpviewer_keywords: ["C3799"]
-ms.assetid: 336a2811-9370-4e6e-b03b-325bda470805
 ---
 # Compiler Error C3799
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
@@ -16,7 +16,7 @@ An indexed property was declared incorrectly. For more information, see [How to:
 
 ## Example
 
-The following sample generates C3799 and shows how to fix it.
+The following example generates C3799 and shows how to fix it.
 
 ```cpp
 // C3799.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
@@ -10,6 +10,8 @@ ms.assetid: 336a2811-9370-4e6e-b03b-325bda470805
 
 > indexed property cannot have an empty parameter list
 
+## Remarks
+
 An indexed property was declared incorrectly. For more information, see [How to: Use Properties in C++/CLI](../../dotnet/how-to-use-properties-in-cpp-cli.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3799.md
@@ -8,7 +8,7 @@ ms.assetid: 336a2811-9370-4e6e-b03b-325bda470805
 ---
 # Compiler Error C3799
 
-indexed property cannot have an empty parameter list
+> indexed property cannot have an empty parameter list
 
 An indexed property was declared incorrectly. For more information, see [How to: Use Properties in C++/CLI](../../dotnet/how-to-use-properties-in-cpp-cli.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
@@ -8,7 +8,7 @@ ms.assetid: c653240a-b6db-4437-8d65-fa58f0e6fcf4
 ---
 # Compiler Error C3800
 
-'declaration': cannot mix properties and events
+> 'declaration': cannot mix properties and events
 
 You cannot declare a construct to be both a property and an event.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3800"
 title: "Compiler Error C3800"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3800"
+ms.date: 11/04/2016
 f1_keywords: ["C3800"]
 helpviewer_keywords: ["C3800"]
-ms.assetid: c653240a-b6db-4437-8d65-fa58f0e6fcf4
 ---
 # Compiler Error C3800
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3800.md
@@ -10,6 +10,8 @@ ms.assetid: c653240a-b6db-4437-8d65-fa58f0e6fcf4
 
 > 'declaration': cannot mix properties and events
 
+## Remarks
+
 You cannot declare a construct to be both a property and an event.
 
 C3800 is only reachable using the obsolete compiler option **/clr:oldSyntax**.


### PR DESCRIPTION
This is batch 64 that structures error/warning references. See #5465 for more information.