### PR TITLE
Structure warning references in range [C6000, C6250]

### DIFF
--- a/docs/code-quality/c6001.md
+++ b/docs/code-quality/c6001.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6001"
 description: "Learn more about: Warning C6001"
-title: Warning C6001
 ms.date: 10/04/2022
 f1_keywords: ["C6001", "USING_UNINIT_VAR", "__WARNING_USING_UNINIT_VAR"]
 helpviewer_keywords: ["C6001"]

--- a/docs/code-quality/c6011.md
+++ b/docs/code-quality/c6011.md
@@ -16,7 +16,7 @@ This warning indicates that your code dereferences a potentially null pointer. I
 
 Code analysis name: `DEREF_NULL_PTR`
 
-## Example
+## Examples
 
 The following code generates this warning because a call to `malloc` might return null if insufficient memory is available:
 

--- a/docs/code-quality/c6011.md
+++ b/docs/code-quality/c6011.md
@@ -1,10 +1,9 @@
 ---
-title: Warning C6011
+title: "Warning C6011"
 description: "Reference for Visual Studio C++ code analysis warning C6011."
 ms.date: 10/04/2022
 f1_keywords: ["C6011", "DEREF_NULL_PTR", "__WARNING_DEREF_NULL_PTR"]
 helpviewer_keywords: ["C6011"]
-ms.assetid: 54b7bc2b-b8f5-43fc-a9a3-8189b03f249a
 ---
 # Warning C6011
 

--- a/docs/code-quality/c6014.md
+++ b/docs/code-quality/c6014.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6014"
 description: "Learn more about: Warning C6014"
-title: Warning C6014
 ms.date: 10/03/2022
 f1_keywords: ["C6014", "MEMORY_LEAK", "__WARNING_MEMORY_LEAK"]
 helpviewer_keywords: ["C6014"]
-ms.assetid: ef76ec88-74d2-4a3b-b6fe-4b0851ab3372
 ---
 # Warning C6014
 

--- a/docs/code-quality/c6014.md
+++ b/docs/code-quality/c6014.md
@@ -10,9 +10,9 @@ ms.assetid: ef76ec88-74d2-4a3b-b6fe-4b0851ab3372
 
 > Leaking memory '*pointer-name*'.
 
-This warning indicates that the specified pointer points to allocated memory or some other allocated resource that hasn't been freed.
-
 ## Remarks
+
+This warning indicates that the specified pointer points to allocated memory or some other allocated resource that hasn't been freed.
 
 The analyzer checks for this condition only when the `_Analysis_mode_(_Analysis_local_leak_checks_)` SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see [Using SAL Annotations to Reduce C/C++ Code Defects](../code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md).
 

--- a/docs/code-quality/c6029.md
+++ b/docs/code-quality/c6029.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6029"]
 
 > Possible buffer overrun in call to '*function*'
 
-Possible buffer overrun in called function due to an unchecked buffer length/size parameter.
-
 ## Remarks
+
+Possible buffer overrun in called function due to an unchecked buffer length/size parameter.
 
 This warning indicates that code passes an unchecked size to a function that takes a buffer and a size. The code doesn't verify that the data read from some external source is smaller than the buffer size. An attacker might intentionally specify a larger than expected value for the size, which can lead to a buffer overrun. Generally, whenever you read data from an untrusted external source, make sure to verify it for validity. It's appropriate to verify the size to make sure it's in the expected range.
 

--- a/docs/code-quality/c6029.md
+++ b/docs/code-quality/c6029.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6029
+title: "Warning C6029"
 description: "Learn more about: Warning C6029"
 ms.date: 2/07/2023
 f1_keywords: ["C6029", "USING_TAINTED_DATA", "__WARNING_USING_TAINTED_DATA"]

--- a/docs/code-quality/c6030.md
+++ b/docs/code-quality/c6030.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6030
+title: "Warning C6030"
 description: "Describes C++ Code Analysis warning C6030 and how to resolve it."
 ms.date: 03/10/2023
 f1_keywords: ["C6030", "USE_ATTRIBUTE_NORETURN", "__WARNING_USE_ATTRIBUTE_NORETURN"]

--- a/docs/code-quality/c6031.md
+++ b/docs/code-quality/c6031.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6031
+title: "Warning C6031"
 description: "Describes C++ Code Analysis warning C6031 and how to resolve it."
 ms.date: 4/5/2024
 f1_keywords: ["C6031", "RETVAL_IGNORED_FUNC_COULD_FAIL", "__WARNING_RETVAL_IGNORED_FUNC_COULD_FAIL"]

--- a/docs/code-quality/c6031.md
+++ b/docs/code-quality/c6031.md
@@ -19,7 +19,7 @@ This warning applies to both C and C++ code.
 
 Code analysis name: `RETVAL_IGNORED_FUNC_COULD_FAIL`
 
-## Example
+## Examples
 
 The following code generates warning C6031:
 

--- a/docs/code-quality/c6053.md
+++ b/docs/code-quality/c6053.md
@@ -18,7 +18,7 @@ Most C standard library and Win32 string handling functions require and produce 
 
 Code analysis name: `MISSING_ZERO_TERMINATION1`
 
-## Examples
+## Example
 
 The following sample code generates this warning:
 

--- a/docs/code-quality/c6053.md
+++ b/docs/code-quality/c6053.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6053"
 description: "Learn more about: Warning C6053"
-title: Warning C6053
 ms.date: 10/04/2022
 f1_keywords: ["C6053", "MISSING_ZERO_TERMINATION1", "__WARNING_MISSING_ZERO_TERMINATION1"]
 helpviewer_keywords: ["C6053"]
