### PR TITLE
Structure warning references in range [C4311, C4360]

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
@@ -9,11 +9,15 @@ helpviewer_keywords: ["C4355"]
 
 > '`this`': used in base member initializer list
 
+## Remarks
+
 The `this` pointer is valid only within nonstatic member functions. It can't be used in the initializer list for a base class.
 
 The base-class constructors and class member constructors are called before `this` constructor. This pattern is the same as passing a pointer to an unconstructed object to another constructor. If those other constructors access any members or call member functions on `this`, the result is undefined. You shouldn't use the `this` pointer until all construction is complete.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4355:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4355.md
@@ -19,7 +19,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4355:
+The following example generates C4355:
 
 ```cpp
 // C4355.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4311"
 title: "Compiler Warning (level 1) C4311"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4311"
+ms.date: 11/04/2016
 f1_keywords: ["C4311"]
 helpviewer_keywords: ["C4311"]
-ms.assetid: ddc579d0-d051-47bc-915d-71ffb32323c9
 ---
 # Compiler Warning (level 1) C4311
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
@@ -8,7 +8,7 @@ ms.assetid: ddc579d0-d051-47bc-915d-71ffb32323c9
 ---
 # Compiler Warning (level 1) C4311
 
-'variable' : pointer truncation from 'type' to 'type'
+> 'variable' : pointer truncation from 'type' to 'type'
 
 This warning detects 64-bit pointer truncation issues. For example, if code is compiled for a 64-bit architecture, the value of a pointer (64 bits) will be truncated if it is assigned to an **`int`** (32 bits). For more information, see [Rules for Using Pointers](/windows/win32/WinProg64/rules-for-using-pointers).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4311.md
@@ -10,9 +10,13 @@ ms.assetid: ddc579d0-d051-47bc-915d-71ffb32323c9
 
 > 'variable' : pointer truncation from 'type' to 'type'
 
+## Remarks
+
 This warning detects 64-bit pointer truncation issues. For example, if code is compiled for a 64-bit architecture, the value of a pointer (64 bits) will be truncated if it is assigned to an **`int`** (32 bits). For more information, see [Rules for Using Pointers](/windows/win32/WinProg64/rules-for-using-pointers).
 
 For additional information about common causes of warning C4311, see [Common Compiler Errors](/windows/win32/WinProg64/common-compiler-errors).
+
+## Example
 
 The following code example generates C4311 when compiled for a 64-bit target, and then demonstrates how to fix it:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
@@ -10,11 +10,15 @@ ms.assetid: 541906ed-4f62-4bcb-947f-cf9ae7411bcb
 
 > 'operation' : conversion from 'type1' to 'type2' of greater size
 
+## Remarks
+
 This warning detects an attempt to assign a 32-bit value to a 64-bit pointer type, for example, casting a 32-bit **`int`** or **`long`** to a 64-bit pointer.
 
 This can be an unsafe conversion even for pointer values that fit in 32 bits when sign extension occurs. If a negative 32-bit integer is assigned to a 64-bit pointer type, sign extension causes the pointer value to reference a memory address different from the value of the integer.
 
 This warning is only issued for 64-bit compilation targets. For more information, see [Rules for Using Pointers](/windows/win32/WinProg64/rules-for-using-pointers).
+
+## Example
 
 The following code example generates C4312 when it is compiled for 64-bit targets:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
@@ -8,7 +8,7 @@ ms.assetid: 541906ed-4f62-4bcb-947f-cf9ae7411bcb
 ---
 # Compiler Warning (level 1) C4312
 
-'operation' : conversion from 'type1' to 'type2' of greater size
+> 'operation' : conversion from 'type1' to 'type2' of greater size
 
 This warning detects an attempt to assign a 32-bit value to a 64-bit pointer type, for example, casting a 32-bit **`int`** or **`long`** to a 64-bit pointer.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4312.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4312"
 title: "Compiler Warning (level 1) C4312"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4312"
+ms.date: 11/04/2016
 f1_keywords: ["C4312"]
 helpviewer_keywords: ["C4312"]
-ms.assetid: 541906ed-4f62-4bcb-947f-cf9ae7411bcb
 ---
 # Compiler Warning (level 1) C4312
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4313"
 title: "Compiler Warning (level 1) C4313"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4313"
+ms.date: 11/04/2016
 f1_keywords: ["C4313"]
 helpviewer_keywords: ["C4313"]
-ms.assetid: bcf64191-e2cf-452e-97b4-423fcec2d07c
 ---
 # Compiler Warning (level 1) C4313
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
@@ -8,7 +8,7 @@ ms.assetid: bcf64191-e2cf-452e-97b4-423fcec2d07c
 ---
 # Compiler Warning (level 1) C4313
 
-'function' : 'format specifier' in format string conflicts with argument number of type 'type'
+> 'function' : 'format specifier' in format string conflicts with argument number of type 'type'
 
 There is a conflict between the format specified and the value that you are passing. For example, you passed a 64-bit parameter to an unqualified %d format specifier, which expects a 32-bit integer parameter. This warning is only in effect when the code is compiled for 64-bit targets.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
@@ -16,7 +16,7 @@ There is a conflict between the format specified and the value that you are pass
 
 ## Example
 
-The following code sample generates C4313 when it is compiled for a 64-bit target.
+The following code example generates C4313 when it is compiled for a 64-bit target.
 
 ```cpp
 // C4313.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4313.md
