### PR TITLE
Fix defunct example and update C2735 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2735.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2735"
 description: "Learn more about: Compiler Error C2735"
-ms.date: 11/04/2016
+ms.date: 09/12/2025
 f1_keywords: ["C2735"]
 helpviewer_keywords: ["C2735"]
 ---


### PR DESCRIPTION
Update error message, fix defunct example, and update `ms.date` metadata.

## Example: `inline int`

Old example that no longer generates C2735:

```cpp
// C2735.cpp
void f(inline int){}   // C7643
```

<details>
<summary>Visual Studio 2022</summary>
<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35216 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(2): error C7643: 'unnamed-parameter': 'inline' specifier cannot appear on a function parameter
```

</details>

<details>
<summary>Visual Studio 2026 Insiders</summary>

<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35503 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(2): error C7643: 'unnamed-parameter': 'inline' specifier cannot appear on a function parameter
```

</details>

## Example: `virtual int`

New example that generates C2735. Tested practically all other keywords and it seems only `virtual` emits it.

```cpp
// C2735.cpp
// compile with: /c

void func(virtual int) {}   // C2735
```

<details>
<summary>Visual Studio 2022</summary>
<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35216 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(4): error C2735: 'virtual' keyword is not permitted in formal parameter type specifier
```

</details>

<details>
<summary>Visual Studio 2026 Insiders</summary>

<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35503 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(4): error C2735: 'virtual' keyword is not permitted in formal parameter type specifier
```

</details>

## Example: `virtual int i`

Tried adding an identifier for the parameter, but that changes the error emitted:

```cpp
// C2735.cpp
// compile with: /c

void func(virtual int i) {}   // C2433
```

<details>
<summary>Visual Studio 2022</summary>
<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35216 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(4): error C2433: 'i': 'virtual' not permitted on data declarations
```

</details>

<details>
<summary>Visual Studio 2026 Insiders</summary>

<br>

```Output
C:\Test>cl /c C2735.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35503 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2735.cpp
C2735.cpp(4): error C2433: 'i': 'virtual' not permitted on data declarations
```

</details>