-ms.assetid: 8e25566a-e3b9-470a-820d-64221a877c53
 ---
 # Warning C6053
 

--- a/docs/code-quality/c6053.md
+++ b/docs/code-quality/c6053.md
@@ -20,7 +20,7 @@ Code analysis name: `MISSING_ZERO_TERMINATION1`
 
 ## Example
 
-The following sample code generates this warning:
+The following example code generates this warning:
 
 ```cpp
 #include <string.h>
@@ -36,7 +36,7 @@ size_t f( )
 }
 ```
 
-To correct this warning, zero-terminate the string as shown in the following sample code:
+To correct this warning, zero-terminate the string as shown in the following example code:
 
 ```cpp
 #include <string.h>
@@ -53,7 +53,7 @@ size_t f( )
 }
 ```
 
-The following sample code corrects this warning using safe string manipulation `strncpy_s` function:
+The following example code corrects this warning using safe string manipulation `strncpy_s` function:
 
 ```cpp
 #include <string.h>

--- a/docs/code-quality/c6054.md
+++ b/docs/code-quality/c6054.md
@@ -1,10 +1,9 @@
 ---
-title: Warning C6054
+title: "Warning C6054"
 description: "Reference guide to Microsoft C++ code analysis warning C6054."
 ms.date: 10/04/2022
 f1_keywords: ["C6054", "MISSING_ZERO_TERMINATION2", "__WARNING_MISSING_ZERO_TERMINATION2"]
 helpviewer_keywords: ["C6054"]
-ms.assetid: d573a5c1-7e74-402b-92e6-8085f967aa50
 ---
 # Warning C6054
 

--- a/docs/code-quality/c6054.md
+++ b/docs/code-quality/c6054.md
@@ -34,7 +34,7 @@ void g ( )
 }
 ```
 
