### PR TITLE
Fix `title` mix-up in "Math errors (M6101 through M6205)"

### DIFF
--- a/docs/error-messages/tool-errors/math-errors-m6101-through-m6205.md
+++ b/docs/error-messages/tool-errors/math-errors-m6101-through-m6205.md
@@ -1,5 +1,5 @@
 ---
-title: "Learn about math errors M6101 through M6205"
+title: "Math errors (M6101 through M6205)"
 description: "Learn more about: Math errors (Mxxxx)"
 ms.date: 04/16/2019
 ---


### PR DESCRIPTION
I don't think the `title` should start with "Learn about...", since it's best to more or less match the topic heading and `name` in `toc.yml`.