### PR TITLE
Structure warning references in range [C6311, C6400]

### DIFF
--- a/docs/code-quality/c6312.md
+++ b/docs/code-quality/c6312.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6312"
 description: "Learn more about: Warning C6312"
-title: Warning C6312
 ms.date: 11/04/2016
 f1_keywords: ["C6312", "EXCEPTIONCONTINUEEXECUTION", "__WARNING_EXCEPTIONCONTINUEEXECUTION"]
 helpviewer_keywords: ["C6312"]
-ms.assetid: 1fc8b9a1-e6ba-4799-84c3-31f289576cca
 ---
 # Warning C6312
 

--- a/docs/code-quality/c6313.md
+++ b/docs/code-quality/c6313.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6313"
 description: "Learn more about: Warning C6313"
-title: Warning C6313
 ms.date: 11/04/2016
 f1_keywords: ["C6313", "BITANDVSZEROVALUEDFLAG", "__WARNING_BITANDVSZEROVALUEDFLAG"]
 helpviewer_keywords: ["C6313"]
-ms.assetid: 2fb95c62-d81e-4525-9ec7-7723844c806c
 ---
 # Warning C6313
 

--- a/docs/code-quality/c6314.md
+++ b/docs/code-quality/c6314.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6314"
 description: "Learn more about: Warning C6314"
-title: Warning C6314
 ms.date: 11/04/2016
 f1_keywords: ["C6314", "BITORVSQUESTION", "__WARNING_BITORVSQUESTION"]
 helpviewer_keywords: ["C6314"]
-ms.assetid: 2145ca62-967c-4223-b582-f1481b74f181
 ---
 # Warning C6314
 

--- a/docs/code-quality/c6315.md
+++ b/docs/code-quality/c6315.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6315"
 description: "Learn more about: Warning C6315"
-title: Warning C6315
 ms.date: 11/04/2016
 f1_keywords: ["C6315", "BITORVSBITAND", "__WARNING_BITORVSBITAND"]
 helpviewer_keywords: ["C6315"]
-ms.assetid: 4bc932d5-04fd-440d-b3af-e32a8bbc0618
 ---
 # Warning C6315
 

--- a/docs/code-quality/c6316.md
+++ b/docs/code-quality/c6316.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6316"
 description: "Learn more about: Warning C6316"
-title: Warning C6316
 ms.date: 11/04/2016
 f1_keywords: ["C6316", "INAPPROPRIATEUSEOFBITOR", "__WARNING_INAPPROPRIATEUSEOFBITOR"]
 helpviewer_keywords: ["C6316"]
-ms.assetid: ddd6a928-76b1-4d1b-9a9d-af1efcf02e3a
 ---
 # Warning C6316
 

--- a/docs/code-quality/c6317.md
+++ b/docs/code-quality/c6317.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6317"
 description: "Learn more about: Warning C6317"
-title: Warning C6317
 ms.date: 11/04/2016
 f1_keywords: ["C6317", "NOTNOTCOMPLEMENT", "__WARNING_NOTNOTCOMPLEMENT"]
 helpviewer_keywords: ["C6317"]
-ms.assetid: dc771bb8-f596-4514-af0f-4b39658af365
 ---
 # Warning C6317
 

--- a/docs/code-quality/c6318.md
+++ b/docs/code-quality/c6318.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6318"
 description: "Learn more about: Warning C6318"
-title: Warning C6318
 ms.date: 11/04/2016
 f1_keywords: ["C6318", "EXCEPTIONCONTINUESEARCH", "__WARNING_EXCEPTIONCONTINUESEARCH"]
 helpviewer_keywords: ["C6318"]
-ms.assetid: 3284a83e-bb8e-461c-adcc-cfc66ceea05e
 ---
 # Warning C6318
 

--- a/docs/code-quality/c6319.md
+++ b/docs/code-quality/c6319.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6319"
 description: "Learn more about: Warning C6319"
-title: Warning C6319
 ms.date: 11/04/2016
 f1_keywords: ["C6319", "IGNOREDBYCOMMA", "__WARNING_IGNOREDBYCOMMA"]
 helpviewer_keywords: ["C6319"]
