### PR TITLE
Fix wrong `-fsanitizer=address` flag in "Walkthrough: Use Address Sanitizer Continue On Error to find memory safety issues"

### DIFF
--- a/docs/sanitizers/asan-continue-on-error.md
+++ b/docs/sanitizers/asan-continue-on-error.md
@@ -44,21 +44,21 @@ Create the example:
     ```cpp
     #include <stdio.h>
     #include <stdlib.h>
-    
+
     void BadFunction(int *pointer)
     {
         free(pointer);
         free(pointer); // double-free!
     }
-    
+
     int main(int argc, const char *argv[])
     {
         int *pointer = static_cast<int *>(malloc(4));
         BadFunction(pointer);
-    
+
         // Normally we'd crash before this, but with COE we can see heap-use-after-free error as well
         printf("\n\n******* Pointer value: %d\n", *pointer);
-    
+
         return 1;
     }
     ```
@@ -181,24 +181,24 @@ Create the example:
 1. In that directory, create a source file, for example, `coe.cpp`, and paste the following code:
 
     ```cpp
-    #include <stdlib.h> 
-    
+    #include <stdlib.h>
+
     char* func(char* buf, size_t sz)
-    { 
-        char* local = (char*)malloc(sz); 
-        for (auto ii = 0; ii <= sz; ii++) // bad loop exit test 
+    {
+        char* local = (char*)malloc(sz);
+        for (auto ii = 0; ii <= sz; ii++) // bad loop exit test
         {
-            local[ii] = ~buf[ii]; // Two memory safety errors 
+            local[ii] = ~buf[ii]; // Two memory safety errors
         }
-     
-        return local; 
-    } 
-    
-    char buffer[10] = {0,1,2,3,4,5,6,7,8,9}; 
-    
+
+        return local;
+    }
+
+    char buffer[10] = {0,1,2,3,4,5,6,7,8,9};
+
     int main()
-    {   
-        char* inverted_buf= func(buffer, 10); 
+    {
+        char* inverted_buf= func(buffer, 10);
     }
     ```
 


### PR DESCRIPTION
Fix wrong `-fsanitizer=address` flag (extra "r") and clean up trailing spaces for examples.