-To correct this warning, null-terminate `wcArray` before calling function `func()` as shown in the following sample code:
+To correct this warning, null-terminate `wcArray` before calling function `func()` as shown in the following example code:
 
 ```cpp
 // C6054_good.cpp

--- a/docs/code-quality/c6059.md
+++ b/docs/code-quality/c6059.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6059"
 description: "Learn more about: Warning C6059"
-title: Warning C6059
 ms.date: 12/14/2023
 f1_keywords: ["C6059", "BAD_CONCATENATION", "__WARNING_BAD_CONCATENATION"]
 helpviewer_keywords: ["C6059"]
-ms.assetid: 343a4cd1-048a-4edf-bb4b-187097bb6093
 ---
 # Warning C6059
 

--- a/docs/code-quality/c6063.md
+++ b/docs/code-quality/c6063.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6063"
 description: "Learn more about: Warning C6063"
-title: Warning C6063
 ms.date: 2/22/2023
 f1_keywords: ["C6063", "MISSING_STRING_ARGUMENT_TO_FORMAT_FUNCTION", "__WARNING_MISSING_STRING_ARGUMENT_TO_FORMAT_FUNCTION"]
 helpviewer_keywords: ["C6063"]

--- a/docs/code-quality/c6064.md
+++ b/docs/code-quality/c6064.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6064"
 description: "Learn more about: Warning C6064"
-title: Warning C6064
 ms.date: 2/07/2023
 f1_keywords: ["C6064", "MISSING_INTEGER_ARGUMENT_TO_FORMAT_FUNCTION", "__WARNING_MISSING_INTEGER_ARGUMENT_TO_FORMAT_FUNCTION"]
 helpviewer_keywords: ["C6064"]

--- a/docs/code-quality/c6064.md
+++ b/docs/code-quality/c6064.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6064"]
 
 > Missing integer argument to '*function-name*' corresponding to conversion specifier '*number*'
 
-This warning indicates that the code doesn't provide enough arguments to match a format string and one of the missing arguments is an integer.
-
 ## Remarks
+
+This warning indicates that the code doesn't provide enough arguments to match a format string and one of the missing arguments is an integer.
 
 This defect is likely to cause incorrect output and, in more dangerous cases, can lead to stack overflow.
 

--- a/docs/code-quality/c6065.md
+++ b/docs/code-quality/c6065.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6065"
 description: "Learn more about: Warning C6065"
-title: Warning C6065
 ms.date: 2/22/2023
 f1_keywords: ["C6065", "MISSING_COUNTED_STRING_ARGUMENT_TO_FORMAT_FUNCTION", "__MISSING_COUNTED_STRING_ARGUMENT_TO_FORMAT_FUNCTION"]
 helpviewer_keywords: ["C6065"]

--- a/docs/code-quality/c6066.md
+++ b/docs/code-quality/c6066.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6066"
 description: "Learn more about: Warning C6066"
-title: Warning C6066
 ms.date: 3/02/2023
 f1_keywords: ["C6066", "NON_POINTER_ARGUMENT_TO_FORMAT_FUNCTION", "__WARNING_NON_POINTER_ARGUMENT_TO_FORMAT_FUNCTION"]
 helpviewer_keywords: ["C6066"]

--- a/docs/code-quality/c6067.md
+++ b/docs/code-quality/c6067.md
@@ -17,7 +17,7 @@ This defect is likely to cause a crash or corruption of some form.
 
 Code analysis name: `NON_STRING_ARGUMENT_TO_FORMAT_FUNCTION`
 
-## Example
+## Examples
 
 The following code generates this warning because an integer is passed instead of a string:
 

--- a/docs/code-quality/c6067.md
+++ b/docs/code-quality/c6067.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6067"
 description: "Learn more about: Warning C6067"
-title: Warning C6067
 ms.date: 3/02/2023
 f1_keywords: ["C6067", "NON_STRING_ARGUMENT_TO_FORMAT_FUNCTION", "__WARNING_NON_STRING_ARGUMENT_TO_FORMAT_FUNCTION"]
 helpviewer_keywords: ["C6067"]

--- a/docs/code-quality/c6101.md
+++ b/docs/code-quality/c6101.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6101"
 description: "Learn more about: Warning C6101"
-title: Warning C6101
 ms.date: 02/7/2023
 f1_keywords: ["C6101", "RETURN_UNINIT_VAR", "__WARNING_RETURN_UNINIT_VAR"]
 helpviewer_keywords: ["C6101"]

--- a/docs/code-quality/c6101.md
+++ b/docs/code-quality/c6101.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6101"]
 
 > Returning uninitialized memory '*parameter-name*'.
 
-A successful path through the function doesn't set the `_Out_` annotated parameter.
-
 ## Remarks
+
+A successful path through the function doesn't set the `_Out_` annotated parameter.
 
 The purpose of this warning is to avoid the use of uninitialized values by callers of the function. The analyzer assumes callers don't initialize any parameters annotated with `_Out_` before the function call, and checks that the function initializes them. The analyzer doesn't emit this warning if the function returns a value that indicates it had an error or wasn't successful. To fix this issue, make sure to initialize the `_Out_` parameter under all successful return paths. The error message contains the line numbers of an example path that doesn't initialize the parameter.
 

--- a/docs/code-quality/c6102.md
+++ b/docs/code-quality/c6102.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6102
+title: "Warning C6102"
 description: "Learn more about: Warning C6102"
 ms.date: 11/04/2016
 f1_keywords: ["C6102"]

--- a/docs/code-quality/c6102.md
+++ b/docs/code-quality/c6102.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C6102"]
 
 > Using '*variable*' from failed function call at line '*location*'.
 
+## Remarks
+
 This warning is reported instead of [C6001](../code-quality/c6001.md) when a variable isn't set because it was marked as an `_Out_` parameter on a prior function call that failed.
 
 The problem might be that the prior called function isn't fully annotated. It may require `_Always_`, `_Outptr_result_nullonfailure_` (`_COM_Outptr_` for COM code), or a related annotation.

--- a/docs/code-quality/c6103.md
+++ b/docs/code-quality/c6103.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C6103"]
 
 > Returning '*variable*' from failed function call at line '*location*'.
 
+## Remarks
+
 A successful path through the function is returning a variable that was used as an `_Out_` parameter to an internal function call that failed.
 
 The problem might be that the called function and the calling function aren't fully annotated. The called function may require `_Always_`, `_Outptr_result_nullonfailure_` (`_COM_Outptr_` for COM code), or a related annotation, and the calling function may require a `_Success_` annotation. Another possible cause for this warning is that the `_Success_` annotation on the called function is incorrect.

--- a/docs/code-quality/c6103.md
+++ b/docs/code-quality/c6103.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6103
+title: "Warning C6103"
 description: "Learn more about: Warning C6103"
 ms.date: 11/04/2016
 f1_keywords: ["C6103"]

--- a/docs/code-quality/c6200.md
+++ b/docs/code-quality/c6200.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6200"
 description: "Learn more about: Warning C6200"
-title: Warning C6200
 ms.date: 08/16/2022
 f1_keywords: ["C6200", "INDEX_EXCEEDS_MAX_NONSTACK", "__WARNING_INDEX_EXCEEDS_MAX_NONSTACK"]
 helpviewer_keywords: ["C6200"]
-ms.assetid: bbeb159b-4e97-4317-9a07-bb83cd03069a
 ---
 # Warning C6200
 

--- a/docs/code-quality/c6200.md
+++ b/docs/code-quality/c6200.md
@@ -10,9 +10,9 @@ ms.assetid: bbeb159b-4e97-4317-9a07-bb83cd03069a
 
 > Index '*index*' is out of valid index range '*min*' to '*max*' for nonstack buffer '*parameter-name*'
 
-This warning indicates that an integer offset into the specified nonstack array exceeds the maximum bounds of that array, causing undefined behavior and potentially crashes.
-
 ## Remarks
+
+This warning indicates that an integer offset into the specified nonstack array exceeds the maximum bounds of that array, causing undefined behavior and potentially crashes.
 
 One common cause of this defect is using the size of an array as an index into the array. Because C/C++ array indexing is zero-based, the maximum legal index into an array is one less than the number of array elements.
 

--- a/docs/code-quality/c6201.md
+++ b/docs/code-quality/c6201.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6201"
 description: "Learn more about: Warning C6201"
-title: Warning C6201
 ms.date: 11/17/2023
 f1_keywords: ["C6201", "INDEX_EXCEEDS_MAX", "__WARNING_INDEX_EXCEEDS_MAX"]
 helpviewer_keywords: ["C6201"]

--- a/docs/code-quality/c6201.md
+++ b/docs/code-quality/c6201.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6201"]
 
 > Index '*index-name*' is out of valid index range '*minimum*' to '*maximum*' for possibly stack allocated buffer '*variable*'
 
-This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. It might potentially cause stack overflow errors, undefined behavior, or crashes.
-
 ## Remarks
+
+This warning indicates that an integer offset into the specified stack array exceeds the maximum bounds of that array. It might potentially cause stack overflow errors, undefined behavior, or crashes.
 
 One common cause of this defect is using an array's size as an index into the array. Because C/C++ array indexing is zero-based, the maximum legal index into an array is one less than the number of array elements.
 

--- a/docs/code-quality/c6211.md
+++ b/docs/code-quality/c6211.md
@@ -10,9 +10,9 @@ ms.assetid: 9b68243b-534c-4a05-b789-bb155dfcba1e
 
 > Leaking memory '*pointer*' due to an exception. Consider using a local catch block to clean up memory
 
-This warning indicates that allocated memory isn't freed when an exception is thrown. The statement at the end of the path could throw an exception.
-
 ## Remarks
+
+This warning indicates that allocated memory isn't freed when an exception is thrown. The statement at the end of the path could throw an exception.
 
 The analyzer checks for this condition only when the `_Analysis_mode_(_Analysis_local_leak_checks_)` SAL annotation is specified. By default, this annotation is specified for Windows kernel mode (driver) code. For more information about SAL annotations, see [Using SAL Annotations to Reduce C/C++ Code Defects](../code-quality/using-sal-annotations-to-reduce-c-cpp-code-defects.md).
 

--- a/docs/code-quality/c6211.md
+++ b/docs/code-quality/c6211.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6211"
 description: "Learn more about: Warning C6211"
-title: Warning C6211
 ms.date: 10/03/2022
 f1_keywords: ["C6211", "MEMORY_LEAK_EXCEPTION", "__WARNING_MEMORY_LEAK_EXCEPTION"]
 helpviewer_keywords: ["C6211"]
-ms.assetid: 9b68243b-534c-4a05-b789-bb155dfcba1e
 ---
 # Warning C6211
 

--- a/docs/code-quality/c6214.md
+++ b/docs/code-quality/c6214.md
@@ -10,9 +10,9 @@ ms.assetid: 233e2395-61c1-4a3b-a54b-f19a9ffc31a8
 
 > Cast between semantically different integer types: HRESULT to a Boolean type
 
-This warning indicates that an `HRESULT` is being cast to a Boolean type. The success value (`S_OK`) of an `HRESULT` equals 0. However, 0 indicates failure for a Boolean type. Casting an `HRESULT` to a Boolean type and then using it in a test expression will yield an incorrect result.
-
 ## Remarks
+
+This warning indicates that an `HRESULT` is being cast to a Boolean type. The success value (`S_OK`) of an `HRESULT` equals 0. However, 0 indicates failure for a Boolean type. Casting an `HRESULT` to a Boolean type and then using it in a test expression will yield an incorrect result.
 
 Sometimes, this warning occurs if an `HRESULT` is being stored in a Boolean variable. Any comparison that uses the Boolean variable to test for `HRESULT` success or failure could lead to incorrect results.
 

--- a/docs/code-quality/c6214.md
+++ b/docs/code-quality/c6214.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6214"
 description: "Learn more about: Warning C6214"
-title: Warning C6214
 ms.date: 10/03/2022
 f1_keywords: ["C6214", "CAST_HRESULT_TO_BOOL", "__WARNING_CAST_HRESULT_TO_BOOL"]
 helpviewer_keywords: ["C6214"]
-ms.assetid: 233e2395-61c1-4a3b-a54b-f19a9ffc31a8
 ---
 # Warning C6214
 

--- a/docs/code-quality/c6215.md
+++ b/docs/code-quality/c6215.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6215"
 description: "Learn more about: Warning C6215"
-title: Warning C6215
 ms.date: 11/04/2016
 f1_keywords: ["C6215", "CAST_BOOL_TO_HRESULT", "__WARNING_CAST_BOOL_TO_HRESULT"]
 helpviewer_keywords: ["C6215"]
-ms.assetid: f20cc258-9c0f-4eaa-828d-74f76580ca78
 ---
 # Warning C6215
 

--- a/docs/code-quality/c6215.md
+++ b/docs/code-quality/c6215.md
@@ -10,9 +10,9 @@ ms.assetid: f20cc258-9c0f-4eaa-828d-74f76580ca78
 
 > Cast between semantically different integer types: a Boolean type to HRESULT
 
-This warning indicates that a Boolean is being cast to an `HRESULT`. Boolean types indicate success by a non-zero value, whereas success (`S_OK`) in `HRESULT` is indicated by a value of 0. Casting a Boolean type to an `HRESULT` and then using it in a test expression will yield an incorrect result.
-
 ## Remarks
+
+This warning indicates that a Boolean is being cast to an `HRESULT`. Boolean types indicate success by a non-zero value, whereas success (`S_OK`) in `HRESULT` is indicated by a value of 0. Casting a Boolean type to an `HRESULT` and then using it in a test expression will yield an incorrect result.
 
 This warning frequently occurs when a Boolean is used as an argument to `SUCCEEDED` or `FAILED` macro, which explicitly casts their arguments to an `HRESULT`.
 

--- a/docs/code-quality/c6216.md
+++ b/docs/code-quality/c6216.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6216"
 description: "Learn more about: Warning C6216"
-title: Warning C6216
 ms.date: 11/04/2016
 f1_keywords: ["C6216", "COMPILER_INSERTED_CAST_BOOL_TO_HRESULT", "__WARNING_COMPILER_INSERTED_CAST_BOOL_TO_HRESULT"]
 helpviewer_keywords: ["C6216"]
-ms.assetid: d5c4dcf9-bfd7-4604-804f-9cc41b08d060
 ---
 # Warning C6216
 

--- a/docs/code-quality/c6216.md
+++ b/docs/code-quality/c6216.md
@@ -10,9 +10,9 @@ ms.assetid: d5c4dcf9-bfd7-4604-804f-9cc41b08d060
 
 > Compiler-inserted cast between semantically different integral types: a Boolean type to HRESULT
 
-A Boolean type is being used as an `HRESULT` without being explicitly cast.
-
 ## Remarks
+
+A Boolean type is being used as an `HRESULT` without being explicitly cast.
 
 Boolean types indicate success by a non-zero value; success (`S_OK`) in `HRESULT` is indicated by a value of 0. A Boolean `false` value used as an `HRESULT` would indicate `S_OK`, which is frequently a mistake.
 

--- a/docs/code-quality/c6217.md
+++ b/docs/code-quality/c6217.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6217"
 description: "Learn more about: Warning C6217"
-title: Warning C6217
 ms.date: 2/07/2023
 f1_keywords: ["C6217", "TESTING_HRESULT_WITH_NOT", "__WARNING_TESTING_HRESULT_WITH_NOT"]
 helpviewer_keywords: ["C6217"]

--- a/docs/code-quality/c6219.md
+++ b/docs/code-quality/c6219.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6219"
 description: "Learn more about: Warning C6219"
-title: Warning C6219
 ms.date: 11/04/2016
 f1_keywords: ["C6219", "COMPARING_HRESULT_TO_ONE", "__WARNING_COMPARING_HRESULT_TO_ONE"]
 helpviewer_keywords: ["C6219"]
-ms.assetid: 889a2de8-c0dc-4e8e-a46b-735384202675
 ---
 # Warning C6219
 

--- a/docs/code-quality/c6220.md
+++ b/docs/code-quality/c6220.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6220"
 description: "Learn more about: Warning C6220"
-title: Warning C6220
 ms.date: 10/03/2022
 f1_keywords: ["C6220", "COMPARING_HRESULT_TO_MINUS_ONE", "__WARNING_COMPARING_HRESULT_TO_MINUS_ONE"]
 helpviewer_keywords: ["C6220"]
-ms.assetid: a13524f4-0a1f-4670-b830-70b06e4d39d2
 ---
 # Warning C6220
 

--- a/docs/code-quality/c6220.md
+++ b/docs/code-quality/c6220.md
@@ -10,9 +10,9 @@ ms.assetid: a13524f4-0a1f-4670-b830-70b06e4d39d2
 
 > Implicit cast between semantically different integer types: comparing HRESULT to -1. Consider using `SUCCEEDED` or `FAILED` macro instead
 
-This warning indicates that an `HRESULT` is being compared with an explicit, non-`HRESULT` value of -1, which isn't a well-formed `HRESULT`.
-
 ## Remarks
+
+This warning indicates that an `HRESULT` is being compared with an explicit, non-`HRESULT` value of -1, which isn't a well-formed `HRESULT`.
 
 A failure in `HRESULT` (`E_FAIL`) isn't represented by a -1. Therefore, an implicit cast of an `HRESULT` to an integer will generate an incorrect value and is likely to lead to the wrong result.
 

--- a/docs/code-quality/c6220.md
+++ b/docs/code-quality/c6220.md
@@ -20,7 +20,7 @@ Code analysis name: `COMPARING_HRESULT_TO_MINUS_ONE`
 
 ## Example
 
-In most cases, warning C6220 is caused by code that mistakenly expects a function to return an integer, and to use -1 as a failure value, but instead the function returns an `HRESULT`. The following code sample generates this warning:
+In most cases, warning C6220 is caused by code that mistakenly expects a function to return an integer, and to use -1 as a failure value, but instead the function returns an `HRESULT`. The following code example generates this warning:
 
 ```cpp
 #include <windows.h>