-ms.assetid: 3ccfc1d4-820d-48f0-8ff0-8fcfc87c45d6
 ---
 # Warning C6319
 

--- a/docs/code-quality/c6320.md
+++ b/docs/code-quality/c6320.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6320"
 description: "Learn more about: Warning C6320"
-title: Warning C6320
 ms.date: 11/04/2016
 f1_keywords: ["C6320", "EXCEPTIONEXECUTEHANDLER", "__WARNING_EXCEPTIONEXECUTEHANDLER"]
 helpviewer_keywords: ["C6320"]
-ms.assetid: fb9e568e-b3d4-4ce2-a276-a64ad74d7b1e
 ---
 # Warning C6320
 

--- a/docs/code-quality/c6322.md
+++ b/docs/code-quality/c6322.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6322"
 description: "Learn more about: Warning C6322"
-title: Warning C6322
 ms.date: 11/04/2016
 f1_keywords: ["C6322", "EXCEPT_BLOCK_EMPTY", "__WARNING_EXCEPT_BLOCK_EMPTY"]
 helpviewer_keywords: ["C6322"]
-ms.assetid: fb23d2b1-b2a0-465c-8bf5-ec039c6c7757
 ---
 # Warning C6322
 

--- a/docs/code-quality/c6323.md
+++ b/docs/code-quality/c6323.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6323"
 description: "Learn more about: Warning C6323"
-title: Warning C6323
 ms.date: 11/04/2016
 f1_keywords: ["C6323", "ARITH_OP_ON_BOOL", "__WARNING_ARITH_OP_ON_BOOL"]
 helpviewer_keywords: ["C6323"]
-ms.assetid: e9ab47d7-21e1-4204-8dad-ed7ec6127647
 ---
 # Warning C6323
 

--- a/docs/code-quality/c6324.md
+++ b/docs/code-quality/c6324.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6324"
 description: "Learn more about: Warning C6324"
-title: Warning C6324
 ms.date: 11/04/2016
 f1_keywords: ["C6324", "STRCPY_INSTEAD_OF_STRCMP", "__WARNING_STRCPY_INSTEAD_OF_STRCMP"]
 helpviewer_keywords: ["C6324"]
-ms.assetid: 08675af3-8957-4640-9bd6-01de71ea1042
 ---
 # Warning C6324
 

--- a/docs/code-quality/c6326.md
+++ b/docs/code-quality/c6326.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6326"
 description: "Learn more about: Warning C6326"
-title: Warning C6326
 ms.date: 11/04/2016
 f1_keywords: ["C6326", "CONST_CONST_COMP", "__WARNING_CONST_CONST_COMP"]
 helpviewer_keywords: ["C6326"]
-ms.assetid: 0b606d29-e3c2-48b5-b520-b71b670c19a1
 ---
 # Warning C6326
 

--- a/docs/code-quality/c6328.md
+++ b/docs/code-quality/c6328.md
@@ -18,6 +18,8 @@ Code analysis name: `FORMAT_SIZE_MISMATCH`
 
 ## Example
 
+The following example generates C6328:
+
 ```cpp
 #include <cstdio>
 

--- a/docs/code-quality/c6328.md
+++ b/docs/code-quality/c6328.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6328"
 description: "Learn more about: Warning C6328"
-title: Warning C6328
 ms.date: 02/14/2024
 f1_keywords: ["C6328", "FORMAT_SIZE_MISMATCH", "__WARNING_FORMAT_SIZE_MISMATCH"]
 helpviewer_keywords: ["C6328"]
-ms.assetid: e25b00fa-d344-4dc9-b322-b4f1ae06f315
 ---
 # Warning C6328
 

--- a/docs/code-quality/c6329.md
+++ b/docs/code-quality/c6329.md
@@ -16,7 +16,7 @@ The program is comparing a number against the return value from a call to `Creat
 
 Code analysis name: `POTENTIAL_INCORRECT_RETVAL_CHECK`
 
-## Examples
+## Example
 
 This code could cause the warning:
 

--- a/docs/code-quality/c6329.md
+++ b/docs/code-quality/c6329.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6329"
 description: "Learn more about: Warning C6329"