@@ -10,6 +10,8 @@ ms.assetid: bcf64191-e2cf-452e-97b4-423fcec2d07c
 
 > 'function' : 'format specifier' in format string conflicts with argument number of type 'type'
 
+## Remarks
+
 There is a conflict between the format specified and the value that you are passing. For example, you passed a 64-bit parameter to an unqualified %d format specifier, which expects a 32-bit integer parameter. This warning is only in effect when the code is compiled for 64-bit targets.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4319.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4319.md
@@ -10,6 +10,8 @@ ms.assetid: 1fac8048-9bd6-4552-a21c-192c67772bb9
 
 > '~' : zero extending '*type1*' to '*type2*' of greater size
 
+## Remarks
+
 The result of the **~** (bitwise complement) operator is unsigned and then zero-extended when it is converted to a larger type.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4319.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4319.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4319"
 title: "Compiler Warning (level 1) C4319"
-ms.date: "01/18/2018"
+description: "Learn more about: Compiler Warning (level 1) C4319"
+ms.date: 01/18/2018
 f1_keywords: ["C4319"]
 helpviewer_keywords: ["C4319"]
-ms.assetid: 1fac8048-9bd6-4552-a21c-192c67772bb9
 ---
 # Compiler Warning (level 1) C4319
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4325.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4325.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4325"
 title: "Compiler Warning (level 1) C4325"
-ms.date: "08/27/2018"
+description: "Learn more about: Compiler Warning (level 1) C4325"
+ms.date: 08/27/2018
 f1_keywords: ["C4325"]
 helpviewer_keywords: ["C4325"]
-ms.assetid: 8127a08c-d626-481b-aa7b-04a3fdc9a9ec
 ---
 # Compiler Warning (level 1) C4325
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4325.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4325.md
@@ -12,7 +12,11 @@ ms.assetid: 8127a08c-d626-481b-aa7b-04a3fdc9a9ec
 
 ## Remarks
 
-You may not change the attributes of a standard section. For example:
+You may not change the attributes of a standard section.
+
+## Example
+
+For example:
 
 ```cpp
 #pragma section(".sdata", long)

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4326.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4326.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4326"
 title: "Compiler Warning (level 1) C4326"
-ms.date: "08/27/2018"
+description: "Learn more about: Compiler Warning (level 1) C4326"
+ms.date: 08/27/2018
 f1_keywords: ["C4326"]
 helpviewer_keywords: ["C4326"]
-ms.assetid: d44d2c4e-9456-42d3-b35b-4ba4b2d42ec7
 ---
 # Compiler Warning (level 1) C4326
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4326.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4326.md
@@ -16,7 +16,7 @@ A function returned a type other than *type1*. For example, using [/Za](../../bu
 
 ## Example
 
-The following sample generates C4326 and shows how to fix it:
+The following example generates C4326 and shows how to fix it:
 
 ```cpp
 // C4326.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
@@ -15,7 +15,7 @@ Use of the alignment specifiers on `enum` isn't allowed. This pattern includes t
 
 ## Example
 
