### PR TITLE
Structure warning references in range [C4121, C4160]

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
@@ -8,7 +8,7 @@ ms.assetid: 9a83eb0d-8708-42f7-988a-b0b6f2f646a0
 ---
 # Compiler Warning (level 1) C4122
 
-'function' : alloc_text applicable only to functions with C linkage
+> 'function' : alloc_text applicable only to functions with C linkage
 
 The **alloc_text** pragma applies only to functions declared with **extern c**. It cannot be used with external C++ functions.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4122"
 title: "Compiler Warning (level 1) C4122"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4122"
+ms.date: 11/04/2016
 f1_keywords: ["C4122"]
 helpviewer_keywords: ["C4122"]
-ms.assetid: 9a83eb0d-8708-42f7-988a-b0b6f2f646a0
 ---
 # Compiler Warning (level 1) C4122
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4122.md
@@ -10,6 +10,8 @@ ms.assetid: 9a83eb0d-8708-42f7-988a-b0b6f2f646a0
 
 > 'function' : alloc_text applicable only to functions with C linkage
 
+## Remarks
+
 The **alloc_text** pragma applies only to functions declared with **extern c**. It cannot be used with external C++ functions.
 
 The pragma is ignored.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
@@ -10,6 +10,8 @@ ms.assetid: c08c3a65-9584-47a1-a147-44f00c4b230e
 
 > __fastcall with stack checking is inefficient
 
+## Remarks
+
 The **`__fastcall`** keyword was used with stack checking enabled.
 
 The **`__fastcall`** convention generates faster code, but stack checking causes slower code. When using **`__fastcall`**, turn off stack checking with the **check_stack** pragma or /Gs.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4124"
 title: "Compiler Warning (level 1) C4124"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4124"
+ms.date: 11/04/2016
 f1_keywords: ["C4124"]
 helpviewer_keywords: ["C4124"]
-ms.assetid: c08c3a65-9584-47a1-a147-44f00c4b230e
 ---
 # Compiler Warning (level 1) C4124
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4124.md
@@ -8,7 +8,7 @@ ms.assetid: c08c3a65-9584-47a1-a147-44f00c4b230e
 ---
 # Compiler Warning (level 1) C4124
 
-__fastcall with stack checking is inefficient
+> __fastcall with stack checking is inefficient
 
 The **`__fastcall`** keyword was used with stack checking enabled.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4129"
 title: "Compiler Warning (level 1) C4129"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4129"
+ms.date: 11/04/2016
 f1_keywords: ["C4129"]
 helpviewer_keywords: ["C4129"]
-ms.assetid: a4190c64-4bfb-48fd-8e98-52720bc0d878
 ---
 # Compiler Warning (level 1) C4129
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
@@ -20,7 +20,7 @@ The C++ standard, in section 2.13.2 discusses escape sequences.
 
 ## Example
 
-The following sample generates C4129:
+The following example generates C4129:
 
 ```cpp
 // C4129.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
@@ -10,11 +10,15 @@ ms.assetid: a4190c64-4bfb-48fd-8e98-52720bc0d878
 
 > 'character' : unrecognized character escape sequence
 
+## Remarks
+
 The `character` following a backslash (\\) in a character or string constant is not recognized as a valid escape sequence. The backslash is ignored and not printed. The character following the backslash is printed.
 
 To print a single backslash, specify a double backslash (\\\\).
 
 The C++ standard, in section 2.13.2 discusses escape sequences.
+
+## Example
 
 The following sample generates C4129:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4129.md
@@ -8,7 +8,7 @@ ms.assetid: a4190c64-4bfb-48fd-8e98-52720bc0d878
 ---
 # Compiler Warning (level 1) C4129
 
-'character' : unrecognized character escape sequence
+> 'character' : unrecognized character escape sequence
 
 The `character` following a backslash (\\) in a character or string constant is not recognized as a valid escape sequence. The backslash is ignored and not printed. The character following the backslash is printed.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
@@ -15,6 +15,8 @@ The closing-comment delimiter is not preceded by an opening-comment delimiter. T
 
 ## Example
 
+The following example generates C4138:
+
 ```cpp
 // C4138a.cpp
 // compile with: /W1

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
@@ -8,7 +8,7 @@ ms.assetid: 65ebf929-bba0-4237-923b-c1b66adfe17d
 ---
 # Compiler Warning (level 1) C4138
 