-title: Warning C6329
 ms.date: 11/04/2016
 f1_keywords: ["C6329", "POTENTIAL_INCORRECT_RETVAL_CHECK", "__WARNING_POTENTIAL_INCORRECT_RETVAL_CHECK"]
 helpviewer_keywords: ["C6329"]
-ms.assetid: 5765bd4d-5fa1-4e51-82d6-c1837b4743db
 ---
 # Warning C6329
 

--- a/docs/code-quality/c6330.md
+++ b/docs/code-quality/c6330.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6330"
 description: "Learn more about: Warning C6330"
-title: Warning C6330
 ms.date: 11/04/2016
 f1_keywords: ["C6330", "POTENTIAL_ARGUMENT_TYPE_MISMATCH", "__WARNING_POTENTIAL_ARGUMENT_TYPE_MISMATCH"]
 helpviewer_keywords: ["C6330"]
-ms.assetid: 48594e1c-0a4b-4848-8598-ae6d7e08b4e9
 ---
 # Warning C6330
 

--- a/docs/code-quality/c6330.md
+++ b/docs/code-quality/c6330.md
@@ -10,4 +10,6 @@ ms.assetid: 48594e1c-0a4b-4848-8598-ae6d7e08b4e9
 
 > '*type1*' passed as Parameter('*number*') when '*type2*' is required in call to '*function*'
 
+## Remarks
+
 Code analysis name: `POTENTIAL_ARGUMENT_TYPE_MISMATCH`

--- a/docs/code-quality/c6331.md
+++ b/docs/code-quality/c6331.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6331"]
 
 > Invalid parameter: passing MEM_RELEASE and MEM_DECOMMIT in conjunction to *`function`* is not allowed. This results in the failure of this call
 
-This message indicates that an invalid parameter is passed to `VirtualFree` or `VirtualFreeEx`. `VirtualFree` and `VirtualFreeEx` both reject the flags (`MEM_RELEASE | MEM_DECOMMIT`) in combination. Therefore, the values `MEM_DECOMMIT` and `MEM_RELEASE` may not be used together in the same call.
-
 ## Remarks
+
+This message indicates that an invalid parameter is passed to `VirtualFree` or `VirtualFreeEx`. `VirtualFree` and `VirtualFreeEx` both reject the flags (`MEM_RELEASE | MEM_DECOMMIT`) in combination. Therefore, the values `MEM_DECOMMIT` and `MEM_RELEASE` may not be used together in the same call.
 
 It's not required for decommit and release to occur as independent steps. Releasing committed memory will decommit the pages as well. Also, ensure the return value of this function isn't ignored.
 

--- a/docs/code-quality/c6331.md
+++ b/docs/code-quality/c6331.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6331
+title: "Warning C6331"
 description: "Learn more about: Warning C6331"
 ms.date: 10/03/2022
 f1_keywords: ["C6331", "VirtualFreeInvalidParam1", "__WARNING_VIRTUALFREEINVALIDPARAM1"]

--- a/docs/code-quality/c6331.md
+++ b/docs/code-quality/c6331.md
@@ -19,7 +19,7 @@ Code analysis name: `VirtualFreeInvalidParam1`
 
 ## Example
 