-The following sample generates C4329:
+The following example generates C4329:
 
 ```cpp
 // C4329.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4329"
 title: "Compiler Warning (level 1) C4329"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4329"
+ms.date: 11/04/2016
 f1_keywords: ["C4329"]
 helpviewer_keywords: ["C4329"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4329.md
@@ -9,7 +9,13 @@ helpviewer_keywords: ["C4329"]
 
 > alignment specifier is ignored on enum
 
-Use of the alignment specifiers on `enum` isn't allowed. This pattern includes the use of the [`align`](../../cpp/align-cpp.md) [`__declspec`](../../cpp/declspec.md) modifier. The following sample generates C4329:
+## Remarks
+
+Use of the alignment specifiers on `enum` isn't allowed. This pattern includes the use of the [`align`](../../cpp/align-cpp.md) [`__declspec`](../../cpp/declspec.md) modifier.
+
+## Example
+
+The following sample generates C4329:
 
 ```cpp
 // C4329.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
@@ -8,7 +8,7 @@ ms.assetid: d3763c52-6110-4da0-84db-5264e3f3f166
 ---
 # Compiler Warning (level 1) C4333
 
-'operator' : right shift by too large amount, data loss
+> 'operator' : right shift by too large amount, data loss
 
 A right shift operation was too large an amount.  All significant bits are shifted out and the result will always be zero.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4333"
 title: "Compiler Warning (level 1) C4333"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4333"
+ms.date: 11/04/2016
 f1_keywords: ["C4333"]
 helpviewer_keywords: ["C4333"]
-ms.assetid: d3763c52-6110-4da0-84db-5264e3f3f166
 ---
 # Compiler Warning (level 1) C4333
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
@@ -16,7 +16,7 @@ A right shift operation was too large an amount.  All significant bits are shift
 
 ## Example
 
-The following sample generates C4333.
+The following example generates C4333.
 
 ```cpp
 // C4333.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4333.md
@@ -10,6 +10,8 @@ ms.assetid: d3763c52-6110-4da0-84db-5264e3f3f166
 
 > 'operator' : right shift by too large amount, data loss
 
+## Remarks
+
 A right shift operation was too large an amount.  All significant bits are shifted out and the result will always be zero.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
@@ -10,4 +10,6 @@ ms.assetid: ddd5344b-5167-4c55-a318-20615052fd54
 
 > 'value' : value wrapped from positive to negative value
 
+## Remarks
+
 The **`enum`** value is greater than the largest **`enum`** positive value wrapped around to a negative value.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4340"
 title: "Compiler Warning (level 1) C4340"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4340"
+ms.date: 11/04/2016
 f1_keywords: ["C4340"]
 helpviewer_keywords: ["C4340"]
-ms.assetid: ddd5344b-5167-4c55-a318-20615052fd54
 ---
 # Compiler Warning (level 1) C4340
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4340.md
@@ -8,6 +8,6 @@ ms.assetid: ddd5344b-5167-4c55-a318-20615052fd54
 ---
 # Compiler Warning (level 1) C4340
 
-'value' : value wrapped from positive to negative value
+> 'value' : value wrapped from positive to negative value
 
 The **`enum`** value is greater than the largest **`enum`** positive value wrapped around to a negative value.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
@@ -8,7 +8,7 @@ ms.assetid: 47d4d5ab-069f-4cdc-98c3-10d649577a37
 ---
 # Compiler Warning (level 1) C4342
 
-behavior change: '*function*' called, but a member operator was called in previous versions
+> behavior change: '*function*' called, but a member operator was called in previous versions
 
 In versions of Visual C++ before Visual Studio 2002, a member was called, but this behavior has been changed and the compiler now finds the best match in namespace scope.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4342"
 title: "Compiler Warning (level 1) C4342"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4342"
+ms.date: 11/04/2016
 f1_keywords: ["C4342"]
 helpviewer_keywords: ["C4342"]
-ms.assetid: 47d4d5ab-069f-4cdc-98c3-10d649577a37
 ---
 # Compiler Warning (level 1) C4342
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
@@ -22,7 +22,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4342:
+The following example generates C4342:
 
 ```cpp
 // C4342.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4342.md
@@ -10,6 +10,8 @@ ms.assetid: 47d4d5ab-069f-4cdc-98c3-10d649577a37
 
 > behavior change: '*function*' called, but a member operator was called in previous versions
 
+## Remarks
+
 In versions of Visual C++ before Visual Studio 2002, a member was called, but this behavior has been changed and the compiler now finds the best match in namespace scope.
 
 If a member operator was found, the compiler would previously not consider any namespace scope operators. If there is a better match at namespace scope, the current compiler correctly calls it, whereas previous compilers wouldn't consider it.
