### PR TITLE
Fix mismatched error/warning code in example leading sentences

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2201.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2201.md
@@ -15,7 +15,7 @@ The exported identifier is **`static`**.
 
 ## Example
 
-The following example generates C2286, and shows how to fix it:
+The following example generates C2201, and shows how to fix it:
 
 ```cpp
 // C2201.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2250.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2250.md
@@ -15,7 +15,7 @@ The derived class inherits more than one override of a virtual function of a vir
 
 ## Example
 
-The following example generates C2286:
+The following example generates C2250:
 
 ```cpp
 // C2250.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2380.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2380.md
@@ -15,7 +15,7 @@ A constructor returns a value or redefines the class name.
 
 ## Example
 
-The following example generates C2326:
+The following example generates C2380:
 
 ```cpp
 // C2380.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2391.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2391.md
@@ -15,7 +15,7 @@ The **`friend`** declaration includes a complete class declaration. A **`friend`
 
 ## Example
 
-The following example generates C2326:
+The following example generates C2391:
 
 ```cpp
 // C2391.cpp

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2449.md
@@ -17,7 +17,7 @@ This error can be caused by a semicolon between a function header and the openin
 
 ## Example
 
-The following example generates C2499:
+The following example generates C2449:
 
 ```c
 // C2449.c

--- a/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c2652.md
@@ -15,7 +15,7 @@ The first parameter in the copy constructor has the same type as the class, stru
 
 ## Example
 
-The following example generates C2651:
+The following example generates C2652:
 
 ```cpp
 // C2652.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3239.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3239.md
@@ -15,7 +15,7 @@ The compiler encountered an invalid type.
 
 ## Example
 
-The following example generates C3229:
+The following example generates C3239:
 
 ```cpp
 // C3239.cpp

--- a/docs/error-messages/compiler-errors-2/compiler-error-c3469.md
+++ b/docs/error-messages/compiler-errors-2/compiler-error-c3469.md
@@ -28,7 +28,7 @@ public ref class GR {};
 public ref class GR2 {};
 ```
 
-The following example generates C3466.
+The following example generates C3469.
 
 ```cpp
 // C3469_b.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-1-c4544.md
@@ -15,7 +15,7 @@ A default template argument was specified in an incorrect location and was ignor
 
 ## Example
 
-This example generates C4545, and the next example shows how to fix it:
+This example generates C4544, and the next example shows how to fix it:
 
 ```cpp
 // C4544.cpp

--- a/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4580.md
+++ b/docs/error-messages/compiler-warnings/compiler-warning-level-3-c4580.md
@@ -15,7 +15,7 @@ helpviewer_keywords: ["C4580"]
 
 ## Example
 
-The following example generates C3454 and shows how to fix it.
+The following example generates C4580 and shows how to fix it.
 
 ```cpp
 // C4580.cpp

--- a/docs/error-messages/tool-errors/command-line-warning-d9043.md
+++ b/docs/error-messages/tool-errors/command-line-warning-d9043.md
@@ -11,7 +11,7 @@ helpviewer_keywords: ["D9043"]
 
 ## Example
 
-The following example generates C9043.
+The following example generates D9043.
 
 ```cpp
 // D9043.cpp


### PR DESCRIPTION
Fix some mismatched error/warning codes found using a regex.