### PR TITLE
Structure error references in range [C3851, C3890]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
@@ -16,7 +16,7 @@ In code compiled as C++, you cannot use a universal character name that represen
 
 ## Example
 
-The following samples generate C3851, and show how to fix it:
+The following example generate C3851, and show how to fix it:
 
 ```cpp
 // C3851.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
@@ -15,7 +15,7 @@ In code compiled as C++, you cannot use a universal character name that represen
 
 ## Example
 
-The following example generate C3851, and show how to fix it:
+The following example generates C3851, and show how to fix it:
 
 ```cpp
 // C3851.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3851.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3851"
 title: "Compiler Error C3851"
-ms.date: "09/05/2018"
+description: "Learn more about: Compiler Error C3851"
+ms.date: 09/05/2018
 f1_keywords: ["C3851"]
 helpviewer_keywords: ["C3851"]
-ms.assetid: da30c21c-33aa-4439-8fb3-2f5021ea4985
 ---
 # Compiler Error C3851
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
@@ -10,7 +10,11 @@ ms.assetid: 194e5c5e-0dfb-414e-86db-791c11eb610c
 
 > 'member' having type 'type': aggregate initialization could not initialize this member
 
+## Remarks
+
 An attempt was made to assign a default initialization as part of an aggregate initialization to a data member that cannot receive a default initialization in an aggregate initialization.
+
+## Example
 
 The following samples generate C3852:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
@@ -8,7 +8,7 @@ ms.assetid: 194e5c5e-0dfb-414e-86db-791c11eb610c
 ---
 # Compiler Error C3852
 
-'member' having type 'type': aggregate initialization could not initialize this member
+> 'member' having type 'type': aggregate initialization could not initialize this member
 
 An attempt was made to assign a default initialization as part of an aggregate initialization to a data member that cannot receive a default initialization in an aggregate initialization.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
@@ -16,7 +16,7 @@ An attempt was made to assign a default initialization as part of an aggregate i
 
 ## Example
 
-The following samples generate C3852:
+The following example generate C3852:
 
 ```cpp
 // C3852.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3852.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3852"
 title: "Compiler Error C3852"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3852"
+ms.date: 11/04/2016
 f1_keywords: ["C3852"]
 helpviewer_keywords: ["C3852"]
-ms.assetid: 194e5c5e-0dfb-414e-86db-791c11eb610c
 ---
 # Compiler Error C3852
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
@@ -10,7 +10,11 @@ ms.assetid: 5b71805d-52b4-44ec-80ae-37c68d876f6a
 
 > '=': re-initializing a reference or assignment through a reference-to-function is illegal
 
+## Remarks
+
 Cannot assign to a reference through a function because functions are not lvalues.
+
+## Example
 
 The following samples generate C3853:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
@@ -16,7 +16,7 @@ Cannot assign to a reference through a function because functions are not lvalue
 
 ## Example
 
-The following samples generate C3853:
+The following example generate C3853:
 
 ```cpp
 // C3853.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3853"
 title: "Compiler Error C3853"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3853"
+ms.date: 11/04/2016
 f1_keywords: ["C3853"]
 helpviewer_keywords: ["C3853"]
-ms.assetid: 5b71805d-52b4-44ec-80ae-37c68d876f6a
 ---
 # Compiler Error C3853
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
@@ -15,7 +15,7 @@ Cannot assign to a reference through a function because functions are not lvalue
 
 ## Example
 
-The following example generate C3853:
+The following example generates C3853:
 
 ```cpp
 // C3853.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3853.md
@@ -8,7 +8,7 @@ ms.assetid: 5b71805d-52b4-44ec-80ae-37c68d876f6a
 ---
 # Compiler Error C3853
 
-'=': re-initializing a reference or assignment through a reference-to-function is illegal
+> '=': re-initializing a reference or assignment through a reference-to-function is illegal
 
 Cannot assign to a reference through a function because functions are not lvalues.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
@@ -10,7 +10,11 @@ ms.assetid: 32a9ead0-c6c7-485a-8802-c7b1fe921d3a
 
 > expression to left of '=' evaluates to a function. Cannot assign to a function (a function is not an l-value)
 
+## Remarks
+
 A reference cannot be reinitialized. Dereferencing a reference to a function yields a function, which is an rvalue, to which you cannot assign. Therefore, you cannot assign through a reference to a function.
+
+## Example
 
 The following sample generates C3854:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3854"
 title: "Compiler Error C3854"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3854"
+ms.date: 11/04/2016
 f1_keywords: ["C3854"]
 helpviewer_keywords: ["C3854"]
-ms.assetid: 32a9ead0-c6c7-485a-8802-c7b1fe921d3a
 ---
 # Compiler Error C3854
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
@@ -8,7 +8,7 @@ ms.assetid: 32a9ead0-c6c7-485a-8802-c7b1fe921d3a
 ---
 # Compiler Error C3854
 
-expression to left of '=' evaluates to a function. Cannot assign to a function (a function is not an l-value)
+> expression to left of '=' evaluates to a function. Cannot assign to a function (a function is not an l-value)
 
 A reference cannot be reinitialized. Dereferencing a reference to a function yields a function, which is an rvalue, to which you cannot assign. Therefore, you cannot assign through a reference to a function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3854.md
@@ -16,7 +16,7 @@ A reference cannot be reinitialized. Dereferencing a reference to a function yie
 
 ## Example
 
-The following sample generates C3854:
+The following example generates C3854:
 
 ```cpp
 // C3854.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
