### PR TITLE
Structure error references in range [M6101, M6205]

### DIFF
--- a/docs/error-messages/tool-errors/math-error-m6101.md
+++ b/docs/error-messages/tool-errors/math-error-m6101.md
@@ -10,6 +10,8 @@ ms.assetid: 8c8d5097-d725-4a2c-92e9-fcf28c871d74
 
 > invalid
 
+## Remarks
+
 Invalid operation.
 
 This error can be caused when an operand is NaN (not a number) or infinity.

--- a/docs/error-messages/tool-errors/math-error-m6101.md
+++ b/docs/error-messages/tool-errors/math-error-m6101.md
@@ -8,7 +8,7 @@ ms.assetid: 8c8d5097-d725-4a2c-92e9-fcf28c871d74
 ---
 # Math Error M6101
 
-invalid
+> invalid
 
 Invalid operation.
 

--- a/docs/error-messages/tool-errors/math-error-m6101.md
+++ b/docs/error-messages/tool-errors/math-error-m6101.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6101"
 title: "Math Error M6101"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6101"
+ms.date: 11/04/2016
 f1_keywords: ["M6101"]
 helpviewer_keywords: ["M6101"]
-ms.assetid: 8c8d5097-d725-4a2c-92e9-fcf28c871d74
 ---
 # Math Error M6101
 

--- a/docs/error-messages/tool-errors/math-error-m6102.md
+++ b/docs/error-messages/tool-errors/math-error-m6102.md
@@ -8,7 +8,7 @@ ms.assetid: dbd2241f-6595-431e-9597-d9dbdb3a0ca2
 ---
 # Math Error M6102
 
-denormal
+> denormal
 
 An operation generated a very small floating-point number, which be invalid due loss of significance. Denormal floating-point exceptions are usually masked, causing them to be trapped and operated upon.
 

--- a/docs/error-messages/tool-errors/math-error-m6102.md
+++ b/docs/error-messages/tool-errors/math-error-m6102.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6102"
 title: "Math Error M6102"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6102"
+ms.date: 11/04/2016
 f1_keywords: ["M6102"]
 helpviewer_keywords: ["M6102"]
-ms.assetid: dbd2241f-6595-431e-9597-d9dbdb3a0ca2
 ---
 # Math Error M6102
 

--- a/docs/error-messages/tool-errors/math-error-m6102.md
+++ b/docs/error-messages/tool-errors/math-error-m6102.md
@@ -10,6 +10,8 @@ ms.assetid: dbd2241f-6595-431e-9597-d9dbdb3a0ca2
 
 > denormal
 
+## Remarks
+
 An operation generated a very small floating-point number, which be invalid due loss of significance. Denormal floating-point exceptions are usually masked, causing them to be trapped and operated upon.
 
 Program terminates with exit code 130.

--- a/docs/error-messages/tool-errors/math-error-m6107.md
+++ b/docs/error-messages/tool-errors/math-error-m6107.md
@@ -8,7 +8,7 @@ ms.assetid: a827a2a4-40b7-4e28-8e8d-530c6ffcf0c9
 ---
 # Math Error M6107
 
-unemulated
+> unemulated
 
 An attempt was made to execute a coprocessor instruction that is invalid or is not supported by the emulator.
 

--- a/docs/error-messages/tool-errors/math-error-m6107.md
+++ b/docs/error-messages/tool-errors/math-error-m6107.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6107"
 title: "Math Error M6107"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6107"
+ms.date: 11/04/2016
 f1_keywords: ["M6107"]
 helpviewer_keywords: ["M6107"]
-ms.assetid: a827a2a4-40b7-4e28-8e8d-530c6ffcf0c9
 ---
 # Math Error M6107
 

--- a/docs/error-messages/tool-errors/math-error-m6107.md
+++ b/docs/error-messages/tool-errors/math-error-m6107.md
@@ -10,6 +10,8 @@ ms.assetid: a827a2a4-40b7-4e28-8e8d-530c6ffcf0c9
 
 > unemulated
 
+## Remarks
+
 An attempt was made to execute a coprocessor instruction that is invalid or is not supported by the emulator.
 
 Program terminates with exit code 135.

--- a/docs/error-messages/tool-errors/math-error-m6108.md
+++ b/docs/error-messages/tool-errors/math-error-m6108.md
@@ -10,6 +10,8 @@ ms.assetid: 054893b4-49bc-45d9-882f-7cb50ba387c0
 
 > square root
 
+## Remarks
+
 The operand in a square-root operation was negative.
 
 Program terminates with exit code 136.

