### PR TITLE
Structure warning references in range [C4041, C4080]

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4041"
 title: "Compiler Warning (level 1) C4041"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4041"
+ms.date: 11/04/2016
 f1_keywords: ["C4041"]
 helpviewer_keywords: ["C4041"]
-ms.assetid: 107ee9fd-4b88-4f22-a18f-a20726831095
 ---
 # Compiler Warning (level 1) C4041
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
@@ -10,6 +10,8 @@ ms.assetid: 107ee9fd-4b88-4f22-a18f-a20726831095
 
 > compiler limit : terminating browser output
 
+## Remarks
+
 Browser information exceeded the compiler limit.
 
 This warning can be caused by compiling with [/FR](../../build/reference/fr-fr-create-dot-sbr-file.md) (browser information including local variables).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4041.md
@@ -8,7 +8,7 @@ ms.assetid: 107ee9fd-4b88-4f22-a18f-a20726831095
 ---
 # Compiler Warning (level 1) C4041
 
-compiler limit : terminating browser output
+> compiler limit : terminating browser output
 
 Browser information exceeded the compiler limit.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
@@ -10,6 +10,8 @@ ms.assetid: e4bd861b-1194-426b-bf79-68c5b021eb0a
 
 > 'identifier' : has bad storage class
 
+## Remarks
+
 The specified storage class cannot be used with this identifier in this context. The compiler uses the default storage class instead:
 
 - **`extern`**, if *identifier* is a function.
@@ -19,6 +21,8 @@ The specified storage class cannot be used with this identifier in this context.
 - No storage class, if *identifier* is a global variable.
 
 This warning can be caused by specifying a storage class other than **`register`** in a parameter declaration.
+
+## Example
 
 The following sample generates C4042
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
@@ -23,7 +23,7 @@ This warning can be caused by specifying a storage class other than **`register`
 
 ## Example
 
-The following example generates C4042
+The following example generates C4042:
 
 ```cpp
 // C4042.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4042"
 title: "Compiler Warning (level 1) C4042"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4042"
+ms.date: 11/04/2016
 f1_keywords: ["C4042"]
 helpviewer_keywords: ["C4042"]
-ms.assetid: e4bd861b-1194-426b-bf79-68c5b021eb0a
 ---
 # Compiler Warning (level 1) C4042
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
@@ -8,7 +8,7 @@ ms.assetid: e4bd861b-1194-426b-bf79-68c5b021eb0a
 ---
 # Compiler Warning (level 1) C4042
 
-'identifier' : has bad storage class
+> 'identifier' : has bad storage class
 
 The specified storage class cannot be used with this identifier in this context. The compiler uses the default storage class instead:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4042.md
@@ -24,7 +24,7 @@ This warning can be caused by specifying a storage class other than **`register`
 
 ## Example
 
-The following sample generates C4042
+The following example generates C4042
 
 ```cpp
 // C4042.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
@@ -8,7 +8,7 @@ ms.assetid: 3c6f7373-da91-45cd-b224-f49f7d8b4df0
 ---
 # Compiler Warning (level 1) C4045
 
-'array' : array bounds overflow
+> 'array' : array bounds overflow
 
 The array has too many initializers. Extra initializers are ignored.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
@@ -10,6 +10,8 @@ ms.assetid: 3c6f7373-da91-45cd-b224-f49f7d8b4df0
 
 > 'array' : array bounds overflow
 
+## Remarks
+
 The array has too many initializers. Extra initializers are ignored.
 
 Make sure that array elements and initializers match in size and quantity.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4045.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4045"
 title: "Compiler Warning (level 1) C4045"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4045"
+ms.date: 11/04/2016
 f1_keywords: ["C4045"]
 helpviewer_keywords: ["C4045"]
-ms.assetid: 3c6f7373-da91-45cd-b224-f49f7d8b4df0
 ---
 # Compiler Warning (level 1) C4045
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
@@ -16,7 +16,7 @@ A pointer can point to a variable (one level of indirection), to another pointer
 
 ## Examples
 