-The following sample code generates warning C6331:
+The following example code generates warning C6331:
 
 ```cpp
 #include <windows.h>

--- a/docs/code-quality/c6332.md
+++ b/docs/code-quality/c6332.md
@@ -10,9 +10,9 @@ ms.assetid: 93d74b3f-4070-4b48-807e-52b1dfee1330
 
 > Invalid parameter: passing zero as the dwFreeType parameter to '*function*' is not allowed. This results in the failure of this call
 
-This warning indicates that an invalid parameter is being passed to `VirtualFree` or `VirtualFreeEx`.
-
 ## Remarks
+
+This warning indicates that an invalid parameter is being passed to `VirtualFree` or `VirtualFreeEx`.
 
 `VirtualFree` and `VirtualFreeEx` both reject a `dwFreeType` parameter of zero. The `dwFreeType` parameter can be either `MEM_DECOMMIT` or `MEM_RELEASE`. However, the values `MEM_DECOMMIT` and `MEM_RELEASE` may not be used together in the same call. Also, make sure that the return value of the `VirtualFree` function isn't ignored.
 

--- a/docs/code-quality/c6332.md
+++ b/docs/code-quality/c6332.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6332"
 description: "Learn more about: Warning C6332"
-title: Warning C6332
 ms.date: 10/03/2022
 f1_keywords: ["C6332", "VirtualFreeInvalidParam2", "__WARNING_VIRTUALFREEINVALIDPARAM2"]
 helpviewer_keywords: ["C6332"]
-ms.assetid: 93d74b3f-4070-4b48-807e-52b1dfee1330
 ---
 # Warning C6332
 

--- a/docs/code-quality/c6333.md
+++ b/docs/code-quality/c6333.md
@@ -18,7 +18,7 @@ Code analysis name: `VIRTUALFREEINVALIDPARAM3`
 
 ## Example
 
-The following code sample generates this warning:
+The following code example generates this warning:
 
 ```cpp
 #include <windows.h>

--- a/docs/code-quality/c6333.md
+++ b/docs/code-quality/c6333.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6333"
 description: "Learn more about: Warning C6333"
-title: Warning C6333
 ms.date: 08/25/2022
 f1_keywords: ["C6333", "VIRTUALFREEINVALIDPARAM3", "__WARNING_VIRTUALFREEINVALIDPARAM3"]
 helpviewer_keywords: ["C6333"]
-ms.assetid: 4b8fa4b2-a3a0-4d00-bec7-76686b66fcf9
 ---
 # Warning C6333
 

--- a/docs/code-quality/c6334.md
+++ b/docs/code-quality/c6334.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6334"
 description: "Learn more about: Warning C6334"
-title: Warning C6334
 ms.date: 08/25/2022
 f1_keywords: ["C6334", "SIZEOFEXPR", "__WARNING_SIZEOFEXPR"]
 helpviewer_keywords: ["C6334"]
-ms.assetid: 83c8abfb-b11e-4573-8c6f-95b205d32137
 ---
 # Warning C6334
 

--- a/docs/code-quality/c6335.md
+++ b/docs/code-quality/c6335.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6335
+title: "Warning C6335"
 description: "Learn more about: Warning C6335"
 ms.date: 11/04/2016
 f1_keywords: ["C6335", "LEAKING_PROCESS_HANDLE", "__WARNING_LEAKING_PROCESS_HANDLE"]

--- a/docs/code-quality/c6336.md
+++ b/docs/code-quality/c6336.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6336"
 description: "Learn more about: Warning C6336"
-title: Warning C6336
 ms.date: 11/04/2016
 f1_keywords: ["C6336", "QUESTIONPRECEDENCE", "__WARNING_QUESTIONPRECEDENCE"]
 helpviewer_keywords: ["C6336"]
-ms.assetid: cf402433-9940-4466-ac15-f94288f51f74
 ---
 # Warning C6336
 

--- a/docs/code-quality/c6340.md
+++ b/docs/code-quality/c6340.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6340"
 description: "Learn more about: Warning C6340"
-title: Warning C6340
 ms.date: 02/14/2024
 f1_keywords: ["C6340", "FORMAT_SIGN_MISMATCH"]
 helpviewer_keywords: ["C6340"]
-ms.assetid: c4fe474f-5a27-4148-ba35-1ef021371e13
 ---
 # Warning C6340
 

--- a/docs/code-quality/c6340.md
+++ b/docs/code-quality/c6340.md
@@ -18,6 +18,8 @@ Code analysis name: `FORMAT_SIGN_MISMATCH`
 
 ## Example
 
