### PR TITLE
Structure error references in range [U1000, U1100]

### DIFF
--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1000.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1000.md
@@ -10,4 +10,6 @@ ms.assetid: 49b9bd9e-f1bc-4b55-a171-c748e40b195e
 
 > syntax error : ')' missing in macro invocation
 
+## Remarks
+
 A left parenthesis, **(**, appeared without a matching right parenthesis, **)**, in a macro invocation. The correct form is **$(**<em>name</em>**)**; **$**<em>n</em> is allowed for one-character names.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1000.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1000.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1000"
 title: "NMAKE Fatal Error U1000"
-ms.date: "08/27/2018"
+description: "Learn more about: NMAKE Fatal Error U1000"
+ms.date: 08/27/2018
 f1_keywords: ["U1000"]
 helpviewer_keywords: ["U1000"]
-ms.assetid: 49b9bd9e-f1bc-4b55-a171-c748e40b195e
 ---
 # NMAKE Fatal Error U1000
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1001"
 title: "NMAKE Fatal Error U1001"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1001"
+ms.date: 11/04/2016
 f1_keywords: ["U1001"]
 helpviewer_keywords: ["U1001"]
-ms.assetid: 5d7da559-6cbd-44d6-848c-aaf54cae0d1a
 ---
 # NMAKE Fatal Error U1001
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
@@ -10,6 +10,8 @@ ms.assetid: 5d7da559-6cbd-44d6-848c-aaf54cae0d1a
 
 > syntax error : illegal character 'character' in macro
 
+## Remarks
+
 The given character appears in a macro but is not a letter, number, or underscore.
 
 This error can be caused by a missing colon in a macro expansion:

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1001.md
@@ -8,7 +8,7 @@ ms.assetid: 5d7da559-6cbd-44d6-848c-aaf54cae0d1a
 ---
 # NMAKE Fatal Error U1001
 
-syntax error : illegal character 'character' in macro
+> syntax error : illegal character 'character' in macro
 
 The given character appears in a macro but is not a letter, number, or underscore.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
@@ -10,6 +10,8 @@ ms.assetid: 64fd78a6-5b27-4aa8-92ea-f1c55e6e5edd
 
 > double quotation mark not allowed in name
 
