### PR TITLE
Structure warning references in range [C4231, C4270]

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
@@ -8,7 +8,7 @@ ms.assetid: f2e86c4b-80d8-460e-9429-83c5f3f5d7ca
 ---
 # Compiler Warning (level 1) C4237
 
-'keyword' keyword is not yet supported, but reserved for future use
+> 'keyword' keyword is not yet supported, but reserved for future use
 
 A keyword in the C++ specification is not implemented in the Microsoft C++ compiler, but the keyword is not available as a user-defined symbol.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4237"
 title: "Compiler Warning (level 1) C4237"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4237"
+ms.date: 11/04/2016
 f1_keywords: ["C4237"]
 helpviewer_keywords: ["C4237"]
-ms.assetid: f2e86c4b-80d8-460e-9429-83c5f3f5d7ca
 ---
 # Compiler Warning (level 1) C4237
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
@@ -16,7 +16,7 @@ A keyword in the C++ specification is not implemented in the Microsoft C++ compi
 
 ## Example
 
-The following sample generates C4237:
+The following example generates C4237:
 
 ```cpp
 // C4237.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4237.md
@@ -10,7 +10,11 @@ ms.assetid: f2e86c4b-80d8-460e-9429-83c5f3f5d7ca
 
 > 'keyword' keyword is not yet supported, but reserved for future use
 
+## Remarks
+
 A keyword in the C++ specification is not implemented in the Microsoft C++ compiler, but the keyword is not available as a user-defined symbol.
+
+## Example
 
 The following sample generates C4237:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4251.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4251.md
@@ -32,6 +32,8 @@ Think carefully about adding `__declspec(dllexport)` or `__declspec(dllimport)` 
 
 ## Example
 
+The following example generates C4251:
+
 ```cpp
 // C4251.cpp
 // Compile with /std:c++20 /EHsc /W2 /c C4251.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
@@ -10,7 +10,13 @@ ms.assetid: bbb75e6d-6693-4e62-8ed3-b006a0ec55e3
 
 > 'variable' : definition from the for loop is ignored; the definition from the enclosing scope is used"
 
-Under [/Ze](../../build/reference/za-ze-disable-language-extensions.md) and [/Zc:forScope](../../build/reference/zc-forscope-force-conformance-in-for-loop-scope.md), variables defined in a [for](../../cpp/for-statement-cpp.md) loop go out of scope after the **`for`** loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the **`for`** loop. For example:
+## Remarks
+
+Under [/Ze](../../build/reference/za-ze-disable-language-extensions.md) and [/Zc:forScope](../../build/reference/zc-forscope-force-conformance-in-for-loop-scope.md), variables defined in a [for](../../cpp/for-statement-cpp.md) loop go out of scope after the **`for`** loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the **`for`** loop.
+
+## Example
+
+For example:
 
 ```cpp
 // C4258.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4258"
 title: "Compiler Warning (level 1) C4258"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4258"
+ms.date: 11/04/2016
 f1_keywords: ["C4258"]
 helpviewer_keywords: ["C4258"]
-ms.assetid: bbb75e6d-6693-4e62-8ed3-b006a0ec55e3
 ---
 # Compiler Warning (level 1) C4258
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4258.md
@@ -8,7 +8,7 @@ ms.assetid: bbb75e6d-6693-4e62-8ed3-b006a0ec55e3
 ---
 # Compiler Warning (level 1) C4258
 
-'variable' : definition from the for loop is ignored; the definition from the enclosing scope is used"
+> 'variable' : definition from the for loop is ignored; the definition from the enclosing scope is used"
 
 Under [/Ze](../../build/reference/za-ze-disable-language-extensions.md) and [/Zc:forScope](../../build/reference/zc-forscope-force-conformance-in-for-loop-scope.md), variables defined in a [for](../../cpp/for-statement-cpp.md) loop go out of scope after the **`for`** loop ends. This warning occurs if a variable with the same name as the loop variable, but defined in the enclosing loop, is used again in the scope containing the **`for`** loop. For example:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4264.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4264.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4264"]
 
 > 'virtual_function' : no override available for virtual member function from base 'class'; function is hidden
 
+## Remarks
+
 C4264 is always generated after [C4263](../../error-messages/compiler-warnings/compiler-warning-level-4-c4263.md).
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4264.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4264.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4264"
 title: "Compiler Warning (level 4, off) C4264"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4, off) C4264"
+ms.date: 11/04/2016
 f1_keywords: ["C4264"]
 helpviewer_keywords: ["C4264"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4269"]
 
 > 'identifier' : 'const' automatic data initialized with compiler generated default constructor produces unreliable results
 
+## Remarks
+
 A **`const`** automatic instance of a non-trivial class is initialized with a compiler-generated default constructor.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4269"]
 ---
 # Compiler Warning (level 1) C4269
 
-'identifier' : 'const' automatic data initialized with compiler generated default constructor produces unreliable results
+> 'identifier' : 'const' automatic data initialized with compiler generated default constructor produces unreliable results
 
 A **`const`** automatic instance of a non-trivial class is initialized with a compiler-generated default constructor.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4269.md
@@ -15,6 +15,8 @@ A **`const`** automatic instance of a non-trivial class is initialized with a co
 
 ## Example
 
+The following example generates C4269:
+
 ```cpp
 // C4269.cpp
 // compile with: /c /LD /W1

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
@@ -10,6 +10,8 @@ ms.assetid: 2c19d157-21d1-42c2-a6c0-3f30f2ce3813
 
 > 'argument' : conversion from 'type1' to 'type2', possible loss of data
 
