### PR TITLE
Structure error references in range [C7000, C7999]

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c7510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7510.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn about the causes of Compiler error C7510 and how to fix it."
 title: "Compiler Error C7510"
+description: "Learn about the causes of Compiler error C7510 and how to fix it."
 ms.date: 04/21/2021
 f1_keywords: ["C7510"]
 helpviewer_keywords: ["C7510"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7510.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7510.md
@@ -10,9 +10,9 @@ helpviewer_keywords: ["C7510"]
 > '*type-name*': use of dependent template name must be prefixed with 'template'\
 > '*type-name*': use of dependent type name must be prefixed with 'typename'
 
-In [`/permissive-`](../../build/reference/permissive-standards-conformance.md) mode, the compiler requires the **`template`** keyword to precede a template name when it comes after a dependent [`nested-name-specifier`](../../cpp/scope-resolution-operator.md). Similar rules hold for types qualified by **`typename`**.
-
 ## Remarks
+
+In [`/permissive-`](../../build/reference/permissive-standards-conformance.md) mode, the compiler requires the **`template`** keyword to precede a template name when it comes after a dependent [`nested-name-specifier`](../../cpp/scope-resolution-operator.md). Similar rules hold for types qualified by **`typename`**.
 
 Compiler behavior has changed starting in Visual Studio 2017 version 15.8 under [`/permissive-`](../../build/reference/permissive-standards-conformance.md) mode. The compiler requires the **`template`** or **`typename`** keyword to precede a template or type name when it comes after a dependent *`nested-name-specifier`*. For more information, see [Name resolution for dependent types](../../cpp/name-resolution-for-dependent-types.md) and [Templates and name resolution](../../cpp/templates-and-name-resolution.md).
 

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7536.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7536.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn about the causes of Compiler error C7536 and how to fix it."
 title: "Compiler Error C7536"
+description: "Learn about the causes of Compiler error C7536 and how to fix it."
 ms.date: 05/03/2021
 f1_keywords: ["C7536"]
 helpviewer_keywords: ["C7536"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7536.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7536.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["C7536"]
 
 > ifc failed integrity checks.  Expected SHA2: '*hash-value*'
 
+## Remarks
+
 The compiler raises C7536 whenever the *`.ifc`* file has been tampered with. The header of the module interface contains an SHA2 hash of the contents below it. On import, the *`.ifc`* file is hashed, then checked against the hash provided in the header. If these don't match, error C7536 is raised:
 
 ```Output

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7553.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7553.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error C7553"
-description: Compiler Error C7553 description and solution.
+description: "Compiler Error C7553 description and solution."
 ms.date: 02/22/2022
 f1_keywords: ["C7553"]
 helpviewer_keywords: ["C7553"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7688.md
@@ -17,7 +17,7 @@ Compiler error C7688 is new in Visual Studio 2022 version 17.4. In previous comp
 
 ## Example
 
-The sample code shows diagnostics generated for non-scalar types in `#pragma omp atomic` constructs.
+The example code shows diagnostics generated for non-scalar types in `#pragma omp atomic` constructs.
 
 ```cpp
 // C7688.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7688.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7688.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler error C7688"
-description: Compiler error C7688 description and solution.
+description: "Compiler error C7688 description and solution."
 ms.date: 03/01/2023
 f1_keywords: ["C7688"]
 helpviewer_keywords: ["C7688"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7742.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7742.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Compiler Error C7742"
 title: "Compiler Error C7742"
-ms.date: "07/02/2025"
+description: "Learn more about: Compiler Error C7742"
+ms.date: 07/02/2025
 ai-usage: ai-assisted
 f1_keywords: ["C7742"]
 helpviewer_keywords: ["C7742"]

--- a/docs/error-messages/compiler-errors-2/compiler-error-c7742.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c7742.md
@@ -10,7 +10,11 @@ helpviewer_keywords: ["C7742"]
 
 > *Identifier*: a forward declaration of an enum can only use a simple identifier
 
+## Remarks
+
 The C++ Standard doesn't allow declaring an opaque enumeration using a qualified-id. An opaque enum declaration specifies the name and the underlying type, but doesn't list the enumerators or their values.
+
+## Example
 
 The following example generates C7742:
 


### PR DESCRIPTION
C7626 was already done in #5739.

This is batch 93 that structures error/warning references. See #5465 for more information.