### PR TITLE
Update all `<stdexcept>` class references

### DIFF
--- a/docs/standard-library/domain-error-class.md
+++ b/docs/standard-library/domain-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: domain_error class"
 title: "domain_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: domain_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::domain_error"]
 helpviewer_keywords: ["domain_error class"]
-ms.assetid: a1d8245d-61c2-4d1e-973f-073bd5dd5fa3
 ---
 # `domain_error` class
 

--- a/docs/standard-library/invalid-argument-class.md
+++ b/docs/standard-library/invalid-argument-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: invalid_argument class"
 title: "invalid_argument class"
-ms.date: "09/09/2021"
+description: "Learn more about: invalid_argument class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::invalid_argument"]
 helpviewer_keywords: ["invalid_argument class"]
-ms.assetid: af6c227d-ad7c-4e63-9dee-67af81d83506
 ---
 # `invalid_argument` class
 

--- a/docs/standard-library/length-error-class.md
+++ b/docs/standard-library/length-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: length_error class"
 title: "length_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: length_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::length_error"]
 helpviewer_keywords: ["length_error class"]
-ms.assetid: d53c46c5-4626-400d-bd76-bf3e1e0f64ae
 ---
 # `length_error` class
 

--- a/docs/standard-library/logic-error-class.md
+++ b/docs/standard-library/logic-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: logic_error class"
 title: "logic_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: logic_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::logic_error"]
 helpviewer_keywords: ["logic_error class"]
-ms.assetid: b290d73d-94e1-4288-af86-2bb5d71f677a
 ---
 # `logic_error` class
 

--- a/docs/standard-library/out-of-range-class.md
+++ b/docs/standard-library/out-of-range-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: out_of_range class"
 title: "out_of_range class"
-ms.date: "09/09/2021"
+description: "Learn more about: out_of_range class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::out_of_range"]
 helpviewer_keywords: ["out_of_range class"]
-ms.assetid: d0e14dc0-065e-4666-9ac9-51e52223c503
 ---
 # `out_of_range` class
 

--- a/docs/standard-library/overflow-error-class.md
+++ b/docs/standard-library/overflow-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: overflow_error class"
 title: "overflow_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: overflow_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::overflow_error"]
 helpviewer_keywords: ["overflow_error class"]
-ms.assetid: bae7128d-e36b-4a45-84f1-2f89da441d20
 ---
 # `overflow_error` class
 

--- a/docs/standard-library/range-error-class.md
+++ b/docs/standard-library/range-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: range_error class"
 title: "range_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: range_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::range_error"]
 helpviewer_keywords: ["range_error class"]
-ms.assetid: 8afb3e88-fc49-4213-b096-ed63d7aea37c
 ---
 # `range_error` class
 

--- a/docs/standard-library/runtime-error-class.md
+++ b/docs/standard-library/runtime-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: runtime_error class"
 title: "runtime_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: runtime_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::runtime_error"]
 helpviewer_keywords: ["runtime_error class"]
-ms.assetid: 4d0227bf-847b-45a2-a320-2351ebf98368
 ---
 # `runtime_error` class
 

--- a/docs/standard-library/underflow-error-class.md
+++ b/docs/standard-library/underflow-error-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: underflow_error class"
 title: "underflow_error class"
-ms.date: "09/09/2021"
+description: "Learn more about: underflow_error class"
+ms.date: 09/09/2021
 f1_keywords: ["stdexcept/std::underflow_error"]
 helpviewer_keywords: ["underflow_error class"]
-ms.assetid: d632f1f9-9c6c-4954-b96b-03041bfab22d
 ---
 # `underflow_error` class
 


### PR DESCRIPTION
- Split output into another code block and change "Class" to "class"
- Add backticks, simplify redundant relative links, remove trailing empty syntax lines, and update metadata