--- a/docs/code-quality/c6221.md
+++ b/docs/code-quality/c6221.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6221"
 description: "Learn more about: Warning C6221"
-title: Warning C6221
 ms.date: 10/03/2022
 f1_keywords: ["C6221", "COMPARING_HRESULT_TO_INT", "__WARNING_COMPARING_HRESULT_TO_INT"]
 helpviewer_keywords: ["C6221"]
-ms.assetid: b07989b7-f50f-46e0-8ed8-d9269b3d3580
 ---
 # Warning C6221
 

--- a/docs/code-quality/c6221.md
+++ b/docs/code-quality/c6221.md
@@ -10,9 +10,9 @@ ms.assetid: b07989b7-f50f-46e0-8ed8-d9269b3d3580
 
 > Implicit cast between semantically different integer types: comparing HRESULT to an integer. Consider using `SUCCEEDED` or `FAILED` macros instead
 
-This warning indicates that an `HRESULT` is being compared to an integer other than zero.
-
 ## Remarks
+
+This warning indicates that an `HRESULT` is being compared to an integer other than zero.
 
 A success in an `HRESULT` (`S_OK`) is represented by a 0. Therefore, an implicit cast of an `HRESULT` to an integer generates an incorrect value and is likely to lead to the wrong result. The error is often caused by mistakenly expecting a function to return an integer when it actually returns an `HRESULT`.
 