@@ -17,6 +19,8 @@ If a member operator was found, the compiler would previously not consider any n
 This warning should be disabled after you successfully port your code to the current version.  The compiler may give false positives, generating this warning for code where there is no behavior change.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4342:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
@@ -10,4 +10,6 @@ ms.assetid: cd20859d-f07f-4c70-904b-cb756a53b1ed
 
 > behavior change: use of explicit template arguments results in call to 'function'
 
+## Remarks
+
 A call to a function using explicit template arguments calls a different function than it would if explicit arguments had not been specified

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4344"
 title: "Compiler Warning (level 1) C4344"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4344"
+ms.date: 11/04/2016
 f1_keywords: ["C4344"]
 helpviewer_keywords: ["C4344"]
-ms.assetid: cd20859d-f07f-4c70-904b-cb756a53b1ed
 ---
 # Compiler Warning (level 1) C4344
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4344.md
@@ -8,6 +8,6 @@ ms.assetid: cd20859d-f07f-4c70-904b-cb756a53b1ed
 ---
 # Compiler Warning (level 1) C4344
 
-behavior change: use of explicit template arguments results in call to 'function'
+> behavior change: use of explicit template arguments results in call to 'function'
 
 A call to a function using explicit template arguments calls a different function than it would if explicit arguments had not been specified

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4346"
 title: "Compiler Warning (level 1) C4346"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4346"
+ms.date: 11/04/2016
 f1_keywords: ["C4346"]
 helpviewer_keywords: ["C4346"]
-ms.assetid: 68ee562d-cca9-4a2a-9a1b-14ad1a1e7396
 ---
 # Compiler Warning (level 1) C4346
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
@@ -8,7 +8,7 @@ ms.assetid: 68ee562d-cca9-4a2a-9a1b-14ad1a1e7396
 ---
 # Compiler Warning (level 1) C4346
 
-'name' : dependent name is not a type
+> 'name' : dependent name is not a type
 
 The [typename](../../cpp/typename.md) keyword is required if a dependent name is to be treated as a type. For code that works the same in all versions of Visual C++, add **`typename`** to the declaration.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
@@ -16,7 +16,7 @@ The [typename](../../cpp/typename.md) keyword is required if a dependent name is
 
 ## Examples
 
-The following sample generates C4346:
+The following example generates C4346:
 
 ```cpp
 // C4346.cpp
@@ -29,7 +29,7 @@ struct C {
 };
 ```
 
-The following samples shows other examples where the **`typename`** keyword is required:
+The following shows other examples where the **`typename`** keyword is required:
 
 ```cpp
 // C4346b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4346.md
@@ -10,7 +10,11 @@ ms.assetid: 68ee562d-cca9-4a2a-9a1b-14ad1a1e7396
 
 > 'name' : dependent name is not a type
 
+## Remarks
+
 The [typename](../../cpp/typename.md) keyword is required if a dependent name is to be treated as a type. For code that works the same in all versions of Visual C++, add **`typename`** to the declaration.
+
+## Examples
 
 The following sample generates C4346:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
@@ -10,7 +10,11 @@ ms.assetid: 816010eb-6079-48d5-a41b-0fc4d67cfe4c
 
 > 'type' : redefinition of default parameter : parameter number
 
+## Remarks
+
 A template parameter was redefined.
+
+## Example
 
 The following sample generates C4348:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
@@ -16,7 +16,7 @@ A template parameter was redefined.
 
 ## Example
 
-The following sample generates C4348:
+The following example generates C4348:
 
 ```cpp
 // C4348.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4348"
 title: "Compiler Warning (level 1) C4348"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4348"
+ms.date: 11/04/2016
 f1_keywords: ["C4348"]
 helpviewer_keywords: ["C4348"]
-ms.assetid: 816010eb-6079-48d5-a41b-0fc4d67cfe4c
 ---
 # Compiler Warning (level 1) C4348
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4348.md
@@ -8,7 +8,7 @@ ms.assetid: 816010eb-6079-48d5-a41b-0fc4d67cfe4c
 ---
 # Compiler Warning (level 1) C4348
 
-'type' : redefinition of default parameter : parameter number
+> 'type' : redefinition of default parameter : parameter number
 
 A template parameter was redefined.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