-The following sample generates C4047:
+The following example generates C4047:
 
 ```c
 // C4047.c
@@ -34,7 +34,7 @@ int main() {
 }
 ```
 
-The following sample generates C4047:
+The following example generates C4047:
 
 ```c
 // C4047b.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
@@ -8,7 +8,7 @@ ms.assetid: b75ad6fb-5c93-4434-a85f-c4083051a5de
 ---
 # Compiler Warning (level 1) C4047
 
-'operator' : 'identifier1' differs in levels of indirection from 'identifier2'
+> 'operator' : 'identifier1' differs in levels of indirection from 'identifier2'
 
 A pointer can point to a variable (one level of indirection), to another pointer that points to a variable (two levels of indirection), and so on.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4047"
 title: "Compiler Warning (level 1) C4047"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4047"
+ms.date: 11/04/2016
 f1_keywords: ["C4047"]
 helpviewer_keywords: ["C4047"]
-ms.assetid: b75ad6fb-5c93-4434-a85f-c4083051a5de
 ---
 # Compiler Warning (level 1) C4047
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4047.md
@@ -10,6 +10,8 @@ ms.assetid: b75ad6fb-5c93-4434-a85f-c4083051a5de
 
 > 'operator' : 'identifier1' differs in levels of indirection from 'identifier2'
 
+## Remarks
+
 A pointer can point to a variable (one level of indirection), to another pointer that points to a variable (two levels of indirection), and so on.
 
 ## Examples

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
@@ -8,7 +8,7 @@ ms.assetid: 8429f513-4732-40f1-8e56-4c224e723bcb
 ---
 # Compiler Warning (level 1) C4048
 
-different declared array subscripts : 'identifier1' and 'identifier2'
+> different declared array subscripts : 'identifier1' and 'identifier2'
 
 An expression involves pointers to arrays of different size. The pointers are used without conversion.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4048"
 title: "Compiler Warning (level 1) C4048"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4048"
+ms.date: 11/04/2016
 f1_keywords: ["C4048"]
 helpviewer_keywords: ["C4048"]
-ms.assetid: 8429f513-4732-40f1-8e56-4c224e723bcb
 ---
 # Compiler Warning (level 1) C4048
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4048.md
@@ -10,6 +10,8 @@ ms.assetid: 8429f513-4732-40f1-8e56-4c224e723bcb
 
 > different declared array subscripts : 'identifier1' and 'identifier2'
 
+## Remarks
+
 An expression involves pointers to arrays of different size. The pointers are used without conversion.
 
 This warning may be fixed if you explicitly cast the arrays to the same or equivalent type.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4049"
 title: "Compiler Warning (level 1) C4049"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4049"
+ms.date: 11/04/2016
 f1_keywords: ["C4049"]
 helpviewer_keywords: ["C4049"]
-ms.assetid: d11c1870-bcfc-4d71-8945-b87ec6ec3514
 ---
 # Compiler Warning (level 1) C4049
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
@@ -10,6 +10,8 @@ ms.assetid: d11c1870-bcfc-4d71-8945-b87ec6ec3514
 
 > compiler limit : terminating line number emission
 
+## Remarks
+
 The file contains more than 16,777,215 (2<sup>24</sup>-1) source lines. The compiler stops numbering at 16,777,215.
 
 For code after line 16,777,215:

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4049.md
@@ -8,7 +8,7 @@ ms.assetid: d11c1870-bcfc-4d71-8945-b87ec6ec3514
 ---
 # Compiler Warning (level 1) C4049
 
-compiler limit : terminating line number emission
+> compiler limit : terminating line number emission
 
 The file contains more than 16,777,215 (2<sup>24</sup>-1) source lines. The compiler stops numbering at 16,777,215.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1 and level 4) C4052"
 title: "Compiler Warning (level 1 and level 4) C4052"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1 and level 4) C4052"
+ms.date: 11/04/2016
 f1_keywords: ["C4052"]
 helpviewer_keywords: ["C4052"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
@@ -15,7 +15,7 @@ One declaration of the function doesn't contain variable arguments. The empty de
 
 ## Example
 
-The following sample generates C4052:
+The following example generates C4052:
 
 ```c
 // C4052.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4052.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C4052"]
 
 > function declarations different; one contains variable arguments
 