@@ -16,7 +16,7 @@ The compiler found nontype template or generic parameters with different names. 
 
 ## Examples
 
-The following sample generates C3855:
+The following example generates C3855:
 
 ```cpp
 // C3855.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3855"
 title: "Compiler Error C3855"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3855"
+ms.date: 11/04/2016
 f1_keywords: ["C3855"]
 helpviewer_keywords: ["C3855"]
-ms.assetid: ed90f8c0-4154-4243-b066-493913df5727
 ---
 # Compiler Error C3855
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
@@ -10,7 +10,11 @@ ms.assetid: ed90f8c0-4154-4243-b066-493913df5727
 
 > 'class': type parameter 'param' is incompatible with the declaration
 
+## Remarks
+
 The compiler found nontype template or generic parameters with different names. This can occur when a specified template parameter in the definition of a template specialization is incompatible with its declaration.
+
+## Examples
 
 The following sample generates C3855:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3855.md
@@ -8,7 +8,7 @@ ms.assetid: ed90f8c0-4154-4243-b066-493913df5727
 ---
 # Compiler Error C3855
 
-'class': type parameter 'param' is incompatible with the declaration
+> 'class': type parameter 'param' is incompatible with the declaration
 
 The compiler found nontype template or generic parameters with different names. This can occur when a specified template parameter in the definition of a template specialization is incompatible with its declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
@@ -8,7 +8,7 @@ ms.assetid: 242d9322-c325-4f20-be58-b2be6da56d60
 ---
 # Compiler Error C3856
 
-'type': class is not a class type
+> 'type': class is not a class type
 
 The most common cause for this error is when there are more generic or template parameter lists at the point of definition than there were at the point of declaration.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
@@ -16,7 +16,7 @@ The most common cause for this error is when there are more generic or template 
 
 ## Examples
 
-The following sample generates C3856:
+The following example generates C3856:
 
 ```cpp
 // C3856.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3856"
 title: "Compiler Error C3856"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3856"
+ms.date: 11/04/2016
 f1_keywords: ["C3856"]
 helpviewer_keywords: ["C3856"]
-ms.assetid: 242d9322-c325-4f20-be58-b2be6da56d60
 ---
 # Compiler Error C3856
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3856.md
@@ -10,7 +10,11 @@ ms.assetid: 242d9322-c325-4f20-be58-b2be6da56d60
 
 > 'type': class is not a class type
 
+## Remarks
+
 The most common cause for this error is when there are more generic or template parameter lists at the point of definition than there were at the point of declaration.
+
+## Examples
 
 The following sample generates C3856:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3857"
 title: "Compiler Error C3857"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3857"
+ms.date: 11/04/2016
 f1_keywords: ["C3857"]
 helpviewer_keywords: ["C3857"]
-ms.assetid: 9f746d1e-9708-4945-bc29-3150d5371d3c
 ---
 # Compiler Error C3857
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
@@ -16,7 +16,7 @@ More than one template or generic was specified for the same type, which is not 
 
 ## Examples
 