--- a/docs/error-messages/tool-errors/math-error-m6108.md
+++ b/docs/error-messages/tool-errors/math-error-m6108.md
@@ -8,7 +8,7 @@ ms.assetid: 054893b4-49bc-45d9-882f-7cb50ba387c0
 ---
 # Math Error M6108
 
-square root
+> square root
 
 The operand in a square-root operation was negative.
 

--- a/docs/error-messages/tool-errors/math-error-m6108.md
+++ b/docs/error-messages/tool-errors/math-error-m6108.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6108"
 title: "Math Error M6108"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6108"
+ms.date: 11/04/2016
 f1_keywords: ["M6108"]
 helpviewer_keywords: ["M6108"]
-ms.assetid: 054893b4-49bc-45d9-882f-7cb50ba387c0
 ---
 # Math Error M6108
 

--- a/docs/error-messages/tool-errors/math-error-m6110.md
+++ b/docs/error-messages/tool-errors/math-error-m6110.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6110"
 title: "Math Error M6110"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6110"
+ms.date: 11/04/2016
 f1_keywords: ["M6110"]
 helpviewer_keywords: ["M6110"]
-ms.assetid: aac9ae37-6a6d-46e9-85d4-dfe03f1c3e11
 ---
 # Math Error M6110
 

--- a/docs/error-messages/tool-errors/math-error-m6110.md
+++ b/docs/error-messages/tool-errors/math-error-m6110.md
@@ -8,7 +8,7 @@ ms.assetid: aac9ae37-6a6d-46e9-85d4-dfe03f1c3e11
 ---
 # Math Error M6110
 
-stack overflow
+> stack overflow
 
 A floating-point expression caused a floating-point stack overflow.
 

--- a/docs/error-messages/tool-errors/math-error-m6110.md
+++ b/docs/error-messages/tool-errors/math-error-m6110.md
@@ -10,6 +10,8 @@ ms.assetid: aac9ae37-6a6d-46e9-85d4-dfe03f1c3e11
 
 > stack overflow
 
+## Remarks
+
 A floating-point expression caused a floating-point stack overflow.
 
 Stack-overflow floating-point exceptions are trapped up to a limit of seven levels in addition to the eight levels usually supported by the 8087/287/387 coprocessor.

--- a/docs/error-messages/tool-errors/math-error-m6111.md
+++ b/docs/error-messages/tool-errors/math-error-m6111.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["M6111"]
 ---
 # Math Error M6111
 
-stack underflow
+> stack underflow
 
 A floating-point operation resulted in a stack underflow on the 8087/287/387 coprocessor or the emulator.
 

--- a/docs/error-messages/tool-errors/math-error-m6111.md
+++ b/docs/error-messages/tool-errors/math-error-m6111.md
@@ -9,9 +9,15 @@ helpviewer_keywords: ["M6111"]
 
 > stack underflow
 
+## Remarks
+
 A floating-point operation resulted in a stack underflow on the 8087/287/387 coprocessor or the emulator.
 