+## Remarks
+
 One declaration of the function doesn't contain variable arguments. The empty declaration is ignored.
+
+## Example
 
 The following sample generates C4052:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4055.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4055.md
@@ -18,7 +18,7 @@ A data pointer is cast (possibly incorrectly) to a function pointer. This is a l
 
 ## Example
 
-The following sample generates C4055:
+The following example generates C4055:
 
 ```C
 // C4055.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4055.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4055.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4055"
 title: "Compiler Warning (level 1) C4055"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4055"
+ms.date: 11/04/2016
 f1_keywords: ["C4055"]
 helpviewer_keywords: ["C4055"]
-ms.assetid: f9955421-16ab-46e5-8f9d-bf1639a519ef
 ---
 # Compiler Warning (level 1) C4055
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4067.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4067.md
@@ -15,6 +15,8 @@ The compiler found and ignored extra characters following a preprocessor directi
 
 ## Example
 
+The following example generates C4067:
+
 ```cpp
 // C4067a.cpp
 // compile with: cl /EHsc /DX /W1 /Za C4067a.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4067.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4067.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4067"
 title: "Compiler Warning (level 1) C4067"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4067"
+ms.date: 11/04/2016
 f1_keywords: ["C4067"]
 helpviewer_keywords: ["C4067"]