-The following sample generates C3857:
+The following example generates C3857:
 
 ```cpp
 // C3857.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
@@ -10,7 +10,11 @@ ms.assetid: 9f746d1e-9708-4945-bc29-3150d5371d3c
 
 > 'type': multiple type parameter lists are not allowed
 
+## Remarks
+
 More than one template or generic was specified for the same type, which is not allowed.
+
+## Examples
 
 The following sample generates C3857:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3857.md
@@ -8,7 +8,7 @@ ms.assetid: 9f746d1e-9708-4945-bc29-3150d5371d3c
 ---
 # Compiler Error C3857
 
-'type': multiple type parameter lists are not allowed
+> 'type': multiple type parameter lists are not allowed
 
 More than one template or generic was specified for the same type, which is not allowed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
@@ -8,7 +8,7 @@ ms.assetid: 46e178d5-a55f-4ac6-a9dc-561fbcba5c1f
 ---
 # Compiler Error C3858
 
-'type': cannot be redeclared in current scope
+> 'type': cannot be redeclared in current scope
 
 The type cannot be declared twice in the same scope.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
@@ -16,7 +16,7 @@ The type cannot be declared twice in the same scope.
 
 ## Example
 
-The following sample generates C3858:
+The following example generates C3858:
 
 ```cpp
 // C3858.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3858"
 title: "Compiler Error C3858"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3858"
+ms.date: 11/04/2016
 f1_keywords: ["C3858"]
 helpviewer_keywords: ["C3858"]
-ms.assetid: 46e178d5-a55f-4ac6-a9dc-561fbcba5c1f
 ---
 # Compiler Error C3858
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3858.md
@@ -10,7 +10,11 @@ ms.assetid: 46e178d5-a55f-4ac6-a9dc-561fbcba5c1f
 
 > 'type': cannot be redeclared in current scope
 
+## Remarks
+
 The type cannot be declared twice in the same scope.
+
+## Example
 
 The following sample generates C3858:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3859.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3859.md
@@ -25,6 +25,8 @@ The message has one of the following notes:
 >PCH: Unable to get the requested block of memory\
 >Consider using /Fp to allow the compiler to reserve the memory early
 
+## Remarks
+
 There isn't enough virtual memory allocated for your [precompiled header (PCH)](../../build/creating-precompiled-header-files.md). If your precompiled header uses an explicit `#pragma hdrstop` directive, use the **`/Zm`** compiler flag to specify a larger value for the precompiled header file. Otherwise, consider reducing the number of parallel compilation processes in your build. For more information, see [`/Zm` (Specify precompiled header memory allocation limit)](../../build/reference/zm-specify-precompiled-header-memory-allocation-limit.md).
 
 This diagnostic shows up mostly in two scenarios: 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3859.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3859.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Error C3859"
 title: "Compiler Error C3859"