@@ -24,7 +24,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4350:
+The following example generates C4350:
 
 ```cpp
 // C4350.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
@@ -8,7 +8,7 @@ ms.assetid: 4cc8ed67-64c4-4da5-a7a5-a639232baa23
 ---
 # Compiler Warning (level 1) C4350
 
-behavior change: 'member1' called instead of 'member2'
+> behavior change: 'member1' called instead of 'member2'
 
 An rvalue cannot be bound to a non-const reference. In versions of Visual C++ before Visual Studio 2003, it was possible to bind an rvalue to a non-const reference in a direct initialization. This code now gives a warning.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4350"
 title: "Compiler Warning (level 1) C4350"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4350"
+ms.date: 11/04/2016
 f1_keywords: ["C4350"]
 helpviewer_keywords: ["C4350"]
-ms.assetid: 4cc8ed67-64c4-4da5-a7a5-a639232baa23
 ---
 # Compiler Warning (level 1) C4350
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4350.md
@@ -10,6 +10,8 @@ ms.assetid: 4cc8ed67-64c4-4da5-a7a5-a639232baa23
 
 > behavior change: 'member1' called instead of 'member2'
 
+## Remarks
+
 An rvalue cannot be bound to a non-const reference. In versions of Visual C++ before Visual Studio 2003, it was possible to bind an rvalue to a non-const reference in a direct initialization. This code now gives a warning.
 
 For backward compatibility, it is still possible to bind rvalues to non-const references, but standard conversions are preferred wherever possible.
@@ -19,6 +21,8 @@ This warning represents a change of behavior from the Visual C++ .NET 2002 compi
 If you get this warning, examine your code to see if it depends on binding rvalues to non-const references. Adding a const to the reference or providing a additional const-reference overload may solve the problem.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4350:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4353"]
 ---
 # Compiler Warning (level 1) C4353
 
-nonstandard extension used: constant 0 as function expression. Use '__noop' function intrinsic instead
+> nonstandard extension used: constant 0 as function expression. Use '__noop' function intrinsic instead
 
 You cannot use the constant zero (0) as a function expression. For more information, see [__noop](../../intrinsics/noop.md).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["C4353"]
 
 > nonstandard extension used: constant 0 as function expression. Use '__noop' function intrinsic instead
 
+## Remarks
+
 You cannot use the constant zero (0) as a function expression. For more information, see [__noop](../../intrinsics/noop.md).
+
+## Example
 
 The following sample generates C4353:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4353.md
@@ -15,7 +15,7 @@ You cannot use the constant zero (0) as a function expression. For more informat
 
 ## Example
 
-The following sample generates C4353:
+The following example generates C4353:
 
 ```cpp
 // C4353.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
@@ -8,7 +8,7 @@ ms.assetid: a9848f84-14b3-405e-81bf-ee3e91a51511
 ---
 # Compiler Warning (level 1) C4358
 
-'operator': return type of combined delegates is not 'void'; returned value is undefined
+> 'operator': return type of combined delegates is not 'void'; returned value is undefined
 
 Two delegates were combined and the return value is not void. If two delegates with non-void return values are combined, the compiler will not be able to do a proper assignment if the return value of the delegate is used.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4358"
 title: "Compiler Warning (level 1) C4358"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4358"
+ms.date: 11/04/2016
 f1_keywords: ["C4358"]
 helpviewer_keywords: ["C4358"]
-ms.assetid: a9848f84-14b3-405e-81bf-ee3e91a51511
 ---
 # Compiler Warning (level 1) C4358
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
@@ -10,7 +10,11 @@ ms.assetid: a9848f84-14b3-405e-81bf-ee3e91a51511
 
 > 'operator': return type of combined delegates is not 'void'; returned value is undefined
 
+## Remarks
+
 Two delegates were combined and the return value is not void. If two delegates with non-void return values are combined, the compiler will not be able to do a proper assignment if the return value of the delegate is used.
+
+## Example
 
 The following sample generates C4358:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4358.md
@@ -16,7 +16,7 @@ Two delegates were combined and the return value is not void. If two delegates w
 
 ## Example
 