-'*/' found outside of comment
+> '*/' found outside of comment
 
 The closing-comment delimiter is not preceded by an opening-comment delimiter. The compiler assumes a space between the asterisk (<strong>\*</strong>) and the forward slash (/).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
@@ -10,6 +10,8 @@ ms.assetid: 65ebf929-bba0-4237-923b-c1b66adfe17d
 
 > '*/' found outside of comment
 
+## Remarks
+
 The closing-comment delimiter is not preceded by an opening-comment delimiter. The compiler assumes a space between the asterisk (<strong>\*</strong>) and the forward slash (/).
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4138.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4138"
 title: "Compiler Warning (level 1) C4138"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4138"
+ms.date: 11/04/2016
 f1_keywords: ["C4138"]
 helpviewer_keywords: ["C4138"]
-ms.assetid: 65ebf929-bba0-4237-923b-c1b66adfe17d
 ---
 # Compiler Warning (level 1) C4138
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4141.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4141.md
@@ -11,6 +11,8 @@ helpviewer_keywords: ["C4141"]
 
 ## Example
 
+The following example generates C4141:
+
 ```cpp
 // C4141.cpp
 // compile with: /W1 /LD

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4141.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4141.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1, Error) C4141"
 title: "Compiler Warning (level 1, Error) C4141"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1, Error) C4141"
+ms.date: 11/04/2016
 f1_keywords: ["C4141"]
 helpviewer_keywords: ["C4141"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
@@ -22,7 +22,7 @@ To fix by checking the following possible causes:
 
 ## Example
 
-The following sample generates C4142:
+The following example generates C4142:
 
 ```c
 // C4142.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
@@ -8,7 +8,7 @@ ms.assetid: 1fdfc3dc-60a2-4f00-b133-20e400f9b7a6
 ---
 # Compiler Warning (level 1) C4142
 
-benign redefinition of type
+> benign redefinition of type
 
 A type is redefined in a manner that has no effect on the generated code.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4142"
 title: "Compiler Warning (level 1) C4142"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4142"
+ms.date: 11/04/2016
 f1_keywords: ["C4142"]
 helpviewer_keywords: ["C4142"]
-ms.assetid: 1fdfc3dc-60a2-4f00-b133-20e400f9b7a6
 ---
 # Compiler Warning (level 1) C4142
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4142.md
@@ -10,6 +10,8 @@ ms.assetid: 1fdfc3dc-60a2-4f00-b133-20e400f9b7a6
 
 > benign redefinition of type
 
+## Remarks
+
 A type is redefined in a manner that has no effect on the generated code.
 
 To fix by checking the following possible causes:
@@ -17,6 +19,8 @@ To fix by checking the following possible causes:
 - A member function of a derived class has a different return type from the corresponding member function of the base class.
 
 - A type defined with the **`typedef`** command is redefined using different syntax.
+
+## Example
 
 The following sample generates C4142:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
@@ -8,6 +8,6 @@ ms.assetid: ef0bd19f-d169-4034-8710-b22971bd642d
 ---
 # Compiler Warning (level 1) C4143
 
-pragma 'same_seg' not supported; use __based allocation
+> pragma 'same_seg' not supported; use __based allocation
 
 The **#pragma same_seg** is no longer supported. Use the [__based](../../cpp/based-pointers-cpp.md) keyword instead.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4143"
 title: "Compiler Warning (level 1) C4143"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4143"
+ms.date: 11/04/2016
 f1_keywords: ["C4143"]
 helpviewer_keywords: ["same_seg", "C4143"]
-ms.assetid: ef0bd19f-d169-4034-8710-b22971bd642d
 ---
 # Compiler Warning (level 1) C4143
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4143.md
@@ -10,4 +10,6 @@ ms.assetid: ef0bd19f-d169-4034-8710-b22971bd642d
 
 > pragma 'same_seg' not supported; use __based allocation
 
+## Remarks
+
 The **#pragma same_seg** is no longer supported. Use the [__based](../../cpp/based-pointers-cpp.md) keyword instead.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4144"
 title: "Compiler Warning (level 1) C4144"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4144"
+ms.date: 11/04/2016
 f1_keywords: ["C4144"]
 helpviewer_keywords: ["C4144"]