+## Remarks
+
 The specified target name or filename contained a double quotation mark (**"**).
 
 Double quotation marks can surround a filename but cannot be contained within it.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
@@ -8,7 +8,7 @@ ms.assetid: 64fd78a6-5b27-4aa8-92ea-f1c55e6e5edd
 ---
 # NMAKE Fatal Error U1007
 
-double quotation mark not allowed in name
+> double quotation mark not allowed in name
 
 The specified target name or filename contained a double quotation mark (**"**).
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1007.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1007"
 title: "NMAKE Fatal Error U1007"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1007"
+ms.date: 11/04/2016
 f1_keywords: ["U1007"]
 helpviewer_keywords: ["U1007"]
-ms.assetid: 64fd78a6-5b27-4aa8-92ea-f1c55e6e5edd
 ---
 # NMAKE Fatal Error U1007
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
@@ -10,6 +10,8 @@ ms.assetid: 22d4c469-85da-43ee-86d1-171b1b99217d
 
 > syntax error in expression
 
+## Remarks
+
 An expression is invalid.
 
 Check the allowed operators and operator precedence.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
@@ -8,7 +8,7 @@ ms.assetid: 22d4c469-85da-43ee-86d1-171b1b99217d
 ---
 # NMAKE Fatal Error U1023
 
-syntax error in expression
+> syntax error in expression
 
 An expression is invalid.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1023.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1023"
 title: "NMAKE Fatal Error U1023"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1023"
+ms.date: 11/04/2016
 f1_keywords: ["U1023"]
 helpviewer_keywords: ["U1023"]
-ms.assetid: 22d4c469-85da-43ee-86d1-171b1b99217d
 ---
 # NMAKE Fatal Error U1023
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1033"
 title: "NMAKE Fatal Error U1033"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1033"
+ms.date: 11/04/2016
 f1_keywords: ["U1033"]
 helpviewer_keywords: ["U1033"]
-ms.assetid: c146f7b5-7d5c-4329-a522-28a648546016
 ---
 # NMAKE Fatal Error U1033
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
@@ -10,6 +10,8 @@ ms.assetid: c146f7b5-7d5c-4329-a522-28a648546016
 
 > syntax error : 'string' unexpected
 
+## Remarks
+
 The string is not part of the valid syntax for a makefile.
 
 ### To fix by checking the following possible causes

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1033.md
@@ -8,7 +8,7 @@ ms.assetid: c146f7b5-7d5c-4329-a522-28a648546016
 ---
 # NMAKE Fatal Error U1033
 
-syntax error : 'string' unexpected
+> syntax error : 'string' unexpected
 
 The string is not part of the valid syntax for a makefile.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
@@ -8,6 +8,6 @@ ms.assetid: 27e678c2-23e2-4247-87f7-66493784af33
 ---
 # NMAKE Fatal Error U1034
 
-syntax error : separator missing
+> syntax error : separator missing
 
 The colon (**:**) that separates targets and dependents is missing.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
@@ -10,4 +10,6 @@ ms.assetid: 27e678c2-23e2-4247-87f7-66493784af33
 
 > syntax error : separator missing
 
+## Remarks
+
 The colon (**:**) that separates targets and dependents is missing.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1034.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1034"
 title: "NMAKE Fatal Error U1034"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1034"
+ms.date: 11/04/2016
 f1_keywords: ["U1034"]
 helpviewer_keywords: ["U1034"]
-ms.assetid: 27e678c2-23e2-4247-87f7-66493784af33
 ---
 # NMAKE Fatal Error U1034
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1035"
 title: "NMAKE Fatal Error U1035"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1035"
+ms.date: 11/04/2016
 f1_keywords: ["U1035"]
 helpviewer_keywords: ["U1035"]
-ms.assetid: 68f0cc59-007e-4109-ac30-7ac4ac447e6d
 ---
 # NMAKE Fatal Error U1035
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
@@ -8,7 +8,7 @@ ms.assetid: 68f0cc59-007e-4109-ac30-7ac4ac447e6d
 ---
 # NMAKE Fatal Error U1035
 
-syntax error : expected ':' or '=' separator
+> syntax error : expected ':' or '=' separator
 
 Either a colon (**:**) or an equal sign (**=**) was expected.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1035.md
@@ -10,6 +10,8 @@ ms.assetid: 68f0cc59-007e-4109-ac30-7ac4ac447e6d
 
 > syntax error : expected ':' or '=' separator
 
+## Remarks
+
 Either a colon (**:**) or an equal sign (**=**) was expected.
 
 ### To fix by checking the following possible causes

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
@@ -8,6 +8,6 @@ ms.assetid: b1d03b6b-ce82-4bbb-9904-d392ba72b437
 ---
 # NMAKE Fatal Error U1036
 
-syntax error : too many names to left of '='
+> syntax error : too many names to left of '='
 
 Only one string is allowed to the left of a macro definition.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
@@ -10,4 +10,6 @@ ms.assetid: b1d03b6b-ce82-4bbb-9904-d392ba72b437
 
 > syntax error : too many names to left of '='
 
+## Remarks
+
 Only one string is allowed to the left of a macro definition.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1036.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1036"
 title: "NMAKE Fatal Error U1036"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1036"
+ms.date: 11/04/2016
 f1_keywords: ["U1036"]
 helpviewer_keywords: ["U1036"]
-ms.assetid: b1d03b6b-ce82-4bbb-9904-d392ba72b437
 ---
 # NMAKE Fatal Error U1036
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1045.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1045.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1045"
 title: "NMAKE Fatal Error U1045"
-ms.date: "08/11/2019"
+description: "Learn more about: NMAKE Fatal Error U1045"
+ms.date: 08/11/2019
 f1_keywords: ["U1045"]
 helpviewer_keywords: ["U1045"]
-ms.assetid: dc70d162-14b9-4107-9237-7514044d72e3
 ---
 # NMAKE Fatal Error U1045
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1045.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1045.md
@@ -10,6 +10,8 @@ ms.assetid: dc70d162-14b9-4107-9237-7514044d72e3
 
 > spawn failed : *message*
 
+## Remarks
+
 A program or command called by NMAKE failed for reason in *message*. When NMAKE calls another program, for example, the compiler or linker, the call may fail. Or, an error may be returned by the called program. This message is used to report the error.
 
 To fix this issue, first determine the cause of the error. You can use the commands reported by the NMAKE [/N](../../build/reference/running-nmake.md#nmake-options) option to verify the environment settings and to repeat the actions done by NMAKE on the command line.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1050"
 title: "NMAKE Fatal Error U1050"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1050"
+ms.date: 11/04/2016
 f1_keywords: ["U1050"]
 helpviewer_keywords: ["U1050"]
-ms.assetid: 3bb2937e-a804-4592-a9e6-afb63360f554
 ---
 # NMAKE Fatal Error U1050
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
@@ -8,6 +8,6 @@ ms.assetid: 3bb2937e-a804-4592-a9e6-afb63360f554
 ---
 # NMAKE Fatal Error U1050
 
-message
+> message
 
 The message specified with the **!ERROR** directive was displayed.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1050.md
@@ -10,4 +10,6 @@ ms.assetid: 3bb2937e-a804-4592-a9e6-afb63360f554
 
 > message
 
+## Remarks
+
 The message specified with the **!ERROR** directive was displayed.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
@@ -10,6 +10,8 @@ ms.assetid: fede5cd5-dac3-47b7-b86d-e1acfb78699f
 
 > out of memory
 
+## Remarks
+
 NMAKE ran out of memory, including virtual memory, because the makefile was too large or complex.
 
 ### To fix by using the following possible solutions

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1051"
 title: "NMAKE Fatal Error U1051"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1051"
+ms.date: 11/04/2016
 f1_keywords: ["U1051"]
 helpviewer_keywords: ["U1051"]
-ms.assetid: fede5cd5-dac3-47b7-b86d-e1acfb78699f
 ---
 # NMAKE Fatal Error U1051
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1051.md
@@ -8,7 +8,7 @@ ms.assetid: fede5cd5-dac3-47b7-b86d-e1acfb78699f
 ---
 # NMAKE Fatal Error U1051
 
-out of memory
+> out of memory
 
 NMAKE ran out of memory, including virtual memory, because the makefile was too large or complex.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1052.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1052.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1052"
 title: "NMAKE Fatal Error U1052"
-ms.date: "09/05/2018"
+description: "Learn more about: NMAKE Fatal Error U1052"
+ms.date: 09/05/2018
 f1_keywords: ["U1052"]
 helpviewer_keywords: ["U1052"]
-ms.assetid: b19b3691-e60b-46bd-8822-8426740a9bc7
 ---
 # NMAKE Fatal Error U1052
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1052.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1052.md
@@ -10,6 +10,8 @@ ms.assetid: b19b3691-e60b-46bd-8822-8426740a9bc7
 
 > file '*filename*' not found
 
+## Remarks
+
 NMAKE could not find the file specified with one of the following:
 
 - **/F** option

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1055"
 title: "NMAKE Fatal Error U1055"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1055"
+ms.date: 11/04/2016
 f1_keywords: ["U1055"]
 helpviewer_keywords: ["U1055"]
-ms.assetid: 1d453922-ba7e-497f-a795-d8d959c40555
 ---
 # NMAKE Fatal Error U1055
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
@@ -10,6 +10,8 @@ ms.assetid: 1d453922-ba7e-497f-a795-d8d959c40555
 
 > out of environment space
 
+## Remarks
+
 The operating system ran out of room for environment variables.
 
 Either increase the environment space or set fewer environment variables.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1055.md
@@ -8,7 +8,7 @@ ms.assetid: 1d453922-ba7e-497f-a795-d8d959c40555
 ---
 # NMAKE Fatal Error U1055
 
-out of environment space
+> out of environment space
 
 The operating system ran out of room for environment variables.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
@@ -10,6 +10,8 @@ ms.assetid: da855728-b69e-413c-83ed-df912126215e
 
 > cannot find command processor
 
+## Remarks
+
 The command processor was not in the path specified in the **COMSPEC** or **PATH** environment variables.
 
 NMAKE uses COMMAND.COM or CMD.EXE as a command processor when executing commands. It looks for the command processor first in the path set in **COMSPEC**. If **COMSPEC** does not exist, NMAKE searches the directories specified in **PATH**.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1056"
 title: "NMAKE Fatal Error U1056"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1056"
+ms.date: 11/04/2016
 f1_keywords: ["U1056"]
 helpviewer_keywords: ["U1056"]
-ms.assetid: da855728-b69e-413c-83ed-df912126215e
 ---
 # NMAKE Fatal Error U1056
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1056.md
@@ -8,7 +8,7 @@ ms.assetid: da855728-b69e-413c-83ed-df912126215e
 ---
 # NMAKE Fatal Error U1056
 
-cannot find command processor
+> cannot find command processor
 
 The command processor was not in the path specified in the **COMSPEC** or **PATH** environment variables.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1059.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1059.md
@@ -10,6 +10,8 @@ ms.assetid: b21d9198-9c63-40d0-b589-80e17294ce24
 
 > syntax error : '}' missing in dependent
 
+## Remarks
+
 A search path for a dependent was incorrectly specified. Either a space existed in the path or the closing brace (**}**) was omitted.
 
 The syntax for a directory specification for a dependent is

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1059.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1059.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1059"
 title: "NMAKE Fatal Error U1059"
-ms.date: "08/27/2018"
+description: "Learn more about: NMAKE Fatal Error U1059"
+ms.date: 08/27/2018
 f1_keywords: ["U1059"]
 helpviewer_keywords: ["U1059"]
-ms.assetid: b21d9198-9c63-40d0-b589-80e17294ce24
 ---
 # NMAKE Fatal Error U1059
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
@@ -10,6 +10,8 @@ ms.assetid: 7141e66e-cde6-4173-84df-a391f3ebcdd1
 
 > MAKEFILE not found and no target specified
 
+## Remarks
+
 The NMAKE command line did not specify a makefile or a target, and the current directory did not contain a file named MAKEFILE.
 
 NMAKE requires either a makefile or a command-line target (or both). To make a makefile available to NMAKE, either specify the /F option or place a file named MAKEFILE in the current directory. NMAKE can create a command-line target by using an inference rule if a makefile is not provided.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1064"
 title: "NMAKE Fatal Error U1064"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1064"
+ms.date: 11/04/2016
 f1_keywords: ["U1064"]
 helpviewer_keywords: ["U1064"]
-ms.assetid: 7141e66e-cde6-4173-84df-a391f3ebcdd1
 ---
 # NMAKE Fatal Error U1064
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1064.md
@@ -8,7 +8,7 @@ ms.assetid: 7141e66e-cde6-4173-84df-a391f3ebcdd1
 ---
 # NMAKE Fatal Error U1064
 
-MAKEFILE not found and no target specified
+> MAKEFILE not found and no target specified
 
 The NMAKE command line did not specify a makefile or a target, and the current directory did not contain a file named MAKEFILE.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1065"
 title: "NMAKE Fatal Error U1065"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1065"
+ms.date: 11/04/2016
 f1_keywords: ["U1065"]
 helpviewer_keywords: ["U1065"]
-ms.assetid: bc890f20-ff46-4073-ab3b-4a5db879f9bd
 ---
 # NMAKE Fatal Error U1065
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
@@ -10,4 +10,6 @@ ms.assetid: bc890f20-ff46-4073-ab3b-4a5db879f9bd
 
 > invalid option 'option'
 
+## Remarks
+
 The option is not valid for NMAKE.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1065.md
@@ -8,6 +8,6 @@ ms.assetid: bc890f20-ff46-4073-ab3b-4a5db879f9bd
 ---
 # NMAKE Fatal Error U1065
 
-invalid option 'option'
+> invalid option 'option'
 
 The option is not valid for NMAKE.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
@@ -10,6 +10,8 @@ ms.assetid: 8639fc39-b4b1-48f5-ac91-0e9fb61680fd
 
 > cycle in macro definition 'macroname'
 
+## Remarks
+
 The given macro definition contained a macro whose definition contained the given macro. Circular macro definitions are invalid.
 
 ## Example

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1070"
 title: "NMAKE Fatal Error U1070"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1070"
+ms.date: 11/04/2016
 f1_keywords: ["U1070"]
 helpviewer_keywords: ["U1070"]
-ms.assetid: 8639fc39-b4b1-48f5-ac91-0e9fb61680fd
 ---
 # NMAKE Fatal Error U1070
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1070.md
@@ -8,7 +8,7 @@ ms.assetid: 8639fc39-b4b1-48f5-ac91-0e9fb61680fd
 ---
 # NMAKE Fatal Error U1070
 
-cycle in macro definition 'macroname'
+> cycle in macro definition 'macroname'
 
 The given macro definition contained a macro whose definition contained the given macro. Circular macro definitions are invalid.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
@@ -10,4 +10,6 @@ ms.assetid: 328a0c1f-a867-410e-943d-7b6b75a975ab
 
 > cycle in dependency tree for target 'targetname'
 
+## Remarks
+
 A circular dependency exists in the dependency tree for the given target. The given target is a dependent of one of the dependents of the given target. Circular dependencies are invalid.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1071"
 title: "NMAKE Fatal Error U1071"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1071"
+ms.date: 11/04/2016
 f1_keywords: ["U1071"]
 helpviewer_keywords: ["U1071"]
-ms.assetid: 328a0c1f-a867-410e-943d-7b6b75a975ab
 ---
 # NMAKE Fatal Error U1071
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1071.md
@@ -8,6 +8,6 @@ ms.assetid: 328a0c1f-a867-410e-943d-7b6b75a975ab
 ---
 # NMAKE Fatal Error U1071
 
-cycle in dependency tree for target 'targetname'
+> cycle in dependency tree for target 'targetname'
 
 A circular dependency exists in the dependency tree for the given target. The given target is a dependent of one of the dependents of the given target. Circular dependencies are invalid.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
@@ -8,7 +8,7 @@ ms.assetid: d46bf2dd-400a-4802-9db2-f832e1c97f02
 ---
 # NMAKE Fatal Error U1073
 
-don't know how to make 'targetname'
+> don't know how to make 'targetname'
 
 The specified target does not exist, and there is no command to execute or inference rule to apply.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
@@ -10,6 +10,8 @@ ms.assetid: d46bf2dd-400a-4802-9db2-f832e1c97f02
 
 > don't know how to make 'targetname'
 
+## Remarks
+
 The specified target does not exist, and there is no command to execute or inference rule to apply.
 
 ### To fix by using the following possible solutions

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1073.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1073"
 title: "NMAKE Fatal Error U1073"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1073"
+ms.date: 11/04/2016
 f1_keywords: ["U1073"]
 helpviewer_keywords: ["U1073"]
-ms.assetid: d46bf2dd-400a-4802-9db2-f832e1c97f02
 ---
 # NMAKE Fatal Error U1073
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
@@ -8,7 +8,7 @@ ms.assetid: f8a6c646-0c49-4ee3-bb74-ab916a7aa6ff
 ---
 # NMAKE Fatal Error U1076
 
-name too long
+> name too long
 
 A string exceeded one of the following limits:
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1076"
 title: "NMAKE Fatal Error U1076"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1076"
+ms.date: 11/04/2016
 f1_keywords: ["U1076"]
 helpviewer_keywords: ["U1076"]
-ms.assetid: f8a6c646-0c49-4ee3-bb74-ab916a7aa6ff
 ---
 # NMAKE Fatal Error U1076
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1076.md
@@ -10,6 +10,8 @@ ms.assetid: f8a6c646-0c49-4ee3-bb74-ab916a7aa6ff
 
 > name too long
 
+## Remarks
+
 A string exceeded one of the following limits:
 
 - 1024 characters for a macro name.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1077"
 title: "NMAKE Fatal Error U1077"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1077"
+ms.date: 11/04/2016
 f1_keywords: ["U1077"]
 helpviewer_keywords: ["U1077"]
-ms.assetid: 70d989f8-ef34-4ad7-8fe0-5b800556b2a1
 ---
 # NMAKE Fatal Error U1077
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
@@ -10,6 +10,8 @@ ms.assetid: 70d989f8-ef34-4ad7-8fe0-5b800556b2a1
 
 > 'program' : return code 'value'
 
+## Remarks
+
 The given command or program called by NMAKE failed and returned the given exit code.
 
 To suppress this error and continue the NMAKE session, use the /I option, the **.IGNORE** dot directive, or the dash (**-**) command modifier. To continue the NMAKE session for unrelated parts of the dependency tree, use the /K option.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1077.md
@@ -8,7 +8,7 @@ ms.assetid: 70d989f8-ef34-4ad7-8fe0-5b800556b2a1
 ---
 # NMAKE Fatal Error U1077
 
-'program' : return code 'value'
+> 'program' : return code 'value'
 
 The given command or program called by NMAKE failed and returned the given exit code.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1078"
 title: "NMAKE Fatal Error U1078"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1078"
+ms.date: 11/04/2016
 f1_keywords: ["U1078"]
 helpviewer_keywords: ["U1078"]
-ms.assetid: 24087955-9362-4ddf-9966-e0de43ea4647
 ---
 # NMAKE Fatal Error U1078
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
@@ -10,6 +10,8 @@ ms.assetid: 24087955-9362-4ddf-9966-e0de43ea4647
 
 > constant overflow at 'expression'
 
+## Remarks
+
 The given expression contained a constant that exceeded the range - 2,147,483,648 to 2,147,483,647. The constant appeared in one of the following situations:
 
 - An expression specified with a preprocessing directive

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1078.md
@@ -8,7 +8,7 @@ ms.assetid: 24087955-9362-4ddf-9966-e0de43ea4647
 ---
 # NMAKE Fatal Error U1078
 
-constant overflow at 'expression'
+> constant overflow at 'expression'
 
 The given expression contained a constant that exceeded the range - 2,147,483,648 to 2,147,483,647. The constant appeared in one of the following situations:
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
@@ -8,6 +8,6 @@ ms.assetid: b09bc34d-35d5-4676-b000-fd7d434400d9
 ---
 # NMAKE Fatal Error U1083
 
-target macro 'target' expands to nothing
+> target macro 'target' expands to nothing
 
 The given target is an invocation of a macro that has not been defined or has a null value. NMAKE cannot process a null target.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1083"
 title: "NMAKE Fatal Error U1083"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1083"
+ms.date: 11/04/2016
 f1_keywords: ["U1083"]
 helpviewer_keywords: ["U1083"]
-ms.assetid: b09bc34d-35d5-4676-b000-fd7d434400d9
 ---
 # NMAKE Fatal Error U1083
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1083.md
@@ -10,4 +10,6 @@ ms.assetid: b09bc34d-35d5-4676-b000-fd7d434400d9
 
 > target macro 'target' expands to nothing
 
+## Remarks
+
 The given target is an invocation of a macro that has not been defined or has a null value. NMAKE cannot process a null target.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
@@ -10,6 +10,8 @@ ms.assetid: 6d3cd68a-ead6-4a6d-a205-01324785de7e
 
 > inference rule cannot have dependents
 
+## Remarks
+
 The colon (**:**) in an inference rule must be followed by one of these:
 
 - Newline character

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1086"
 title: "NMAKE Fatal Error U1086"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1086"
+ms.date: 11/04/2016
 f1_keywords: ["U1086"]
 helpviewer_keywords: ["U1086"]
-ms.assetid: 6d3cd68a-ead6-4a6d-a205-01324785de7e
 ---
 # NMAKE Fatal Error U1086
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1086.md
@@ -8,7 +8,7 @@ ms.assetid: 6d3cd68a-ead6-4a6d-a205-01324785de7e
 ---
 # NMAKE Fatal Error U1086
 
-**inference rule cannot have dependents**
+> inference rule cannot have dependents
 
 The colon (**:**) in an inference rule must be followed by one of these:
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1087"
 title: "NMAKE Fatal Error U1087"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1087"
+ms.date: 11/04/2016
 f1_keywords: ["U1087"]
 helpviewer_keywords: ["U1087"]
-ms.assetid: 5236ab54-e117-484d-99c3-852b061fd3d0
 ---
 # NMAKE Fatal Error U1087
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
@@ -10,6 +10,8 @@ ms.assetid: 5236ab54-e117-484d-99c3-852b061fd3d0
 
 > cannot have : and :: dependents for same target
 
+## Remarks
+
 A target cannot be specified in both a single-colon (**:**) and a double-colon (`::`) dependency.
 
 To specify a target in multiple description blocks, use `::` in each dependency line.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1087.md
@@ -8,7 +8,7 @@ ms.assetid: 5236ab54-e117-484d-99c3-852b061fd3d0
 ---
 # NMAKE Fatal Error U1087
 
-cannot have : and :: dependents for same target
+> cannot have : and :: dependents for same target
 
 A target cannot be specified in both a single-colon (**:**) and a double-colon (`::`) dependency.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
@@ -8,6 +8,6 @@ ms.assetid: 75f3527b-9923-408b-a66e-701322c63803
 ---
 # NMAKE Fatal Error U1088
 
-invalid separator '::' on inference rule
+> invalid separator '::' on inference rule
 
 An inference rule must be followed by a single colon (**:**).

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1088"
 title: "NMAKE Fatal Error U1088"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1088"
+ms.date: 11/04/2016
 f1_keywords: ["U1088"]
 helpviewer_keywords: ["U1088"]
-ms.assetid: 75f3527b-9923-408b-a66e-701322c63803
 ---
 # NMAKE Fatal Error U1088
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1088.md
@@ -10,4 +10,6 @@ ms.assetid: 75f3527b-9923-408b-a66e-701322c63803
 
 > invalid separator '::' on inference rule
 
+## Remarks
+
 An inference rule must be followed by a single colon (**:**).

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1095"
 title: "NMAKE Fatal Error U1095"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1095"
+ms.date: 11/04/2016
 f1_keywords: ["U1095"]
 helpviewer_keywords: ["U1095"]
-ms.assetid: a392582b-06db-4568-9c13-450293a4fbda
 ---
 # NMAKE Fatal Error U1095
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
@@ -10,6 +10,8 @@ ms.assetid: a392582b-06db-4568-9c13-450293a4fbda
 
 > expanded command line 'commandline' too long
 
+## Remarks
+
 After macro expansion, the given command line exceeded the limit on length of command lines for the operating system.
 
 MS-DOS permits up to 128 characters on a command line.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1095.md
@@ -8,7 +8,7 @@ ms.assetid: a392582b-06db-4568-9c13-450293a4fbda
 ---
 # NMAKE Fatal Error U1095
 
-expanded command line 'commandline' too long
+> expanded command line 'commandline' too long
 
 After macro expansion, the given command line exceeded the limit on length of command lines for the operating system.
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
@@ -10,4 +10,6 @@ ms.assetid: dc6868b3-8425-4920-858a-774ad0c4c5f1
 
 > filename-parts syntax requires dependent
 
+## Remarks
+
 The current dependency does not have either an explicit dependent or an implicit dependent. Filename-parts syntax, which uses the percent (`%`) specifier, represents components of the first dependent of the current target.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
@@ -8,6 +8,6 @@ ms.assetid: dc6868b3-8425-4920-858a-774ad0c4c5f1
 ---
 # NMAKE Fatal Error U1097
 
-filename-parts syntax requires dependent
+> filename-parts syntax requires dependent
 
 The current dependency does not have either an explicit dependent or an implicit dependent. Filename-parts syntax, which uses the percent (`%`) specifier, represents components of the first dependent of the current target.

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1097.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1097"
 title: "NMAKE Fatal Error U1097"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1097"
+ms.date: 11/04/2016
 f1_keywords: ["U1097"]
 helpviewer_keywords: ["U1097"]
-ms.assetid: dc6868b3-8425-4920-858a-774ad0c4c5f1
 ---
 # NMAKE Fatal Error U1097
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: NMAKE Fatal Error U1099"
 title: "NMAKE Fatal Error U1099"
-ms.date: "11/04/2016"
+description: "Learn more about: NMAKE Fatal Error U1099"
+ms.date: 11/04/2016
 f1_keywords: ["U1099"]
 helpviewer_keywords: ["U1099"]
-ms.assetid: 6688a805-43e6-4247-a2d0-14be082f0b13
 ---
 # NMAKE Fatal Error U1099
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
@@ -8,7 +8,7 @@ ms.assetid: 6688a805-43e6-4247-a2d0-14be082f0b13
 ---
 # NMAKE Fatal Error U1099
 
-stack overflow
+> stack overflow
 
 The makefile being processed was too complex for the current stack allocation in NMAKE. NMAKE has an allocation of 0x3000 (12K).
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1099.md
@@ -10,6 +10,8 @@ ms.assetid: 6688a805-43e6-4247-a2d0-14be082f0b13
 
 > stack overflow
 
+## Remarks
+
 The makefile being processed was too complex for the current stack allocation in NMAKE. NMAKE has an allocation of 0x3000 (12K).
 
 To increase NMAKE's stack allocation, run the [editbin /stack](../../build/reference/stack.md) utility with a larger stack option:

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1100.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1100.md
@@ -4,7 +4,6 @@ description: "A description of the causes of Microsoft NMAKE fatal error U1100."
 ms.date: 07/17/2020
 f1_keywords: ["U1100"]
 helpviewer_keywords: ["U1100"]
-ms.assetid: c71910a7-c581-4d9c-a38c-d2d557d56289
 ---
 # NMAKE Fatal Error U1100
 

--- a/docs/error-messages/tool-errors/nmake-fatal-error-u1100.md
+++ b/docs/error-messages/tool-errors/nmake-fatal-error-u1100.md
@@ -10,6 +10,8 @@ ms.assetid: c71910a7-c581-4d9c-a38c-d2d557d56289
 
 > macro '*macro-name*' is illegal in the context of batch rule '*rule-name*'
 
+## Remarks
+
 NMAKE generates this error when the command block of a batch-mode rule directly or indirectly references a special file macro that isn't `$<`.
 
 `$<` is the only allowed macro for batch-mode rules.


### PR DESCRIPTION
This is batch 96 that structures error/warning references. See #5465 for more information.