--- a/docs/code-quality/c6225.md
+++ b/docs/code-quality/c6225.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6225"
 description: "Learn more about: Warning C6225"
-title: Warning C6225
 ms.date: 10/03/2022
 f1_keywords: ["C6225", "ASSIGNING_ONE_TO_HRESULT", "__WARNING_ASSIGNING_ONE_TO_HRESULT"]
 helpviewer_keywords: ["C6225"]
-ms.assetid: 2d98ffec-9842-4cd1-b1a9-9ac9d1d2a136
 ---
 # Warning C6225
 

--- a/docs/code-quality/c6225.md
+++ b/docs/code-quality/c6225.md
@@ -10,9 +10,9 @@ ms.assetid: 2d98ffec-9842-4cd1-b1a9-9ac9d1d2a136
 
 > Implicit cast between semantically different integer types: assigning 1 or `TRUE` to `HRESULT`. Consider using `S_FALSE` instead
 
-This warning indicates that an `HRESULT` is being assigned or initialized with a value of an explicit 1. Boolean types indicate success by a non-zero value; success (`S_OK`) in `HRESULT` is indicated by a value of 0.
-
 ## Remarks
+
+This warning indicates that an `HRESULT` is being assigned or initialized with a value of an explicit 1. Boolean types indicate success by a non-zero value; success (`S_OK`) in `HRESULT` is indicated by a value of 0.
 
 This warning is frequently caused by accidental confusion of Boolean and `HRESULT` types. To indicate success, the symbolic constant `S_OK` should be used.
 