-The following sample generates C4358:
+The following example generates C4358:
 
 ```cpp
 // C4358.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
@@ -8,7 +8,7 @@ ms.assetid: 3af3defe-de33-43b6-bd6c-2c2e09e34f3f
 ---
 # Compiler Warning (level 2) C4356
 
-'member' : static data member cannot be initialized via derived class
+> 'member' : static data member cannot be initialized via derived class
 
 The initialization of a static data member was ill formed. The compiler accepted the initialization. To avoid the warning, initialize the member through the base class.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 2) C4356"
 title: "Compiler Warning (level 2) C4356"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 2) C4356"
+ms.date: 11/04/2016
 f1_keywords: ["C4356"]
 helpviewer_keywords: ["C4356"]
-ms.assetid: 3af3defe-de33-43b6-bd6c-2c2e09e34f3f
 ---
 # Compiler Warning (level 2) C4356
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
@@ -10,9 +10,13 @@ ms.assetid: 3af3defe-de33-43b6-bd6c-2c2e09e34f3f
 
 > 'member' : static data member cannot be initialized via derived class
 
+## Remarks
+
 The initialization of a static data member was ill formed. The compiler accepted the initialization. To avoid the warning, initialize the member through the base class.
 
 Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning.
+
+## Example
 
 The following sample generates C4356:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-2-c4356.md
@@ -18,7 +18,7 @@ Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning
 
 ## Example
 
-The following sample generates C4356:
+The following example generates C4356:
 
 ```cpp
 // C4356.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
@@ -10,7 +10,13 @@ ms.assetid: 10371f01-aeb8-40ac-a290-59e63efa5ad4
 
 > Object allocated on the heap may not be aligned for this type.
 
-An over-aligned object allocated by using `operator new` may not have the specified alignment. Override [operator new](../../c-runtime-library/new-operator-crt.md) and [operator delete](../../c-runtime-library/delete-operator-crt.md) for over-aligned types so that they use the aligned allocation routines—for example, [_aligned_malloc](../../c-runtime-library/reference/aligned-malloc.md) and [_aligned_free](../../c-runtime-library/reference/aligned-free.md). The following sample generates C4316:
+## Remarks
+
+An over-aligned object allocated by using `operator new` may not have the specified alignment. Override [operator new](../../c-runtime-library/new-operator-crt.md) and [operator delete](../../c-runtime-library/delete-operator-crt.md) for over-aligned types so that they use the aligned allocation routines—for example, [_aligned_malloc](../../c-runtime-library/reference/aligned-malloc.md) and [_aligned_free](../../c-runtime-library/reference/aligned-free.md).
+
+## Example
+
+The following sample generates C4316:
 
 ```cpp
 // C4316.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
@@ -8,7 +8,7 @@ ms.assetid: 10371f01-aeb8-40ac-a290-59e63efa5ad4
 ---
 # Compiler Warning (level 3) C4316
 
-Object allocated on the heap may not be aligned for this type.
+> Object allocated on the heap may not be aligned for this type.
 
 An over-aligned object allocated by using `operator new` may not have the specified alignment. Override [operator new](../../c-runtime-library/new-operator-crt.md) and [operator delete](../../c-runtime-library/delete-operator-crt.md) for over-aligned types so that they use the aligned allocation routines—for example, [_aligned_malloc](../../c-runtime-library/reference/aligned-malloc.md) and [_aligned_free](../../c-runtime-library/reference/aligned-free.md). The following sample generates C4316:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
@@ -1,10 +1,9 @@
 ---
 title: "Compiler Warning (level 3) C4316"
 description: "Description of C++ compiler warning C4316"
-ms.date: "11/04/2016"
+ms.date: 11/04/2016
 f1_keywords: ["C4316"]
 helpviewer_keywords: ["C4316"]
-ms.assetid: 10371f01-aeb8-40ac-a290-59e63efa5ad4
 ---
 # Compiler Warning (level 3) C4316
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4316.md
@@ -16,7 +16,7 @@ An over-aligned object allocated by using `operator new` may not have the specif
 
 ## Example
 
-The following sample generates C4316:
+The following example generates C4316:
 
 ```cpp
 // C4316.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4334"
 title: "Compiler Warning (level 3) C4334"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4334"
+ms.date: 11/04/2016
 f1_keywords: ["C4334"]
 helpviewer_keywords: ["C4334"]
-ms.assetid: d845857f-bc95-4faf-a079-626a0cf935ba
 ---
 # Compiler Warning (level 3) C4334
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
@@ -10,6 +10,8 @@ ms.assetid: d845857f-bc95-4faf-a079-626a0cf935ba
 
 > 'operator': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
 