-ms.assetid: 1d10353e-8cd5-4b01-9184-a06189b965a4
 ---
 # Compiler Warning (level 1) C4067
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
@@ -16,7 +16,7 @@ The compiler ignored an unrecognized [pragma](../../preprocessor/pragma-directiv
 
 ## Example
 
-The following sample generates C4068:
+The following example generates C4068:
 
 ```cpp
 // C4068.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
@@ -8,7 +8,7 @@ ms.assetid: 96a7397a-4eab-44ab-b3bb-36747503f7e5
 ---
 # Compiler Warning (level 1) C4068
 
-unknown pragma
+> unknown pragma
 
 The compiler ignored an unrecognized [pragma](../../preprocessor/pragma-directives-and-the-pragma-keyword.md). Be sure the **pragma** is allowed by the compiler you are using. The following sample generates C4068:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
@@ -10,7 +10,13 @@ ms.assetid: 96a7397a-4eab-44ab-b3bb-36747503f7e5
 
 > unknown pragma
 
-The compiler ignored an unrecognized [pragma](../../preprocessor/pragma-directives-and-the-pragma-keyword.md). Be sure the **pragma** is allowed by the compiler you are using. The following sample generates C4068:
+## Remarks
+
+The compiler ignored an unrecognized [pragma](../../preprocessor/pragma-directives-and-the-pragma-keyword.md). Be sure the **pragma** is allowed by the compiler you are using.
+
+## Example
+
+The following sample generates C4068:
 
 ```cpp
 // C4068.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4068.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4068"
 title: "Compiler Warning (level 1) C4068"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4068"
+ms.date: 11/04/2016
 f1_keywords: ["C4068"]
 helpviewer_keywords: ["C4068"]
-ms.assetid: 96a7397a-4eab-44ab-b3bb-36747503f7e5
 ---
 # Compiler Warning (level 1) C4068
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
@@ -10,7 +10,11 @@ ms.assetid: cd510e66-c338-4a86-a4d7-bfa1df9b16c3
 
 > initializers put in compiler reserved initialization area
 
+## Remarks
+
 The compiler initialization area, which is specified by [#pragma init_seg](../../preprocessor/init-seg.md), is reserved by Microsoft. Code in this area may be executed before initialization of the C run-time library.
+
+## Example
 
 The following sample generates C4074:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
@@ -8,7 +8,7 @@ ms.assetid: cd510e66-c338-4a86-a4d7-bfa1df9b16c3
 ---
 # Compiler Warning (level 1) C4074
 
-initializers put in compiler reserved initialization area
+> initializers put in compiler reserved initialization area
 
 The compiler initialization area, which is specified by [#pragma init_seg](../../preprocessor/init-seg.md), is reserved by Microsoft. Code in this area may be executed before initialization of the C run-time library.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4074"
 title: "Compiler Warning (level 1) C4074"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4074"
+ms.date: 11/04/2016
 f1_keywords: ["C4074"]
 helpviewer_keywords: ["C4074"]
-ms.assetid: cd510e66-c338-4a86-a4d7-bfa1df9b16c3
 ---
 # Compiler Warning (level 1) C4074
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4074.md
@@ -16,7 +16,7 @@ The compiler initialization area, which is specified by [#pragma init_seg](../..
 
 ## Example
 
-The following sample generates C4074:
+The following example generates C4074:
 
 ```cpp
 // C4074.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
@@ -10,7 +10,11 @@ ms.assetid: 19a700b6-f210-4b9d-a2f2-76cfe39ab178
 
 > initializers put in unrecognized initialization area
 
+## Remarks
+
 A [#pragma init_seg](../../preprocessor/init-seg.md) uses an unrecognized section name. The compiler ignores the **pragma** command.
+
+## Example
 
 The following sample generates C4075:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
@@ -16,7 +16,7 @@ A [#pragma init_seg](../../preprocessor/init-seg.md) uses an unrecognized sectio
 
 ## Example
 
-The following sample generates C4075:
+The following example generates C4075:
 
 ```cpp
 // C4075.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
@@ -8,7 +8,7 @@ ms.assetid: 19a700b6-f210-4b9d-a2f2-76cfe39ab178
 ---
 # Compiler Warning (level 1) C4075
 
-initializers put in unrecognized initialization area
+> initializers put in unrecognized initialization area
 
 A [#pragma init_seg](../../preprocessor/init-seg.md) uses an unrecognized section name. The compiler ignores the **pragma** command.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4075.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4075"
 title: "Compiler Warning (level 1) C4075"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4075"
+ms.date: 11/04/2016
 f1_keywords: ["C4075"]
 helpviewer_keywords: ["C4075"]
-ms.assetid: 19a700b6-f210-4b9d-a2f2-76cfe39ab178
 ---
 # Compiler Warning (level 1) C4075
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4076.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4076.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4076"
 title: "Compiler Warning (level 1) C4076"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4076"
+ms.date: 11/04/2016
 f1_keywords: ["C4076"]
 helpviewer_keywords: ["C4076"]
-ms.assetid: 04581066-313a-4a11-bb60-721e6d038d75
 ---
 # Compiler Warning (level 1) C4076
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4076.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4076.md
@@ -16,7 +16,7 @@ A type modifier, whether it is **`signed`** or **`unsigned`**, cannot be used wi
 
 ## Example
 
-The following sample generates C4076; to fix it, remove the **`unsigned`** type modifier:
+The following example generates C4076; to fix it, remove the **`unsigned`** type modifier:
 
 ```cpp
 // C4076.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4077"
 title: "Compiler Warning (level 1) C4077"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4077"
+ms.date: 11/04/2016
 f1_keywords: ["C4077"]
 helpviewer_keywords: ["C4077"]
-ms.assetid: c2d28805-b33f-41ad-afba-33b3f788c649
 ---
 # Compiler Warning (level 1) C4077
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
@@ -8,7 +8,7 @@ ms.assetid: c2d28805-b33f-41ad-afba-33b3f788c649
 ---
 # Compiler Warning (level 1) C4077
 
-unknown check_stack option
+> unknown check_stack option
 
 The old form of the **check_stack** pragma is used with an unknown argument. The argument must be `+`, `-`, `(on)`, `(off)`, or empty.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
@@ -17,6 +17,8 @@ The compiler ignores the pragma and leaves the stack checking unchanged.
 
 ## Example
 
+The following example generates C4077:
+
 ```cpp
 // C4077.cpp
 // compile with: /W1 /LD

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4077.md
@@ -10,6 +10,8 @@ ms.assetid: c2d28805-b33f-41ad-afba-33b3f788c649
 
 > unknown check_stack option
 
+## Remarks
+
 The old form of the **check_stack** pragma is used with an unknown argument. The argument must be `+`, `-`, `(on)`, `(off)`, or empty.
 
 The compiler ignores the pragma and leaves the stack checking unchanged.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
@@ -10,7 +10,11 @@ ms.assetid: 549759f0-e168-47e9-8c9a-de93ac843689
 
 > unexpected token 'token'
 
+## Remarks
+
 An unexpected separator token occurs in a pragma argument list. The remainder of the pragma was ignored.
+
+## Example
 
 The following sample generates C4079:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
@@ -8,7 +8,7 @@ ms.assetid: 549759f0-e168-47e9-8c9a-de93ac843689
 ---
 # Compiler Warning (level 1) C4079
 
-unexpected token 'token'
+> unexpected token 'token'
 
 An unexpected separator token occurs in a pragma argument list. The remainder of the pragma was ignored.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4079"
 title: "Compiler Warning (level 1) C4079"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4079"
+ms.date: 11/04/2016
 f1_keywords: ["C4079"]
 helpviewer_keywords: ["C4079"]
-ms.assetid: 549759f0-e168-47e9-8c9a-de93ac843689
 ---
 # Compiler Warning (level 1) C4079
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4079.md
@@ -16,7 +16,7 @@ An unexpected separator token occurs in a pragma argument list. The remainder of
 
 ## Example
 
-The following sample generates C4079:
+The following example generates C4079:
 
 ```cpp
 // C4079.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
@@ -10,7 +10,11 @@ ms.assetid: 964fb3f4-b9fd-450b-aa23-35cece126172
 
 > expected identifier for segment name; found 'symbol'
 
+## Remarks
+
 The name of the segment in [#pragma alloc_text](../../preprocessor/alloc-text.md) must be a string or an identifier. The compiler ignores the pragma if a valid identifier is not found.
+
+## Example
 
 The following sample generates C4080:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4080"
 title: "Compiler Warning (level 1) C4080"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4080"
+ms.date: 11/04/2016
 f1_keywords: ["C4080"]
 helpviewer_keywords: ["C4080"]
-ms.assetid: 964fb3f4-b9fd-450b-aa23-35cece126172
 ---
 # Compiler Warning (level 1) C4080
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
@@ -16,7 +16,7 @@ The name of the segment in [#pragma alloc_text](../../preprocessor/alloc-text.md
 
 ## Example
 
-The following sample generates C4080:
+The following example generates C4080:
 
 ```cpp
 // C4080.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4080.md
@@ -8,7 +8,7 @@ ms.assetid: 964fb3f4-b9fd-450b-aa23-35cece126172
 ---
 # Compiler Warning (level 1) C4080
 
-expected identifier for segment name; found 'symbol'
+> expected identifier for segment name; found 'symbol'
 
 The name of the segment in [#pragma alloc_text](../../preprocessor/alloc-text.md) must be a string or an identifier. The compiler ignores the pragma if a valid identifier is not found.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
@@ -10,6 +10,8 @@ ms.assetid: 8c964e70-df12-45ff-93b9-496ad4271191
 
 > type conversion; possible loss of data
 
+## Remarks
+
 An expression contains two data items with different base types. Converting one type causes the data item to be truncated.
 
 This warning may be fixed if you cast the data items to the appropriate type.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4051"
 title: "Compiler Warning (level 2) C4051"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4051"
+ms.date: 11/04/2016
 f1_keywords: ["C4051"]
 helpviewer_keywords: ["C4051"]
-ms.assetid: 8c964e70-df12-45ff-93b9-496ad4271191
 ---
 # Compiler Warning (level 2) C4051
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4051.md
@@ -8,7 +8,7 @@ ms.assetid: 8c964e70-df12-45ff-93b9-496ad4271191
 ---
 # Compiler Warning (level 2) C4051
 
-type conversion; possible loss of data
+> type conversion; possible loss of data
 
 An expression contains two data items with different base types. Converting one type causes the data item to be truncated.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
@@ -8,7 +8,7 @@ ms.assetid: a3c3a9b8-ec30-452d-96cb-3694adcce789
 ---
 # Compiler Warning (level 2) C4056
 
-overflow in floating point constant arithmetic
+> overflow in floating point constant arithmetic
 
 Floating-point constant arithmetic generates a result that exceeds the maximum allowable value.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
@@ -18,7 +18,7 @@ This warning can be caused by compiler optimizations performed during constant a
 
 ## Example
 
-The following sample generates C4056:
+The following example generates C4056:
 
 ```cpp
 // C4056.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4056"
 title: "Compiler Warning (level 2) C4056"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4056"
+ms.date: 11/04/2016
 f1_keywords: ["C4056"]
 helpviewer_keywords: ["C4056"]
-ms.assetid: a3c3a9b8-ec30-452d-96cb-3694adcce789
 ---
 # Compiler Warning (level 2) C4056
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4056.md
@@ -10,9 +10,13 @@ ms.assetid: a3c3a9b8-ec30-452d-96cb-3694adcce789
 
 > overflow in floating point constant arithmetic
 
+## Remarks
+
 Floating-point constant arithmetic generates a result that exceeds the maximum allowable value.
 
 This warning can be caused by compiler optimizations performed during constant arithmetic. You can safely ignore this warning if it goes away when you turn off optimization ([/Od](../../build/reference/od-disable-debug.md)).
+
+## Example
 
 The following sample generates C4056:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C4066"]
 
 > characters beyond first in wide-character constant ignored
 
+## Remarks
+
 The compiler processes only the first character of a wide-character constant.
+
+## Example
 
 ```cpp
 // C4066.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4066"
 title: "Compiler Warning (level 3) C4066"
-ms.date: "03/06/2024"
+description: "Learn more about: Compiler Warning (level 3) C4066"
+ms.date: 03/06/2024
 f1_keywords: ["C4066"]
 helpviewer_keywords: ["C4066"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4066"]
 ---
 # Compiler Warning (level 3) C4066
 
-characters beyond first in wide-character constant ignored
+> characters beyond first in wide-character constant ignored
 
 The compiler processes only the first character of a wide-character constant.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4066.md
@@ -15,6 +15,8 @@ The compiler processes only the first character of a wide-character constant.
 
 ## Example
 
+The following example generates C4066:
+
 ```cpp
 // C4066.cpp
 // compile with: /W3

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
@@ -16,7 +16,7 @@ Only third-party library developers should use the library initialization area, 
 
 ## Example
 
-The following sample generates C4073:
+The following example generates C4073:
 
 ```cpp
 // C4073.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4073"
 title: "Compiler Warning (level 3) C4073"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4073"
+ms.date: 11/04/2016
 f1_keywords: ["C4073"]
 helpviewer_keywords: ["C4073"]
-ms.assetid: 50081a6e-6acd-45ff-8484-9b1ea926cc5c
 ---
 # Compiler Warning (level 3) C4073
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
@@ -10,7 +10,13 @@ ms.assetid: 50081a6e-6acd-45ff-8484-9b1ea926cc5c
 
 > initializers put in library initialization area
 
-Only third-party library developers should use the library initialization area, which is specified by [#pragma init_seg](../../preprocessor/init-seg.md). The following sample generates C4073:
+## Remarks
+
+Only third-party library developers should use the library initialization area, which is specified by [#pragma init_seg](../../preprocessor/init-seg.md).
+
+## Example
+
+The following sample generates C4073:
 
 ```cpp
 // C4073.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4073.md
@@ -8,7 +8,7 @@ ms.assetid: 50081a6e-6acd-45ff-8484-9b1ea926cc5c
 ---
 # Compiler Warning (level 3) C4073
 
-initializers put in library initialization area
+> initializers put in library initialization area
 
 Only third-party library developers should use the library initialization area, which is specified by [#pragma init_seg](../../preprocessor/init-seg.md). The following sample generates C4073:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
@@ -10,4 +10,6 @@ ms.assetid: e3b8c46e-e36d-412c-99b9-3db860b6e307
 
 > one void operand for '?:'
 
+## Remarks
+
 The `?:` operator is given an expression of type **`void`**. The value of the **`void`** operand is undefined.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4053"
 title: "Compiler Warning (level 4) C4053"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4053"
+ms.date: 11/04/2016
 f1_keywords: ["C4053"]
 helpviewer_keywords: ["C4053"]
-ms.assetid: e3b8c46e-e36d-412c-99b9-3db860b6e307
 ---
 # Compiler Warning (level 4) C4053
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4053.md
@@ -8,6 +8,6 @@ ms.assetid: e3b8c46e-e36d-412c-99b9-3db860b6e307
 ---
 # Compiler Warning (level 4) C4053
 
-one void operand for '?:'
+> one void operand for '?:'
 
 The `?:` operator is given an expression of type **`void`**. The value of the **`void`** operand is undefined.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4057"
 title: "Compiler Warning (level 4) C4057"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4057"
+ms.date: 11/04/2016
 f1_keywords: ["C4057"]
 helpviewer_keywords: ["C4057"]
-ms.assetid: e75d0645-84c9-4bef-a812-942ed9879aa3
 ---
 # Compiler Warning (level 4) C4057
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
@@ -10,6 +10,8 @@ ms.assetid: e75d0645-84c9-4bef-a812-942ed9879aa3
 
 > 'operator' : 'identifier1' indirection to slightly different base types from 'identifier2'
 
+## Remarks
+
 Two pointer expressions refer to different base types. The expressions are used without conversion.
 
 ### To fix by checking the following possible causes

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4057.md
@@ -8,7 +8,7 @@ ms.assetid: e75d0645-84c9-4bef-a812-942ed9879aa3
 ---
 # Compiler Warning (level 4) C4057
 
-'operator' : 'identifier1' indirection to slightly different base types from 'identifier2'
+> 'operator' : 'identifier1' indirection to slightly different base types from 'identifier2'
 
 Two pointer expressions refer to different base types. The expressions are used without conversion.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4061"
 title: "Compiler Warning (level 4, off) C4061"
-ms.date: "04/05/2019"
+description: "Learn more about: Compiler Warning (level 4, off) C4061"
+ms.date: 04/05/2019
 f1_keywords: ["C4061"]
 helpviewer_keywords: ["C4061"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information about how to enable warning
 
 ## Example
 
-The following sample generates C4061; add a case for the missing enumerator to fix:
+The following example generates C4061; add a case for the missing enumerator to fix:
 
 ```cpp
 // C4061.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4061.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4061"]
 
 > enumerator '*identifier*' in switch of `enum` '*enumeration*' is not explicitly handled by a `case` label
 
+## Remarks
+
 The specified enumerator *identifier* has no associated handler in a `switch` statement that has a `default` case. The missing case might be an oversight, or it may not be an issue. Whether the missing `case` is an issue in practice depends on if the default case handles the enumerator. For a related warning on unused enumerators in `switch` statements that have no `default` case, see [C4062](compiler-warning-level-4-c4062.md).
 
 This warning is off by default. For more information about how to enable warnings that are off by default, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4062"]
 
 > enumerator '*identifier*' in switch of `enum` '*enumeration*' is not handled
 
+## Remarks
+
 The enumerator *identifier* doesn't have a `case` handler associated with it in a **`switch`** statement, and there's no **`default`** label that can catch it. The missing case may be an oversight, and is a potential error in your code. For a related warning on unused enumerators in **`switch`** statements that have a **`default`** case, see [C4061](compiler-warning-level-4-c4061.md).
 
 This warning is off by default. For more information about how to enable warnings that are off by default, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information about how to enable warning
 
 ## Example
 
-The following sample generates C4062, and shows how to fix it:
+The following example generates C4062, and shows how to fix it:
 
 ```cpp
 // C4062.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4062.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4062"
 title: "Compiler Warning (level 4, off) C4062"
-ms.date: "04/05/2019"
+description: "Learn more about: Compiler Warning (level 4, off) C4062"
+ms.date: 04/05/2019
 f1_keywords: ["C4062"]
 helpviewer_keywords: ["C4062"]
 ---


### PR DESCRIPTION
This is batch 69 that structures error/warning references. See #5465 for more information.