### PR TITLE
Augment C2033 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2033"]
 ---
 # Compiler Error C2033
 
-> 'identifier' : bit field cannot have indirection
+> '*identifier*': bit field cannot have indirection
 
 ## Remarks
 

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
@@ -28,3 +28,7 @@ struct S
     int arr[3] : 1;   // C2033
 };
 ```
+
+## See also
+
+[Compiler Error C2531](../compiler-errors-2/compiler-error-c2531.md)

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
@@ -19,17 +19,12 @@ The following example generates C2033:
 
 ```cpp
 // C2033.cpp
-struct S {
-   int *b : 1;  // C2033
-};
-```
-
-Possible resolution:
-
-```cpp
-// C2033b.cpp
 // compile with: /c
-struct S {
-   int b : 1;
+
+struct S
+{
+    int* ptr : 1;     // C2033
+    int& ref : 1;     // C2033
+    int arr[3] : 1;   // C2033
 };
 ```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2033"
 description: "Learn more about: Compiler Error C2033"
-ms.date: 11/04/2016
+ms.date: 09/10/2025
 f1_keywords: ["C2033"]
 helpviewer_keywords: ["C2033"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2033.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["C2033"]
 
 ## Remarks
 
-The bit field was declared as a pointer, which is not allowed.
+Bit fields can't be declared as a pointer, reference, or array. For more information, see [C++ Bit Fields](../../cpp/cpp-bit-fields.md).
 
 ## Example
 


### PR DESCRIPTION
- Update error message
- Add new "array of bit fields" scenario as seen on various Stack Overflow questions ([[1]](https://stackoverflow.com/questions/41918433/is-it-possible-to-use-array-of-bit-fields) [[2]](https://stackoverflow.com/questions/1772395/c-bool-array-as-bitfield) [[3]](https://stackoverflow.com/questions/32462088/how-to-add-an-array-to-a-bitfield-struct))
- Augment the remarks and overhaul the example
- Add C2531 "See also" link as C2531 is emitted alongside the "reference to bit field" example

## Example

```cpp
// C2033.cpp
// compile with: /c

struct S
{
    int* ptr : 1;     // C2033
    int& ref : 1;     // C2033
    int arr[3] : 1;   // C2033
};
```

```Output
C:\Test>cl /c C2033.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35215 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2033.cpp
C2033.cpp(6): error C2033: 'S::ptr': bit field cannot have indirection
C2033.cpp(7): error C2531: 'S::ref': you cannot bind a reference to a bit-field
C2033.cpp(7): error C2033: 'S::ref': bit field cannot have indirection
C2033.cpp(8): error C2033: 'S::arr': bit field cannot have indirection
```