--- a/docs/code-quality/c6226.md
+++ b/docs/code-quality/c6226.md
@@ -10,9 +10,9 @@ ms.assetid: c18aa576-b316-4f11-b48f-f5183fa49c7c
 
 > Implicit cast between semantically different integer types: assigning -1 to HRESULT. Consider using E_FAIL instead.
 
-This warning indicates that an `HRESULT` is assigned or initialized to an explicit value of -1.
-
 ## Remarks
+
+This warning indicates that an `HRESULT` is assigned or initialized to an explicit value of -1.
 
 This warning is frequently caused by accidental confusion of integer and `HRESULT` types. To indicate success, use the symbolic constant `S_OK` instead. To indicate failure, use the symbolic constants that start with E_*constant*, such as `E_FAIL`.
 

--- a/docs/code-quality/c6226.md
+++ b/docs/code-quality/c6226.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6226"
 description: "Learn more about: Warning C6226"
-title: Warning C6226
 ms.date: 11/04/2016
 f1_keywords: ["C6226", "ASSIGNING_MINUS_ONE_TO_HRESULT", "__WARNING_ASSIGNING_MINUS_ONE_TO_HRESULT"]
 helpviewer_keywords: ["C6226"]
-ms.assetid: c18aa576-b316-4f11-b48f-f5183fa49c7c
 ---
 # Warning C6226
 

--- a/docs/code-quality/c6230.md
+++ b/docs/code-quality/c6230.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6230"
 description: "Learn more about: Warning C6230"
-title: Warning C6230
 ms.date: 11/04/2016
 f1_keywords: ["C6230", "USING_HRESULT_IN_BOOLEAN_CONTEXT", "__WARNING_USING_HRESULT_IN_BOOLEAN_CONTEXT"]
 helpviewer_keywords: ["C6230"]
-ms.assetid: aa91291d-cdc5-4720-89d4-194ce0557e99
 ---
 # Warning C6230
 

--- a/docs/code-quality/c6235.md
+++ b/docs/code-quality/c6235.md
@@ -10,9 +10,9 @@ ms.assetid: e225955e-0bb5-43a4-a83d-83290e209df4
 
 > ('*non-zero constant*' \|\| '*expression*') is always a non-zero constant
 
-This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation isn't evaluated because the resulting expression always evaluates to true. This language feature is referred to as "short-circuit evaluation."
-
 ## Remarks
+
+This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-or operation that occurs in a test context. The right side of the logical-or operation isn't evaluated because the resulting expression always evaluates to true. This language feature is referred to as "short-circuit evaluation."
 
 A non-zero constant value, other than one, suggests that the bitwise-AND operator (`&`) may have been intended. This warning isn't generated for the common idiom when the non-zero constant is 1, because of its use for selectively enabling code paths. However, it's generated if the non-zero constant evaluates to 1, for example `1+0`.
 

--- a/docs/code-quality/c6235.md
+++ b/docs/code-quality/c6235.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6235"
 description: "Learn more about: Warning C6235"
-title: Warning C6235
 ms.date: 11/04/2016
 f1_keywords: ["C6235", "NONZEROLOGICALOR", "__WARNING_NONZEROLOGICALOR"]
 helpviewer_keywords: ["C6235"]
-ms.assetid: e225955e-0bb5-43a4-a83d-83290e209df4
 ---
 # Warning C6235
 

--- a/docs/code-quality/c6236.md
+++ b/docs/code-quality/c6236.md
@@ -10,9 +10,9 @@ ms.assetid: 3d5ae268-6f40-4c45-a483-b5b0e6a808fc
 
 > ('*expression*' \|\| '*non-zero constant*') is always a non-zero constant
 
-This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical OR operation that occurs in a test context. Logically, it implies that the test is redundant and can be removed safely. Alternatively, it suggests that the programmer may have intended to use a different operator, for example, the equality (`==`), bitwise-AND (`&`) or bitwise-XOR (`^`) operator, to test for a specific value or flag.
-
 ## Remarks
+
+This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical OR operation that occurs in a test context. Logically, it implies that the test is redundant and can be removed safely. Alternatively, it suggests that the programmer may have intended to use a different operator, for example, the equality (`==`), bitwise-AND (`&`) or bitwise-XOR (`^`) operator, to test for a specific value or flag.
 
 This warning isn't generated for the common idiom when the non-zero constant is 1, because of its use for selectively enabling code paths at compile time. However, the warning is generated if the non-zero constant is formed by an expression that evaluates to 1, for example, 1 + 0.
 

--- a/docs/code-quality/c6236.md
+++ b/docs/code-quality/c6236.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6236"
 description: "Learn more about: Warning C6236"