+description: "Learn more about: Compiler Error C3859"
 ms.date: 02/22/2022
 f1_keywords: ["C3859"]
 helpviewer_keywords: ["C3859"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
@@ -8,7 +8,7 @@ ms.assetid: 1fb5110d-594e-4f1c-8773-888233af1313
 ---
 # Compiler Error C3860
 
-type argument list following class type name must list parameters in the order used in type parameter list
+> type argument list following class type name must list parameters in the order used in type parameter list
 
 A generic or template argument list was ill formed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
@@ -10,7 +10,11 @@ ms.assetid: 1fb5110d-594e-4f1c-8773-888233af1313
 
 > type argument list following class type name must list parameters in the order used in type parameter list
 
+## Remarks
+
 A generic or template argument list was ill formed.
+
+## Examples
 
 The following sample generates C3860:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
@@ -16,7 +16,7 @@ A generic or template argument list was ill formed.
 
 ## Examples
 
-The following sample generates C3860:
+The following example generates C3860:
 
 ```cpp
 // C3860.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3860.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3860"
 title: "Compiler Error C3860"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3860"
+ms.date: 11/04/2016
 f1_keywords: ["C3860"]
 helpviewer_keywords: ["C3860"]
-ms.assetid: 1fb5110d-594e-4f1c-8773-888233af1313
 ---
 # Compiler Error C3860
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3861.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3861.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C3861"]
 
 > '*identifier*': identifier not found
 
-The compiler was unable to resolve a reference to an identifier, even using argument-dependent lookup.
-
 ## Remarks
+
+The compiler was unable to resolve a reference to an identifier, even using argument-dependent lookup.
 
 To fix this error, compare use of *identifier* to the identifier declaration for case and spelling. Verify that [scope resolution operators](../../cpp/scope-resolution-operator.md) and namespace [`using` directives](../../cpp/namespaces-cpp.md#using_directives) are used correctly. If the identifier is declared in a header file, verify that the header is included before the identifier is referenced. If the identifier is meant to be externally visible, make sure that it's declared in any source file that uses it. Also check that the identifier declaration or definition isn't excluded by [conditional compilation directives](../../preprocessor/hash-if-hash-elif-hash-else-and-hash-endif-directives-c-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3861.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3861.md
@@ -23,7 +23,7 @@ If error C3861 appears after project migration from older versions of the compil
 
 ### Undefined identifier
 
-The following sample generates C3861 because the identifier isn't defined.
+The following example generates C3861 because the identifier isn't defined.
 
 ```cpp
 // C3861.cpp
@@ -36,7 +36,7 @@ int main() {
 
 ### Identifier not in scope
 
-The following sample generates C3861, because an identifier is only visible in the file scope of its definition, unless it's declared in other source files that use it.
+The following example generates C3861, because an identifier is only visible in the file scope of its definition, unless it's declared in other source files that use it.
 
 Source file `C3861_a1.cpp`:
 
@@ -97,7 +97,7 @@ int main() {
 
 ### ADL and friend functions
 
-The following sample generates C3861 because the compiler can't use argument dependent lookup for `FriendFunc`:
+The following example generates C3861 because the compiler can't use argument dependent lookup for `FriendFunc`:
 
 ```cpp
 namespace N {

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3862.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3862.md
@@ -20,7 +20,7 @@ For more information, see [/clr (Common Language Runtime Compilation)](../../bui
 
 ## Example
 
-The following sample generates C3862:
+The following example generates C3862:
 
 ```cpp
 // C3862.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3862.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3862.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3862"
 title: "Compiler Error C3862"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3862"
+ms.date: 11/04/2016
 f1_keywords: ["C3862"]
 helpviewer_keywords: ["C3862"]
-ms.assetid: ba547366-4189-4077-8c00-ab45e08a9533
 ---
 # Compiler Error C3862
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
@@ -8,7 +8,7 @@ ms.assetid: 9bc62bb0-4fb8-4856-a5cf-c7cb4029a596
 ---
 # Compiler Error C3865
 
-'calling_convention' : can only be used on native member functions
+> 'calling_convention' : can only be used on native member functions
 
 A calling convention was used on a function that was either a global function or on a managed member function. The calling convention can only be used on a native (not managed) member function.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
@@ -18,7 +18,7 @@ For more information, see [Calling Conventions](../../cpp/calling-conventions.md
 
 ## Example
 
-The following sample generates C3865:
+The following example generates C3865:
 
 ```cpp
 // C3865.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
@@ -10,9 +10,13 @@ ms.assetid: 9bc62bb0-4fb8-4856-a5cf-c7cb4029a596
 
 > 'calling_convention' : can only be used on native member functions
 
+## Remarks
+
 A calling convention was used on a function that was either a global function or on a managed member function. The calling convention can only be used on a native (not managed) member function.
 
 For more information, see [Calling Conventions](../../cpp/calling-conventions.md).
+
+## Example
 
 The following sample generates C3865:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3865.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3865"
 title: "Compiler Error C3865"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3865"
+ms.date: 11/04/2016
 f1_keywords: ["C3865"]
 helpviewer_keywords: ["C3865"]
-ms.assetid: 9bc62bb0-4fb8-4856-a5cf-c7cb4029a596
 ---
 # Compiler Error C3865
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
@@ -10,7 +10,11 @@ ms.assetid: 685870af-2440-4cdf-a6cb-284a5b96ef9d
 
 > function call missing argument list
 
+## Remarks
+
 Inside a nonstatic member function, a destructor or finalizer call did not have an argument list.
+
+## Example
 
 The following sample generates C3866:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
@@ -8,7 +8,7 @@ ms.assetid: 685870af-2440-4cdf-a6cb-284a5b96ef9d
 ---
 # Compiler Error C3866
 
-function call missing argument list
+> function call missing argument list
 
 Inside a nonstatic member function, a destructor or finalizer call did not have an argument list.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
@@ -16,7 +16,7 @@ Inside a nonstatic member function, a destructor or finalizer call did not have 
 
 ## Example
 
-The following sample generates C3866:
+The following example generates C3866:
 
 ```cpp
 // C3866.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3866.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3866"
 title: "Compiler Error C3866"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3866"
+ms.date: 11/04/2016
 f1_keywords: ["C3866"]
 helpviewer_keywords: ["C3866"]
-ms.assetid: 685870af-2440-4cdf-a6cb-284a5b96ef9d
 ---
 # Compiler Error C3866
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C3867"]
 ---
 # Compiler Error C3867
 
-'func': function call missing argument list; use '&func' to create a pointer to member
+> 'func': function call missing argument list; use '&func' to create a pointer to member
 
 You tried to take the address of a member function without qualifying the member function with its class name and the address-of operator.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C3867"
 description: "Learn more about: Compiler Error C3867"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["C3867"]
 helpviewer_keywords: ["C3867"]
 ---

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C3867"]
 
 > 'func': function call missing argument list; use '&func' to create a pointer to member
 
+## Remarks
+
 You tried to take the address of a member function without qualifying the member function with its class name and the address-of operator.
 
 This error can also be generated as a result of compiler conformance work that was done for Visual Studio 2005: enhanced pointer-to-member conformance. Code that compiled prior to Visual Studio 2005 will now generate C3867.

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3867.md
@@ -19,7 +19,7 @@ This error can also be generated as a result of compiler conformance work that w
 
 C3867 can be issued from the compiler with a misleading suggested resolution. Whenever possible, use the most derived class.
 
-The following sample generates C3867 and shows how to fix it.
+The following example generates C3867 and shows how to fix it.
 
 ```cpp
 // C3867_1.cpp
@@ -39,7 +39,7 @@ void Derived::Bar() {
 }
 ```
 
-The following sample generates C3867 and shows how to fix it.
+The following example generates C3867 and shows how to fix it.
 
 ```cpp
 // C3867_2.cpp
@@ -69,7 +69,7 @@ int main() {
 }
 ```
 
-The following sample generates C3867 and shows how to fix it.
+The following example generates C3867 and shows how to fix it.
 
 ```cpp
 // C3867_3.cpp
@@ -86,7 +86,7 @@ int main() {
 }
 ```
 
-The following sample generates C3867.
+The following example generates C3867.
 
 ```cpp
 // C3867_4.cpp
@@ -108,7 +108,7 @@ public:
 };
 ```
 
-The following sample generates C3867.
+The following example generates C3867.
 
 ```cpp
 // C3867_5.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3868"
 title: "Compiler Error C3868"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3868"
+ms.date: 11/04/2016
 f1_keywords: ["C3868"]
 helpviewer_keywords: ["C3868"]
-ms.assetid: f0e45c2a-2149-4885-a03b-0d230069f03a
 ---
 # Compiler Error C3868
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
@@ -10,6 +10,8 @@ ms.assetid: f0e45c2a-2149-4885-a03b-0d230069f03a
 
 > 'type': constraints on generic parameter 'parameter' differ from those on the declaration
 
+## Remarks
+
 Multiple declarations must have the same generic constraints.  For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
@@ -16,7 +16,7 @@ Multiple declarations must have the same generic constraints.  For more informat
 
 ## Example
 
-The following sample generates C3868.
+The following example generates C3868.
 
 ```cpp
 // C3868.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3868.md
@@ -8,7 +8,7 @@ ms.assetid: f0e45c2a-2149-4885-a03b-0d230069f03a
 ---
 # Compiler Error C3868
 
-'type': constraints on generic parameter 'parameter' differ from those on the declaration
+> 'type': constraints on generic parameter 'parameter' differ from those on the declaration
 
 Multiple declarations must have the same generic constraints.  For more information, see [Generics](../../extensions/generics-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3869"
 title: "Compiler Error C3869"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3869"
+ms.date: 11/04/2016
 f1_keywords: ["C3869"]
 helpviewer_keywords: ["C3869"]
-ms.assetid: 85b2ad72-95c1-4ed6-9761-6ef66c3802b7
 ---
 # Compiler Error C3869
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
@@ -8,7 +8,7 @@ ms.assetid: 85b2ad72-95c1-4ed6-9761-6ef66c3802b7
 ---
 # Compiler Error C3869
 
-gcnew constraint is missing empty parameter list '()'
+> gcnew constraint is missing empty parameter list '()'
 
 The **`gcnew`** special constraint was specified without the empty parameter list. See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
@@ -16,7 +16,7 @@ The **`gcnew`** special constraint was specified without the empty parameter lis
 
 ## Example
 
-The following sample generates C3869.
+The following example generates C3869.
 
 ```cpp
 // C3869.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3869.md
@@ -10,6 +10,8 @@ ms.assetid: 85b2ad72-95c1-4ed6-9761-6ef66c3802b7
 
 > gcnew constraint is missing empty parameter list '()'
 
+## Remarks
+
 The **`gcnew`** special constraint was specified without the empty parameter list. See [Constraints on Generic Type Parameters (C++/CLI)](../../extensions/constraints-on-generic-type-parameters-cpp-cli.md) for more information.
 
 ## Example

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
@@ -18,7 +18,7 @@ The range of characters allowed in an identifier is less restrictive when compil
 
 ## Example
 
-The following sample generates C3872:
+The following example generates C3872:
 
 ```cpp
 // C3872.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
@@ -10,9 +10,13 @@ ms.assetid: 519e95be-5641-40cc-894c-da4819506604
 
 > 'char': this character is not allowed in an identifier
 
+## Remarks
+
 The C++ compiler follows the C++11 standard on characters allowed in an identifier. Only certain ranges of characters and universal character names are allowed in an identifier. Additional restrictions apply to the initial character of an identifier. For more information and a list of allowed characters and universal character name ranges, see [Identifiers](../../cpp/identifiers-cpp.md).
 
 The range of characters allowed in an identifier is less restrictive when compiling C++/CLI code. Identifiers in code compiled by using /clr should follow  [Standard ECMA-335: Common Language Infrastructure (CLI)](https://ecma-international.org/publications-and-standards/standards/ecma-335/).
+
+## Example
 
 The following sample generates C3872:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
@@ -8,7 +8,7 @@ ms.assetid: 519e95be-5641-40cc-894c-da4819506604
 ---
 # Compiler Error C3872
 
-'char': this character is not allowed in an identifier
+> 'char': this character is not allowed in an identifier
 
 The C++ compiler follows the C++11 standard on characters allowed in an identifier. Only certain ranges of characters and universal character names are allowed in an identifier. Additional restrictions apply to the initial character of an identifier. For more information and a list of allowed characters and universal character name ranges, see [Identifiers](../../cpp/identifiers-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3872.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3872"
 title: "Compiler Error C3872"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3872"
+ms.date: 11/04/2016
 f1_keywords: ["C3872"]
 helpviewer_keywords: ["C3872"]
-ms.assetid: 519e95be-5641-40cc-894c-da4819506604
 ---
 # Compiler Error C3872
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
@@ -18,7 +18,7 @@ The range of characters allowed in an identifier is less restrictive when compil
 
 ## Example
 
-The following sample generates C3873:
+The following example generates C3873:
 
 ```cpp
 // C3873.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3873"
 title: "Compiler Error C3873"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3873"
+ms.date: 11/04/2016
 f1_keywords: ["C3873"]
 helpviewer_keywords: ["C3873"]
-ms.assetid: e68fd3be-2391-492b-ac3f-d2428901b2e9
 ---
 # Compiler Error C3873
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
@@ -10,9 +10,13 @@ ms.assetid: e68fd3be-2391-492b-ac3f-d2428901b2e9
 
 > 'char': this character is not allowed as a first character of an identifier
 
+## Remarks
+
 The C++ compiler follows the C++11 standard on characters allowed in an identifier. Only certain ranges of characters and universal character names are allowed in an identifier. Additional restrictions apply to the initial character of an identifier. For more information and a list of allowed characters and universal character name ranges, see [Identifiers](../../cpp/identifiers-cpp.md).
 
 The range of characters allowed in an identifier is less restrictive when compiling C++/CLI code. Identifiers in code compiled by using /clr should follow  [Standard ECMA-335: Common Language Infrastructure (CLI)](https://ecma-international.org/publications-and-standards/standards/ecma-335/).
+
+## Example
 
 The following sample generates C3873:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3873.md
@@ -8,7 +8,7 @@ ms.assetid: e68fd3be-2391-492b-ac3f-d2428901b2e9
 ---
 # Compiler Error C3873
 
-'char': this character is not allowed as a first character of an identifier
+> 'char': this character is not allowed as a first character of an identifier
 
 The C++ compiler follows the C++11 standard on characters allowed in an identifier. Only certain ranges of characters and universal character names are allowed in an identifier. Additional restrictions apply to the initial character of an identifier. For more information and a list of allowed characters and universal character name ranges, see [Identifiers](../../cpp/identifiers-cpp.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
@@ -10,7 +10,11 @@ ms.assetid: fd55fc05-69a7-4237-b3b7-dca1d5400b4f
 
 > return type of 'function' should be 'int' instead of 'type'
 
+## Remarks
+
 A function does not have the return type that was expected by the compiler.
+
+## Example
 
 The following sample generates C3874:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3874"
 title: "Compiler Error C3874"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3874"
+ms.date: 11/04/2016
 f1_keywords: ["C3874"]
 helpviewer_keywords: ["C3874"]
-ms.assetid: fd55fc05-69a7-4237-b3b7-dca1d5400b4f
 ---
 # Compiler Error C3874
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
@@ -8,7 +8,7 @@ ms.assetid: fd55fc05-69a7-4237-b3b7-dca1d5400b4f
 ---
 # Compiler Error C3874
 
-return type of 'function' should be 'int' instead of 'type'
+> return type of 'function' should be 'int' instead of 'type'
 
 A function does not have the return type that was expected by the compiler.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3874.md
@@ -16,7 +16,7 @@ A function does not have the return type that was expected by the compiler.
 
 ## Example
 
-The following sample generates C3874:
+The following example generates C3874:
 
 ```cpp
 // C3874b.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
@@ -22,7 +22,7 @@ The type of a [literal](../../extensions/literal-cpp-component-extensions.md) at
 
 ## Example
 
-The following sample generates C3880:
+The following example generates C3880:
 
 ```cpp
 // C3880.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
@@ -10,6 +10,8 @@ ms.assetid: b0e05d1e-32d0-4034-9246-f37d23573ea9
 
 > 'var' : cannot be a literal data member
 
+## Remarks
+
 The type of a [literal](../../extensions/literal-cpp-component-extensions.md) attribute must be, or compile-time convertible to, one of the following types:
 
 - integral type
@@ -17,6 +19,8 @@ The type of a [literal](../../extensions/literal-cpp-component-extensions.md) at
 - string
 
 - enum with an integral or underlying type
+
+## Example
 
 The following sample generates C3880:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3880"
 title: "Compiler Error C3880"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3880"
+ms.date: 11/04/2016
 f1_keywords: ["C3880"]
 helpviewer_keywords: ["C3880"]
-ms.assetid: b0e05d1e-32d0-4034-9246-f37d23573ea9
 ---
 # Compiler Error C3880
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3880.md
@@ -8,7 +8,7 @@ ms.assetid: b0e05d1e-32d0-4034-9246-f37d23573ea9
 ---
 # Compiler Error C3880
 
-'var' : cannot be a literal data member
+> 'var' : cannot be a literal data member
 
 The type of a [literal](../../extensions/literal-cpp-component-extensions.md) attribute must be, or compile-time convertible to, one of the following types:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C3883"]
 
 > '*member*': an initonly static data member must be initialized
 
+## Remarks
+
 A variable marked with [initonly](../../dotnet/initonly-cpp-cli.md) was not initialized correctly.
+
+## Example
 
 The following sample generates C3883:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C3883"
 description: "Learn more about: Compiler Error C3883"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["C3883"]
 helpviewer_keywords: ["C3883"]
 ---

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3883.md
@@ -15,7 +15,7 @@ A variable marked with [initonly](../../dotnet/initonly-cpp-cli.md) was not init
 
 ## Example
 
-The following sample generates C3883:
+The following example generates C3883:
 
 ```cpp
 // C3883.cpp
@@ -26,7 +26,7 @@ ref struct Y1 {
 };
 ```
 
-The following sample demonstrates a possible resolution:
+The following example demonstrates a possible resolution:
 
 ```cpp
 // C3883b.cpp
@@ -37,7 +37,7 @@ ref struct Y1 {
 };
 ```
 
-The following sample shows how to initialize in a static constructor:
+The following example shows how to initialize in a static constructor:
 
 ```cpp
 // C3883c.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
@@ -16,7 +16,7 @@ A [literal](../../extensions/literal-cpp-component-extensions.md) variable must 
 
 ## Example
 
-The following sample generates C3886:
+The following example generates C3886:
 
 ```cpp
 // C3886.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
@@ -10,7 +10,11 @@ ms.assetid: 485f6c12-cc1b-4146-9034-409a0a5e615e
 
 > 'var' : a literal data member must be initialized
 
+## Remarks
+
 A [literal](../../extensions/literal-cpp-component-extensions.md) variable must be initialized when it is declaraed.
+
+## Example
 
 The following sample generates C3886:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3886"
 title: "Compiler Error C3886"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3886"
+ms.date: 11/04/2016
 f1_keywords: ["C3886"]
 helpviewer_keywords: ["C3886"]
-ms.assetid: 485f6c12-cc1b-4146-9034-409a0a5e615e
 ---
 # Compiler Error C3886
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3886.md
@@ -8,7 +8,7 @@ ms.assetid: 485f6c12-cc1b-4146-9034-409a0a5e615e
 ---
 # Compiler Error C3886
 
-'var' : a literal data member must be initialized
+> 'var' : a literal data member must be initialized
 
 A [literal](../../extensions/literal-cpp-component-extensions.md) variable must be initialized when it is declaraed.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
@@ -8,7 +8,7 @@ ms.assetid: a7e82426-ef99-437b-9562-2822004e18fe
 ---
 # Compiler Error C3887
 
-'var' : the initializer for a literal data member must be a constant expression
+> 'var' : the initializer for a literal data member must be a constant expression
 
 A [literal](../../extensions/literal-cpp-component-extensions.md) data member can only be initialized with a constant expresion.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
@@ -16,7 +16,7 @@ A [literal](../../extensions/literal-cpp-component-extensions.md) data member ca
 
 ## Example
 
-The following sample generates C3887:
+The following example generates C3887:
 
 ```cpp
 // C3887.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3887"
 title: "Compiler Error C3887"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3887"
+ms.date: 11/04/2016
 f1_keywords: ["C3887"]
 helpviewer_keywords: ["C3887"]
-ms.assetid: a7e82426-ef99-437b-9562-2822004e18fe
 ---
 # Compiler Error C3887
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3887.md
@@ -10,7 +10,11 @@ ms.assetid: a7e82426-ef99-437b-9562-2822004e18fe
 
 > 'var' : the initializer for a literal data member must be a constant expression
 
+## Remarks
+
 A [literal](../../extensions/literal-cpp-component-extensions.md) data member can only be initialized with a constant expresion.
+
+## Example
 
 The following sample generates C3887:
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3888"
 title: "Compiler Error C3888"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3888"
+ms.date: 11/04/2016
 f1_keywords: ["C3888"]
 helpviewer_keywords: ["C3888"]
-ms.assetid: 40820812-79c5-4dcd-a19d-b4164d25fc8a
 ---
 # Compiler Error C3888
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
@@ -10,6 +10,8 @@ ms.assetid: 40820812-79c5-4dcd-a19d-b4164d25fc8a
 
 > 'name' : the const expression associated with this literal data member is not supported by C++/CLI
 
+## Remarks
+
 The *name* data member that is declared with the [literal](../../extensions/literal-cpp-component-extensions.md) keyword is initialized with a value the compiler does not support. The compiler supports only constant integral, enum, or string types. The likely cause for the **C3888** error is that the data member is initialized with a byte array.
 
 ### To correct this error

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3888.md
@@ -8,7 +8,7 @@ ms.assetid: 40820812-79c5-4dcd-a19d-b4164d25fc8a
 ---
 # Compiler Error C3888
 
-'name' : the const expression associated with this literal data member is not supported by C++/CLI
+> 'name' : the const expression associated with this literal data member is not supported by C++/CLI
 
 The *name* data member that is declared with the [literal](../../extensions/literal-cpp-component-extensions.md) keyword is initialized with a value the compiler does not support. The compiler supports only constant integral, enum, or string types. The likely cause for the **C3888** error is that the data member is initialized with a byte array.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
@@ -8,7 +8,7 @@ ms.assetid: 2f22c2fd-c14e-45e1-b936-b739ffc0b135
 ---
 # Compiler Error C3890
 
-'var' : you cannot take the address of a literal data member
+> 'var' : you cannot take the address of a literal data member
 
 A literal data member exists on the garbage-collected heap.  An object on the garbage-collected heap can be moved, so taking the address is not useful.
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Error C3890"
 title: "Compiler Error C3890"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Error C3890"
+ms.date: 11/04/2016
 f1_keywords: ["C3890"]
 helpviewer_keywords: ["C3890"]
-ms.assetid: 2f22c2fd-c14e-45e1-b936-b739ffc0b135
 ---
 # Compiler Error C3890
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
@@ -16,7 +16,7 @@ A literal data member exists on the garbage-collected heap.  An object on the ga
 
 ## Example
 
-The following sample generates C3890:
+The following example generates C3890:
 
 ```cpp
 // C3890.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3890.md
@@ -10,7 +10,11 @@ ms.assetid: 2f22c2fd-c14e-45e1-b936-b739ffc0b135
 
 > 'var' : you cannot take the address of a literal data member
 
+## Remarks
+
 A literal data member exists on the garbage-collected heap.  An object on the garbage-collected heap can be moved, so taking the address is not useful.
+
+## Example
 
 The following sample generates C3890:
 


### PR DESCRIPTION
This is batch 66 that structures error/warning references. See #5465 for more information.