### PR TITLE
Structure warning references in range [C4461, C4520]

### DIFF
--- a/docs/error-messages/compiler-warnings/c4477.md
+++ b/docs/error-messages/compiler-warnings/c4477.md
@@ -19,7 +19,7 @@ This warning is new in Visual Studio 2015.
 
 ## Example
 
-This sample shows two C4477 warnings for the first printf_s function, when two arguments are found to be of the wrong type, and also shows how to fix the issues.
+This example shows two C4477 warnings for the first printf_s function, when two arguments are found to be of the wrong type, and also shows how to fix the issues.
 
 ```cpp
 // C4477p.cpp

--- a/docs/error-messages/compiler-warnings/c4477.md
+++ b/docs/error-messages/compiler-warnings/c4477.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4477"
 title: "Compiler Warning C4477"
-ms.date: "02/16/2018"
+description: "Learn more about: Compiler Warning (level 1) C4477"
+ms.date: 02/16/2018
 f1_keywords: ["C4477"]
 helpviewer_keywords: ["C4477"]
 ---

--- a/docs/error-messages/compiler-warnings/c4477.md
+++ b/docs/error-messages/compiler-warnings/c4477.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C4477"]
 
 > '*function*' : format string '*string*' requires an argument of type '*type*', but variadic argument *number* has type '*type*'
 
+## Remarks
+
 The compiler detected a mismatch between the type of argument required to satisfy the placeholder in a format string, and the type of argument supplied. Correct use of the printf and scanf families of variadic functions requires that you supply arguments of the types specified by the format string. A mismatch generally means there is a bug in your code.
 
 For information on the arguments associated with printf family format string placeholders, see [Format specification syntax: printf and wprintf functions](../../c-runtime-library/format-specification-syntax-printf-and-wprintf-functions.md). See the documentation for information specific to function *function*.

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
@@ -26,7 +26,7 @@ C4484 is always issued as an error. Use the [warning](../../preprocessor/warning
 
 ## Example
 
-The following sample generates C4484.
+The following example generates C4484.
 
 ```cpp
 // C4484.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
@@ -8,7 +8,7 @@ ms.assetid: 3d30e5b3-2297-45b7-a37a-1360056fdd0e
 ---
 # Compiler Warning C4484
 
-'override_function' : matches base ref class method 'base_class_function', but is not marked 'virtual', 'new' or 'override'; 'new' (and not 'virtual') is assumed
+> 'override_function' : matches base ref class method 'base_class_function', but is not marked 'virtual', 'new' or 'override'; 'new' (and not 'virtual') is assumed
 
 When compiling with **/clr**, the compiler will not implicitly override a base class function, which means the function will get a new slot in the vtable. To resolve, explicitly specify whether a function is an override.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning C4484"
 title: "Compiler Warning C4484"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning C4484"
+ms.date: 11/04/2016
 f1_keywords: ["C4484"]
 helpviewer_keywords: ["C4484"]
-ms.assetid: 3d30e5b3-2297-45b7-a37a-1360056fdd0e
 ---
 # Compiler Warning C4484
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4484.md
@@ -10,6 +10,8 @@ ms.assetid: 3d30e5b3-2297-45b7-a37a-1360056fdd0e
 
 > 'override_function' : matches base ref class method 'base_class_function', but is not marked 'virtual', 'new' or 'override'; 'new' (and not 'virtual') is assumed
 