+## Remarks
+
 A floating point type was converted to an integer type.  A possible loss of data may have occurred.
 
 If you get C4244, you should either change your program to use compatible types, or add some logic to your code, to ensure that the range of possible values will always be compatible with the types you are using.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4244"
 title: "Compiler Warning (level 2) C4244"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4244"
+ms.date: 11/04/2016
 f1_keywords: ["C4244"]
 helpviewer_keywords: ["C4244"]
-ms.assetid: 2c19d157-21d1-42c2-a6c0-3f30f2ce3813
 ---
 # Compiler Warning (level 2) C4244
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
@@ -8,7 +8,7 @@ ms.assetid: 2c19d157-21d1-42c2-a6c0-3f30f2ce3813
 ---
 # Compiler Warning (level 2) C4244
 
-'argument' : conversion from 'type1' to 'type2', possible loss of data
+> 'argument' : conversion from 'type1' to 'type2', possible loss of data
 
 A floating point type was converted to an integer type.  A possible loss of data may have occurred.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4244.md
@@ -20,7 +20,7 @@ C4244 can also fire at level 3, and 4; see [Compiler Warning (levels 3 and 4) C4
 
 ## Example
 
-The following sample generates C4244:
+The following example generates C4244:
 
 ```cpp
 // C4244_level2.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
@@ -19,6 +19,8 @@ Because a virtual base class is shared among multiple derived classes, a name in
 
 ## Examples
 
+The following example generates C4250:
+
 ```cpp
 // C4250.cpp
 // compile with: /c /W2

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
@@ -8,7 +8,7 @@ ms.assetid: d47f7249-6b5a-414b-b2d4-56e5d246a782
 ---
 # Compiler Warning (level 2) C4250
 
-'class1' : inherits 'class2::member' via dominance
+> 'class1' : inherits 'class2::member' via dominance
 
 Two or more members have the same name. The one in `class2` is inherited because it is a base class for the other classes that contained this member.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
@@ -42,7 +42,7 @@ int main() {
 }
 ```
 
-The following sample generates C4250.
+The following example generates C4250.
 
 ```cpp
 // C4250_b.cpp
@@ -73,7 +73,7 @@ int main() {
 }
 ```
 
-This sample shows a more complex situation. The following sample generates C4250.
+This example shows a more complex situation. The following example generates C4250.
 
 ```cpp
 // C4250_c.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4250"
 title: "Compiler Warning (level 2) C4250"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4250"
+ms.date: 11/04/2016
 f1_keywords: ["C4250"]
 helpviewer_keywords: ["C4250"]
-ms.assetid: d47f7249-6b5a-414b-b2d4-56e5d246a782
 ---
 # Compiler Warning (level 2) C4250
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4250.md
@@ -10,6 +10,8 @@ ms.assetid: d47f7249-6b5a-414b-b2d4-56e5d246a782
 
 > 'class1' : inherits 'class2::member' via dominance
 
+## Remarks
+
 Two or more members have the same name. The one in `class2` is inherited because it is a base class for the other classes that contained this member.
 
 To suppress C4250, use the [warning](../../preprocessor/warning.md) pragma.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
@@ -10,6 +10,8 @@ ms.assetid: a2657cdb-18e1-493f-882b-4e10c0bca71d
 
 > nonstandard extension used : access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'
 
+## Remarks
+
 Under ANSI compatibility ([/Za](../../build/reference/za-ze-disable-language-extensions.md)), you cannot change the access to a nested class. Under the default Microsoft extensions (/Ze), you can, with this warning.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
@@ -15,6 +15,8 @@ Under ANSI compatibility ([/Za](../../build/reference/za-ze-disable-language-ext
 
 ## Example
 
+The following example generates C4240:
+
 ```cpp
 // C4240.cpp
 // compile with: /W3

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
@@ -8,7 +8,7 @@ ms.assetid: a2657cdb-18e1-493f-882b-4e10c0bca71d
 ---
 # Compiler Warning (level 3) C4240
 
-nonstandard extension used : access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'
+> nonstandard extension used : access to 'classname' now defined to be 'access specifier', previously it was defined to be 'access specifier'
 
 Under ANSI compatibility ([/Za](../../build/reference/za-ze-disable-language-extensions.md)), you cannot change the access to a nested class. Under the default Microsoft extensions (/Ze), you can, with this warning.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4240.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4240"
 title: "Compiler Warning (level 3) C4240"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4240"
+ms.date: 11/04/2016
 f1_keywords: ["C4240"]
 helpviewer_keywords: ["C4240"]
-ms.assetid: a2657cdb-18e1-493f-882b-4e10c0bca71d
 ---
 # Compiler Warning (level 3) C4240
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4243"]
 ---
 # Compiler Warning (level 3) C4243
 
-'conversion type' conversion exists from 'type1' to 'type2', but is inaccessible
+> 'conversion type' conversion exists from 'type1' to 'type2', but is inaccessible
 
 A pointer to a derived class is converted to a pointer to a base class, but the derived class inherits the base class with private or protected access.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
@@ -15,7 +15,7 @@ A pointer to a derived class is converted to a pointer to a base class, but the 
 
 ## Example
 
-The following sample generates C4243:
+The following example generates C4243:
 
 ```cpp
 // C4243.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4243.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C4243"]
 
 > 'conversion type' conversion exists from 'type1' to 'type2', but is inaccessible
 
+## Remarks
+
 A pointer to a derived class is converted to a pointer to a base class, but the derived class inherits the base class with private or protected access.
+
+## Example
 
 The following sample generates C4243:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 3, off) C4265"
 title: "Compiler Warning (level 3, off) C4265"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3, off) C4265"
+ms.date: 11/04/2016
 f1_keywords: ["C4265"]
 helpviewer_keywords: ["C4265"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4265"]
 
 > '*classname*': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
 
+## Remarks
+
 When a class has virtual functions but a nonvirtual destructor, objects of the type might not be destroyed properly when the class is destroyed through a base class pointer.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4265:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4265.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4265:
+The following example generates C4265:
 
 ```cpp
 // C4265.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4267"
 title: "Compiler Warning (level 3) C4267"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4267"
+ms.date: 11/04/2016
 f1_keywords: ["C4267"]
 helpviewer_keywords: ["C4267"]
-ms.assetid: 2fa2f13f-fa4f-47bb-ad8f-6cb19cfc91e6
 ---
 # Compiler Warning (level 3) C4267
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
@@ -10,6 +10,8 @@ ms.assetid: 2fa2f13f-fa4f-47bb-ad8f-6cb19cfc91e6
 
 > 'var' : conversion from 'size_t' to 'type', possible loss of data
 
+## Remarks
+
 The compiler detected a conversion from `size_t` to a smaller type.
 
 To fix this warning, use `size_t` instead of `type`. Alternatively, use an integral type that is at least as large as `size_t`.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4267.md
@@ -8,7 +8,7 @@ ms.assetid: 2fa2f13f-fa4f-47bb-ad8f-6cb19cfc91e6
 ---
 # Compiler Warning (level 3) C4267
 
-'var' : conversion from 'size_t' to 'type', possible loss of data
+> 'var' : conversion from 'size_t' to 'type', possible loss of data
 
 The compiler detected a conversion from `size_t` to a smaller type.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
@@ -8,7 +8,7 @@ ms.assetid: f92028a5-4ddd-43c1-97f5-4f724e5e14af
 ---
 # Compiler Warning (level 4) C4232
 
-nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed
+> nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed
 
 Under Microsoft extensions (/Ze), you can give a nonstatic value as the address of a function declared with the **`dllimport`** modifier. Under ANSI compatibility ([/Za](../../build/reference/za-ze-disable-language-extensions.md)), this causes an error.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4232"
 title: "Compiler Warning (level 4) C4232"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4232"
+ms.date: 11/04/2016
 f1_keywords: ["C4232"]
 helpviewer_keywords: ["C4232"]
-ms.assetid: f92028a5-4ddd-43c1-97f5-4f724e5e14af
 ---
 # Compiler Warning (level 4) C4232
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
@@ -16,7 +16,7 @@ Under Microsoft extensions (/Ze), you can give a nonstatic value as the address 
 
 ## Example
 
-The following sample generates C4232:
+The following example generates C4232:
 
 ```c
 // C4232.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4232.md
@@ -10,7 +10,11 @@ ms.assetid: f92028a5-4ddd-43c1-97f5-4f724e5e14af
 
 > nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed
 
+## Remarks
+
 Under Microsoft extensions (/Ze), you can give a nonstatic value as the address of a function declared with the **`dllimport`** modifier. Under ANSI compatibility ([/Za](../../build/reference/za-ze-disable-language-extensions.md)), this causes an error.
+
+## Example
 
 The following sample generates C4232:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4233.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4233.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1, Error) C4233"
 title: "Compiler Warning (level 1, Error) C4233"
-ms.date: "10/25/2017"
+description: "Learn more about: Compiler Warning (level 1, Error) C4233"
+ms.date: 10/25/2017
 f1_keywords: ["C4233"]
 helpviewer_keywords: ["C4233"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4233.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4233.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4233"]
 
 > nonstandard extension used: '*keyword*' keyword only supported in C++, not C
 
+## Remarks
+
 The compiler compiled your source code as C rather than C++, and you used a keyword that is only valid in C++. The compiler compiles your source file as C if the extension of the source file is .c or you use [/Tc](../../build/reference/tc-tp-tc-tp-specify-source-file-type.md).
 
 This warning is always issued as an error. Use the [warning](../../preprocessor/warning.md) pragma to disable.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4234"
 title: "Compiler Warning (level 4) C4234"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4234"
+ms.date: 11/04/2016
 f1_keywords: ["C4234"]
 helpviewer_keywords: ["C4234"]
-ms.assetid: f7fecd5c-8248-4fde-8446-502aedc357ca
 ---
 # Compiler Warning (level 4) C4234
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
@@ -10,6 +10,8 @@ ms.assetid: f7fecd5c-8248-4fde-8446-502aedc357ca
 
 > nonstandard extension used: 'keyword' keyword reserved for future use
 
+## Remarks
+
 The compiler does not yet implement the keyword you used.
 
 This warning is automatically promoted to an error. If you wish to modify this behavior, use [#pragma warning](../../preprocessor/warning.md). For example, to make C4234 into a level 4 warning issue,

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4234.md
@@ -8,7 +8,7 @@ ms.assetid: f7fecd5c-8248-4fde-8446-502aedc357ca
 ---
 # Compiler Warning (level 4) C4234
 
-nonstandard extension used: 'keyword' keyword reserved for future use
+> nonstandard extension used: 'keyword' keyword reserved for future use
 
 The compiler does not yet implement the keyword you used.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
@@ -8,7 +8,7 @@ ms.assetid: 5d4051d3-7b0f-43ea-8c8d-d194bfdceb71
 ---
 # Compiler Warning (level 4) C4238
 
-nonstandard extension used : class rvalue used as lvalue
+> nonstandard extension used : class rvalue used as lvalue
 
 For compatibility with previous versions of Visual C++, Microsoft extensions (**/Ze**) allow you to use a class type as an rvalue in a context that implicitly or explicitly takes its address. In some cases, such as the example below, this can be dangerous.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4238"
 title: "Compiler Warning (level 4) C4238"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4238"
+ms.date: 11/04/2016
 f1_keywords: ["C4238"]
 helpviewer_keywords: ["C4238"]
-ms.assetid: 5d4051d3-7b0f-43ea-8c8d-d194bfdceb71
 ---
 # Compiler Warning (level 4) C4238
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
@@ -15,6 +15,8 @@ For compatibility with previous versions of Visual C++, Microsoft extensions (**
 
 ## Example
 
+The following example generates C4238:
+
 ```cpp
 // C4238.cpp
 // compile with: /W4 /c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4238.md
@@ -10,6 +10,8 @@ ms.assetid: 5d4051d3-7b0f-43ea-8c8d-d194bfdceb71
 
 > nonstandard extension used : class rvalue used as lvalue
 
+## Remarks
+
 For compatibility with previous versions of Visual C++, Microsoft extensions (**/Ze**) allow you to use a class type as an rvalue in a context that implicitly or explicitly takes its address. In some cases, such as the example below, this can be dangerous.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
@@ -16,7 +16,7 @@ This type conversion is not allowed by the C++ standard, but it is permitted her
 
 ## Examples
 
-The following sample generates C4239.
+The following example generates C4239.
 
 ```cpp
 // C4239.cpp
@@ -34,7 +34,7 @@ void func(void) {
 
 Conversion from integral type to enum type is not strictly allowed.
 
-The following sample generates C4239.
+The following example generates C4239.
 
 ```cpp
 // C4239b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
@@ -10,6 +10,8 @@ ms.assetid: a23dc16a-649e-4870-9a24-275de1584fcd
 
 > nonstandard extension used : 'token' : conversion from 'type' to 'type'
 
+## Remarks
+
 This type conversion is not allowed by the C++ standard, but it is permitted here as an extension. This warning is always followed by at least one line of explanation describing the language rule being violated.
 
 ## Examples

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
@@ -8,7 +8,7 @@ ms.assetid: a23dc16a-649e-4870-9a24-275de1584fcd
 ---
 # Compiler Warning (level 4) C4239
 
-nonstandard extension used : 'token' : conversion from 'type' to 'type'
+> nonstandard extension used : 'token' : conversion from 'type' to 'type'
 
 This type conversion is not allowed by the C++ standard, but it is permitted here as an extension. This warning is always followed by at least one line of explanation describing the language rule being violated.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4239.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4239"
 title: "Compiler Warning (level 4) C4239"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4239"
+ms.date: 11/04/2016
 f1_keywords: ["C4239"]
 helpviewer_keywords: ["C4239"]
-ms.assetid: a23dc16a-649e-4870-9a24-275de1584fcd
 ---
 # Compiler Warning (level 4) C4239
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 3, off) C4242"
 title: "Compiler Warning (level 3, off) C4242"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3, off) C4242"
+ms.date: 11/04/2016
 f1_keywords: ["C4242"]
 helpviewer_keywords: ["C4242"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
@@ -19,7 +19,7 @@ For more information on C4242, see [Common Compiler Errors](/windows/win32/WinPr
 
 ## Example
 
-The following sample generates C4242:
+The following example generates C4242:
 
 ```cpp
 // C4242.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4242.md
@@ -9,11 +9,15 @@ helpviewer_keywords: ["C4242"]
 
 > '*identifier*': conversion from '*type1*' to '*type2*', possible loss of data
 
+## Remarks
+
 The types are different. Type conversion may result in loss of data. The compiler makes the type conversion.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
 
 For more information on C4242, see [Common Compiler Errors](/windows/win32/WinProg64/common-compiler-errors).
+
+## Example
 
 The following sample generates C4242:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
@@ -10,7 +10,11 @@ ms.assetid: 85083d53-9cc2-4d12-b58c-6dad28f15cbe
 
 > '*conversion*' : conversion from '*type1*' to '*type2*', signed/unsigned mismatch
 
+## Remarks
+
 You tried to convert a **`signed const`** type that has a negative value to an **`unsigned`** type.
+
+## Example
 
 The following sample generates C4245:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4245"
 title: "Compiler Warning (level 4) C4245"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4245"
+ms.date: 11/04/2016
 f1_keywords: ["C4245"]
 helpviewer_keywords: ["C4245"]
-ms.assetid: 85083d53-9cc2-4d12-b58c-6dad28f15cbe
 ---
 # Compiler Warning (level 4) C4245
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4245.md
@@ -16,7 +16,7 @@ You tried to convert a **`signed const`** type that has a negative value to an *
 
 ## Example
 
-The following sample generates C4245:
+The following example generates C4245:
 
 ```cpp
 // C4245.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4254.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4254.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4254:
+The following example generates C4254:
 
 ```cpp
 // C4254.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4254.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4254.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4254"]
 
 > '*operator*': conversion from '*type1*':'*field_bits*' to '*type2*':'*field_bits*', possible loss of data
 
+## Remarks
+
 A larger bit field was assigned to a smaller bit field. There could be a loss of data.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4254:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4255"]
 
 > 'function' : no function prototype given: converting '()' to '(void)'
 
+## Remarks
+
 The compiler didn't find an explicit list of arguments to a function. This warning is for the C compiler only.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4255:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4255"
 title: "Compiler Warning (level 4, off) C4255"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4, off) C4255"
+ms.date: 11/04/2016
 f1_keywords: ["C4255"]
 helpviewer_keywords: ["C4255"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4255.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4255:
+The following example generates C4255:
 
 ```c
 // C4255.c

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4256"
 title: "Compiler Warning (level 4) C4256"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4256"
+ms.date: 11/04/2016
 f1_keywords: ["C4256"]
 helpviewer_keywords: ["C4256"]
-ms.assetid: a755a32e-895a-4837-a2b5-4ea06b736798
 ---
 # Compiler Warning (level 4) C4256
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
@@ -10,6 +10,8 @@ ms.assetid: a755a32e-895a-4837-a2b5-4ea06b736798
 
 > 'function' : constructor for class with virtual bases has '...'; calls may not be compatible with older versions of Visual C++
 
+## Remarks
+
 Possible incompatibility.
 
 Consider the following code example. If the definition of the constructor S2::S2( int i, ... ) was compiled by using a version of the Microsoft C++ compiler before version 7, but the following example is compiled by using the current version, the call to the constructor for S3 would not work correctly because of a special-case calling-convention change. If both were compiled by using Visual C++ 6.0, the call would not work quite right either, unless no parameters were passed for the ellipsis.
@@ -19,6 +21,8 @@ To fix this warning,
 1. Don't use ellipsis in a constructor.
 
 1. Make sure that all components in their project are built with the current version (including any libraries that may define or reference this class), then disable the warning using the [warning](../../preprocessor/warning.md) pragma.
+
+## Example
 
 The following sample generates C4256:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
@@ -8,7 +8,7 @@ ms.assetid: a755a32e-895a-4837-a2b5-4ea06b736798
 ---
 # Compiler Warning (level 4) C4256
 
-'function' : constructor for class with virtual bases has '...'; calls may not be compatible with older versions of Visual C++
+> 'function' : constructor for class with virtual bases has '...'; calls may not be compatible with older versions of Visual C++
 
 Possible incompatibility.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4256.md
@@ -24,7 +24,7 @@ To fix this warning,
 
 ## Example
 
-The following sample generates C4256:
+The following example generates C4256:
 
 ```cpp
 // C4256.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4263"
 title: "Compiler Warning (level 4, off) C4263"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4, off) C4263"
+ms.date: 11/04/2016
 f1_keywords: ["C4263"]
 helpviewer_keywords: ["C4263"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4263"]
 
 > 'function' : member function does not override any base class virtual member function
 
+## Remarks
+
 A class function definition has the same name as a virtual function in a base class but not the same number or type of arguments. This pattern effectively hides the virtual function in the base class.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4263:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4263.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4263:
+The following example generates C4263:
 
 ```cpp
 // C4263.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4266:
+The following example generates C4266:
 
 ```cpp
 // C4266.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4266"
 title: "Compiler Warning (level 4, off) C4266"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4, off) C4266"
+ms.date: 11/04/2016
 f1_keywords: ["C4266"]
 helpviewer_keywords: ["C4266"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4266.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4266"]
 
 > 'function' : no override available for virtual member function from base 'type'; function is hidden
 
+## Remarks
+
 A derived class didn't override all overloads of a virtual function.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4266:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
@@ -10,6 +10,8 @@ ms.assetid: d0511e80-904f-4ee1-b4d7-39b5c0bd8234
 
 > 'identifier' : 'const' static/global data initialized with compiler generated default constructor fills the object with zeros
 
+## Remarks
+
 A **`const`** global or static instance of a non-trivial class is initialized with a compiler-generated default constructor.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
@@ -15,6 +15,8 @@ A **`const`** global or static instance of a non-trivial class is initialized wi
 
 ## Example
 
+The following example generates C4268:
+
 ```cpp
 // C4268.cpp
 // compile with: /c /LD /W4

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
@@ -8,7 +8,7 @@ ms.assetid: d0511e80-904f-4ee1-b4d7-39b5c0bd8234
 ---
 # Compiler Warning (level 4) C4268
 
-'identifier' : 'const' static/global data initialized with compiler generated default constructor fills the object with zeros
+> 'identifier' : 'const' static/global data initialized with compiler generated default constructor fills the object with zeros
 
 A **`const`** global or static instance of a non-trivial class is initialized with a compiler-generated default constructor.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4268.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4268"
 title: "Compiler Warning (level 4) C4268"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4268"
+ms.date: 11/04/2016
 f1_keywords: ["C4268"]
 helpviewer_keywords: ["C4268"]
-ms.assetid: d0511e80-904f-4ee1-b4d7-39b5c0bd8234
 ---
 # Compiler Warning (level 4) C4268
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -19,7 +19,7 @@ C4244 can also appear when the warning level is 2. For more information, see [Co
 
 ## Examples
 
-The following sample generates C4244:
+The following example generates C4244:
 
 ```cpp
 // C4244_level4.cpp
@@ -56,7 +56,7 @@ int main() {
 
 Warning C4244 can occur when building code for 64-bit targets that doesn't generate the warning when building for 32-bit targets. For example, pointer arithmetic results in a 32-bit quantity on 32-bit platforms, but a 64-bit quantity on 64-bit platforms.
 
-The following sample generates C4244 when compiled for 64-bit targets:
+The following example generates C4244 when compiled for 64-bit targets:
 
 ```cpp
 // C4244_level3_b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (levels 3 and 4) C4244"
 title: "Compiler Warning (levels 3 and 4) C4244"
-ms.date: "11/6/2023"
+description: "Learn more about: Compiler Warning (levels 3 and 4) C4244"
+ms.date: 11/6/2023
 ---
 # Compiler Warning (levels 3 and 4) C4244
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -7,6 +7,8 @@ ms.date: "11/6/2023"
 
 > 'conversion' conversion from 'type1' to 'type2', possible loss of data
 
+## Remarks
+
 An integer type is converted to a smaller integer type.
 - This is a level-4 warning if *type1* is a signed or unsigned **`int`** and *type2* is a smaller, such as a signed or unsigned **`short`**.
 - It's a level 3 warning if a value of type [`__int64`](../../cpp/int8-int16-int32-int64.md) or **`unsigned __int64`** is assigned to a signed or unsigned **`int`**. A possible loss of data may have occurred due to a narrowing conversion, which might lead to unexpected results.
@@ -14,6 +16,8 @@ An integer type is converted to a smaller integer type.
 To fix this warning, either change your program to use compatible types, or add logic that ensures that the range of possible values is compatible with the types you're using. If the conversion is intended, use an explicit cast to silence the warning.
 
 C4244 can also appear when the warning level is 2. For more information, see [Compiler Warning (level 2) C4244](../../error-messages/compiler-warnings/compiler-warning-level-2-c4244.md).
+
+## Examples
 
 The following sample generates C4244:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244.md
@@ -5,7 +5,7 @@ ms.date: "11/6/2023"
 ---
 # Compiler Warning (levels 3 and 4) C4244
 
-'conversion' conversion from 'type1' to 'type2', possible loss of data
+> 'conversion' conversion from 'type1' to 'type2', possible loss of data
 
 An integer type is converted to a smaller integer type.
 - This is a level-4 warning if *type1* is a signed or unsigned **`int`** and *type2* is a smaller, such as a signed or unsigned **`short`**.


### PR DESCRIPTION
C4235 is skipped due to #5586.

This is batch 74 that structures error/warning references. See #5465 for more information.