+## Remarks
+
 The result of 32-bit shift was converted to 64-bit, and the compiler suspects that a 64-bit shift was intended. Resolve this warning by using a 64-bit shift. If a 32-bit shift is intentional, then cast the shift result to 32-bit to make it clear to the compiler.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
@@ -16,7 +16,7 @@ The result of 32-bit shift was converted to 64-bit, and the compiler suspects th
 
 ## Example
 
-The following sample generates C4334.
+The following example generates C4334.
 
 ```cpp
 // C4334.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4334.md
@@ -8,7 +8,7 @@ ms.assetid: d845857f-bc95-4faf-a079-626a0cf935ba
 ---
 # Compiler Warning (level 3) C4334
 
-'operator': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+> 'operator': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
 
 The result of 32-bit shift was converted to 64-bit, and the compiler suspects that a 64-bit shift was intended. Resolve this warning by using a 64-bit shift. If a 32-bit shift is intentional, then cast the shift result to 32-bit to make it clear to the compiler.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
@@ -16,7 +16,7 @@ The `ParamArray` attribute was ignored, and `function` cannot be called with var
 
 ## Example
 
-The following sample generates C4357:
+The following example generates C4357:
 
 ```cpp
 // C4357.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
@@ -8,7 +8,7 @@ ms.assetid: 9259c633-3c02-4900-b94a-2d8d366d61cd
 ---
 # Compiler Warning (level 3) C4357
 
-param array argument in formal argument list for delegate 'del' ignored when generating 'function'
+> param array argument in formal argument list for delegate 'del' ignored when generating 'function'
 
 The `ParamArray` attribute was ignored, and `function` cannot be called with variable arguments.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4357"
 title: "Compiler Warning (level 3) C4357"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4357"
+ms.date: 11/04/2016
 f1_keywords: ["C4357"]
 helpviewer_keywords: ["C4357"]
-ms.assetid: 9259c633-3c02-4900-b94a-2d8d366d61cd
 ---
 # Compiler Warning (level 3) C4357
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4357.md
@@ -10,7 +10,11 @@ ms.assetid: 9259c633-3c02-4900-b94a-2d8d366d61cd
 
 > param array argument in formal argument list for delegate 'del' ignored when generating 'function'
 
+## Remarks
+
 The `ParamArray` attribute was ignored, and `function` cannot be called with variable arguments.
+
+## Example
 
 The following sample generates C4357:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4359"]
 
 > 'type': actual alignment (8) is greater than the value specified in __declspec(align())
 
+## Remarks
+
 The alignment specified for a type is less than the alignment of the type of one of its data members. For more information, see [align](../../cpp/align-cpp.md).
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1 and level 3) C4359"
 title: "Compiler Warning (level 1 and level 3) C4359"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1 and level 3) C4359"
+ms.date: 11/04/2016
 f1_keywords: ["C4359"]
 helpviewer_keywords: ["C4359"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4359.md
@@ -15,7 +15,7 @@ The alignment specified for a type is less than the alignment of the type of one
 
 ## Example
 
-The following sample generates C4359.
+The following example generates C4359.
 
 ```cpp
 // C4359.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
@@ -8,7 +8,7 @@ ms.assetid: 93f199dd-d6dd-42c0-82d8-c12d101a7235
 ---
 # Compiler Warning (level 4) C4336
 
-import cross-referenced type library 'type_lib1' before importing 'type_lib2'
+> import cross-referenced type library 'type_lib1' before importing 'type_lib2'
 
 A type library was referenced with the [#import](../../preprocessor/hash-import-directive-cpp.md) directive. However, the type library contained a reference to another type library that was not referenced with `#import`. This other .tlb file was found by the compiler.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
@@ -10,7 +10,11 @@ ms.assetid: 93f199dd-d6dd-42c0-82d8-c12d101a7235
 
 > import cross-referenced type library 'type_lib1' before importing 'type_lib2'
 
+## Remarks
+
 A type library was referenced with the [#import](../../preprocessor/hash-import-directive-cpp.md) directive. However, the type library contained a reference to another type library that was not referenced with `#import`. This other .tlb file was found by the compiler.
+
+## Example
 
 Given two type libraries on disk created from the following two files (compiled with midl.exe):
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
@@ -47,7 +47,7 @@ library C4336bLib
 };
 ```
 
-The following sample generates C4336:
+The following example generates C4336:
 
 ```cpp
 // C4336.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4336.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4336"
 title: "Compiler Warning (level 4) C4336"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4336"
+ms.date: 11/04/2016
 f1_keywords: ["C4336"]
 helpviewer_keywords: ["C4336"]
-ms.assetid: 93f199dd-d6dd-42c0-82d8-c12d101a7235
 ---
 # Compiler Warning (level 4) C4336
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4337"
 title: "Compiler Warning (level 4) C4337"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4337"
+ms.date: 11/04/2016
 f1_keywords: ["C4337"]
 helpviewer_keywords: ["C4337"]
-ms.assetid: 70bc72d9-aac5-45cd-abd3-ebe42a05897b
 ---
 # Compiler Warning (level 4) C4337
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
@@ -55,7 +55,7 @@ library C4337bLib
 };
 ```
 
-The following sample generates C4337:
+The following example generates C4337:
 
 ```cpp
 // C4337.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
