### PR TITLE
Add example in C2154 error reference

### DIFF
--- a/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
@@ -12,3 +12,21 @@ helpviewer_keywords: ["C2154"]
 ## Remarks
 
 You can only get the underlying type of an [enumeration](../../cpp/enumerations-cpp.md) type.
+
+## Example
+
+The following example generates C2154:
+
+```cpp
+// C2154.cpp
+// compile with: /c
+
+struct S {};
+enum E {};
+enum class EC {};
+
+__underlying_type(S) s;     // C2154
+__underlying_type(int) i;   // C2154
+__underlying_type(E) e;     // OK
+__underlying_type(EC) ec;   // OK
+```

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
@@ -30,3 +30,7 @@ __underlying_type(int) i;   // C2154
 __underlying_type(E) e;     // OK
 __underlying_type(EC) ec;   // OK
 ```
+
+## See also
+
+[`underlying_type` class](../../standard-library/underlying-type-class.md)

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Error C2154"
 description: "Learn more about: Compiler Error C2154"
-ms.date: 11/04/2016
+ms.date: 09/21/2025
 f1_keywords: ["C2154"]
 helpviewer_keywords: ["C2154"]
 ---

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
@@ -11,6 +11,4 @@ helpviewer_keywords: ["C2154"]
 
 ## Remarks
 
-You can only get the underlying type of an enumeration type.
-
-For more information, see [Compiler Support for Type Traits](../../extensions/compiler-support-for-type-traits-cpp-component-extensions.md).
+You can only get the underlying type of an [enumeration](../../cpp/enumerations-cpp.md) type.

--- a/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
+++ b/docs/error-messages/compiler-errors-1/compiler-error-c2154.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["C2154"]
 ---
 # Compiler Error C2154
 
-> 'type' : only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
+> '*type*': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
 
 ## Remarks
 

--- a/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
+++ b/docs/error-messages/compiler-errors-1/compiler-errors-c2100-through-c2199.md
@@ -69,7 +69,7 @@ The articles in this section of the documentation explain a subset of the error 
 |[Compiler error C2151](compiler-error-c2151.md)|more than one language attribute|
 |[Compiler error C2152](compiler-error-c2152.md)|'*identifier*': pointers to functions with different attributes|
 |[Compiler error C2153](compiler-error-c2153.md)|integer literals must have at least one digit|
-|[Compiler error C2154](compiler-error-c2154.md)|'*type*': only enumeration type is allowed as an argument to compiler intrinsic type trait '*trait*'|
+|[Compiler error C2154](compiler-error-c2154.md)|'*type*': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'|
 |[Compiler error C2155](compiler-error-c2155.md)|'?': invalid left operand, expected arithmetic or pointer type|
 |[Compiler error C2156](compiler-error-c2156.md)|pragma must be outside function|
 |[Compiler error C2157](compiler-error-c2157.md)|'*identifier*': must be declared before use in pragma list|


### PR DESCRIPTION
- Add new example that generates C2154.
- In the error index page, change `*trait*` to `__underlying_type` as it seems to be the only trait that can cause C2154 (also to ensure both instances of the C2154 error message are identical).
- Remove link to [`Compiler Support for Type Traits`](https://github.com/MicrosoftDocs/cpp-docs/blob/087364a48127c5ede776795a09516103285dc177/docs/extensions/compiler-support-for-type-traits-cpp-component-extensions.md) as there is no mention of `__underlying_type`. In fact, across the entire repository, the only mention of `__underlying_type` is in this error topic.
- Add links to [`enumeration`](https://github.com/MicrosoftDocs/cpp-docs/blob/087364a48127c5ede776795a09516103285dc177/docs/cpp/enumerations-cpp.md) and [`underlying_type`](https://github.com/MicrosoftDocs/cpp-docs/blob/087364a48127c5ede776795a09516103285dc177/docs/standard-library/underlying-type-class.md).

## Example

```cpp
// C2154.cpp
// compile with: /c

struct S {};
enum E {};
enum class EC {};

__underlying_type(S) s;     // C2154
__underlying_type(int) i;   // C2154
__underlying_type(E) e;     // OK
__underlying_type(EC) ec;   // OK
```

<details>
<summary>Visual Studio 2022</summary>
<br>

```Output
C:\Test>cl /c C2154.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35217 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2154.cpp
C2154.cpp(8): error C2154: 'S': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
C2154.cpp(9): error C2154: 'int': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
```

</details>

<details>
<summary>Visual Studio 2026 Insiders</summary>

<br>

```Output
C:\Test>cl /c C2154.cpp
Microsoft (R) C/C++ Optimizing Compiler Version 19.50.35503 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.

C2154.cpp
C2154.cpp(8): error C2154: 'S': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
C2154.cpp(9): error C2154: 'int': only enumeration type is allowed as an argument to compiler intrinsic type trait '__underlying_type'
```

</details>