-title: Warning C6236
 ms.date: 11/04/2016
 f1_keywords: ["C6236", "LOGICALORNONZERO", "__WARNING_LOGICALORNONZERO"]
 helpviewer_keywords: ["C6236"]
-ms.assetid: 3d5ae268-6f40-4c45-a483-b5b0e6a808fc
 ---
 # Warning C6236
 

--- a/docs/code-quality/c6237.md
+++ b/docs/code-quality/c6237.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6237"
 description: "Learn more about: Warning C6237"
-title: Warning C6237
 ms.date: 11/04/2016
 f1_keywords: ["C6237", "ZEROLOGICALANDLOSINGSIDEEFFECTS", "__WARNING_ZEROLOGICALANDLOSINGSIDEEFFECTS"]
 helpviewer_keywords: ["C6237"]
-ms.assetid: a18d8630-e4d6-4132-b976-c1f3e7c5c3f0
 ---
 # Warning C6237
 

--- a/docs/code-quality/c6237.md
+++ b/docs/code-quality/c6237.md
@@ -22,7 +22,7 @@ Code analysis name: `ZEROLOGICALANDLOSINGSIDEEFFECTS`
 
 ## Example
 
-The following code shows various code samples that generate this warning:
+The following code shows various code examples that generate this warning:
 
 ```cpp
 #include <stdio.h>

--- a/docs/code-quality/c6237.md
+++ b/docs/code-quality/c6237.md
@@ -10,9 +10,9 @@ ms.assetid: a18d8630-e4d6-4132-b976-c1f3e7c5c3f0
 
 > ('*zero*' && '*expression*') is always zero. '*expression*' is never evaluated and may have side effects
 
-This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation isn't evaluated. This language feature is referred to as "short-circuit evaluation."
-
 ## Remarks
+
+This warning indicates that a constant value of zero was detected on the left side of a logical-and operation that occurs in a test context. The resulting expression always evaluates to false. Therefore, the right side of the logical-AND operation isn't evaluated. This language feature is referred to as "short-circuit evaluation."
 
 You should examine the right side of the expression carefully: Ensure that any side effects such as assignment, function call, increment, and decrement operations needed for proper functionality aren't affected by the short-circuit evaluation.
 

--- a/docs/code-quality/c6239.md
+++ b/docs/code-quality/c6239.md
@@ -10,9 +10,9 @@ ms.assetid: c80e02bc-ff54-4fde-8c1c-5852853bed24
 
 > ('*non-zero constant*' && '*expression*') always evaluates to the result of '*expression*'. Did you intend to use the bitwise-and operator?
 
-This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-AND operation that occurs in a test context. For example, the expression `( 2 && n )` is reduced to `(!!n)`, which is the Boolean value of `n`.
-
 ## Remarks
+
+This warning indicates that a non-zero constant value, other than one, was detected on the left side of a logical-AND operation that occurs in a test context. For example, the expression `( 2 && n )` is reduced to `(!!n)`, which is the Boolean value of `n`.
 
 This warning typically indicates an attempt to check a bit mask in which the bitwise-AND (`&`) operator should be used, and isn't generated if the non-zero constant evaluates to 1 because of its use for selectively choosing code paths.
 

--- a/docs/code-quality/c6239.md
+++ b/docs/code-quality/c6239.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6239"
 description: "Learn more about: Warning C6239"
-title: Warning C6239
 ms.date: 11/04/2016
 f1_keywords: ["C6239", "NONZEROLOGICALAND", "__WARNING_NONZEROLOGICALAND"]
 helpviewer_keywords: ["C6239"]
-ms.assetid: c80e02bc-ff54-4fde-8c1c-5852853bed24
 ---
 # Warning C6239
 

--- a/docs/code-quality/c6240.md
+++ b/docs/code-quality/c6240.md
@@ -10,9 +10,9 @@ ms.assetid: b9412ae4-622d-4aed-8c34-b67db1ccd48a
 
 > ('*expression*' && '*non-zero constant*') always evaluates to the result of '*expression*'. Did you intend to use the bitwise-and operator?
 
-This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical-and operation that occurs in a test context. For example, the  expression `(n && 3)` reduces to `(!!n)`, which is the Boolean value of `n`.
-
 ## Remarks
+
+This warning indicates that a non-zero constant value, other than one, was detected on the right side of a logical-and operation that occurs in a test context. For example, the  expression `(n && 3)` reduces to `(!!n)`, which is the Boolean value of `n`.
 
 This warning typically indicates an attempt to check a bit mask in which the bitwise-AND (`&`) operator should be used. It isn't generated if the non-zero constant evaluates to 1 because of its use for selectively choosing code paths.
 

--- a/docs/code-quality/c6240.md
+++ b/docs/code-quality/c6240.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6240"
 description: "Learn more about: Warning C6240"
-title: Warning C6240
 ms.date: 11/04/2016
 f1_keywords: ["C6240", "LOGICALANDNONZERO", "__WARNING_LOGICALANDNONZERO"]
 helpviewer_keywords: ["C6240"]
-ms.assetid: b9412ae4-622d-4aed-8c34-b67db1ccd48a
 ---
 # Warning C6240
 

--- a/docs/code-quality/c6242.md
+++ b/docs/code-quality/c6242.md
@@ -10,9 +10,9 @@ ms.assetid: 523d46ce-8370-434c-a752-2e3a18cca9a5
 
 > A jump out of this try-block forces local unwind. Incurs severe performance penalty
 
-This warning indicates that a jump statement causes control-flow to leave the protected block of a `try-finally` other than by fall-through.
-
 ## Remarks
+
+This warning indicates that a jump statement causes control-flow to leave the protected block of a `try-finally` other than by fall-through.
 
 Leaving the protected block of a `try-finally` other than by falling through from the last statement requires local unwind to occur. Local unwind typically requires approximately 1000 machine instructions, so it's detrimental to performance.
 

--- a/docs/code-quality/c6242.md
+++ b/docs/code-quality/c6242.md
@@ -1,10 +1,9 @@
 ---
-title: Warning C6242
+title: "Warning C6242"
 description: "Describes Microsoft C/C++ compiler warning C6242."
 ms.date: 08/24/2020
 f1_keywords: ["C6242", "LOCALUNWINDFORCED", "__WARNING_LOCALUNWINDFORCED"]
 helpviewer_keywords: ["C6242"]
-ms.assetid: 523d46ce-8370-434c-a752-2e3a18cca9a5
 ---
 # Warning C6242
 

--- a/docs/code-quality/c6244.md
+++ b/docs/code-quality/c6244.md
@@ -42,7 +42,7 @@ void test()
 #pragma warning(pop)
 ```
 
