### PR TITLE
Structure error references in range [LNK2001, LNK2039]

### DIFF
--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2001.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2001.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2001"
 title: "Linker Tools Error LNK2001"
+description: "Learn more about: Linker Tools Error LNK2001"
 ms.date: 10/22/2021
 f1_keywords: ["LNK2001"]
 helpviewer_keywords: ["LNK2001"]
-ms.assetid: dc1cf267-c984-486c-abd2-fd07c799f7ef
 ---
 # Linker Tools Error LNK2001
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2001.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2001.md
@@ -10,6 +10,8 @@ ms.assetid: dc1cf267-c984-486c-abd2-fd07c799f7ef
 
 > unresolved external symbol "*symbol*"
 
+## Remarks
+
 The compiled code makes a reference or call to *symbol*. The symbol isn't defined in any libraries or object files searched by the linker.
 
 This error message is followed by fatal error [LNK1120](../../error-messages/tool-errors/linker-tools-error-lnk1120.md). To fix error LNK1120, first fix all LNK2001 and LNK2019 errors.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
@@ -10,6 +10,8 @@ ms.assetid: 07645371-e67b-4a2c-b0e0-dde24c94ef7e
 
 > gp relative fixup overflow to 'target'; short section 'section' is too large or out of range.
 
+## Remarks
+
 The section was too large.
 
 To resolve this error, reduce the size of the short section, either by explicitly putting data in the long sections via #pragma section(".sectionname", read, write, long) and using `__declspec(allocate(".sectionname"))` on data definitions and declarations.  For example,

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2004"
 title: "Linker Tools Error LNK2004"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2004"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2004"]
 helpviewer_keywords: ["LNK2004"]
-ms.assetid: 07645371-e67b-4a2c-b0e0-dde24c94ef7e
 ---
 # Linker Tools Error LNK2004
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2004.md
@@ -8,7 +8,7 @@ ms.assetid: 07645371-e67b-4a2c-b0e0-dde24c94ef7e
 ---
 # Linker Tools Error LNK2004
 
-gp relative fixup overflow to 'target'; short section 'section' is too large or out of range.
+> gp relative fixup overflow to 'target'; short section 'section' is too large or out of range.
 
 The section was too large.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2005.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2005.md
@@ -10,6 +10,8 @@ ms.assetid: d9587adc-68be-425c-8a30-15dbc86717a4
 
 > *symbol* already defined in object
 
+## Remarks
+
 The symbol *symbol* was defined more than once.
 
 This error is followed by fatal error [LNK1169](../../error-messages/tool-errors/linker-tools-error-lnk1169.md).

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2005.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2005.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2005"
 title: "Linker Tools Error LNK2005"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2005"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2005"]
 helpviewer_keywords: ["LNK2005"]
-ms.assetid: d9587adc-68be-425c-8a30-15dbc86717a4
 ---
 # Linker Tools Error LNK2005
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
@@ -10,6 +10,8 @@ ms.assetid: bbcd83c5-c8ae-439e-a033-63643a5bb373
 
 > Fixup target is not aligned 'symbol_name'
 
+## Remarks
+
 LINK found a fixup target in your object file that was not aligned properly.
 
 This error can be caused by custom secton alignment (for example, #pragma [pack](../../preprocessor/pack.md)), [align](../../cpp/align-cpp.md) modifier, or by using assembly language code that modifies secton alignment.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
@@ -8,7 +8,7 @@ ms.assetid: bbcd83c5-c8ae-439e-a033-63643a5bb373
 ---
 # Linker Tools Error LNK2008
 
-Fixup target is not aligned 'symbol_name'
+> Fixup target is not aligned 'symbol_name'
 
 LINK found a fixup target in your object file that was not aligned properly.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2008.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2008"
 title: "Linker Tools Error LNK2008"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2008"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2008"]
 helpviewer_keywords: ["LNK2008"]
-ms.assetid: bbcd83c5-c8ae-439e-a033-63643a5bb373
 ---
 # Linker Tools Error LNK2008
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2011.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2011.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["LNK2011"]
 ---
 # Linker Tools Error LNK2011
 