+The following example generates C6340:
+
 ```cpp
 #include <cstdio>
 

--- a/docs/code-quality/c6381.md
+++ b/docs/code-quality/c6381.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6381"
 description: "Learn more about: Warning C6381"
-title: Warning C6381
 ms.date: 11/04/2016
 f1_keywords: ["C6381", "SHUTDOWN_API", "__WARNING_SHUTDOWN_API"]
 helpviewer_keywords: ["C6381"]
-ms.assetid: c01a3040-26d4-47ac-b72d-7e1292ca435f
 ---
 # Warning C6381
 

--- a/docs/code-quality/c6383.md
+++ b/docs/code-quality/c6383.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6383
+title: "Warning C6383"
 description: "Learn more about: Warning C6383"
 ms.date: 09/07/2022
 f1_keywords: ["C6383", "ELEMENTS_TO_BYTES", "__WARNING_ELEMENTS_TO_BYTES"]

--- a/docs/code-quality/c6383.md
+++ b/docs/code-quality/c6383.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6383"]
 
 > Buffer overrun due to conversion of an element count into a byte count: an element count is expected for parameter *`parameter_name`* in call to *`function_name`*
 
-This warning indicates that a non-constant byte count is being passed when an element count is instead required.
-
 ## Remarks
+
+This warning indicates that a non-constant byte count is being passed when an element count is instead required.
 
 Typically, this warning occurs when a variable is multiplied by the `sizeof` a type. This issue will likely result in more bytes being copied to the buffer than it can hold.
 

--- a/docs/code-quality/c6384.md
+++ b/docs/code-quality/c6384.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6384"
 description: "Learn more about: Warning C6384"
-title: Warning C6384
 ms.date: 10/03/2022
 f1_keywords: ["C6384", "DIVIDING_SIZEOF_POINTER", "__WARNING_DIVIDING_SIZEOF_POINTER"]
 helpviewer_keywords: ["C6384"]
-ms.assetid: 9c605b61-1485-49a8-847b-41170193dbf4
 ---
 # Warning C6384
 

--- a/docs/code-quality/c6384.md
+++ b/docs/code-quality/c6384.md
@@ -10,9 +10,9 @@ ms.assetid: 9c605b61-1485-49a8-847b-41170193dbf4
 
 > Dividing sizeof a pointer by another value
 
-This warning indicates that a size calculation might be incorrect. To calculate the number of elements in an array, you sometimes divide the size of the array by the size of the first element. However, when the array is actually a pointer, the result is typically different than intended.
-
 ## Remarks
+
+This warning indicates that a size calculation might be incorrect. To calculate the number of elements in an array, you sometimes divide the size of the array by the size of the first element. However, when the array is actually a pointer, the result is typically different than intended.
 
 If the pointer is a function parameter and the size of the buffer wasn't passed, it isn't possible to calculate the maximum buffer available. When the pointer is allocated locally, the size used in the allocation should be used.
 

--- a/docs/code-quality/c6385.md
+++ b/docs/code-quality/c6385.md
@@ -1,10 +1,9 @@
 ---
-title: Warning C6385
+title: "Warning C6385"
 description: "Describes C++ Code Analysis warning C6385 and how to resolve it."
 ms.date: 03/16/2020
 f1_keywords: ["C6385", "READ_OVERRUN", "__WARNING_READ_OVERRUN"]
 helpviewer_keywords: ["C6385"]
-ms.assetid: 3e4961e7-0f09-42a8-8cc2-151109dfdbda
 ---
 # Warning C6385
 

--- a/docs/code-quality/c6386.md
+++ b/docs/code-quality/c6386.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6386"
 description: "Learn more about: Warning C6386"
-title: Warning C6386
 ms.date: 4/30/2025
 f1_keywords: ["C6386", "WRITE_OVERRUN", "__WARNING_WRITE_OVERRUN"]
 helpviewer_keywords: ["C6386"]

--- a/docs/code-quality/c6387.md
+++ b/docs/code-quality/c6387.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6387
+title: "Warning C6387"
 description: "Learn more about: Warning C6387"
 ms.date: 11/04/2016
 f1_keywords: ["C6387", "INVALID_PARAM_VALUE_1", "__WARNING_INVALID_PARAM_VALUE_1"]

--- a/docs/code-quality/c6388.md
+++ b/docs/code-quality/c6388.md
@@ -37,7 +37,7 @@ void f()
 }
 ```
 
