### PR TITLE
Structure warning references in range [C5051, C5999]

### DIFF
--- a/docs/error-messages/compiler-warnings/c5054.md
+++ b/docs/error-messages/compiler-warnings/c5054.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5054"
-description: Compiler warning C5054 description and solution.
+description: "Compiler warning C5054 description and solution."
 ms.date: 02/22/2022
 f1_keywords: ["C5054"]
 helpviewer_keywords: ["C5054"]

--- a/docs/error-messages/compiler-warnings/c5055.md
+++ b/docs/error-messages/compiler-warnings/c5055.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5055"
-description: Compiler warning C5055 description and solution.
+description: "Compiler warning C5055 description and solution."
 ms.date: 02/22/2022
 f1_keywords: ["C5055"]
 helpviewer_keywords: ["C5055"]

--- a/docs/error-messages/compiler-warnings/c5056.md
+++ b/docs/error-messages/compiler-warnings/c5056.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5056"
-description: Compiler warning C5056 description and solution.
+description: "Compiler warning C5056 description and solution."
 ms.date: 02/22/2022
 f1_keywords: ["C5056"]
 helpviewer_keywords: ["C5056"]

--- a/docs/error-messages/compiler-warnings/c5105.md
+++ b/docs/error-messages/compiler-warnings/c5105.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Warning C5105"
-description: Compiler warning C5105 description and solution.
-ms.date: "09/22/2019"
+description: "Compiler warning C5105 description and solution."
+ms.date: 09/22/2019
 f1_keywords: ["C5105"]
 helpviewer_keywords: ["C5105"]
 ---

--- a/docs/error-messages/compiler-warnings/c5105.md
+++ b/docs/error-messages/compiler-warnings/c5105.md
@@ -29,7 +29,7 @@ To turn off the warning for an entire project in the Visual Studio IDE:
 
 ## Example
 
-This sample program shows how to generate warning C5105, and how to fix it.
+This example program shows how to generate warning C5105, and how to fix it.
 
 ```cpp
 // C5105.cpp

--- a/docs/error-messages/compiler-warnings/c5208.md
+++ b/docs/error-messages/compiler-warnings/c5208.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5208, Error C7626"
-description: Compiler warning C5208 and error C7626 description and solution.
+description: "Compiler warning C5208 and error C7626 description and solution."
 ms.date: 04/18/2021
 f1_keywords: ["C5208", "C7626"]
 helpviewer_keywords: ["C5208", "C7626"]

--- a/docs/error-messages/compiler-warnings/c5208.md
+++ b/docs/error-messages/compiler-warnings/c5208.md
@@ -33,7 +33,7 @@ To turn off the warning for an entire project in the Visual Studio IDE:
 
 ## Example
 
-The following sample shows the constructs that are no longer allowed in unnamed structs. Depending on the standards mode specified, C5208 or C7626 errors or warnings are emitted:
+The following example shows the constructs that are no longer allowed in unnamed structs. Depending on the standards mode specified, C5208 or C7626 errors or warnings are emitted:
 
 ```cpp
 struct Base { };

--- a/docs/error-messages/compiler-warnings/c5240.md
+++ b/docs/error-messages/compiler-warnings/c5240.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5240"
-description: Compiler warning C5240 description and solution.
+description: "Compiler warning C5240 description and solution."
 ms.date: 02/22/2022
 f1_keywords: ["C5240"]
 helpviewer_keywords: ["C5240"]

--- a/docs/error-messages/compiler-warnings/c5243.md
+++ b/docs/error-messages/compiler-warnings/c5243.md
@@ -1,6 +1,6 @@
 ---
-title: Compiler warning C5243
-description: Compiler warning C5243 description and solution.
+title: "Compiler warning C5243"
+description: "Compiler warning C5243 description and solution."
 ms.date: 08/09/2021
 f1_keywords: ["C5243"]
 helpviewer_keywords: ["C5243"]

--- a/docs/error-messages/compiler-warnings/c5247.md
+++ b/docs/error-messages/compiler-warnings/c5247.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5247"
-description: Compiler warning C5247 description and solution.
+description: "Compiler warning C5247 description and solution."
 ms.date: 08/02/2021
 f1_keywords: ["C5247"]
 helpviewer_keywords: ["C5247"]

