### PR TITLE
Tweak C5072 "Example" section

### DIFF
--- a/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-c5072.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Warning (level 1) C5072"
 description: "Learn more about: Compiler Warning (level 1) C5072"
-ms.date: 02/09/2024
+ms.date: 09/10/2025
 f1_keywords: ["C5072"]
 helpviewer_keywords: ["C5072"]
 ---


### PR DESCRIPTION
- Remove backticks for error code
- Change example code block language to correct `cmd` and remove leading space
- Move the resolving example to new code block for ease of copy
- Update `ms.date` metadata as I checked the warning message and other content