### PR TITLE
Elide stray escapes in columns

### DIFF
--- a/docs/assembler/masm/option-language-masm.md
+++ b/docs/assembler/masm/option-language-masm.md
@@ -1,6 +1,6 @@
 ---
-description: Learn more about the alternatives for the OPTION LANGUAGE directive
 title: "OPTION LANGUAGE"
+description: "Learn more about the alternatives for the OPTION LANGUAGE directive"
 ms.date: 09/21/2021
 f1_keywords: ["language"]
 helpviewer_keywords: ["OPTION LANGUAGE directive"]

--- a/docs/assembler/masm/option-language-masm.md
+++ b/docs/assembler/masm/option-language-masm.md
@@ -20,11 +20,11 @@ Available languages include:
 :::row:::
    :::column span="":::
       **`C`**\
-      **`SYSCALL`**\
+      **`SYSCALL`**
    :::column-end:::
    :::column span="":::
       **`STDCALL`**\
-      **`PASCAL`**\
+      **`PASCAL`**
    :::column-end:::
    :::column span="":::
       **`FORTRAN`**\

--- a/docs/c-runtime-library/ismbb-routines.md
+++ b/docs/c-runtime-library/ismbb-routines.md
@@ -21,7 +21,7 @@ Tests the given integer value `c` for a particular condition, by using the curre
       [`_ismbblead`, `_ismbblead_l`](./reference/ismbblead-ismbblead-l.md)\
       [`_ismbbprint`, `_ismbbprint_l`](./reference/ismbbprint-ismbbprint-l.md)\
       [`_ismbbpunct`, `_ismbbpunct_l`](./reference/ismbbpunct-ismbbpunct-l.md)\
-      [`_ismbbtrail`, `_ismbbtrail_l`](./reference/ismbbtrail-ismbbtrail-l.md)\
+      [`_ismbbtrail`, `_ismbbtrail_l`](./reference/ismbbtrail-ismbbtrail-l.md)
    :::column-end:::
 :::row-end:::
 

--- a/docs/c-runtime-library/ismbb-routines.md
+++ b/docs/c-runtime-library/ismbb-routines.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: _ismbb routines"
 title: "_ismbb routines"
+description: "Learn more about: _ismbb routines"
 ms.date: 01/11/2022
 helpviewer_keywords: ["ismbb routines", "_ismbb routines"]
 ---

--- a/docs/dotnet/stl-clr-library-reference.md
+++ b/docs/dotnet/stl-clr-library-reference.md
@@ -51,7 +51,7 @@ In addition, this section also describes the following components of STL/CLR:
       [`hash_multimap` (STL/CLR)](../dotnet/hash-multimap-stl-clr.md)\
       [`hash_multiset` (STL/CLR)](../dotnet/hash-multiset-stl-clr.md)\
       [`hash_set` (STL/CLR)](../dotnet/hash-set-stl-clr.md)\
-      [`list` (STL/CLR)](../dotnet/list-stl-clr.md)\
+      [`list` (STL/CLR)](../dotnet/list-stl-clr.md)
    :::column-end:::
    :::column span="":::
       [`map` (STL/CLR)](../dotnet/map-stl-clr.md)\
@@ -63,7 +63,7 @@ In addition, this section also describes the following components of STL/CLR:
       [`set` (STL/CLR)](../dotnet/set-stl-clr.md)\
       [`stack` (STL/CLR)](../dotnet/stack-stl-clr.md)\
       [`utility` (STL/CLR)](../dotnet/utility-stl-clr.md)\
-      [`vector` (STL/CLR)](../dotnet/vector-stl-clr.md)\
+      [`vector` (STL/CLR)](../dotnet/vector-stl-clr.md)
    :::column-end:::
 :::row-end:::
 

--- a/docs/dotnet/stl-clr-library-reference.md
+++ b/docs/dotnet/stl-clr-library-reference.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: STL/CLR Library Reference"
 title: "STL/CLR Library Reference"
+description: "Learn more about: STL/CLR Library Reference"
 ms.date: 09/18/2018
 ms.topic: "reference"
 helpviewer_keywords: ["STL/CLR Library", "STL/CLR, redistribution", "cliext directory"]
-ms.assetid: a9d9ca00-7bf2-48c1-b205-3ae6f8c25f82
 ---
 # STL/CLR Library Reference
 

--- a/docs/standard-library/type-traits.md
+++ b/docs/standard-library/type-traits.md
@@ -44,7 +44,7 @@ These are the provided aliases for the `type` members:
       `add_rvalue_reference_t`\
       `add_volatile_t`\
       `aligned_storage_t`\
-      `aligned_union_t`\
+      `aligned_union_t`
    :::column-end:::
    :::column:::
       `common_type_t`\
@@ -54,7 +54,7 @@ These are the provided aliases for the `type` members:
       `invoke_result_t`\
       `make_signed_t`\
       `make_unsigned_t`\
-      `remove_all_extents_t`\
+      `remove_all_extents_t`
    :::column-end:::
    :::column:::
       `remove_const_t`\
@@ -64,7 +64,7 @@ These are the provided aliases for the `type` members:
       `remove_reference_t`\
       `remove_volatile_t`\
       `result_of_t`\
-      `underlying_type_t`\
+      `underlying_type_t`
    :::column-end:::
 :::row-end:::
 

--- a/docs/standard-library/type-traits.md
+++ b/docs/standard-library/type-traits.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: <type_traits>"
 title: "<type_traits>"
-ms.date: "02/21/2019"
+description: "Learn more about: <type_traits>"
+ms.date: 02/21/2019
 f1_keywords: ["<type_traits>"]
 helpviewer_keywords: ["typetrait header", "type_traits"]
-ms.assetid: 2260b51f-8160-4c66-a82f-00b534cb60d4
 ---
 # `<type_traits>`
 


### PR DESCRIPTION
Elide stray escapes that render verbatim:

<img width="840" height="359" alt="image" src="https://github.com/user-attachments/assets/783656ec-8747-44f7-8be4-e6a059deb59c" />