--- a/docs/error-messages/compiler-warnings/c5248.md
+++ b/docs/error-messages/compiler-warnings/c5248.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning C5248"
-description: Compiler warning C5248 description and solution.
+description: "Compiler warning C5248 description and solution."
 ms.date: 08/02/2021
 f1_keywords: ["C5248"]
 helpviewer_keywords: ["C5248"]

--- a/docs/error-messages/compiler-warnings/c5262.md
+++ b/docs/error-messages/compiler-warnings/c5262.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler warning (level 1, error, off) C5262"
-description: Compiler warning C5262 description and solution.
+description: "Compiler warning C5262 description and solution."
 ms.date: 03/01/2023
 f1_keywords: ["C5262"]
 helpviewer_keywords: ["C5262"]

--- a/docs/error-messages/compiler-warnings/c5262.md
+++ b/docs/error-messages/compiler-warnings/c5262.md
@@ -17,7 +17,7 @@ Compiler warning C5262 is new in Visual Studio 2022 version 17.4, and is both of
 
 ## Example
 
-The sample code shows diagnostics for `switch` cases that fall through without `break` or `return` statements or the `[[fallthrough]]` attribute.
+The example code shows diagnostics for `switch` cases that fall through without `break` or `return` statements or the `[[fallthrough]]` attribute.
 
 ```cpp
 // C5262.cpp

--- a/docs/error-messages/compiler-warnings/c5267.md
+++ b/docs/error-messages/compiler-warnings/c5267.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler warning C5267"
-description: Learn about compiler warning C5267
+description: "Learn about compiler warning C5267"
 ms.date: 11/08/2023
 f1_keywords: ["C5267"]
 helpviewer_keywords: ["C5267"]

--- a/docs/error-messages/compiler-warnings/c5301-c5302.md
+++ b/docs/error-messages/compiler-warnings/c5301-c5302.md
@@ -19,7 +19,7 @@ These compiler warnings are new in Visual Studio 2022 version 17.4.
 
 ## Example
 
-The sample code shows a diagnostic for a `for` loop that decrements the index, but it uses a `<=` comparison that tests whether the index is less than a value higher than the starting value.
+The example code shows a diagnostic for a `for` loop that decrements the index, but it uses a `<=` comparison that tests whether the index is less than a value higher than the starting value.
 
 ```C
 // C5302.c

--- a/docs/error-messages/compiler-warnings/c5301-c5302.md
+++ b/docs/error-messages/compiler-warnings/c5301-c5302.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler warnings (level 1) C5301 and C5302"
-description: Compiler warnings C5301 and C5302 description and solution.
+description: "Compiler warnings C5301 and C5302 description and solution."
 ms.date: 03/01/2023
 f1_keywords: ["C5301", "C5302"]
 helpviewer_keywords: ["C5301", "C5302"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Warning (level 1) C5072"
 title: "Compiler Warning (level 1) C5072"
+description: "Learn more about: Compiler Warning (level 1) C5072"
 ms.date: 02/09/2024
 f1_keywords: ["C5072"]
 helpviewer_keywords: ["C5072"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C5072"]
 
 > ASAN enabled without debug information emission. Enable debug info for better ASAN error reporting
 
+## Remarks
+
 This warning occurs when you compile with [Address Sanitizer](/cpp/sanitizers/asan) (ASAN) turned on, but you don't also instruct the compiler to emit debug info. ASAN uses debug info to provide better diagnostics.
 
 ## Example

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C5266"]
 
 > 'const' qualifier on return type has no effect
 
+## Remarks
+
 The C++ Standard specifies that a top-level const (or volatile) qualification on a function return type is ignored.
 
 This warning is off by default.\

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: Compiler Warning (level 4) C5266"
 title: "Compiler Warning (level 4) C5266"
+description: "Learn more about: Compiler Warning (level 4) C5266"
 ms.date: 01/18/2024
 f1_keywords: ["C5266"]
 helpviewer_keywords: ["C5266"]

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-4-c5266.md
@@ -18,7 +18,7 @@ This warning was introduced in Visual Studio 17.6
 
 ## Example
 
-The following sample generates C5266:
+The following example generates C5266:
 
 ```cpp
 // compile with: /W4 /c


### PR DESCRIPTION
This is batch 88 that structures error/warning references. See #5465 for more information.