-To correct this warning, use the following sample code:
+To correct this warning, use the following example code:
 
 ```cpp
 // C6388_no_warning.cpp

--- a/docs/code-quality/c6388.md
+++ b/docs/code-quality/c6388.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6388"
 description: "Learn more about: Warning C6388"
-title: Warning C6388
 ms.date: 11/04/2016
 f1_keywords: ["C6388", "INVALID_PARAM_VALUE_2", "__WARNING_INVALID_PARAM_VALUE_2"]
 helpviewer_keywords: ["C6388"]
-ms.assetid: 667fe9cf-cc53-49f9-b6c0-6ee87c397568
 ---
 # Warning C6388
 

--- a/docs/code-quality/c6389.md
+++ b/docs/code-quality/c6389.md
@@ -21,6 +21,8 @@ Code analysis name: `MARK_INTERNAL_OR_MISSING_COMMON_DECL`
 
 ## Example
 
+The following example generates C6389:
+
 ```cpp
 // A.h
 struct X;

--- a/docs/code-quality/c6389.md
+++ b/docs/code-quality/c6389.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6389
+title: "Warning C6389"
 description: "Describes the Microsoft C/C++ code analysis warning C6389, its causes, and how to address it."
 ms.date: 06/09/2021
 f1_keywords: ["C6389", "MARK_INTERNAL_OR_MISSING_COMMON_DECL"]

--- a/docs/code-quality/c6390.md
+++ b/docs/code-quality/c6390.md
@@ -17,6 +17,8 @@ Code analysis name: `NO_NULLCHECK_FOR_THIS`
 
 ## Example
 
