### PR TITLE
Structure warning references in range [C4521, C4560]

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
@@ -8,7 +8,7 @@ ms.assetid: 490f8916-5fdc-4cad-b412-76c3382a5976
 ---
 # Compiler Warning (level 1) C4526
 
-'function' : static member function cannot override virtual function 'virtual function'override ignored, virtual function will be hidden
+> 'function' : static member function cannot override virtual function 'virtual function'override ignored, virtual function will be hidden
 
 The static member function meets the criteria to override the virtual function, which makes the member function both virtual and static.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
@@ -10,7 +10,11 @@ ms.assetid: 490f8916-5fdc-4cad-b412-76c3382a5976
 
 > 'function' : static member function cannot override virtual function 'virtual function'override ignored, virtual function will be hidden
 
+## Remarks
+
 The static member function meets the criteria to override the virtual function, which makes the member function both virtual and static.
+
+## Example
 
 The following code generates C4526:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4526.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4526"
 title: "Compiler Warning (level 1) C4526"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4526"
+ms.date: 11/04/2016
 f1_keywords: ["C4526"]
 helpviewer_keywords: ["C4526"]
-ms.assetid: 490f8916-5fdc-4cad-b412-76c3382a5976
 ---
 # Compiler Warning (level 1) C4526
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
@@ -26,7 +26,7 @@ If no exceptions can possibly be thrown in your executable, you may safely ignor
 
 ## Example
 
-The following sample generates C4530:
+The following example generates C4530:
 
 ```cpp
 // C4530.cpp
@@ -36,4 +36,4 @@ int main() {
 }
 ```
 
-Compile the sample with **`/EHsc`** to resolve the warning.
+Compile the example with **`/EHsc`** to resolve the warning.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
@@ -1,10 +1,9 @@
 ---
 title: "Compiler Warning (level 1) C4530"
 description: "Reference guide to Microsoft C++ compiler warning C4530."
-ms.date: "04/02/2020"
+ms.date: 04/02/2020
 f1_keywords: ["C4530"]
 helpviewer_keywords: ["C4530"]
-ms.assetid: a04dcdb2-84db-459d-9e5e-4e743887465f
 ---
 # Compiler Warning (level 1) C4530
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4530.md
@@ -10,9 +10,9 @@ ms.assetid: a04dcdb2-84db-459d-9e5e-4e743887465f
 
 > C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
 
-The code uses C++ exception handling, but [/EHsc](../../build/reference/eh-exception-handling-model.md) wasn't included in the compiler options.
-
 ## Remarks
+
+The code uses C++ exception handling, but [/EHsc](../../build/reference/eh-exception-handling-model.md) wasn't included in the compiler options.
 
 The compiler requires the **`/EHsc`** option to build C++ code that follows the C++ standard for exception handling. Standard C++ *unwind semantics* specifies that objects and stack frames constructed between where an exception is thrown and where it's caught must be destroyed and their resources recovered. This process is known as *unwinding the stack*.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4532.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4532.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4532"
 title: "Compiler Warning (level 1) C4532"
+description: "Learn more about: Compiler Warning (level 1) C4532"
 ms.date: 08/30/2022
 f1_keywords: ["C4532"]
 helpviewer_keywords: ["C4532"]