@@ -10,7 +10,11 @@ ms.assetid: 70bc72d9-aac5-45cd-abd3-ebe42a05897b
 
 > cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported
 
+## Remarks
+
 The auto_search attribute of [the #import directive](../../preprocessor/hash-import-directive-cpp.md) caused a type library to be implicitly imported.
+
+## Example
 
 Given two type libraries on disk created from the following two files (compiled with midl.exe):
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4337.md
@@ -8,7 +8,7 @@ ms.assetid: 70bc72d9-aac5-45cd-abd3-ebe42a05897b
 ---
 # Compiler Warning (level 4) C4337
 
-cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported
+> cross-referenced type library 'typelib1' in 'typelib2' is being automatically imported
 
 The auto_search attribute of [the #import directive](../../preprocessor/hash-import-directive-cpp.md) caused a type library to be implicitly imported.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4339"]
 
 > 'type' : use of undefined type detected in WinRT or CLR meta-data - use of this type may lead to a runtime exception
 
+## Remarks
+
 A type wasn't defined in code that was compiled for Windows Runtime or the common language runtime. Define the type to avoid a possible runtime exception.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4339 and shows how to fix it:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4339"
 title: "Compiler Warning (level 4, off) C4339"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4, off) C4339"
+ms.date: 11/04/2016
 f1_keywords: ["C4339"]
 helpviewer_keywords: ["C4339"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4339.md
@@ -17,7 +17,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4339 and shows how to fix it:
+The following example generates C4339 and shows how to fix it:
 
 ```cpp
 // C4339.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
@@ -16,7 +16,7 @@ This warning, only valid in the Itanium Processor Family (IPF) compiler, reports
 
 ## Example
 
-The following sample generates C4343:
+The following example generates C4343:
 
 ```cpp
 // C4343.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4343"
 title: "Compiler Warning (level 4) C4343"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4343"
+ms.date: 11/04/2016
 f1_keywords: ["C4343"]
 helpviewer_keywords: ["C4343"]
-ms.assetid: a721b710-e04f-4d15-b678-e4a2c8fd0181
 ---
 # Compiler Warning (level 4) C4343
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
@@ -8,7 +8,7 @@ ms.assetid: a721b710-e04f-4d15-b678-e4a2c8fd0181
 ---
 # Compiler Warning (level 4) C4343
 
-\#pragma optimize("g",off) overrides /Og option
+> #pragma optimize("g",off) overrides /Og option
 
 This warning, only valid in the Itanium Processor Family (IPF) compiler, reports that a pragma [optimize](../../preprocessor/optimize.md) overrode a [/Og](../../build/reference/og-global-optimizations.md) compiler option.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4343.md
@@ -10,7 +10,11 @@ ms.assetid: a721b710-e04f-4d15-b678-e4a2c8fd0181
 
 > #pragma optimize("g",off) overrides /Og option
 
+## Remarks
+
 This warning, only valid in the Itanium Processor Family (IPF) compiler, reports that a pragma [optimize](../../preprocessor/optimize.md) overrode a [/Og](../../build/reference/og-global-optimizations.md) compiler option.
+
+## Example
 
 The following sample generates C4343:
 


### PR DESCRIPTION
C4324 is skipped due to #5569.

This is batch 76 that structures error/warning references. See #5465 for more information.