-precompiled object not linked in; image may not run
+> precompiled object not linked in; image may not run
 
 If you use precompiled headers, LINK requires that all of the object files created with precompiled headers must be linked in. If you have a source file that you use to generate a precompiled header for use with other source files, you now must include the object file created along with the precompiled header.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2011.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2011.md
@@ -9,7 +9,11 @@ helpviewer_keywords: ["LNK2011"]
 
 > precompiled object not linked in; image may not run
 
+## Remarks
+
 If you use precompiled headers, LINK requires that all of the object files created with precompiled headers must be linked in. If you have a source file that you use to generate a precompiled header for use with other source files, you now must include the object file created along with the precompiled header.
+
+## Example
 
 For example, if you compile a file called STUB.cpp to create a precompiled header for use with other source files, you must link with STUB.obj or you will get this error. In the following command lines, line one is used to create a precompiled header, COMMON.pch, which is used with PROG1.cpp and PROG2.cpp in lines two and three. The file STUB.cpp contains only `#include` lines (the same `#include` lines as in PROG1.cpp and PROG2.cpp) and is used only to generate precompiled headers. In the last line, STUB.obj must be linked in to avoid LNK2011.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
@@ -10,6 +10,8 @@ ms.assetid: 21408e2d-3f56-4d1f-a031-00df70785ed4
 
 > fixup type fixup overflow. Target 'symbol name' is out of range
 
+## Remarks
+
 The linker cannot fit the necessary address or offset into the given instruction because the target symbol is too far away from the instruction's location.
 
 You can resolve this problem by creating multiple images or by using the [/ORDER](../../build/reference/order-put-functions-in-order.md) option so the instruction and target are closer together.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2013"
 title: "Linker Tools Error LNK2013"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2013"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2013"]
 helpviewer_keywords: ["LNK2013"]
-ms.assetid: 21408e2d-3f56-4d1f-a031-00df70785ed4
 ---
 # Linker Tools Error LNK2013
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2013.md
@@ -8,7 +8,7 @@ ms.assetid: 21408e2d-3f56-4d1f-a031-00df70785ed4
 ---
 # Linker Tools Error LNK2013
 
-fixup type fixup overflow. Target 'symbol name' is out of range
+> fixup type fixup overflow. Target 'symbol name' is out of range
 
 The linker cannot fit the necessary address or offset into the given instruction because the target symbol is too far away from the instruction's location.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
@@ -10,6 +10,8 @@ ms.assetid: f7c21733-b0fb-4888-a295-9b453ba6ee77
 
 > 'symbol' relocation to 'segment' invalid without /LARGEADDRESSAWARE:NO
 
+## Remarks
+
 You are trying to build a 64-bit image with 32-bit addresses. To do this, you must:
 
 - Use a fixed load address.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
@@ -8,7 +8,7 @@ ms.assetid: f7c21733-b0fb-4888-a295-9b453ba6ee77
 ---
 # Linker Tools Error LNK2017
 
-'symbol' relocation to 'segment' invalid without /LARGEADDRESSAWARE:NO
+> 'symbol' relocation to 'segment' invalid without /LARGEADDRESSAWARE:NO
 
 You are trying to build a 64-bit image with 32-bit addresses. To do this, you must:
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2017.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2017"
 title: "Linker Tools Error LNK2017"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2017"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2017"]
 helpviewer_keywords: ["LNK2017"]