-ms.assetid: 4e2a286a-d233-4106-9f65-29be1a94ca02
 ---
 # Compiler Warning (level 1) C4532
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4532.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4532.md
@@ -30,7 +30,7 @@ The [`/sdl` (Enable Additional Security Checks)](../../build/reference/sdl-enabl
 
 ## Example
 
-The following sample generates C4532; delete or comment out the jump statements to resolve the warnings.
+The following example generates C4532; delete or comment out the jump statements to resolve the warnings.
 
 ```cpp
 // C4532.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4533.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4533.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4533"
 title: "Compiler Warning (level 1) C4533"
+description: "Learn more about: Compiler Warning (level 1) C4533"
 ms.date: 08/30/2022
 f1_keywords: ["C4533"]
 helpviewer_keywords: ["C4533"]
-ms.assetid: 359fecda-d540-46e5-b214-dbabe9ef50d2
 ---
 # Compiler Warning (level 1) C4533
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4533.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4533.md
@@ -18,7 +18,7 @@ The [`/sdl` (Enable Additional Security Checks)](../../build/reference/sdl-enabl
 
 ## Example
 
-The following sample generates C4533. To resolve the issue, move the initialization before the jump instruction or after the target of the jump.
+The following example generates C4533. To resolve the issue, move the initialization before the jump instruction or after the target of the jump.
 
 ```cpp
 // C4533.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4537.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4537.md
@@ -16,7 +16,7 @@ A reference was passed where an object (user-defined type) was expected. A refer
 
 ## Example
 
-The following sample generates C4537 and shows how to fix it:
+The following example generates C4537 and shows how to fix it:
 
 ```cpp
 // C4537.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4537.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4537.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4537"
 title: "Compiler Warning (level 1) C4537"
-ms.date: "08/27/2018"
+description: "Learn more about: Compiler Warning (level 1) C4537"
+ms.date: 08/27/2018
 f1_keywords: ["C4537"]
 helpviewer_keywords: ["C4537"]
-ms.assetid: 9454493c-d419-475e-8f35-9c00233c9329
 ---
 # Compiler Warning (level 1) C4537
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
@@ -10,7 +10,11 @@ ms.assetid: 8085e748-5f4d-43c2-b06d-eaf794edbf72
 
 > dynamic_cast used to convert to inaccessible or ambiguous base; run-time test will fail ('type1' to 'type2')
 
+## Remarks
+
 You used **`dynamic_cast`** to convert from one type to another. The compiler determined that the cast would always fail (return **NULL**) because a base class is inaccessible (**`private`**, for instance) or ambiguous (appears more than once in the class hierarchy, for instance).
+
+## Example
 
 The following shows an example of this warning. Class **B** is derived from class **A**. The program uses **`dynamic_cast`** to cast from class **B** (the derived class) to class **A**, which will always fail because class **B** is **`private`** and thus inaccessible. Changing the access of **A** to **`public`** will resolve the warning.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4540"
 title: "Compiler Warning (level 1) C4540"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4540"
+ms.date: 11/04/2016
 f1_keywords: ["C4540"]
 helpviewer_keywords: ["C4540"]
-ms.assetid: 8085e748-5f4d-43c2-b06d-eaf794edbf72
 ---
 # Compiler Warning (level 1) C4540
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4540.md
@@ -8,7 +8,7 @@ ms.assetid: 8085e748-5f4d-43c2-b06d-eaf794edbf72
 ---
 # Compiler Warning (level 1) C4540
 
-dynamic_cast used to convert to inaccessible or ambiguous base; run-time test will fail ('type1' to 'type2')
+> dynamic_cast used to convert to inaccessible or ambiguous base; run-time test will fail ('type1' to 'type2')
 
 You used **`dynamic_cast`** to convert from one type to another. The compiler determined that the cast would always fail (return **NULL**) because a base class is inaccessible (**`private`**, for instance) or ambiguous (appears more than once in the class hierarchy, for instance).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
@@ -16,7 +16,7 @@ A default template argument was specified in an incorrect location and was ignor
 
 ## Example
 
-This sample generates C4545, and the next sample shows how to fix it:
+This example generates C4545, and the next example shows how to fix it:
 
 ```cpp
 // C4544.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
@@ -8,7 +8,7 @@ ms.assetid: 11ee04df-41ae-435f-af44-881e801315a8
 ---
 # Compiler Warning (level 1) C4544
 
-'declaration': Default template argument ignored on this template declaration
+> 'declaration': Default template argument ignored on this template declaration
 
 A default template argument was specified in an incorrect location and was ignored. A default template argument for a class template can only be specified in the declaration or definition of the class template and not on a member of the class template.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
@@ -10,7 +10,11 @@ ms.assetid: 11ee04df-41ae-435f-af44-881e801315a8
 
 > 'declaration': Default template argument ignored on this template declaration
 
+## Remarks
+
 A default template argument was specified in an incorrect location and was ignored. A default template argument for a class template can only be specified in the declaration or definition of the class template and not on a member of the class template.
+
+## Example
 
 This sample generates C4545, and the next sample shows how to fix it:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4544"
 title: "Compiler Warning (level 1) C4544"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4544"
+ms.date: 11/04/2016
 f1_keywords: ["C4544"]
 helpviewer_keywords: ["C4544"]
-ms.assetid: 11ee04df-41ae-435f-af44-881e801315a8
 ---
 # Compiler Warning (level 1) C4544
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4545"
 title: "Compiler Warning (level 1) C4545"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4545"
+ms.date: 11/04/2016
 f1_keywords: ["C4545"]
 helpviewer_keywords: ["C4545"]
-ms.assetid: 43f8f34f-ed46-4661-95c0-c588c577ff73
 ---
 # Compiler Warning (level 1) C4545
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
@@ -8,7 +8,7 @@ ms.assetid: 43f8f34f-ed46-4661-95c0-c588c577ff73
 ---
 # Compiler Warning (level 1) C4545
 
-expression before comma evaluates to a function which is missing an argument list
+> expression before comma evaluates to a function which is missing an argument list
 
 The compiler detected an ill-formed comma expression.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
@@ -10,9 +10,13 @@ ms.assetid: 43f8f34f-ed46-4661-95c0-c588c577ff73
 
 > expression before comma evaluates to a function which is missing an argument list
 
+## Remarks
+
 The compiler detected an ill-formed comma expression.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4545:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4545.md
@@ -18,7 +18,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4545:
+The following example generates C4545:
 
 ```cpp
 // C4545.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
@@ -10,6 +10,8 @@ ms.assetid: 071e1709-3841-46c1-8e71-96109cd22041
 
 > function call before comma missing argument list
 
+## Remarks
+
 The compiler detected an ill-formed comma expression.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
@@ -18,7 +18,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4546:
+The following example generates C4546:
 
 ```cpp
 // C4546.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
@@ -8,7 +8,7 @@ ms.assetid: 071e1709-3841-46c1-8e71-96109cd22041
 ---
 # Compiler Warning (level 1) C4546
 
-function call before comma missing argument list
+> function call before comma missing argument list
 
 The compiler detected an ill-formed comma expression.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4546.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4546"
 title: "Compiler Warning (level 1) C4546"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4546"
+ms.date: 11/04/2016
 f1_keywords: ["C4546"]
 helpviewer_keywords: ["C4546"]
-ms.assetid: 071e1709-3841-46c1-8e71-96109cd22041
 ---
 # Compiler Warning (level 1) C4546
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
@@ -8,7 +8,7 @@ ms.assetid: 3edf1c2e-c0d5-444d-ae83-44a7cce24bb2
 ---
 # Compiler Warning (level 1) C4547
 
-'operator' : operator before comma has no effect; expected operator with side-effect
+> 'operator' : operator before comma has no effect; expected operator with side-effect
 
 The compiler detected an ill-formed comma expression.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
@@ -18,7 +18,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4547:
+The following example generates C4547:
 
 ```cpp
 // C4547.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
@@ -10,9 +10,13 @@ ms.assetid: 3edf1c2e-c0d5-444d-ae83-44a7cce24bb2
 
 > 'operator' : operator before comma has no effect; expected operator with side-effect
 
+## Remarks
+
 The compiler detected an ill-formed comma expression.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4547:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4547.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4547"
 title: "Compiler Warning (level 1) C4547"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4547"
+ms.date: 11/04/2016
 f1_keywords: ["C4547"]
 helpviewer_keywords: ["C4547"]
-ms.assetid: 3edf1c2e-c0d5-444d-ae83-44a7cce24bb2
 ---
 # Compiler Warning (level 1) C4547
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
@@ -8,7 +8,7 @@ ms.assetid: 2cee817e-e463-4d90-bbd2-de120d48c101
 ---
 # Compiler Warning (level 1) C4548
 
-expression before comma has no effect; expected expression with side-effect
+> expression before comma has no effect; expected expression with side-effect
 
 The compiler detected an ill-formed comma expression.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
@@ -18,7 +18,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4548:
+The following example generates C4548:
 
 ```cpp
 // C4548.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
@@ -10,9 +10,13 @@ ms.assetid: 2cee817e-e463-4d90-bbd2-de120d48c101
 
 > expression before comma has no effect; expected expression with side-effect
 
+## Remarks
+
 The compiler detected an ill-formed comma expression.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4548:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4548.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4548"
 title: "Compiler Warning (level 1) C4548"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4548"
+ms.date: 11/04/2016
 f1_keywords: ["C4548"]
 helpviewer_keywords: ["C4548"]
-ms.assetid: 2cee817e-e463-4d90-bbd2-de120d48c101
 ---
 # Compiler Warning (level 1) C4548
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
@@ -18,7 +18,7 @@ This warning is off by default. For more information, see [Compiler Warnings Tha
 
 ## Example
 
-The following sample generates C4549:
+The following example generates C4549:
 
 ```cpp
 // C4549.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
@@ -8,7 +8,7 @@ ms.assetid: 81a07676-625b-4f58-9b0c-3ee22830b04a
 ---
 # Compiler Warning (level 1) C4549
 
-'operator' : operator before comma has no effect; did you intend 'operator'?
+> 'operator' : operator before comma has no effect; did you intend 'operator'?
 
 The compiler detected an ill-formed comma expression.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4549"
 title: "Compiler Warning (level 1) C4549"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4549"
+ms.date: 11/04/2016
 f1_keywords: ["C4549"]
 helpviewer_keywords: ["C4549"]
-ms.assetid: 81a07676-625b-4f58-9b0c-3ee22830b04a
 ---
 # Compiler Warning (level 1) C4549
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4549.md
@@ -10,9 +10,13 @@ ms.assetid: 81a07676-625b-4f58-9b0c-3ee22830b04a
 
 > 'operator' : operator before comma has no effect; did you intend 'operator'?
 
+## Remarks
+
 The compiler detected an ill-formed comma expression.
 
 This warning is off by default. For more information, see [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md).
+
+## Example
 
 The following sample generates C4549:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
@@ -8,7 +8,7 @@ ms.assetid: f902b4ed-5f17-48ea-b693-92f4fb8c8054
 ---
 # Compiler Warning (level 1) C4550
 
-expression evaluates to a function which is missing an argument list
+> expression evaluates to a function which is missing an argument list
 
 A dereferenced pointer to a function is missing an argument list.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
@@ -10,6 +10,8 @@ ms.assetid: f902b4ed-5f17-48ea-b693-92f4fb8c8054
 
 > expression evaluates to a function which is missing an argument list
 
+## Remarks
+
 A dereferenced pointer to a function is missing an argument list.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
@@ -15,6 +15,8 @@ A dereferenced pointer to a function is missing an argument list.
 
 ## Example
 
+The following example generates C4550:
+
 ```cpp
 // C4550.cpp
 // compile with: /W1

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4550.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4550"
 title: "Compiler Warning (level 1) C4550"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4550"
+ms.date: 11/04/2016
 f1_keywords: ["C4550"]
 helpviewer_keywords: ["C4550"]
-ms.assetid: f902b4ed-5f17-48ea-b693-92f4fb8c8054
 ---
 # Compiler Warning (level 1) C4550
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
@@ -16,7 +16,7 @@ A function call must include the open and close parentheses after the function n
 
 ## Example
 
-The following sample generates C4551:
+The following example generates C4551:
 
 ```cpp
 // C4551.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
@@ -8,7 +8,7 @@ ms.assetid: 458b59bd-e2d7-425f-9ba6-268ff200424f
 ---
 # Compiler Warning (level 1) C4551
 
-function call missing argument list
+> function call missing argument list
 
 A function call must include the open and close parentheses after the function name even if the function takes no parameters.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4551"
 title: "Compiler Warning (level 1) C4551"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4551"
+ms.date: 11/04/2016
 f1_keywords: ["C4551"]
 helpviewer_keywords: ["C4551"]
-ms.assetid: 458b59bd-e2d7-425f-9ba6-268ff200424f
 ---
 # Compiler Warning (level 1) C4551
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4551.md
@@ -10,7 +10,11 @@ ms.assetid: 458b59bd-e2d7-425f-9ba6-268ff200424f
 
 > function call missing argument list
 
+## Remarks
+
 A function call must include the open and close parentheses after the function name even if the function takes no parameters.
+
+## Example
 
 The following sample generates C4551:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4552"
 title: "Compiler Warning (level 1) C4552"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4552"
+ms.date: 11/04/2016
 f1_keywords: ["C4552"]
 helpviewer_keywords: ["C4552"]
-ms.assetid: ebbbb5ee-1c19-45bd-b386-41a19630fc76
 ---
 # Compiler Warning (level 1) C4552
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
@@ -10,9 +10,13 @@ ms.assetid: ebbbb5ee-1c19-45bd-b386-41a19630fc76
 
 > 'operator' : operator has no effect; expected operator with side-effect
 
+## Remarks
+
 If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.
 
 To override this warning, put the expression in parentheses.
+
+## Example
 
 The following sample generates C4552:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
@@ -18,7 +18,7 @@ To override this warning, put the expression in parentheses.
 
 ## Example
 
-The following sample generates C4552:
+The following example generates C4552:
 
 ```cpp
 // C4552.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4552.md
@@ -8,7 +8,7 @@ ms.assetid: ebbbb5ee-1c19-45bd-b386-41a19630fc76
 ---
 # Compiler Warning (level 1) C4552
 
-'operator' : operator has no effect; expected operator with side-effect
+> 'operator' : operator has no effect; expected operator with side-effect
 
 If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
@@ -8,7 +8,7 @@ ms.assetid: d8aacbe0-3cb5-4367-a6e5-fd7e28f0ff9d
 ---
 # Compiler Warning (level 1) C4553
 
-'operator' : operator has no effect; did you intend 'operator'?
+> 'operator' : operator has no effect; did you intend 'operator'?
 
 If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4553"
 title: "Compiler Warning (level 1) C4553"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4553"
+ms.date: 11/04/2016
 f1_keywords: ["C4553"]
 helpviewer_keywords: ["C4553"]
-ms.assetid: d8aacbe0-3cb5-4367-a6e5-fd7e28f0ff9d
 ---
 # Compiler Warning (level 1) C4553
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
@@ -16,7 +16,7 @@ If an expression statement has an operator with no side effect as the top of the
 
 ## Example
 
-The following sample generates C4553:
+The following example generates C4553:
 
 ```cpp
 // C4553.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4553.md
@@ -10,7 +10,11 @@ ms.assetid: d8aacbe0-3cb5-4367-a6e5-fd7e28f0ff9d
 
 > 'operator' : operator has no effect; did you intend 'operator'?
 
+## Remarks
+
 If an expression statement has an operator with no side effect as the top of the expression, it's probably a mistake.
+
+## Example
 
 The following sample generates C4553:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
@@ -10,9 +10,13 @@ ms.assetid: 50b286c1-f7bf-4292-b1fa-baaac9538611
 
 > expression has no effect; expected expression with side-effect
 
+## Remarks
+
 This warning informs you when an expression has no effect.
 
 This warning is off by default. See [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md) for more information.
+
+## Example
 
 For example:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4555"
 title: "Compiler Warning (level 1) C4555"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4555"
+ms.date: 11/04/2016
 f1_keywords: ["C4555"]
 helpviewer_keywords: ["C4555"]
-ms.assetid: 50b286c1-f7bf-4292-b1fa-baaac9538611
 ---
 # Compiler Warning (level 1) C4555
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4555.md
@@ -8,7 +8,7 @@ ms.assetid: 50b286c1-f7bf-4292-b1fa-baaac9538611
 ---
 # Compiler Warning (level 1) C4555
 
-expression has no effect; expected expression with side-effect
+> expression has no effect; expected expression with side-effect
 
 This warning informs you when an expression has no effect.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4556.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4556.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Warning (level 1) C4556"
 description: "Learn more about: Compiler Warning (level 1) C4556"
-ms.date: "03/28/2025"
+ms.date: 03/28/2025
 f1_keywords: ["C4556"]
 helpviewer_keywords: ["C4556"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
@@ -16,7 +16,7 @@ The value passed to an assembly language instruction is out of the range specifi
 
 ## Example
 
-The following sample generates C4558:
+The following example generates C4558:
 
 ```cpp
 // C4558.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C4558"
 title: "Compiler Warning (level 1) C4558"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 1) C4558"
+ms.date: 11/04/2016
 f1_keywords: ["C4558"]
 helpviewer_keywords: ["C4558"]
-ms.assetid: 52bb0324-7bec-468c-b35b-13a08d38e578
 ---
 # Compiler Warning (level 1) C4558
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
@@ -10,7 +10,11 @@ ms.assetid: 52bb0324-7bec-468c-b35b-13a08d38e578
 
 > value of operand 'value' is out of range 'lowerbound - upperbound'
 
+## Remarks
+
 The value passed to an assembly language instruction is out of the range specified for the parameter. The value will be truncated.
+
+## Example
 
 The following sample generates C4558:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4558.md
@@ -8,7 +8,7 @@ ms.assetid: 52bb0324-7bec-468c-b35b-13a08d38e578
 ---
 # Compiler Warning (level 1) C4558
 
-value of operand 'value' is out of range 'lowerbound - upperbound'
+> value of operand 'value' is out of range 'lowerbound - upperbound'
 
 The value passed to an assembly language instruction is out of the range specified for the parameter. The value will be truncated.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
@@ -10,6 +10,8 @@ ms.assetid: 057d770c-ebcf-44cd-b943-1b1bb1ceaa8c
 
 > 'class' : multiple copy constructors specified
 
+## Remarks
+
 The class has multiple copy constructors of a single type. This warning is informational; the constructors are callable in your program.
 
 Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
@@ -8,7 +8,7 @@ ms.assetid: 057d770c-ebcf-44cd-b943-1b1bb1ceaa8c
 ---
 # Compiler Warning (level 3) C4521
 
-'class' : multiple copy constructors specified
+> 'class' : multiple copy constructors specified
 
 The class has multiple copy constructors of a single type. This warning is informational; the constructors are callable in your program.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4521"
 title: "Compiler Warning (level 3) C4521"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4521"
+ms.date: 11/04/2016
 f1_keywords: ["C4521"]
 helpviewer_keywords: ["C4521"]
-ms.assetid: 057d770c-ebcf-44cd-b943-1b1bb1ceaa8c
 ---
 # Compiler Warning (level 3) C4521
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4521.md
@@ -18,7 +18,7 @@ Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning
 
 ## Example
 
-The following sample generates C4521.
+The following example generates C4521.
 
 ```cpp
 // C4521.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4522"
 title: "Compiler Warning (level 3) C4522"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4522"
+ms.date: 11/04/2016
 f1_keywords: ["C4522"]
 helpviewer_keywords: ["C4522"]
-ms.assetid: 7065dc27-0b6c-4e68-a345-c51cdb99a20b
 ---
 # Compiler Warning (level 3) C4522
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
@@ -8,7 +8,7 @@ ms.assetid: 7065dc27-0b6c-4e68-a345-c51cdb99a20b
 ---
 # Compiler Warning (level 3) C4522
 
-'class' : multiple assignment operators specified
+> 'class' : multiple assignment operators specified
 
 The class has multiple assignment operators of a single type. This warning is informational; the constructors are callable in your program.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
@@ -10,6 +10,8 @@ ms.assetid: 7065dc27-0b6c-4e68-a345-c51cdb99a20b
 
 > 'class' : multiple assignment operators specified
 
+## Remarks
+
 The class has multiple assignment operators of a single type. This warning is informational; the constructors are callable in your program.
 
 Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4522.md
@@ -18,7 +18,7 @@ Use the [warning](../../preprocessor/warning.md) pragma to suppress this warning
 
 ## Example
 
-The following sample generates C4522.
+The following example generates C4522.
 
 ```cpp
 // C4522.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
@@ -10,4 +10,6 @@ ms.assetid: 0f28761d-999f-43fe-9481-d02afd9b4f60
 
 > 'class' : multiple destructors specified
 
+## Remarks
+
 The class has multiple destructors.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4523"
 title: "Compiler Warning (level 3) C4523"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4523"
+ms.date: 11/04/2016
 f1_keywords: ["C4523"]
 helpviewer_keywords: ["C4523"]
-ms.assetid: 0f28761d-999f-43fe-9481-d02afd9b4f60
 ---
 # Compiler Warning (level 3) C4523
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4523.md
@@ -8,6 +8,6 @@ ms.assetid: 0f28761d-999f-43fe-9481-d02afd9b4f60
 ---
 # Compiler Warning (level 3) C4523
 
-'class' : multiple destructors specified
+> 'class' : multiple destructors specified
 
 The class has multiple destructors.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4534"
 title: "Compiler Warning (level 3) C4534"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4534"
+ms.date: 11/04/2016
 f1_keywords: ["C4534"]
 helpviewer_keywords: ["C4534"]
 ---

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
@@ -9,9 +9,13 @@ helpviewer_keywords: ["C4534"]
 
 > 'constructor' will not be a default constructor for class 'class' due to the default argument
 
+## Remarks
+
 An unmanaged class can have a constructor with parameters that have default values and the compiler will use this as the default constructor. A class marked with the `value` keyword will not use a constructor with default values for its parameters as a default constructor.
 
 For more information, see [Classes and Structs](../../extensions/classes-and-structs-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C4534:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
@@ -17,7 +17,7 @@ For more information, see [Classes and Structs](../../extensions/classes-and-str
 
 ## Example
 
-The following sample generates C4534:
+The following example generates C4534:
 
 ```cpp
 // C4534.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4534.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C4534"]
 ---
 # Compiler Warning (level 3) C4534
 
-'constructor' will not be a default constructor for class 'class' due to the default argument
+> 'constructor' will not be a default constructor for class 'class' due to the default argument
 
 An unmanaged class can have a constructor with parameters that have default values and the compiler will use this as the default constructor. A class marked with the `value` keyword will not use a constructor with default values for its parameters as a default constructor.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
@@ -16,7 +16,7 @@ The use of [_set_se_translator](../../c-runtime-library/reference/set-se-transla
 
 ## Example
 
-The following sample generates C4535.
+The following example generates C4535.
 
 ```cpp
 // C4535.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
@@ -8,7 +8,7 @@ ms.assetid: 2c5ad1aa-2558-41d1-8f06-47fef74c8d9b
 ---
 # Compiler Warning (level 3) C4535
 
-calling _set_se_translator() requires /EHa
+> calling _set_se_translator() requires /EHa
 
 The use of [_set_se_translator](../../c-runtime-library/reference/set-se-translator.md) requires the [/EHa](../../build/reference/eh-exception-handling-model.md) compiler option and not **/EHs**.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
@@ -10,6 +10,8 @@ ms.assetid: 2c5ad1aa-2558-41d1-8f06-47fef74c8d9b
 
 > calling _set_se_translator() requires /EHa
 
+## Remarks
+
 The use of [_set_se_translator](../../c-runtime-library/reference/set-se-translator.md) requires the [/EHa](../../build/reference/eh-exception-handling-model.md) compiler option and not **/EHs**.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4535.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4535"
 title: "Compiler Warning (level 3) C4535"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4535"
+ms.date: 11/04/2016
 f1_keywords: ["C4535"]
 helpviewer_keywords: ["C4535"]
-ms.assetid: 2c5ad1aa-2558-41d1-8f06-47fef74c8d9b
 ---
 # Compiler Warning (level 3) C4535
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4538"
 title: "Compiler Warning (level 3) C4538"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4538"
+ms.date: 11/04/2016
 f1_keywords: ["C4538"]
 helpviewer_keywords: ["C4538"]
-ms.assetid: 747e3d51-b6d0-41c1-a726-7af3253b59d7
 ---
 # Compiler Warning (level 3) C4538
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
@@ -16,7 +16,7 @@ A qualifier keyword was applied to an array incorrectly. For more information, s
 
 ## Example
 
-The following sample generates C4538:
+The following example generates C4538:
 
 ```cpp
 // C4538.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
@@ -10,7 +10,11 @@ ms.assetid: 747e3d51-b6d0-41c1-a726-7af3253b59d7
 
 > 'type' : const/volatile qualifiers on this type are not supported
 
+## Remarks
+
 A qualifier keyword was applied to an array incorrectly. For more information, see [array](../../extensions/arrays-cpp-component-extensions.md).
+
+## Example
 
 The following sample generates C4538:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4538.md
@@ -8,7 +8,7 @@ ms.assetid: 747e3d51-b6d0-41c1-a726-7af3253b59d7
 ---
 # Compiler Warning (level 3) C4538
 
-'type' : const/volatile qualifiers on this type are not supported
+> 'type' : const/volatile qualifiers on this type are not supported
 
 A qualifier keyword was applied to an array incorrectly. For more information, see [array](../../extensions/arrays-cpp-component-extensions.md).
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
@@ -8,7 +8,7 @@ ms.assetid: a09b39a7-d3b8-435c-86a3-2233c512f24b
 ---
 # Compiler Warning (level 3) C4543
 
-Injected text suppressed by attribute 'no_injected_text'
+> Injected text suppressed by attribute 'no_injected_text'
 
 The [no_injected_text](../../windows/attributes/no-injected-text.md) attribute appeared in source code, which means the compiler will prevent attributes from injecting code.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4543"
 title: "Compiler Warning (level 3) C4543"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4543"
+ms.date: 11/04/2016
 f1_keywords: ["C4543"]
 helpviewer_keywords: ["C4543"]
-ms.assetid: a09b39a7-d3b8-435c-86a3-2233c512f24b
 ---
 # Compiler Warning (level 3) C4543
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4543.md
@@ -10,6 +10,8 @@ ms.assetid: a09b39a7-d3b8-435c-86a3-2233c512f24b
 
 > Injected text suppressed by attribute 'no_injected_text'
 
+## Remarks
+
 The [no_injected_text](../../windows/attributes/no-injected-text.md) attribute appeared in source code, which means the compiler will prevent attributes from injecting code.
 
 This warning is to remind you that attributes will not be able to inject code.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
@@ -8,7 +8,7 @@ ms.assetid: 55bb68f0-2e80-4330-8921-51083c4f8d53
 ---
 # Compiler Warning (level 3) C4554
 
-'operator' : check operator precedence for possible error; use parentheses to clarify precedence
+> 'operator' : check operator precedence for possible error; use parentheses to clarify precedence
 
 The following sample generates C4554:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
@@ -12,7 +12,7 @@ ms.assetid: 55bb68f0-2e80-4330-8921-51083c4f8d53
 
 ## Example
 
-The following sample generates C4554:
+The following example generates C4554:
 
 ```cpp
 // C4554.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
@@ -10,6 +10,8 @@ ms.assetid: 55bb68f0-2e80-4330-8921-51083c4f8d53
 
 > 'operator' : check operator precedence for possible error; use parentheses to clarify precedence
 
+## Example
+
 The following sample generates C4554:
 
 ```cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4554.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4554"
 title: "Compiler Warning (level 3) C4554"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4554"
+ms.date: 11/04/2016
 f1_keywords: ["C4554"]
 helpviewer_keywords: ["C4554"]
-ms.assetid: 55bb68f0-2e80-4330-8921-51083c4f8d53
 ---
 # Compiler Warning (level 3) C4554
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
@@ -10,9 +10,13 @@ ms.assetid: 7d9db716-03b2-4ee5-9b09-ba8aa5aa7e4c
 
 > '__assume' contains effect 'effect'
 
+## Remarks
+
 The value passed to an [__assume](../../intrinsics/assume.md) statement2 was modified.
 
 This warning is off by default. See [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md) for more information.
+
+## Example
 
 The following sample generates C4557:
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
@@ -18,7 +18,7 @@ This warning is off by default. See [Compiler Warnings That Are Off by Default](
 
 ## Example
 
-The following sample generates C4557:
+The following example generates C4557:
 
 ```cpp
 // C4557.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
@@ -8,7 +8,7 @@ ms.assetid: 7d9db716-03b2-4ee5-9b09-ba8aa5aa7e4c
 ---
 # Compiler Warning (level 3) C4557
 
-'__assume' contains effect 'effect'
+> '__assume' contains effect 'effect'
 
 The value passed to an [__assume](../../intrinsics/assume.md) statement2 was modified.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4557.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 3) C4557"
 title: "Compiler Warning (level 3) C4557"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 3) C4557"
+ms.date: 11/04/2016
 f1_keywords: ["C4557"]
 helpviewer_keywords: ["C4557"]
-ms.assetid: 7d9db716-03b2-4ee5-9b09-ba8aa5aa7e4c
 ---
 # Compiler Warning (level 3) C4557
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
@@ -8,7 +8,7 @@ ms.assetid: ab4d0686-f813-4e88-a264-b40d3630ed6c
 ---
 # Compiler Warning (level 4) C4536
 
-'type name' : type-name exceeds meta-data limit of 'limit' characters
+> 'type name' : type-name exceeds meta-data limit of 'limit' characters
 
 A type name would be truncated in metadata if it was a managed type. See [C3180](../../error-messages/compiler-errors-2/compiler-error-c3180.md) for more information.
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4536"
 title: "Compiler Warning (level 4) C4536"
-ms.date: "11/04/2016"
+description: "Learn more about: Compiler Warning (level 4) C4536"
+ms.date: 11/04/2016
 f1_keywords: ["C4536"]
 helpviewer_keywords: ["C4536"]
-ms.assetid: ab4d0686-f813-4e88-a264-b40d3630ed6c
 ---
 # Compiler Warning (level 4) C4536
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4536.md
@@ -10,6 +10,8 @@ ms.assetid: ab4d0686-f813-4e88-a264-b40d3630ed6c
 
 > 'type name' : type-name exceeds meta-data limit of 'limit' characters
 
+## Remarks
+
 A type name would be truncated in metadata if it was a managed type. See [C3180](../../error-messages/compiler-errors-2/compiler-error-c3180.md) for more information.
 
 This warning is off by default. See [Compiler Warnings That Are Off by Default](../../preprocessor/compiler-warnings-that-are-off-by-default.md) for more information.

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4559.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4559.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C4559"
 title: "Compiler Warning (level 4) C4559"
-ms.date: "08/27/2018"
+description: "Learn more about: Compiler Warning (level 4) C4559"
+ms.date: 08/27/2018
 f1_keywords: ["C4559"]
 helpviewer_keywords: ["C4559"]
-ms.assetid: ed542f60-454d-45cb-85da-987ede61b1ab
 ---
 # Compiler Warning (level 4) C4559
 

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4559.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c4559.md
@@ -16,7 +16,7 @@ A function was redefined or redeclared and the second definition or declaration 
 
 ## Example
 
-The following sample generates C4559:
+The following example generates C4559:
 
 ```cpp
 // C4559.cpp


### PR DESCRIPTION
C4541 is skipped due to #5705.

This is batch 80 that structures error/warning references. See #5465 for more information.