-ms.assetid: a37b445d-dbc6-43b4-8d95-ffd0e4225464
 ---
 # Compiler Warning (level 1) C4144
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
@@ -16,7 +16,7 @@ The specified relational expression was used as the control expression of a [swi
 
 ## Example
 
-The following sample generates C4144:
+The following example generates C4144:
 
 ```cpp
 // C4144.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
@@ -8,7 +8,7 @@ ms.assetid: a37b445d-dbc6-43b4-8d95-ffd0e4225464
 ---
 # Compiler Warning (level 1) C4144
 
-'expression' : relational expression as switch expression
+> 'expression' : relational expression as switch expression
 
 The specified relational expression was used as the control expression of a [switch](../../cpp/switch-statement-cpp.md) statement. The associated case statements will be offered Boolean values. The following sample generates C4144:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4144.md
@@ -10,7 +10,13 @@ ms.assetid: a37b445d-dbc6-43b4-8d95-ffd0e4225464
 
 > 'expression' : relational expression as switch expression
 
-The specified relational expression was used as the control expression of a [switch](../../cpp/switch-statement-cpp.md) statement. The associated case statements will be offered Boolean values. The following sample generates C4144:
+## Remarks
+
+The specified relational expression was used as the control expression of a [switch](../../cpp/switch-statement-cpp.md) statement. The associated case statements will be offered Boolean values.
+
+## Example
+
+The following sample generates C4144:
 
 ```cpp
 // C4144.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
@@ -8,7 +8,7 @@ ms.assetid: 0440777a-cca2-4159-aff5-e67a254ad64a
 ---
 # Compiler Warning (level 1) C4145
 
-'expression1' : relational expression as switch expression; possible confusion with 'expression2'
+> 'expression1' : relational expression as switch expression; possible confusion with 'expression2'
 
 A **`switch`** statement uses a relational expression as its control expression, which results in a Boolean value for the **`case`** statements. Did you mean *expression2*?
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
@@ -16,7 +16,7 @@ A **`switch`** statement uses a relational expression as its control expression,
 
 ## Example
 
-The following sample generates C4145:
+The following example generates C4145:
 
 ```cpp
 // C4145.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
@@ -10,6 +10,8 @@ ms.assetid: 0440777a-cca2-4159-aff5-e67a254ad64a
 
 > 'expression1' : relational expression as switch expression; possible confusion with 'expression2'
 
+## Remarks
+
 A **`switch`** statement uses a relational expression as its control expression, which results in a Boolean value for the **`case`** statements. Did you mean *expression2*?
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4145.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4145"
 title: "Compiler Warning (level 1) C4145"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4145"
+ms.date: 11/04/2016
 f1_keywords: ["C4145"]
 helpviewer_keywords: ["C4145"]
-ms.assetid: 0440777a-cca2-4159-aff5-e67a254ad64a
 ---
 # Compiler Warning (level 1) C4145
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
@@ -8,6 +8,6 @@ ms.assetid: 37a15754-9dba-470b-adda-c4b888064b3e
 ---
 # Compiler Warning (level 1) C4153
 
-function/data pointer conversion in expression
+> function/data pointer conversion in expression
 
 A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4153"
 title: "Compiler Warning (level 1) C4153"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4153"
+ms.date: 11/04/2016
 f1_keywords: ["C4153"]
 helpviewer_keywords: ["C4153"]
-ms.assetid: 37a15754-9dba-470b-adda-c4b888064b3e
 ---
 # Compiler Warning (level 1) C4153
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4153.md
@@ -10,4 +10,6 @@ ms.assetid: 37a15754-9dba-470b-adda-c4b888064b3e
 
 > function/data pointer conversion in expression
 
+## Remarks
+
 A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
@@ -8,7 +8,7 @@ ms.assetid: 4511afeb-e893-4cc6-83b6-4c7a0477f76b
 ---
 # Compiler Warning (level 1) C4154
 
-deletion of an array expression; conversion to pointer supplied
+> deletion of an array expression; conversion to pointer supplied
 
 You cannot use **`delete`** on an array, so the compiler converts the array to a pointer.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
@@ -10,6 +10,8 @@ ms.assetid: 4511afeb-e893-4cc6-83b6-4c7a0477f76b
 
 > deletion of an array expression; conversion to pointer supplied
 
+## Remarks
+
 You cannot use **`delete`** on an array, so the compiler converts the array to a pointer.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
@@ -15,6 +15,8 @@ You cannot use **`delete`** on an array, so the compiler converts the array to a
 
 ## Example
 
+The following example generates C4154:
+
 ```cpp
 // C4154.cpp
 // compile with: /c /W1

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4154.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4154"
 title: "Compiler Warning (level 1) C4154"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4154"
+ms.date: 11/04/2016
 f1_keywords: ["C4154"]
 helpviewer_keywords: ["C4154"]
-ms.assetid: 4511afeb-e893-4cc6-83b6-4c7a0477f76b
 ---
 # Compiler Warning (level 1) C4154
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
@@ -8,7 +8,7 @@ ms.assetid: ba233353-09e3-4195-8127-13a27ddd8d70
 ---
 # Compiler Warning (level 1) C4155
 
-deletion of an array expression without using the array form of 'delete'
+> deletion of an array expression without using the array form of 'delete'
 
 The array form of **`delete`** should be used to delete an array. This warning occurs only under ANSI-compatibility (/Za).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
@@ -10,6 +10,8 @@ ms.assetid: ba233353-09e3-4195-8127-13a27ddd8d70
 
 > deletion of an array expression without using the array form of 'delete'
 
+## Remarks
+
 The array form of **`delete`** should be used to delete an array. This warning occurs only under ANSI-compatibility (/Za).
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
@@ -16,7 +16,7 @@ The array form of **`delete`** should be used to delete an array. This warning o
 
 ## Example
 
-The following sample generates C4155:
+The following example generates C4155:
 
 ```cpp
 // C4155.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4155.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4155"
 title: "Compiler Warning (level 1) C4155"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4155"
+ms.date: 11/04/2016
 f1_keywords: ["C4155"]
 helpviewer_keywords: ["C4155"]
-ms.assetid: ba233353-09e3-4195-8127-13a27ddd8d70
 ---
 # Compiler Warning (level 1) C4155
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
@@ -10,4 +10,6 @@ ms.assetid: 6dabc303-eba1-4a8e-a124-a6e1dc84f4bd
 
 > pragma was ignored by C compiler
 
+## Remarks
+
 Only the C++ compiler recognizes **init_seg()**.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
@@ -8,6 +8,6 @@ ms.assetid: 6dabc303-eba1-4a8e-a124-a6e1dc84f4bd
 ---
 # Compiler Warning (level 1) C4157
 
-pragma was ignored by C compiler
+> pragma was ignored by C compiler
 
 Only the C++ compiler recognizes **init_seg()**.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4157.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4157"
 title: "Compiler Warning (level 1) C4157"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4157"
+ms.date: 11/04/2016
 f1_keywords: ["C4157"]
 helpviewer_keywords: ["C4157"]
-ms.assetid: 6dabc303-eba1-4a8e-a124-a6e1dc84f4bd
 ---
 # Compiler Warning (level 1) C4157
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4158.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4158.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4158"
 title: "Compiler Warning (level 1) C4158"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4158"
+ms.date: 11/04/2016
 f1_keywords: ["C4158"]
 helpviewer_keywords: ["C4158"]
-ms.assetid: 6513c6b9-6772-4849-b96c-5bb093d54de6
 ---
 # Compiler Warning (level 1) C4158
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4158.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4158.md
@@ -10,4 +10,6 @@ ms.assetid: 6513c6b9-6772-4849-b96c-5bb093d54de6
 
 > assuming #pragma pointers_to_members(full_generality, inheritance)
 
+## Remarks
+
 A `#pragma pointers_to_members( single | multiple | virtual )` was issued without an accompanying `#pragma pointers_to_members(full_generality)`.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4160.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4160.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4160"
 title: "Compiler Warning (level 1) C4160"
-ms.date: "08/27/2018"
+description: "Learn more about: Compiler Warning (level 1) C4160"
+ms.date: 08/27/2018
 f1_keywords: ["C4160"]
 helpviewer_keywords: ["C4160"]
-ms.assetid: a9610cb7-cac4-4a74-8b4e-049030ebb92b
 ---
 # Compiler Warning (level 1) C4160
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
@@ -28,7 +28,7 @@ The [`/sdl` (Enable Additional Security Checks)](../../build/reference/sdl-enabl
 
 ## Example
 
-The following sample demonstrates the unexpected behavior that can happen when the compiler generates warning C4146:
+The following example demonstrates the unexpected behavior that can happen when the compiler generates warning C4146:
 
 ```cpp
 // C4146.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler warning (level 2) C4146"
 title: "Compiler warning (level 2) C4146"
+description: "Learn more about: Compiler warning (level 2) C4146"
 ms.date: 04/22/2025
 f1_keywords: ["C4146"]
 helpviewer_keywords: ["C4146"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4146.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C4146"]
 
 > unary minus operator applied to unsigned type, result still unsigned
 
-Unsigned types only hold non-negative values. So unary minus (negation) usually doesn't make sense when applied to an unsigned type. Both the operand and the result are non-negative.
-
 ## Remarks
+
+Unsigned types only hold non-negative values. So unary minus (negation) usually doesn't make sense when applied to an unsigned type. Both the operand and the result are non-negative.
 
 When you express a negative integer literal, the **`-`** in front of the value is parsed as a [unary negation](../../cpp/unary-plus-and-negation-operators-plus-and.md) operator. The compiler applies the operator after it parses the numeric value. If the numeric value fits in the range of an unsigned integer type, but not the corresponding signed integer type, the compiler interprets the value as unsigned.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
@@ -1,5 +1,5 @@
 ---
-title: Compiler warning (level 2) C4150
+title: "Compiler warning (level 2) C4150"
 description: "Learn more about: Compiler Warning (level 2) C4150"
 ms.date: 11/04/2016
 f1_keywords: ["C4150"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4150"]
 
 > deletion of pointer to incomplete type 'type'; no destructor called
 
+## Remarks
+
 The `delete` operator is called to delete a type that was declared but not defined. The compiler can't find the destructor to call because the definition isn't in the same translation unit as the `delete`.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4150.md
@@ -15,7 +15,7 @@ The `delete` operator is called to delete a type that was declared but not defin
 
 ## Example
 
-The following sample generates C4150 by declaring but not defining `class IncClass`:
+The following example generates C4150 by declaring but not defining `class IncClass`:
 
 ```cpp
 // compile with: /W2

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
@@ -17,6 +17,8 @@ This warning occurs only under Microsoft extensions (/Ze).
 
 ## Example
 
+The following example generates C4156:
+
 ```cpp
 // C4156.cpp
 // compile with: /W2

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4156"
 title: "Compiler Warning (level 2) C4156"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4156"
+ms.date: 11/04/2016
 f1_keywords: ["C4156"]
 helpviewer_keywords: ["C4156"]
-ms.assetid: 9adf3acb-c0fe-42a8-a4db-5822b1493f77
 ---
 # Compiler Warning (level 2) C4156
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
@@ -8,7 +8,7 @@ ms.assetid: 9adf3acb-c0fe-42a8-a4db-5822b1493f77
 ---
 # Compiler Warning (level 2) C4156
 
-deletion of an array expression without using the array form of 'delete'; array form substituted
+> deletion of an array expression without using the array form of 'delete'; array form substituted
 
 The non-array form of **`delete`** cannot delete an array. The compiler translated **`delete`** to the array form.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4156.md
@@ -10,6 +10,8 @@ ms.assetid: 9adf3acb-c0fe-42a8-a4db-5822b1493f77
 
 > deletion of an array expression without using the array form of 'delete'; array form substituted
 
+## Remarks
+
 The non-array form of **`delete`** cannot delete an array. The compiler translated **`delete`** to the array form.
 
 This warning occurs only under Microsoft extensions (/Ze).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4133.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4133.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4133"]
 
 > '*expression*': incompatible types - from '*type1*' to '*type2*'
 
+## Remarks
+
 This warning is emitted when incompatible types are used in an expression. For example, doing arithmetic operations such as subtraction with different pointer types.
 
 To avoid this warning, provide an appropriate type cast.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4133.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4133.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1 and level 3) C4133"
 title: "Compiler Warning (level 1 and level 3) C4133"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1 and level 3) C4133"
+ms.date: 11/04/2016
 f1_keywords: ["C4133"]
 helpviewer_keywords: ["C4133"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4159.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4159.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4159"
 title: "Compiler Warning (level 3) C4159"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4159"
+ms.date: 11/04/2016
 f1_keywords: ["C4159"]
 helpviewer_keywords: ["C4159"]
-ms.assetid: e2cf964e-f4b8-4b2c-9569-1abb94307232
 ---
 # Compiler Warning (level 3) C4159
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
@@ -10,7 +10,13 @@ ms.assetid: 8c5b85c9-2543-426b-88bc-319c50158c7e
 
 > 'symbol' : alignment of a member was sensitive to packing
 
-The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size. For example, the following code snippet produces C4121:
+## Remarks
+
+The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size.
+
+## Example
+
+For example, the following code snippet produces C4121:
 
 ```cpp
 // C4121.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4121"
 title: "Compiler Warning (level 4) C4121"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4121"
+ms.date: 11/04/2016
 f1_keywords: ["C4121"]
 helpviewer_keywords: ["C4121"]
-ms.assetid: 8c5b85c9-2543-426b-88bc-319c50158c7e
 ---
 # Compiler Warning (level 4) C4121
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4121.md
@@ -8,7 +8,7 @@ ms.assetid: 8c5b85c9-2543-426b-88bc-319c50158c7e
 ---
 # Compiler Warning (level 4) C4121
 
-'symbol' : alignment of a member was sensitive to packing
+> 'symbol' : alignment of a member was sensitive to packing
 
 The compiler added padding to align a structure member on the packing boundary but the packing value is less than the member's size. For example, the following code snippet produces C4121:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
@@ -15,6 +15,8 @@ The compiler evaluates the octal number without the decimal digit and assumes th
 
 ## Example
 
+The following example generates C4125:
+
 ```cpp
 // C4125a.cpp
 // compile with: /W4

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
@@ -8,7 +8,7 @@ ms.assetid: a081d1f4-0789-4915-91df-7ff0b28ca245
 ---
 # Compiler Warning (level 4) C4125
 
-decimal digit terminates octal escape sequence
+> decimal digit terminates octal escape sequence
 
 The compiler evaluates the octal number without the decimal digit and assumes the decimal digit is a character.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4125"
 title: "Compiler Warning (level 4) C4125"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4125"
+ms.date: 11/04/2016
 f1_keywords: ["C4125"]
 helpviewer_keywords: ["C4125"]
-ms.assetid: a081d1f4-0789-4915-91df-7ff0b28ca245
 ---
 # Compiler Warning (level 4) C4125
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4125.md
@@ -10,6 +10,8 @@ ms.assetid: a081d1f4-0789-4915-91df-7ff0b28ca245
 
 > decimal digit terminates octal escape sequence
 
+## Remarks
+
 The compiler evaluates the octal number without the decimal digit and assumes the decimal digit is a character.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
@@ -18,7 +18,7 @@ If the controlling expression of a **`while`** loop is a constant because the lo
 
 ## Examples
 
-The following sample shows two ways C4127 is generated, and shows how to use a for loop to avoid the warning:
+The following example shows two ways C4127 is generated, and shows how to use a for loop to avoid the warning:
 
 ```cpp
 // C4127.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
@@ -16,7 +16,7 @@ The controlling expression of an **`if`** statement or **`while`** loop evaluate
 
 If the controlling expression of a **`while`** loop is a constant because the loop exits in the middle, consider replacing the **`while`** loop with a **`for`** loop. You can omit the initialization, termination test and loop increment of a **`for`** loop, which causes the loop to be infinite, just like `while(1)`, and you can exit the loop from the body of the **`for`** statement.
 
-## Example
+## Examples
 
 The following sample shows two ways C4127 is generated, and shows how to use a for loop to avoid the warning:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4127.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4127"
 title: "Compiler Warning (level 4) C4127"
-ms.date: "10/16/2019"
+description: "Learn more about: Compiler Warning (level 4) C4127"
+ms.date: 10/16/2019
 f1_keywords: ["C4127"]
 helpviewer_keywords: ["C4127"]
-ms.assetid: f59ded9e-5227-45bd-ac43-2aa861581363
 ---
 # Compiler Warning (level 4) C4127
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
@@ -10,7 +10,11 @@ ms.assetid: 45e4c7b2-6b51-41c7-ba5e-941aa5c7d3dc
 
 > 'operator' : logical operation on address of string constant
 
+## Remarks
+
 Using the operator with the address of a string literal produces unexpected code.
+
+## Example
 
 The following sample generates C4130:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
@@ -16,7 +16,7 @@ Using the operator with the address of a string literal produces unexpected code
 
 ## Example
 
-The following sample generates C4130:
+The following example generates C4130:
 
 ```cpp
 // C4130.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4130"
 title: "Compiler Warning (level 4) C4130"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4130"
+ms.date: 11/04/2016
 f1_keywords: ["C4130"]
 helpviewer_keywords: ["C4130"]
-ms.assetid: 45e4c7b2-6b51-41c7-ba5e-941aa5c7d3dc
 ---
 # Compiler Warning (level 4) C4130
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4130.md
@@ -8,7 +8,7 @@ ms.assetid: 45e4c7b2-6b51-41c7-ba5e-941aa5c7d3dc
 ---
 # Compiler Warning (level 4) C4130
 
-'operator' : logical operation on address of string constant
+> 'operator' : logical operation on address of string constant
 
 Using the operator with the address of a string literal produces unexpected code.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4131"
 title: "Compiler Warning (level 4) C4131"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4131"
+ms.date: 11/04/2016
 f1_keywords: ["C4131"]
 helpviewer_keywords: ["C4131"]
-ms.assetid: 7903b3e1-454f-4be2-aa9b-230992f96a2d
 ---
 # Compiler Warning (level 4) C4131
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
@@ -8,7 +8,7 @@ ms.assetid: 7903b3e1-454f-4be2-aa9b-230992f96a2d
 ---
 # Compiler Warning (level 4) C4131
 
-'function' : uses old-style declarator
+> 'function' : uses old-style declarator
 
 The specified function declaration is not in prototype form.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4131.md
@@ -10,9 +10,13 @@ ms.assetid: 7903b3e1-454f-4be2-aa9b-230992f96a2d
 
 > 'function' : uses old-style declarator
 
+## Remarks
+
 The specified function declaration is not in prototype form.
 
 Old-style function declarations should be converted to prototype form.
+
+## Example
 
 The following example shows an old-style function declaration:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
@@ -8,6 +8,6 @@ ms.assetid: b60e5b4a-53ac-4503-8456-235477f48afd
 ---
 # Compiler Warning (level 4) C4132
 
-'object' : const object should be initialized
+> 'object' : const object should be initialized
 
 The constant is not initialized. The value of a symbol with the **`const`** attribute cannot be changed after its definition, it should be given an initialization value.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
@@ -10,4 +10,6 @@ ms.assetid: b60e5b4a-53ac-4503-8456-235477f48afd
 
 > 'object' : const object should be initialized
 
+## Remarks
+
 The constant is not initialized. The value of a symbol with the **`const`** attribute cannot be changed after its definition, it should be given an initialization value.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4132.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4132"
 title: "Compiler Warning (level 4) C4132"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4132"
+ms.date: 11/04/2016
 f1_keywords: ["C4132"]
 helpviewer_keywords: ["C4132"]
-ms.assetid: b60e5b4a-53ac-4503-8456-235477f48afd
 ---
 # Compiler Warning (level 4) C4132
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
@@ -8,6 +8,6 @@ ms.assetid: 6025ab70-d7cf-4730-913a-3ca0b1186a3a
 ---
 # Compiler Warning (level 4) C4152
 
-non standard extension, function/data ptr conversion in expression
+> non standard extension, function/data ptr conversion in expression
 
 A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
@@ -10,4 +10,6 @@ ms.assetid: 6025ab70-d7cf-4730-913a-3ca0b1186a3a
 
 > non standard extension, function/data ptr conversion in expression
 
+## Remarks
+
 A function pointer is converted to or from a data pointer. This conversion is allowed under Microsoft extensions (/Ze) but not under ANSI C.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4152.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4152"
 title: "Compiler Warning (level 4) C4152"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4152"
+ms.date: 11/04/2016
 f1_keywords: ["C4152"]
 helpviewer_keywords: ["C4152"]
-ms.assetid: 6025ab70-d7cf-4730-913a-3ca0b1186a3a
 ---
 # Compiler Warning (level 4) C4152
 


### PR DESCRIPTION
This is batch 71 that structures error/warning references. See #5465 for more information.