-ms.assetid: f7c21733-b0fb-4888-a295-9b453ba6ee77
 ---
 # Linker Tools Error LNK2017
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2019.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2019.md
@@ -10,6 +10,8 @@ no-loc: [main, WinMain, wmain, wWinMain, __cdecl, __stdcall, __fastcall, __vecto
 
 > unresolved external symbol '*symbol*' referenced in function '*function*'
 
+## Remarks
+
 The compiled code for *function* makes a reference or call to *symbol*, but the linker can't find the symbol definition in any of the libraries or object files.
 
 This error message is followed by fatal error [LNK1120](../../error-messages/tool-errors/linker-tools-error-lnk1120.md). To fix error LNK1120, you must fix all LNK2001 and LNK2019 errors first.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2019.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2019.md
@@ -145,7 +145,7 @@ Unless `i` and `g` are defined in one of the files included in the build, the li
 
 ### A static data member is declared but not defined
 
-LNK2019 can also occur when a static data member is declared but not defined. The following sample generates LNK2019, and shows how to fix it.
+LNK2019 can also occur when a static data member is declared but not defined. The following example generates LNK2019, and shows how to fix it.
 
 ```cpp
 // LNK2019b.cpp
@@ -166,7 +166,7 @@ int main() {
 
 ### Declaration parameters don't match the definition
 
-Code that invokes function templates must have matching function template declarations. Declarations must include the same template parameters as the definition. The following sample generates LNK2019 on a user-defined operator, and shows how to fix it.
+Code that invokes function templates must have matching function template declarations. Declarations must include the same template parameters as the definition. The following example generates LNK2019 on a user-defined operator, and shows how to fix it.
 
 ```cpp
 // LNK2019e.cpp
@@ -196,7 +196,7 @@ int main() {
 
 ### Inconsistent wchar_t type definitions
 
-This sample creates a DLL that has an export that uses `WCHAR`, which resolves to **`wchar_t`**.
+This example creates a DLL that has an export that uses `WCHAR`, which resolves to **`wchar_t`**.
 
 ```cpp
 // LNK2019g.cpp
@@ -206,7 +206,7 @@ This sample creates a DLL that has an export that uses `WCHAR`, which resolves t
 __declspec(dllexport) void func(WCHAR*) {}
 ```
 
-The next sample uses the DLL in the previous sample, and generates LNK2019 because the types `unsigned short*` and `WCHAR*` aren't the same.
+The next example uses the DLL in the previous example, and generates LNK2019 because the types `unsigned short*` and `WCHAR*` aren't the same.
 
 ```cpp
 // LNK2019h.cpp

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["LNK2020"]
 
 > unresolved token 'token'
 
+## Remarks
+
 Similar to an undefined external error, except that the reference is via metadata. In metadata, all functions and data must be defined.
 
 To resolve:

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
@@ -21,7 +21,7 @@ To resolve:
 
 ## Examples
 
-The following sample generates LNK2020.
+The following example generates LNK2020.
 
 ```cpp
 // LNK2020.cpp
@@ -40,7 +40,7 @@ ref struct B {
 
 LNK2020 will also occur if you create a variable of a managed template type, but do not also instantiate the type.
 
-The following sample generates LNK2020.
+The following example generates LNK2020.
 
 ```cpp
 // LNK2020_b.cpp

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2020.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["LNK2020"]
 ---
 # Linker Tools Error LNK2020
 
-unresolved token 'token'
+> unresolved token 'token'
 
 Similar to an undefined external error, except that the reference is via metadata. In metadata, all functions and data must be defined.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
@@ -8,7 +8,7 @@ ms.assetid: c99e35a8-739a-4a20-a715-29b8c3744703
 ---
 # Linker Tools Error LNK2023
 
-bad dll or entry point \<dll or entry point>
+> bad dll or entry point \<dll or entry point>
 
 The linker is loading an incorrect version of msobj90.dll. Ensure that link.exe and msobj90.dll in your path have the same version.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2023"
 title: "Linker Tools Error LNK2023"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2023"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2023"]
 helpviewer_keywords: ["LNK2023"]
-ms.assetid: c99e35a8-739a-4a20-a715-29b8c3744703
 ---
 # Linker Tools Error LNK2023
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2023.md
@@ -10,6 +10,8 @@ ms.assetid: c99e35a8-739a-4a20-a715-29b8c3744703
 
 > bad dll or entry point \<dll or entry point>
 
+## Remarks
+
 The linker is loading an incorrect version of msobj90.dll. Ensure that link.exe and msobj90.dll in your path have the same version.
 
 A dependency of msobj90.dll may not be present. The dependency list for msobj90.dll is:

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
@@ -10,4 +10,6 @@ ms.assetid: 9955bf7c-59b5-4fa1-8481-147db0d7df45
 
 > module unsafe for SAFESEH image
 
+## Remarks
+
 [/SAFESEH](../../build/reference/safeseh-image-has-safe-exception-handlers.md) was specified, but a module was not compatible with the safe exception handling feature. If you want to use this module with **/SAFESEH**, then you will need to recompile the module.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
@@ -8,6 +8,6 @@ ms.assetid: 9955bf7c-59b5-4fa1-8481-147db0d7df45
 ---
 # Linker Tools Error LNK2026
 
-module unsafe for SAFESEH image
+> module unsafe for SAFESEH image
 
 [/SAFESEH](../../build/reference/safeseh-image-has-safe-exception-handlers.md) was specified, but a module was not compatible with the safe exception handling feature. If you want to use this module with **/SAFESEH**, then you will need to recompile the module.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2026.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2026"
 title: "Linker Tools Error LNK2026"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2026"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2026"]
 helpviewer_keywords: ["LNK2026"]
-ms.assetid: 9955bf7c-59b5-4fa1-8481-147db0d7df45
 ---
 # Linker Tools Error LNK2026
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
@@ -8,7 +8,7 @@ ms.assetid: e2f857a8-8e8a-4697-bbff-12ccb84a35c1
 ---
 # Linker Tools Error LNK2027
 
-unresolved module reference 'module'
+> unresolved module reference 'module'
 
 A file passed to the linker has a dependency on a module that was neither specified with **/ASSEMBLYMODULE** nor passed directly to the linker.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
@@ -10,6 +10,8 @@ ms.assetid: e2f857a8-8e8a-4697-bbff-12ccb84a35c1
 
 > unresolved module reference 'module'
 
+## Remarks
+
 A file passed to the linker has a dependency on a module that was neither specified with **/ASSEMBLYMODULE** nor passed directly to the linker.
 
 To resolve LNK2027, do one of the following:

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2027.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2027"
 title: "Linker Tools Error LNK2027"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2027"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2027"]
 helpviewer_keywords: ["LNK2027"]
-ms.assetid: e2f857a8-8e8a-4697-bbff-12ccb84a35c1
 ---
 # Linker Tools Error LNK2027
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
@@ -18,7 +18,7 @@ The **/clr:pure** compiler option is deprecated in Visual Studio 2015 and unsupp
 
 ## Examples
 
-This code sample generates a component with an exported, native, function whose calling convention is implicitly [__cdecl](../../cpp/cdecl.md).
+This code example generates a component with an exported, native, function whose calling convention is implicitly [__cdecl](../../cpp/cdecl.md).
 
 ```cpp
 // LNK2028.cpp
@@ -28,7 +28,7 @@ __declspec(dllexport) int func() {
 }
 ```
 
-The following sample creates a pure client that consumes the native function. However, the calling convention under **/clr:pure** is [__clrcall](../../cpp/clrcall.md). The following sample generates LNK2028.
+The following example creates a pure client that consumes the native function. However, the calling convention under **/clr:pure** is [__clrcall](../../cpp/clrcall.md). The following example generates LNK2028.
 
 ```cpp
 // LNK2028_b.cpp

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2028"
 title: "Linker Tools Error LNK2028"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2028"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2028"]
 helpviewer_keywords: ["LNK2028"]
-ms.assetid: e2b03293-6066-464d-a050-ce747bcf7f0e
 ---
 # Linker Tools Error LNK2028
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2028.md
@@ -8,7 +8,7 @@ ms.assetid: e2b03293-6066-464d-a050-ce747bcf7f0e
 ---
 # Linker Tools Error LNK2028
 
-"*exported_function*" (*decorated_name*) referenced in function "*function_containing_function_call*" (*decorated_name*)
+> "*exported_function*" (*decorated_name*) referenced in function "*function_containing_function_call*" (*decorated_name*)
 
 ## Remarks
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2031.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2031.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2031"
 title: "Linker Tools Error LNK2031"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2031"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2031"]
 helpviewer_keywords: ["LNK2031"]
-ms.assetid: 18ed4b6e-3e75-443c-bbd8-2f6030dc89ee
 ---
 # Linker Tools Error LNK2031
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2031.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2031.md
@@ -18,7 +18,7 @@ The **/clr:pure** compiler option is deprecated in Visual Studio 2015 and unsupp
 
 ## Examples
 
-This code sample generates a component with an exported, native, function whose calling convention is implicitly [__cdecl](../../cpp/cdecl.md).
+This code example generates a component with an exported, native, function whose calling convention is implicitly [__cdecl](../../cpp/cdecl.md).
 
 ```cpp
 // LNK2031.cpp
@@ -28,7 +28,7 @@ extern "C" {
 };
 ```
 
-The following sample creates a pure client that consumes the native function. However, the calling convention under **/clr:pure** is [__clrcall](../../cpp/clrcall.md). The following sample generates LNK2031.
+The following example creates a pure client that consumes the native function. However, the calling convention under **/clr:pure** is [__clrcall](../../cpp/clrcall.md). The following example generates LNK2031.
 
 ```cpp
 // LNK2031_b.cpp
@@ -41,7 +41,7 @@ int main() {
 }
 ```
 
-The following sample shows how to consume the native function from a pure image. Note the explicit **`__cdecl`** calling convention specifier.
+The following example shows how to consume the native function from a pure image. Note the explicit **`__cdecl`** calling convention specifier.
 
 ```cpp
 // LNK2031_c.cpp

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
@@ -7,7 +7,7 @@ helpviewer_keywords: ["LNK2033"]
 ---
 # Linker Tools Error LNK2033
 
-unresolved typeref token (token) for 'type'
+> unresolved typeref token (token) for 'type'
 
 A type doesn't have a definition in MSIL metadata.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
@@ -21,7 +21,7 @@ For more information, see [/clr (Common Language Runtime Compilation)](../../bui
 
 ## Example
 
-The following sample generates LNK2033.
+The following example generates LNK2033.
 
 ```cpp
 // LNK2033.cpp

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2033.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["LNK2033"]
 
 > unresolved typeref token (token) for 'type'
 
+## Remarks
+
 A type doesn't have a definition in MSIL metadata.
 
 LNK2033 can occur when compiling with **/clr:safe** and where there is only a forward declaration for a type in an MSIL module, where the type is referenced in the MSIL module.

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2038.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2038.md
@@ -1,7 +1,7 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2038"
 title: "Linker Tools Error LNK2038"
-ms.date: "12/15/2017"
+description: "Learn more about: Linker Tools Error LNK2038"
+ms.date: 12/15/2017
 f1_keywords: ["LNK2038"]
 helpviewer_keywords: ["LNK2038"]
 ---

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2038.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2038.md
@@ -9,6 +9,8 @@ helpviewer_keywords: ["LNK2038"]
 
 > mismatch detected for '*name*': value '*value_1*' doesn't match value '*value_2*' in *filename.obj*
 
+## Remarks
+
 A symbol mismatch has been detected by the linker. This error indicates that different parts of an app, including libraries or other object code that the app links to, use conflicting definitions of the symbol. The [detect mismatch](../../preprocessor/detect-mismatch.md) pragma is used to define such symbols and detect their conflicting values.
 
 ## Possible causes and solutions

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
@@ -8,7 +8,7 @@ ms.assetid: eaa296bd-4901-41f6-8410-6d03ee827144
 ---
 # Linker Tools Error LNK2039
 
-importing ref class '\<type>' that is defined in another.obj; it should be either imported or defined, but not both
+> importing ref class '\<type>' that is defined in another.obj; it should be either imported or defined, but not both
 
 The ref class '<`type`>' is imported in the specified .obj file but is also defined in another .obj file. This condition can cause runtime failure or other unexpected behavior.
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Linker Tools Error LNK2039"
 title: "Linker Tools Error LNK2039"
-ms.date: "11/04/2016"
+description: "Learn more about: Linker Tools Error LNK2039"
+ms.date: 11/04/2016
 f1_keywords: ["LNK2039"]
 helpviewer_keywords: ["LNK2039"]
-ms.assetid: eaa296bd-4901-41f6-8410-6d03ee827144
 ---
 # Linker Tools Error LNK2039
 

--- a/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
+++ b/docs/error-messages/tool-errors/linker-tools-error-lnk2039.md
@@ -10,6 +10,8 @@ ms.assetid: eaa296bd-4901-41f6-8410-6d03ee827144
 
 > importing ref class '\<type>' that is defined in another.obj; it should be either imported or defined, but not both
 
+## Remarks
+
 The ref class '<`type`>' is imported in the specified .obj file but is also defined in another .obj file. This condition can cause runtime failure or other unexpected behavior.
 
 ### To correct this error


### PR DESCRIPTION
LNK2022 is skipped to prevent potential merge conflicts with #5727. A separate PR will be issued once that is merged.

This is batch 116 that structures error/warning references. See #5465 for more information.