+## Remarks
+
 When compiling with **/clr**, the compiler will not implicitly override a base class function, which means the function will get a new slot in the vtable. To resolve, explicitly specify whether a function is an override.
 
 For more information, see:

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
@@ -20,7 +20,7 @@ C4485 is always issued as an error. Use the [warning](../../preprocessor/warning
 
 ## Example
 
-The following sample generates C4485
+The following example generates C4485
 
 ```cpp
 // C4485.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning C4485"
 title: "Compiler Warning C4485"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning C4485"
+ms.date: 11/04/2016
 f1_keywords: ["C4485"]
 helpviewer_keywords: ["C4485"]
-ms.assetid: a6f2b437-ca93-4dcd-b9cb-df415e10df86
 ---
 # Compiler Warning C4485
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
@@ -8,7 +8,7 @@ ms.assetid: a6f2b437-ca93-4dcd-b9cb-df415e10df86
 ---
 # Compiler Warning C4485
 
-'override_function' : matches base ref class method 'base_class_function ', but is not marked 'new' or 'override'; 'new' (and 'virtual') is assumed
+> 'override_function' : matches base ref class method 'base_class_function ', but is not marked 'new' or 'override'; 'new' (and 'virtual') is assumed
 
 An accessor overrides, with or without the **`virtual`** keyword, a base class accessor function, but the `override` or **`new`** specifier was not part of the overriding function signature. Add the **`new`** or `override` specifier to resolve this warning.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c4485.md
@@ -10,6 +10,8 @@ ms.assetid: a6f2b437-ca93-4dcd-b9cb-df415e10df86
 
 > 'override_function' : matches base ref class method 'base_class_function ', but is not marked 'new' or 'override'; 'new' (and 'virtual') is assumed
 
+## Remarks
+
 An accessor overrides, with or without the **`virtual`** keyword, a base class accessor function, but the `override` or **`new`** specifier was not part of the overriding function signature. Add the **`new`** or `override` specifier to resolve this warning.
 
 See [override](../../extensions/override-cpp-component-extensions.md) and [new (new slot in vtable)](../../extensions/new-new-slot-in-vtable-cpp-component-extensions.md) for more information.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4461"
 title: "Compiler Warning (level 1) C4461"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4461"
+ms.date: 11/04/2016
 f1_keywords: ["C4461"]
 helpviewer_keywords: ["C4461"]
-ms.assetid: 104ffecc-3dd4-4cb1-89a8-81154fbe46d9
 ---
 # Compiler Warning (level 1) C4461
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
@@ -8,7 +8,7 @@ ms.assetid: 104ffecc-3dd4-4cb1-89a8-81154fbe46d9
 ---
 # Compiler Warning (level 1) C4461
 
-'type' : this class has a finalizer 'finalizer' but no destructor 'dtor'
+> 'type' : this class has a finalizer 'finalizer' but no destructor 'dtor'
 
 The presence of a finalizer in a type implies resources to delete. Unless a finalizer is explicitly called from the type's destructor, the common language runtime determines when to run the finalizer, after your object goes out of scope.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
@@ -10,6 +10,8 @@ ms.assetid: 104ffecc-3dd4-4cb1-89a8-81154fbe46d9
 
 > 'type' : this class has a finalizer 'finalizer' but no destructor 'dtor'
 
+## Remarks
+
 The presence of a finalizer in a type implies resources to delete. Unless a finalizer is explicitly called from the type's destructor, the common language runtime determines when to run the finalizer, after your object goes out of scope.
 
 If you define a destructor in the type and explicitly call the finalizer from the destructor, you can deterministically run your finalizer.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4461.md
@@ -20,7 +20,7 @@ For more information, see [Destructors and finalizers](../../dotnet/how-to-defin
 
 ## Example
 
-The following sample generates C4461.
+The following example generates C4461.
 
 ```cpp
 // C4461.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4462"
 title: "Compiler Warning (level 1) C4462"
-ms.date: "10/25/2017"
+description: "Learn more about: Compiler Warning (level 1) C4462"
+ms.date: 10/25/2017
 f1_keywords: ["C4462"]
 helpviewer_keywords: ["C4462"]
-ms.assetid: 4e20aca4-293e-4c75-a83d-961c27ab7840
 ---
 # Compiler Warning (level 1) C4462
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
@@ -22,7 +22,7 @@ This warning is automatically promoted to an error. If you wish to modify this b
 
 ## Example
 
-This sample generates warning C4462:
+This example generates warning C4462:
 
 ```cpp
 namespace N

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4462.md
@@ -10,6 +10,8 @@ ms.assetid: 4e20aca4-293e-4c75-a83d-961c27ab7840
 
 > cannot determine the GUID of the type. Program may fail at runtime.
 
+## Remarks
+
 Warning C4462 occurs in a Windows Runtime app or component when a public `TypedEventHandler` has as one of its type parameters a reference to the enclosing class.
 
 This warning is automatically promoted to an error. If you wish to modify this behavior, use [#pragma warning](../../preprocessor/warning.md). For example, to make C4462 into a level 4 warning issue, add this line to your source code file:

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4470"
 title: "Compiler Warning (level 1) C4470"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4470"
+ms.date: 11/04/2016
 f1_keywords: ["C4470"]
 helpviewer_keywords: ["C4470"]
-ms.assetid: f52a3eaa-a235-4747-a47d-9ec4ad4cb0ea
 ---
 # Compiler Warning (level 1) C4470
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
@@ -8,7 +8,7 @@ ms.assetid: f52a3eaa-a235-4747-a47d-9ec4ad4cb0ea
 ---
 # Compiler Warning (level 1) C4470
 
-floating-point control pragmas ignored under /clr
+> floating-point control pragmas ignored under /clr
 
 The float-control pragmas:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
@@ -24,7 +24,7 @@ have no effect under [/clr](../../build/reference/clr-common-language-runtime-co
 
 ## Example
 
-The following sample generates C4470:
+The following example generates C4470:
 
 ```cpp
 // C4470.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4470.md
@@ -10,6 +10,8 @@ ms.assetid: f52a3eaa-a235-4747-a47d-9ec4ad4cb0ea
 
 > floating-point control pragmas ignored under /clr
 
+## Remarks
+
 The float-control pragmas:
 
 - [fenv_access](../../preprocessor/fenv-access.md)
@@ -19,6 +21,8 @@ The float-control pragmas:
 - [fp_contract](../../preprocessor/fp-contract.md)
 
 have no effect under [/clr](../../build/reference/clr-common-language-runtime-compilation.md).
+
+## Example
 
 The following sample generates C4470:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
@@ -8,7 +8,7 @@ ms.assetid: 2c0c59e3-d025-4d97-8da2-fa27df1402fc
 ---
 # Compiler Warning (level 1) C4486
 
-'function' : a private virtual method of a ref class or value class should be marked 'sealed'
+> 'function' : a private virtual method of a ref class or value class should be marked 'sealed'
 
 Since a private virtual member function of a managed class or struct cannot be accessed or overridden, it should be marked [sealed](../../extensions/sealed-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
@@ -16,7 +16,7 @@ Since a private virtual member function of a managed class or struct cannot be a
 
 ## Example
 
-The following sample generates C4486.
+The following example generates C4486.
 
 ```cpp
 // C4486.cpp
@@ -28,7 +28,7 @@ private:
 };
 ```
 
-The following sample shows one possible use of a private sealed, virtual function.
+The following example shows one possible use of a private sealed, virtual function.
 
 ```cpp
 // C4486_b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
@@ -10,9 +10,11 @@ ms.assetid: 2c0c59e3-d025-4d97-8da2-fa27df1402fc
 
 > 'function' : a private virtual method of a ref class or value class should be marked 'sealed'
 
+## Remarks
+
 Since a private virtual member function of a managed class or struct cannot be accessed or overridden, it should be marked [sealed](../../extensions/sealed-cpp-component-extensions.md).
 
-## Examples
+## Example
 
 The following sample generates C4486.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4486.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4486"
 title: "Compiler Warning (level 1) C4486"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4486"
+ms.date: 11/04/2016
 f1_keywords: ["C4486"]
 helpviewer_keywords: ["C4486"]
-ms.assetid: 2c0c59e3-d025-4d97-8da2-fa27df1402fc
 ---
 # Compiler Warning (level 1) C4486
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
@@ -8,7 +8,7 @@ ms.assetid: 55625e46-ddb5-4c7c-99c7-cd4aa9f879bd
 ---
 # Compiler Warning (level 1) C4488
 
-'function' : requires 'keyword' keyword to implement the interface method 'interface_method'
+> 'function' : requires 'keyword' keyword to implement the interface method 'interface_method'
 
 A class must implement all members of an interface from which it directly inherits. An implemented member must have public accessibility, and must be marked virtual.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
@@ -16,7 +16,7 @@ A class must implement all members of an interface from which it directly inheri
 
 ## Examples
 
-C4488 can occur if an implemented member is not public. The following sample generates C4488.
+C4488 can occur if an implemented member is not public. The following example generates C4488.
 
 ```cpp
 // C4488.cpp
@@ -35,7 +35,7 @@ public:
 };
 ```
 
-C4488 can occur if an implemented member is not marked virtual. The following sample generates C4488.
+C4488 can occur if an implemented member is not marked virtual. The following example generates C4488.
 
 ```cpp
 // C4488_b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4488"
 title: "Compiler Warning (level 1) C4488"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4488"
+ms.date: 11/04/2016
 f1_keywords: ["C4488"]
 helpviewer_keywords: ["C4488"]
-ms.assetid: 55625e46-ddb5-4c7c-99c7-cd4aa9f879bd
 ---
 # Compiler Warning (level 1) C4488
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4488.md
@@ -10,6 +10,8 @@ ms.assetid: 55625e46-ddb5-4c7c-99c7-cd4aa9f879bd
 
 > 'function' : requires 'keyword' keyword to implement the interface method 'interface_method'
 
+## Remarks
+
 A class must implement all members of an interface from which it directly inherits. An implemented member must have public accessibility, and must be marked virtual.
 
 ## Examples

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
@@ -8,7 +8,7 @@ ms.assetid: 43b51c8c-27b5-44c9-b974-fe4b48f4896f
 ---
 # Compiler Warning (level 1) C4489
 
-'specifier' : not allowed on interface method 'method'; override specifiers are only allowed on ref class and value class methods
+> 'specifier' : not allowed on interface method 'method'; override specifiers are only allowed on ref class and value class methods
 
 A specifier keyword was incorrectly used on an interface method.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4489"
 title: "Compiler Warning (level 1) C4489"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4489"
+ms.date: 11/04/2016
 f1_keywords: ["C4489"]
 helpviewer_keywords: ["C4489"]
-ms.assetid: 43b51c8c-27b5-44c9-b974-fe4b48f4896f
 ---
 # Compiler Warning (level 1) C4489
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
@@ -10,6 +10,8 @@ ms.assetid: 43b51c8c-27b5-44c9-b974-fe4b48f4896f
 
 > 'specifier' : not allowed on interface method 'method'; override specifiers are only allowed on ref class and value class methods
 
+## Remarks
+
 A specifier keyword was incorrectly used on an interface method.
 
 For more information, see [Override Specifiers](../../extensions/override-specifiers-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4489.md
@@ -18,7 +18,7 @@ For more information, see [Override Specifiers](../../extensions/override-specif
 
 ## Example
 
-The following sample generates C4489.
+The following example generates C4489.
 
 ```cpp
 // C4489.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
@@ -10,6 +10,8 @@ ms.assetid: f9b03ecf-41a1-4f4d-a74c-2c1e88234ccc
 
 > 'override' : incorrect use of override specifier; 'function' does not match a base ref class method
 
+## Remarks
+
 An override specifier was used incorrectly. For example, you do not override an interface function, you implement it.
 
 For more information, see [Override Specifiers](../../extensions/override-specifiers-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4490"
 title: "Compiler Warning (level 1) C4490"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4490"
+ms.date: 11/04/2016
 f1_keywords: ["C4490"]
 helpviewer_keywords: ["C4490"]
-ms.assetid: f9b03ecf-41a1-4f4d-a74c-2c1e88234ccc
 ---
 # Compiler Warning (level 1) C4490
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
@@ -8,7 +8,7 @@ ms.assetid: f9b03ecf-41a1-4f4d-a74c-2c1e88234ccc
 ---
 # Compiler Warning (level 1) C4490
 
-'override' : incorrect use of override specifier; 'function' does not match a base ref class method
+> 'override' : incorrect use of override specifier; 'function' does not match a base ref class method
 
 An override specifier was used incorrectly. For example, you do not override an interface function, you implement it.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4490.md
@@ -18,7 +18,7 @@ For more information, see [Override Specifiers](../../extensions/override-specif
 
 ## Example
 
-The following sample generates C4490.
+The following example generates C4490.
 
 ```cpp
 // C4490.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
@@ -8,7 +8,7 @@ ms.assetid: d8d43153-a40c-4b96-bc11-64028a144d70
 ---
 # Compiler Warning (level 1) C4502
 
-'linkage specification' requires use of keyword 'extern' and must precede all other specifiers
+> 'linkage specification' requires use of keyword 'extern' and must precede all other specifiers
 
 A linkage was specified without the **`extern`** keyword. Linkage is not relevant to non-extern types.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
@@ -10,6 +10,8 @@ ms.assetid: d8d43153-a40c-4b96-bc11-64028a144d70
 
 > 'linkage specification' requires use of keyword 'extern' and must precede all other specifiers
 
+## Remarks
+
 A linkage was specified without the **`extern`** keyword. Linkage is not relevant to non-extern types.
 
 The compiler assumed the **`extern`** keyword.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4502.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4502"
 title: "Compiler Warning (level 1) C4502"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4502"
+ms.date: 11/04/2016
 f1_keywords: ["C4502"]
 helpviewer_keywords: ["C4502"]
-ms.assetid: d8d43153-a40c-4b96-bc11-64028a144d70
 ---
 # Compiler Warning (level 1) C4502
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4503.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4503.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4503"
 title: "Compiler Warning (level 1) C4503"
-ms.date: "05/14/2018"
+description: "Learn more about: Compiler Warning (level 1) C4503"
+ms.date: 05/14/2018
 f1_keywords: ["C4503"]
 helpviewer_keywords: ["C4503"]
-ms.assetid: 7c5a98ae-5b6d-41d8-b881-12d3ffd5e392
 ---
 # Compiler Warning (level 1) C4503
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4503.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4503.md
@@ -22,7 +22,7 @@ You might, however, decide to not restructure your code.  It is possible to ship
 
 ## Example
 
-The following sample generates C4503 in compilers before Visual Studio 2017:
+The following example generates C4503 in compilers before Visual Studio 2017:
 
 ```cpp
 // C4503.cpp
@@ -40,7 +40,7 @@ typedef std::map<std::string, WebAppTest> Hello;
 Hello MyWAT;
 ```
 
-This sample shows one way to rewrite your code to resolve C4503:
+This example shows one way to rewrite your code to resolve C4503:
 
 ```cpp
 // C4503b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
@@ -8,7 +8,7 @@ ms.assetid: aa682869-65d1-4dad-ba32-198f10b44f91
 ---
 # Compiler Warning (level 1) C4506
 
-no definition for inline function 'function'
+> no definition for inline function 'function'
 
 The given function was declared and marked for inlining but was not defined.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4506"
 title: "Compiler Warning (level 1) C4506"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4506"
+ms.date: 11/04/2016
 f1_keywords: ["C4506"]
 helpviewer_keywords: ["C4506"]
-ms.assetid: aa682869-65d1-4dad-ba32-198f10b44f91
 ---
 # Compiler Warning (level 1) C4506
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4506.md
@@ -10,6 +10,8 @@ ms.assetid: aa682869-65d1-4dad-ba32-198f10b44f91
 
 > no definition for inline function 'function'
 
+## Remarks
+
 The given function was declared and marked for inlining but was not defined.
 
 The compiler did not inline the function.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
@@ -10,9 +10,13 @@ ms.assetid: c05f113b-b789-4df0-a4ef-78bce4767021
 
 > 'function' : function should return a value; 'void' return type assumed
 
+## Remarks
+
 The function has no return type specified. In this case, C4430 should also fire and the compiler implements the fix reported by C4430 (default value is int).
 
 To resolve this warning, explicitly declare the return type of functions.
+
+## Example
 
 The following sample generates C4508:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
@@ -18,7 +18,7 @@ To resolve this warning, explicitly declare the return type of functions.
 
 ## Example
 
-The following sample generates C4508:
+The following example generates C4508:
 
 ```cpp
 // C4508.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4508"
 title: "Compiler Warning (level 1) C4508"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4508"
+ms.date: 11/04/2016
 f1_keywords: ["C4508"]
 helpviewer_keywords: ["C4508"]
-ms.assetid: c05f113b-b789-4df0-a4ef-78bce4767021
 ---
 # Compiler Warning (level 1) C4508
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4508.md
@@ -8,7 +8,7 @@ ms.assetid: c05f113b-b789-4df0-a4ef-78bce4767021
 ---
 # Compiler Warning (level 1) C4508
 
-'function' : function should return a value; 'void' return type assumed
+> 'function' : function should return a value; 'void' return type assumed
 
 The function has no return type specified. In this case, C4430 should also fire and the compiler implements the fix reported by C4430 (default value is int).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
@@ -10,6 +10,8 @@ ms.assetid: 4ad21004-f076-43fd-99f4-4bf1f9be4c0b
 
 > 'specifier' : storage-class or type specifier(s) unexpected here; ignored
 
+## Example
+
 The following sample generates C4518:
 
 ```cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
@@ -8,7 +8,7 @@ ms.assetid: 4ad21004-f076-43fd-99f4-4bf1f9be4c0b
 ---
 # Compiler Warning (level 1) C4518
 
-'specifier' : storage-class or type specifier(s) unexpected here; ignored
+> 'specifier' : storage-class or type specifier(s) unexpected here; ignored
 
 The following sample generates C4518:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4518"
 title: "Compiler Warning (level 1) C4518"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4518"
+ms.date: 11/04/2016
 f1_keywords: ["C4518"]
 helpviewer_keywords: ["C4518"]
-ms.assetid: 4ad21004-f076-43fd-99f4-4bf1f9be4c0b
 ---
 # Compiler Warning (level 1) C4518
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4518.md
@@ -12,7 +12,7 @@ ms.assetid: 4ad21004-f076-43fd-99f4-4bf1f9be4c0b
 
 ## Example
 
-The following sample generates C4518:
+The following example generates C4518:
 
 ```cpp
 // C4518.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
@@ -10,4 +10,6 @@ ms.assetid: a01286b2-3dd9-4a97-a5ee-dd0e7b63ef8b
 
 > 'class' : copy constructor could not be generated
 
+## Remarks
+
 The compiler could not generate a default copy-constructor for a class; a base class may have a private copy-constructor.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
@@ -8,6 +8,6 @@ ms.assetid: a01286b2-3dd9-4a97-a5ee-dd0e7b63ef8b
 ---
 # Compiler Warning (level 3) C4511
 
-'class' : copy constructor could not be generated
+> 'class' : copy constructor could not be generated
 
 The compiler could not generate a default copy-constructor for a class; a base class may have a private copy-constructor.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4511.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4511"
 title: "Compiler Warning (level 3) C4511"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4511"
+ms.date: 11/04/2016
 f1_keywords: ["C4511"]
 helpviewer_keywords: ["C4511"]
-ms.assetid: a01286b2-3dd9-4a97-a5ee-dd0e7b63ef8b
 ---
 # Compiler Warning (level 3) C4511
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4463.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4463.md
@@ -10,6 +10,8 @@ ms.assetid: a07ae70c-db4e-472b-8b58-9137d9997323
 
 > overflow; assigning *value* to bit-field that can only hold values from *low_value* to *high_value*
 
+## Remarks
+
 The assigned *value* is outside the range of values that the bit-field can hold. Signed bit-field types use the high-order bit for the sign, so if *n* is the bit-field size, the range for signed bit-fields is -2<sup>n-1</sup> to 2<sup>n-1</sup>-1, while unsigned bit-fields have a range from 0 to 2<sup>n</sup>-1.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4463.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4463.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4463"
 title: "Compiler Warning (level 4) C4463"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4463"
+ms.date: 11/04/2016
 f1_keywords: ["C4463"]
 helpviewer_keywords: ["C4463"]
-ms.assetid: a07ae70c-db4e-472b-8b58-9137d9997323
 ---
 # Compiler Warning (level 4) C4463
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4464.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4464.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C4464"]
 
 > relative include path contains '..'
 
-A `#include` directive has a path that includes a parent directory specifier (a `..` path segment).
-
 ## Remarks
+
+A `#include` directive has a path that includes a parent directory specifier (a `..` path segment).
 
 In Visual Studio 2015 Update 1 and later versions, if enabled, the compiler can detect and issue a warning for a `#include` directive that contains a parent directory path segment (`..`). Code is sometimes written that uses parent directory relative paths to include headers from external libraries. When these parent directory-relative header paths are specified in source files, it creates a risk: The program could be compiled by including a different header file than the programmer intends. These relative paths may not be portable to other developers' build environments.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4464.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4464.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Warning (level 4, off) C4464"
 title: "Compiler Warning (level 4) C4464"
+description: "Learn more about: Compiler Warning (level 4, off) C4464"
 ms.date: 09/14/2022
 f1_keywords: ["C4464"]
 helpviewer_keywords: ["C4464"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
@@ -8,7 +8,7 @@ ms.assetid: ccfd8bd5-bc1b-4be7-a6ea-0e3a7add6607
 ---
 # Compiler Warning (level 4) C4471
 
-'*enumeration*': a forward declaration of an unscoped enumeration must have an underlying type (int assumed)
+> '*enumeration*': a forward declaration of an unscoped enumeration must have an underlying type (int assumed)
 
 A forward declaration of an unscoped enumeration was found without a specifier for the underlying type. By default, Visual C++ assumes **`int`** is the underlying type for an enumeration. This can cause issues if a different type is used in the enumeration definition, for example, if a different explicit type is specified, or if a different type is implicitly set by an initializer. You may also have portability issues; other compilers do not assume **`int`** is the underlying type of an enumeration.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4471"
 title: "Compiler Warning (level 4) C4471"
-ms.date: "04/24/2017"
+description: "Learn more about: Compiler Warning (level 4) C4471"
+ms.date: 04/24/2017
 f1_keywords: ["C4471"]
 helpviewer_keywords: ["C4471"]
-ms.assetid: ccfd8bd5-bc1b-4be7-a6ea-0e3a7add6607
 ---
 # Compiler Warning (level 4) C4471
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4471.md
@@ -10,6 +10,8 @@ ms.assetid: ccfd8bd5-bc1b-4be7-a6ea-0e3a7add6607
 
 > '*enumeration*': a forward declaration of an unscoped enumeration must have an underlying type (int assumed)
 
+## Remarks
+
 A forward declaration of an unscoped enumeration was found without a specifier for the underlying type. By default, Visual C++ assumes **`int`** is the underlying type for an enumeration. This can cause issues if a different type is used in the enumeration definition, for example, if a different explicit type is specified, or if a different type is implicitly set by an initializer. You may also have portability issues; other compilers do not assume **`int`** is the underlying type of an enumeration.
 
 This warning is off by default; you can use /Wall or /w*N*4471 to enable it on the command line, or use #pragma [warning](../../preprocessor/warning.md) in your source file.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
@@ -8,7 +8,7 @@ ms.assetid: 7bfd4e0c-b452-4e6c-b7c4-ac5cc93fe4ea
 ---
 # Compiler Warning (level 4) C4481
 
-nonstandard extension used: override specifier 'keyword'
+> nonstandard extension used: override specifier 'keyword'
 
 A keyword was used that is not in the C++ standard, for example, one of the override specifiers that also works under /clr.  For more information, see,
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
@@ -10,6 +10,8 @@ ms.assetid: 7bfd4e0c-b452-4e6c-b7c4-ac5cc93fe4ea
 
 > nonstandard extension used: override specifier 'keyword'
 
+## Remarks
+
 A keyword was used that is not in the C++ standard, for example, one of the override specifiers that also works under /clr.  For more information, see,
 
 - [/clr (Common Language Runtime Compilation)](../../build/reference/clr-common-language-runtime-compilation.md)

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
@@ -20,7 +20,7 @@ A keyword was used that is not in the C++ standard, for example, one of the over
 
 ## Example
 
-The following sample generates C4481.
+The following example generates C4481.
 
 ```cpp
 // C4481.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4481.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4481"
 title: "Compiler Warning (level 4) C4481"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4481"
+ms.date: 11/04/2016
 f1_keywords: ["C4481"]
 helpviewer_keywords: ["C4481"]
-ms.assetid: 7bfd4e0c-b452-4e6c-b7c4-ac5cc93fe4ea
 ---
 # Compiler Warning (level 4) C4481
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
@@ -8,7 +8,7 @@ ms.assetid: 796144cf-cd3c-4edc-b6a4-96192b7eb4f0
 ---
 # Compiler Warning (level 4) C4487
 
-'derived_class_function' : matches inherited non-virtual method 'base_class_function' but is not explicitly marked 'new'
+> 'derived_class_function' : matches inherited non-virtual method 'base_class_function' but is not explicitly marked 'new'
 
 A function in a derived class has the same signature as a non-virtual base class function. C4487 reminds you that the derived class function does not override the base class function. Explicitly mark the derived class function as **`new`** to resolve this warning.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
@@ -18,7 +18,7 @@ For more information, see [new (new slot in vtable)](../../extensions/new-new-sl
 
 ## Example
 
-The following sample generates C4487.
+The following example generates C4487.
 
 ```cpp
 // C4487.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
@@ -10,6 +10,8 @@ ms.assetid: 796144cf-cd3c-4edc-b6a4-96192b7eb4f0
 
 > 'derived_class_function' : matches inherited non-virtual method 'base_class_function' but is not explicitly marked 'new'
 
+## Remarks
+
 A function in a derived class has the same signature as a non-virtual base class function. C4487 reminds you that the derived class function does not override the base class function. Explicitly mark the derived class function as **`new`** to resolve this warning.
 
 For more information, see [new (new slot in vtable)](../../extensions/new-new-slot-in-vtable-cpp-component-extensions.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4487.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4487"
 title: "Compiler Warning (level 4) C4487"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4487"
+ms.date: 11/04/2016
 f1_keywords: ["C4487"]
 helpviewer_keywords: ["C4487"]
-ms.assetid: 796144cf-cd3c-4edc-b6a4-96192b7eb4f0
 ---
 # Compiler Warning (level 4) C4487
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
@@ -10,6 +10,8 @@ ms.assetid: 068716a0-7dd2-40af-abf4-478f893b48c5
 
 > 'function' : unreferenced local function has been removed
 
+## Remarks
+
 The given function is local and not referenced in the body of the module; therefore, the function is dead code.
 
 The compiler did not generate code for this dead function.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4505"
 title: "Compiler Warning (level 4) C4505"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4505"
+ms.date: 11/04/2016
 f1_keywords: ["C4505"]
 helpviewer_keywords: ["C4505"]
-ms.assetid: 068716a0-7dd2-40af-abf4-478f893b48c5
 ---
 # Compiler Warning (level 4) C4505
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4505.md
@@ -8,7 +8,7 @@ ms.assetid: 068716a0-7dd2-40af-abf4-478f893b48c5
 ---
 # Compiler Warning (level 4) C4505
 
-'function' : unreferenced local function has been removed
+> 'function' : unreferenced local function has been removed
 
 The given function is local and not referenced in the body of the module; therefore, the function is dead code.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4510.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4510.md
@@ -1,10 +1,9 @@
 ---
 title: "Compiler Warning (level 4) C4510"
-description: Compiler warning C4510 description and solution.
-ms.date: "09/22/2019"
+description: "Compiler warning C4510 description and solution."
+ms.date: 09/22/2019
 f1_keywords: ["C4510"]
 helpviewer_keywords: ["C4510"]
-ms.assetid: fd28d1d4-ad27-4dad-94c0-9dba46c93180
 ---
 # Compiler Warning (level 4) C4510
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4510.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4510.md
@@ -10,6 +10,8 @@ ms.assetid: fd28d1d4-ad27-4dad-94c0-9dba46c93180
 
 > '*class*' : default constructor could not be generated
 
+## Remarks
+
 The compiler can't generate a default constructor for the specified class, which has no user-defined constructors. Objects of this type can't be created.
 
 There are several situations that prevent the compiler from generating a default constructor, including:

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
@@ -8,7 +8,7 @@ ms.assetid: afb68995-684a-4be5-a73a-38d7a16dc030
 ---
 # Compiler Warning (level 4) C4512
 
-'class' : assignment operator could not be generated
+> 'class' : assignment operator could not be generated
 
 The compiler cannot generate an assignment operator for the given class. No assignment operator was created.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4512"
 title: "Compiler Warning (level 4) C4512"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4512"
+ms.date: 11/04/2016
 f1_keywords: ["C4512"]
 helpviewer_keywords: ["C4512"]
-ms.assetid: afb68995-684a-4be5-a73a-38d7a16dc030
 ---
 # Compiler Warning (level 4) C4512
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
@@ -10,6 +10,8 @@ ms.assetid: afb68995-684a-4be5-a73a-38d7a16dc030
 
 > 'class' : assignment operator could not be generated
 
+## Remarks
+
 The compiler cannot generate an assignment operator for the given class. No assignment operator was created.
 
 An assignment operator for the base class that is not accessible by the derived class can cause this warning.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4512.md
@@ -30,7 +30,7 @@ You can resolve the C4512 warning for your code in one of three ways:
 
 ## Example
 
-The following sample generates C4512.
+The following example generates C4512.
 
 ```cpp
 // C4512.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
@@ -10,4 +10,6 @@ ms.assetid: 6877334a-f30a-4184-9483-dac3348737a4
 
 > 'class' : destructor could not be generated
 
+## Remarks
+
 The compiler cannot generate a default destructor for the given class; no destructor was created. The destructor is in a base class that is not accessible to the derived class. If the base class has a private destructor, make it public or protected.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4513"
 title: "Compiler Warning (level 4) C4513"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4513"
+ms.date: 11/04/2016
 f1_keywords: ["C4513"]
 helpviewer_keywords: ["C4513"]
-ms.assetid: 6877334a-f30a-4184-9483-dac3348737a4
 ---
 # Compiler Warning (level 4) C4513
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4513.md
@@ -8,6 +8,6 @@ ms.assetid: 6877334a-f30a-4184-9483-dac3348737a4
 ---
 # Compiler Warning (level 4) C4513
 
-'class' : destructor could not be generated
+> 'class' : destructor could not be generated
 
 The compiler cannot generate a default destructor for the given class; no destructor was created. The destructor is in a base class that is not accessible to the derived class. If the base class has a private destructor, make it public or protected.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4514"
 title: "Compiler Warning (level 4) C4514"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4514"
+ms.date: 11/04/2016
 f1_keywords: ["C4514"]
 helpviewer_keywords: ["C4514"]
-ms.assetid: cdae966a-9cd4-4e31-af30-2a014e68f614
 ---
 # Compiler Warning (level 4) C4514
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
@@ -8,7 +8,7 @@ ms.assetid: cdae966a-9cd4-4e31-af30-2a014e68f614
 ---
 # Compiler Warning (level 4) C4514
 
-'function' : unreferenced inline function has been removed
+> 'function' : unreferenced inline function has been removed
 
 The optimizer removed an inline function that is not called.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
@@ -10,9 +10,13 @@ ms.assetid: cdae966a-9cd4-4e31-af30-2a014e68f614
 
 > 'function' : unreferenced inline function has been removed
 
+## Remarks
+
 The optimizer removed an inline function that is not called.
 
 This warning is off by default. See [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md) for more information.
+
+## Example
 
 The following sample generates C4514:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4514.md
@@ -18,7 +18,7 @@ This warning is off by default. See [Compiler Warnings That Are Off by Default](
 
 ## Example
 
-The following sample generates C4514:
+The following example generates C4514:
 
 ```cpp
 // C4514.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
@@ -8,7 +8,7 @@ ms.assetid: 167b5177-3f89-418b-b6c8-7de634f6b28f
 ---
 # Compiler Warning (level 4) C4515
 
-'namespace' : namespace uses itself
+> 'namespace' : namespace uses itself
 
 A namespace is used recursively.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
@@ -16,7 +16,7 @@ A namespace is used recursively.
 
 ## Example
 
-The following sample generates C4515:
+The following example generates C4515:
 
 ```cpp
 // C4515.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
@@ -10,7 +10,11 @@ ms.assetid: 167b5177-3f89-418b-b6c8-7de634f6b28f
 
 > 'namespace' : namespace uses itself
 
+## Remarks
+
 A namespace is used recursively.
+
+## Example
 
 The following sample generates C4515:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4515.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4515"
 title: "Compiler Warning (level 4) C4515"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4515"
+ms.date: 11/04/2016
 f1_keywords: ["C4515"]
 helpviewer_keywords: ["C4515"]
-ms.assetid: 167b5177-3f89-418b-b6c8-7de634f6b28f
 ---
 # Compiler Warning (level 4) C4515
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4516"
 title: "Compiler Warning (level 4) C4516"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4516"
+ms.date: 11/04/2016
 f1_keywords: ["C4516"]
 helpviewer_keywords: ["C4516"]
-ms.assetid: 6677bb1f-d26e-4ab9-8644-6b5a2a8f4ff8
 ---
 # Compiler Warning (level 4) C4516
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
@@ -16,7 +16,7 @@ The ANSI C++ committee has declared access declarations (changing the access of 
 
 ## Example
 
-The following sample generates C4516:
+The following example generates C4516:
 
 ```cpp
 // C4516.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
@@ -8,7 +8,7 @@ ms.assetid: 6677bb1f-d26e-4ab9-8644-6b5a2a8f4ff8
 ---
 # Compiler Warning (level 4) C4516
 
-'class::symbol' : access-declarations are deprecated; member using-declarations provide a better alternative
+> 'class::symbol' : access-declarations are deprecated; member using-declarations provide a better alternative
 
 The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the [using](../../cpp/using-declaration.md) keyword) to be outdated. Access declarations may not be supported by future versions of C++.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4516.md
@@ -10,7 +10,11 @@ ms.assetid: 6677bb1f-d26e-4ab9-8644-6b5a2a8f4ff8
 
 > 'class::symbol' : access-declarations are deprecated; member using-declarations provide a better alternative
 
+## Remarks
+
 The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the [using](../../cpp/using-declaration.md) keyword) to be outdated. Access declarations may not be supported by future versions of C++.
+
+## Example
 
 The following sample generates C4516:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4517"
 title: "Compiler Warning (level 4) C4517"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4517"
+ms.date: 11/04/2016
 f1_keywords: ["C4517"]
 helpviewer_keywords: ["C4517"]
-ms.assetid: 87cc12b8-7331-4f3a-a863-d6a75d9599c3
 ---
 # Compiler Warning (level 4) C4517
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
@@ -10,4 +10,6 @@ ms.assetid: 87cc12b8-7331-4f3a-a863-d6a75d9599c3
 
 > access-declarations are deprecated; member using-declarations provide a better alternative
 
+## Remarks
+
 The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the [using](../../cpp/using-declaration.md) keyword) to be outdated. Access declarations may not be supported by future versions of C++.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4517.md
@@ -8,6 +8,6 @@ ms.assetid: 87cc12b8-7331-4f3a-a863-d6a75d9599c3
 ---
 # Compiler Warning (level 4) C4517
 
-access-declarations are deprecated; member using-declarations provide a better alternative
+> access-declarations are deprecated; member using-declarations provide a better alternative
 
 The ANSI C++ committee has declared access declarations (changing the access of a member in a derived class without the [using](../../cpp/using-declaration.md) keyword) to be outdated. Access declarations may not be supported by future versions of C++.


### PR DESCRIPTION
C4473 is skipped to prevent potential merge conflicts with #5635. A separate PR will be issued once that is merged.

This is batch 79 that structures error/warning references. See #5465 for more information.