+The following example generates C6390:
+
 ```cpp
 struct X
 {

--- a/docs/code-quality/c6390.md
+++ b/docs/code-quality/c6390.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6390
+title: "Warning C6390"
 description: "Describes the Microsoft C/C++ code analysis warning C6390, its causes, and how to address it."
 ms.date: 06/17/2022
 f1_keywords: ["C6390", "NO_NULLCHECK_FOR_THIS"]

--- a/docs/code-quality/c6392.md
+++ b/docs/code-quality/c6392.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6392"
 description: "Learn more about: Warning C6392"
-title: Warning C6392
 ms.date: 03/06/2024
 f1_keywords: ["C6392", "STREAM_OUTPUT_VOID_PTR", "__STREAM_OUTPUT_VOID_PTR"]
 helpviewer_keywords: ["C6392"]

--- a/docs/code-quality/c6392.md
+++ b/docs/code-quality/c6392.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6392"]
 
 > This expression writes the value of the pointer to the stream. If this is intentional, add an explicit cast to 'void *'
 
-This rule was added in Visual Studio 2022 17.8.
-
 ## Remarks
+
+This rule was added in Visual Studio 2022 17.8.
 
 C++ supports wide character streams such as `std::wostringstream`, and nonwide character streams such as `std::ostringstream`. Trying to print a wide string to a nonwide stream calls the `void*` overload of `operator<<`. This overload prints the address of the wide string instead of the value.
 

--- a/docs/code-quality/c6393.md
+++ b/docs/code-quality/c6393.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6393
+title: "Warning C6393"
 description: "Learn more about: Warning C6393"
 ms.date: 11/29/2023
 f1_keywords: ["C6393", "LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP", "__WARNING_LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP"]

--- a/docs/code-quality/c6393.md
+++ b/docs/code-quality/c6393.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6393"]
 
 > A lookup table of size 365 isn't sufficient to handle leap years
 
-This rule was added in Visual Studio 2022 17.8.
-
 ## Remarks
+
+This rule was added in Visual Studio 2022 17.8.
 
 In the Gregorian calendar, every year exactly divisible by four is a leap year--except for years that are exactly divisible by 100. The centurial years are also leap years if they're exactly divisible by 400.
 

--- a/docs/code-quality/c6394.md
+++ b/docs/code-quality/c6394.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6394
+title: "Warning C6394"
 description: "Learn more about: Warning C6394"
 ms.date: 11/29/2023
 f1_keywords: ["C6394", "LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP_MUTABLE", "__WARNING_LEAP_YEAR_INVALID_DATE_KEYED_LOOKUP_MUTABLE"]

--- a/docs/code-quality/c6394.md
+++ b/docs/code-quality/c6394.md
@@ -9,9 +9,9 @@ helpviewer_keywords: ["C6394"]
 
 > A lookup table of size 365 isn't sufficient to handle leap years
 
-This rule was added in Visual Studio 2022 17.8.
-
 ## Remarks
+
+This rule was added in Visual Studio 2022 17.8.
 
 In the Gregorian calendar, every year exactly divisible by four is a leap year--except for years that are exactly divisible by 100. The centurial years are also leap years if they're exactly divisible by 400.
 

--- a/docs/code-quality/c6395.md
+++ b/docs/code-quality/c6395.md
@@ -1,5 +1,5 @@
 ---
-title: Warning C6395
+title: "Warning C6395"
 description: "Describes the Microsoft C/C++ code analysis warning C6395, its causes, and how to address it."
 ms.date: 10/12/2023
 f1_keywords: ["C6395", "EVAL_ORDER_CHANGE"]

--- a/docs/code-quality/c6395.md
+++ b/docs/code-quality/c6395.md
@@ -17,6 +17,8 @@ Code analysis name: `EVAL_ORDER_CHANGE`
 
 ## Example
 
+The following example generates C6395:
+
 ```cpp
 void foo(int* a, int i)
 {

--- a/docs/code-quality/c6396.md
+++ b/docs/code-quality/c6396.md
@@ -17,6 +17,8 @@ This check ignores character literals because `buffer_size += sizeof(UNICODE_NUL
 
 ## Example
 
+The following example generates C6396:
+
 ```cpp
 void f()
 {  

--- a/docs/code-quality/c6396.md
+++ b/docs/code-quality/c6396.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6396"
 description: "Learn more about: Warning C6396: sizeof('integerConstant') always returns the size of the underlying integer type"
-title: Warning C6396
 ms.date: 02/05/2024
 f1_keywords: ["C6396", "SIZEOF_CONSTANT"]
 helpviewer_keywords: ["C6396"]

--- a/docs/code-quality/c6397.md
+++ b/docs/code-quality/c6397.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6397"
 description: "Learn more about: Warning C6397: The address-of operator cannot return null pointer in well-defined code"
-title: Warning C6397
 ms.date: 02/05/2024
 f1_keywords: ["C6397", "DUBIOUS_NULL_CHECK"]
 helpviewer_keywords: ["C6397"]

--- a/docs/code-quality/c6397.md
+++ b/docs/code-quality/c6397.md
@@ -17,6 +17,8 @@ The address-of operator returns the address of its operand. This value should ne
 
 ## Example
 
+The following example generates C6397:
+
 ```cpp
 bool isNull(int *a)
 {  

--- a/docs/code-quality/c6398.md
+++ b/docs/code-quality/c6398.md
@@ -17,6 +17,8 @@ The address-of operator returns the address of its operand. This value should ne
 
 ## Example
 
+The following example generates C6398:
+
 ```cpp
 struct A { int* x; };
 

--- a/docs/code-quality/c6398.md
+++ b/docs/code-quality/c6398.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C6398"
 description: "Learn more about: Warning C6398: The address-of a field cannot be null in well-defined code"
-title: Warning C6398
 ms.date: 02/05/2024
 f1_keywords: ["C6398", "DUBIOUS_NULL_CHECK_FIELD"]
 helpviewer_keywords: ["C6398"]

--- a/docs/code-quality/c6400.md
+++ b/docs/code-quality/c6400.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C6400"
 description: "Learn more about: Warning C6400"
-title: Warning C6400
 ms.date: 11/04/2016
 f1_keywords: ["C6400", "LOCALE_DEPENDENT_CONSTANT_STRING_COMPARISON", "__WARNING_LOCALE_DEPENDENT_CONSTANT_STRING_COMPARISON"]
 helpviewer_keywords: ["C6400"]
-ms.assetid: 35808969-1d43-41e8-bcda-33635637fb26
 ---
 # Warning C6400
 


### PR DESCRIPTION
This is batch 91 that structures error/warning references. See #5465 for more information.