-To correct this warning, use the following sample code:
+To correct this warning, use the following example code:
 
 ```cpp
 #include <stdlib.h>

--- a/docs/code-quality/c6244.md
+++ b/docs/code-quality/c6244.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6244"
 description: "Learn more about: Warning C6244"
-title: Warning C6244
 ms.date: 11/04/2016
 f1_keywords: ["C6244", "LOCALDECLHIDESGLOBAL", "__WARNING_LOCALDECLHIDESGLOBAL"]
 helpviewer_keywords: ["C6244"]
-ms.assetid: ce2c853d-3354-40f2-a8c5-569f6e4bfc0a
 ---
 # Warning C6244
 

--- a/docs/code-quality/c6246.md
+++ b/docs/code-quality/c6246.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6246"
 description: "Learn more about: Warning C6246"
-title: Warning C6246
 ms.date: 11/04/2016
 f1_keywords: ["C6246", "LOCALDECLHIDESLOCAL", "__WARNING_LOCALDECLHIDESLOCAL"]
 helpviewer_keywords: ["C6246"]
-ms.assetid: cd895cdb-ab3b-4671-ab43-419228fbf980
 ---
 # Warning C6246
 

--- a/docs/code-quality/c6248.md
+++ b/docs/code-quality/c6248.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6248"
 description: "Learn more about: Warning C6248"
-title: Warning C6248
 ms.date: 08/16/2022
 f1_keywords: ["C6248", "__WARNING_CREATINGNULLDACL", "CREATINGNULLDACL"]
 helpviewer_keywords: ["C6248"]
-ms.assetid: 75743622-7a79-4fe8-81b9-dbdfa1a12f3d
 ---
 # Warning C6248
 

--- a/docs/code-quality/c6250.md
+++ b/docs/code-quality/c6250.md
@@ -10,9 +10,9 @@ ms.assetid: 6949c9c5-e8bd-4f95-bc80-42073a293357
 
 > Calling 'VirtualFree' without the MEM_RELEASE flag may free memory but not address descriptors (VADs); results in address space leaks
 
-This warning indicates that a call to `VirtualFree` without the `MEM_RELEASE` flag only decommits the pages, and doesn't release them. To both decommit and release pages, use the `MEM_RELEASE` flag in the call to `VirtualFree`. If any pages in the region are committed, the function first decommits and then releases them. After this operation, the pages are in the free state. If you specify this flag, `dwSize` must be zero, and `lpAddress` must point to the base address returned by the `VirtualAlloc` function when the region was reserved. The function fails if either of these conditions isn't met.
-
 ## Remarks
+
+This warning indicates that a call to `VirtualFree` without the `MEM_RELEASE` flag only decommits the pages, and doesn't release them. To both decommit and release pages, use the `MEM_RELEASE` flag in the call to `VirtualFree`. If any pages in the region are committed, the function first decommits and then releases them. After this operation, the pages are in the free state. If you specify this flag, `dwSize` must be zero, and `lpAddress` must point to the base address returned by the `VirtualAlloc` function when the region was reserved. The function fails if either of these conditions isn't met.
 
 You can ignore this warning if your code later frees the address space by calling `VirtualFree` with the `MEM_RELEASE` flag.
 

--- a/docs/code-quality/c6250.md
+++ b/docs/code-quality/c6250.md
@@ -24,7 +24,7 @@ Code analysis name: `WIN32UNRELEASEDVADS`
 
 ## Example
 
-The following sample code generates warning C6250:
+The following example code generates warning C6250:
 
 ```cpp
 #include <windows.h>
@@ -70,7 +70,7 @@ VOID f( )
 }
 ```
 
-To correct this warning, use the following sample code:
+To correct this warning, use the following example code:
 
 ```cpp
 #include <windows.h>

--- a/docs/code-quality/c6250.md
+++ b/docs/code-quality/c6250.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6250"
 description: "Learn more about: Warning C6250"
-title: Warning C6250
 ms.date: 10/03/2022
 f1_keywords: ["C6250", "WIN32UNRELEASEDVADS", "__WARNING_WIN32UNRELEASEDVADS"]
 helpviewer_keywords: ["C6250"]
-ms.assetid: 6949c9c5-e8bd-4f95-bc80-42073a293357
 ---
 # Warning C6250
 


### PR DESCRIPTION
This is batch 89 that structures error/warning references. See #5465 for more information.