-This error is often caused by a call to a **`long double`** function that does not return a value. For example, the following generates this error when compiled and run:
+This error is often caused by a call to a **`long double`** function that does not return a value.
+
+## Example
+
+For example, the following generates this error when compiled and run:
 
 ```c
 long double ld() {}

--- a/docs/error-messages/tool-errors/math-error-m6201.md
+++ b/docs/error-messages/tool-errors/math-error-m6201.md
@@ -8,7 +8,7 @@ ms.assetid: 4041c331-d9aa-4dd4-b565-7dbe0218538c
 ---
 # Math Error M6201
 
-'function' : _DOMAIN error
+> 'function' : _DOMAIN error
 
 An argument to the given function was outside the domain of legal input values for that function.
 

--- a/docs/error-messages/tool-errors/math-error-m6201.md
+++ b/docs/error-messages/tool-errors/math-error-m6201.md
@@ -10,6 +10,8 @@ ms.assetid: 4041c331-d9aa-4dd4-b565-7dbe0218538c
 
 > 'function' : _DOMAIN error
 
+## Remarks
+
 An argument to the given function was outside the domain of legal input values for that function.
 
 ## Example

--- a/docs/error-messages/tool-errors/math-error-m6201.md
+++ b/docs/error-messages/tool-errors/math-error-m6201.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6201"
 title: "Math Error M6201"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6201"
+ms.date: 11/04/2016
 f1_keywords: ["M6201"]
 helpviewer_keywords: ["M6201"]
-ms.assetid: 4041c331-d9aa-4dd4-b565-7dbe0218538c
 ---
 # Math Error M6201
 

--- a/docs/error-messages/tool-errors/math-error-m6202.md
+++ b/docs/error-messages/tool-errors/math-error-m6202.md
@@ -10,6 +10,8 @@ ms.assetid: 4d17045f-c6dc-4705-9512-e9af12c35fb4
 
 > 'function' : _SING error
 
+## Remarks
+
 An argument to the given function was a singularity value for this function. The function is not defined for that argument.
 
 This error calls the `_matherr` function with the function name, its arguments, and the error type. You can rewrite the `_matherr` function to customize the handling of certain run-time floating-point math errors.

--- a/docs/error-messages/tool-errors/math-error-m6202.md
+++ b/docs/error-messages/tool-errors/math-error-m6202.md
@@ -8,7 +8,7 @@ ms.assetid: 4d17045f-c6dc-4705-9512-e9af12c35fb4
 ---
 # Math Error M6202
 
-'function' : _SING error
+> 'function' : _SING error
 
 An argument to the given function was a singularity value for this function. The function is not defined for that argument.
 

--- a/docs/error-messages/tool-errors/math-error-m6202.md
+++ b/docs/error-messages/tool-errors/math-error-m6202.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6202"
 title: "Math Error M6202"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6202"
+ms.date: 11/04/2016
 f1_keywords: ["M6202"]
 helpviewer_keywords: ["M6202"]
-ms.assetid: 4d17045f-c6dc-4705-9512-e9af12c35fb4
 ---
 # Math Error M6202
 

--- a/docs/error-messages/tool-errors/math-error-m6203.md
+++ b/docs/error-messages/tool-errors/math-error-m6203.md
@@ -10,6 +10,8 @@ ms.assetid: bd7fdd1c-83e4-4d6a-901e-10a0308bf5be
 
 > 'function' : _OVERFLOW error
 
+## Remarks
+
 The given function result was too large to be represented.
 
 This error calls the `_matherr` function with the function name, its arguments, and the error type. You can rewrite the `_matherr` function to customize the handling of certain run-time floating-point math errors.

--- a/docs/error-messages/tool-errors/math-error-m6203.md
+++ b/docs/error-messages/tool-errors/math-error-m6203.md
@@ -8,7 +8,7 @@ ms.assetid: bd7fdd1c-83e4-4d6a-901e-10a0308bf5be
 ---
 # Math Error M6203
 
-'function' : _OVERFLOW error
+> 'function' : _OVERFLOW error
 
 The given function result was too large to be represented.
 

--- a/docs/error-messages/tool-errors/math-error-m6203.md
+++ b/docs/error-messages/tool-errors/math-error-m6203.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6203"
 title: "Math Error M6203"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6203"
+ms.date: 11/04/2016
 f1_keywords: ["M6203"]
 helpviewer_keywords: ["M6203"]
-ms.assetid: bd7fdd1c-83e4-4d6a-901e-10a0308bf5be
 ---
 # Math Error M6203
 

--- a/docs/error-messages/tool-errors/math-error-m6205.md
+++ b/docs/error-messages/tool-errors/math-error-m6205.md
@@ -10,6 +10,8 @@ ms.assetid: fd28e7c9-a463-4a9c-a863-cc9e75315550
 
 > 'function' : _TLOSS error
 
+## Remarks
+
 A total loss of significance (precision) occurred.
 
 This error may be caused by giving a very large number as the operand of sin, cos, or tan because the operand must be reduced to a number between 0 and 2*pi.

--- a/docs/error-messages/tool-errors/math-error-m6205.md
+++ b/docs/error-messages/tool-errors/math-error-m6205.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Math Error M6205"
 title: "Math Error M6205"
-ms.date: "11/04/2016"
+description: "Learn more about: Math Error M6205"
+ms.date: 11/04/2016
 f1_keywords: ["M6205"]
 helpviewer_keywords: ["M6205"]
-ms.assetid: fd28e7c9-a463-4a9c-a863-cc9e75315550
 ---
 # Math Error M6205
 

--- a/docs/error-messages/tool-errors/math-error-m6205.md
+++ b/docs/error-messages/tool-errors/math-error-m6205.md
@@ -8,7 +8,7 @@ ms.assetid: fd28e7c9-a463-4a9c-a863-cc9e75315550
 ---
 # Math Error M6205
 
-'function' : _TLOSS error
+> 'function' : _TLOSS error
 
 A total loss of significance (precision) occurred.
 


### PR DESCRIPTION
This is batch 112 that structures error/warning references. See #5465 for more information.