### PR TITLE
Structure warning references in range [C26100, C26167]

### DIFF
--- a/docs/code-quality/c26100.md
+++ b/docs/code-quality/c26100.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26100"
 description: "Learn more about: Warning C26100"
-title: Warning C26100
 ms.date: 11/04/2016
 f1_keywords: ["C26100", "RACE_CONDITION", "__WARNING_RACE_CONDITION"]
 helpviewer_keywords: ["C26100"]
-ms.assetid: 470ab2b2-5b55-424f-b192-3863a773c892
 ---
 # Warning C26100
 

--- a/docs/code-quality/c26101.md
+++ b/docs/code-quality/c26101.md
@@ -10,6 +10,8 @@ ms.assetid: 86046553-09ec-40ce-82b3-fd641928f0b0
 
 > Failing to use interlocked operation properly for variable '*var*'.
 
+## Remarks
+
 Windows APIs offer various interlocked operations. Annotation `_Interlocked_` specifies that a variable should only be accessed through an interlocked operation. Warning C26101 is issued when a variable access isn't consistent with the `_Interlocked_` annotation.
 
 ## Example

--- a/docs/code-quality/c26101.md
+++ b/docs/code-quality/c26101.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26101"
 description: "Learn more about: Warning C26101"
-title: Warning C26101
 ms.date: 11/04/2016
 f1_keywords: ["C26101"]
 helpviewer_keywords: ["C26101"]
-ms.assetid: 86046553-09ec-40ce-82b3-fd641928f0b0
 ---
 # Warning C26101
 

--- a/docs/code-quality/c26105.md
+++ b/docs/code-quality/c26105.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26105"
 description: "Learn more about: Warning C26105"
-title: Warning C26105
 ms.date: 11/04/2016
 f1_keywords: ["C26105"]
 helpviewer_keywords: ["C26105"]
-ms.assetid: 5558a3db-0513-43b4-8579-ccdc17e2b92f
 ---
 # Warning C26105
 

--- a/docs/code-quality/c26105.md
+++ b/docs/code-quality/c26105.md
@@ -10,6 +10,8 @@ ms.assetid: 5558a3db-0513-43b4-8579-ccdc17e2b92f
 
 > Lock order violation. Acquiring lock '*lock*' with level '*level*' causes order inversion.
 
+## Remarks
+
 Concurrency SAL supports *lock levels*. To declare a lock level, which is denoted by a string literal without double quotes, use `_Create_lock_level_`. You can impose an order of acquisition between two lock levels by using the annotation `_Set_lock_level_order_(A,B)`, which states that locks that have level `A` must be acquired before locks that have level `B`. To establish a lock order hierarchy (a partial order among lock levels), use multiple `_Set_lock_level_order_` annotations. To associate a lock with a lock level, use the `_Set_lock_level_` annotation when you declare the lock. Warning C26105 is issued when a lock ordering violation is detected.
 
 ## Example

--- a/docs/code-quality/c26110.md
+++ b/docs/code-quality/c26110.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26110"
 description: "Learn more about: Warning C26110"
-title: Warning C26110
 ms.date: 10/01/2019
 f1_keywords: ["C26110"]
 helpviewer_keywords: ["C26110"]
-ms.assetid: d82b79ec-6d7f-438b-bd6a-da874a3e08e5
 ---
 # Warning C26110
 

--- a/docs/code-quality/c26110.md
+++ b/docs/code-quality/c26110.md
@@ -10,6 +10,8 @@ ms.assetid: d82b79ec-6d7f-438b-bd6a-da874a3e08e5
 
 > Caller failing to hold lock '*lock*' before calling function '*func*'.
 
+## Remarks
+
 When a lock is required, make sure to clarify whether the function itself, or its caller, should acquire the lock. Warning C26110 is issued when there's a violation of the `_Requires_lock_held_` annotation, or other lock-related annotations. For more information, see [Annotating Locking Behavior](annotating-locking-behavior.md)
 
 ## Example

--- a/docs/code-quality/c26111.md
+++ b/docs/code-quality/c26111.md
@@ -10,6 +10,8 @@ ms.assetid: 85fc740a-3bbb-41b8-a848-95e243a08da9
 
 > Caller failing to release lock '*lock*' before calling function '*func*'.
 
+## Remarks
+
 The annotation `_Requires_lock_not_held_` imposes a precondition that the lock count for the specified lock can't be greater than zero when the function is called. Warning C26111 is issued when a function fails to release the lock before it calls another function.
 
 ## Example

--- a/docs/code-quality/c26111.md
+++ b/docs/code-quality/c26111.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26111"
 description: "Learn more about: Warning C26111"
-title: Warning C26111
 ms.date: 11/04/2016
 f1_keywords: ["C26111"]
 helpviewer_keywords: ["C26111"]
-ms.assetid: 85fc740a-3bbb-41b8-a848-95e243a08da9
 ---
 # Warning C26111
 

--- a/docs/code-quality/c26112.md
+++ b/docs/code-quality/c26112.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26112"
 description: "Learn more about: Warning C26112"
-title: Warning C26112
 ms.date: 11/04/2016
 f1_keywords: ["C26112"]
 helpviewer_keywords: ["C26112"]
-ms.assetid: 926de738-b9b0-43d7-9137-ab2daa44ad4d
 ---
 # Warning C26112
 

--- a/docs/code-quality/c26112.md
+++ b/docs/code-quality/c26112.md
@@ -10,6 +10,8 @@ ms.assetid: 926de738-b9b0-43d7-9137-ab2daa44ad4d
 
 > Caller cannot hold any lock before calling '*func*'.
 
+## Remarks
+
 The annotation `_Requires_no_locks_held_` imposes a precondition that the caller must not hold any lock while it calls the function. Warning C26112 is issued when a function fails to release all locks before it calls another function.
 
 ## Example

--- a/docs/code-quality/c26115.md
+++ b/docs/code-quality/c26115.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26115"
 description: "Learn more about: Warning C26115"
-title: Warning C26115
 ms.date: 11/04/2016
 f1_keywords: ["C26115"]
 helpviewer_keywords: ["C26115"]
-ms.assetid: 3977a2bb-d1fe-4510-89dd-07fdc69e911c
 ---
 # Warning C26115
 

--- a/docs/code-quality/c26115.md
+++ b/docs/code-quality/c26115.md
@@ -10,6 +10,8 @@ ms.assetid: 3977a2bb-d1fe-4510-89dd-07fdc69e911c
 
 > Failing to release lock '*lock*' in function '*func*'.
 
+## Remarks
+
 Enforcement of syntactically scoped lock *acquire* and lock *release* pairs in C/C++ programs isn't performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock.
 
 You can annotate a function that has a side effect from a lock acquire or lock release by using `_Acquires_lock_` or `_Releases_lock_`, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases aren't balanced, they're considered to be *orphaned*. Warning C26115 is issued when a function introduces an orphaned lock.

--- a/docs/code-quality/c26117.md
+++ b/docs/code-quality/c26117.md
@@ -10,6 +10,8 @@ ms.assetid: cc7ebc8d-9826-4cad-a4d5-2d3ad5896734
 
 > Releasing unheld lock '*lock*' in function '*func*'.
 
+## Remarks
+
 Enforcement of syntactically scoped lock *acquire* and lock *release* pairs in C/C++ programs isn't performed by the language. A function may introduce a locking side effect by making an observable modification to the concurrency state. For example, a lock wrapper function increments the number of lock acquisitions, or lock count, for a given lock. You can annotate a function that has a side effect from a lock acquire or lock release by using `_Acquires_lock_` or `_Releases_lock_`, respectively. Without such annotations, a function is expected not to change any lock count after it returns. If acquires and releases aren't balanced, they're considered to be *orphaned*. Warning C26117 is issued when a function that hasn't been annotated with `_Releases_lock_` releases a lock that it doesn't hold, because the function must own the lock before it releases it.
 
 ## Examples

--- a/docs/code-quality/c26117.md
+++ b/docs/code-quality/c26117.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26117"
 description: "Learn more about: Warning C26117"
-title: Warning C26117
 ms.date: 11/04/2016
 f1_keywords: ["C26117"]
 helpviewer_keywords: ["C26117"]
-ms.assetid: cc7ebc8d-9826-4cad-a4d5-2d3ad5896734
 ---
 # Warning C26117
 

--- a/docs/code-quality/c26130.md
+++ b/docs/code-quality/c26130.md
@@ -10,6 +10,8 @@ ms.assetid: 535e2356-bc84-4549-983d-7d29aee2249c
 
 > Missing annotation \_Requires\_lock\_held\_('*lock*') or \_No\_competing\_thread\_ at function '*func*'. Otherwise it could be a race condition. Variable '*var*' should be protected by lock '*lock*'.
 
+## Remarks
+
 Warning C26130 is issued when the analyzer detects a potential race condition but infers that the function is likely to be run in a single threaded mode. For example, when the function is in the initialization stage, based on certain heuristics.
 
 ## Examples

--- a/docs/code-quality/c26130.md
+++ b/docs/code-quality/c26130.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26130"
 description: "Learn more about: Warning C26130"
-title: Warning C26130
 ms.date: 11/04/2016
 f1_keywords: ["C26130"]
 helpviewer_keywords: ["C26130"]
-ms.assetid: 535e2356-bc84-4549-983d-7d29aee2249c
 ---
 # Warning C26130
 

--- a/docs/code-quality/c26135.md
+++ b/docs/code-quality/c26135.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26135"
 description: "Learn more about: Warning C26135"
-title: Warning C26135
 ms.date: 11/04/2016
 f1_keywords: ["C26135"]
 helpviewer_keywords: ["C26135"]
-ms.assetid: e9515189-8d21-473b-89f4-8b92ebd3a4f1
 ---
 # Warning C26135
 

--- a/docs/code-quality/c26135.md
+++ b/docs/code-quality/c26135.md
@@ -10,6 +10,8 @@ ms.assetid: e9515189-8d21-473b-89f4-8b92ebd3a4f1
 
 > Missing annotation '*annotation*' at function '*func*'.
 
+## Remarks
+
 Warning C26135 is issued when the analyzer infers that a function is a lock wrapper function that has a "lock acquire" or "lock release" side effect. If the code isn't intended to be a wrapper function, then either the lock is leaking (if it's being acquired), or it's being released incorrectly (if the lock is being released).
 
 ## Examples

--- a/docs/code-quality/c26138.md
+++ b/docs/code-quality/c26138.md
@@ -1,6 +1,6 @@
 ---
+title: "Warning C26138"
 description: "Learn more about: Warning C26138"
-title: Warning C26138
 ms.date: 01/14/2019
 f1_keywords: ["C26138", "SUSPENDED_WITH_LOCK"]
 helpviewer_keywords: ["C26138"]

--- a/docs/code-quality/c26140.md
+++ b/docs/code-quality/c26140.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26140"
 description: "Learn more about: Warning C26140"
-title: Warning C26140
 ms.date: 11/04/2016
 f1_keywords: ["C26140"]
 helpviewer_keywords: ["C26140"]
-ms.assetid: a0b521b4-0c2f-470a-8904-f7bbb8014536
 ---
 # Warning C26140
 

--- a/docs/code-quality/c26160.md
+++ b/docs/code-quality/c26160.md
@@ -10,6 +10,8 @@ ms.assetid: e6518687-36b4-4eae-a732-758881638295
 
 > Caller possibly failing to hold lock '*lock*' before calling function '*func*'.
 
+## Remarks
+
 Warning C26160 resembles warning [C26110](../code-quality/c26110.md) except that the confidence level is lower. For example, the function may contain annotation errors.
 
 ## Examples

--- a/docs/code-quality/c26160.md
+++ b/docs/code-quality/c26160.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26160"
 description: "Learn more about: Warning C26160"
-title: Warning C26160
 ms.date: 11/04/2016
 f1_keywords: ["C26160"]
 helpviewer_keywords: ["C26160"]
-ms.assetid: e6518687-36b4-4eae-a732-758881638295
 ---
 # Warning C26160
 

--- a/docs/code-quality/c26165.md
+++ b/docs/code-quality/c26165.md
@@ -10,6 +10,8 @@ ms.assetid: a1d89bd6-08f3-4215-8a0c-b8ecfeb0cffc
 
 > Possibly failing to release lock '*lock*' in function '*func*'.
 
+## Remarks
+
 Warning C26165 resembles warning [C26115](../code-quality/c26115.md) except that the confidence level is lower. For example, the function may contain annotation errors.
 
 ## Examples

--- a/docs/code-quality/c26165.md
+++ b/docs/code-quality/c26165.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26165"
 description: "Learn more about: Warning C26165"
-title: Warning C26165
 ms.date: 11/04/2016
 f1_keywords: ["C26165"]
 helpviewer_keywords: ["C26165"]
-ms.assetid: a1d89bd6-08f3-4215-8a0c-b8ecfeb0cffc
 ---
 # Warning C26165
 

--- a/docs/code-quality/c26166.md
+++ b/docs/code-quality/c26166.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26166"
 description: "Learn more about: Warning C26166"
-title: Warning C26166
 ms.date: 11/04/2016
 f1_keywords: ["C26166"]
 helpviewer_keywords: ["C26166"]
-ms.assetid: a3d21838-07da-40f6-8d2e-1ada72765af2
 ---
 # Warning C26166
 

--- a/docs/code-quality/c26166.md
+++ b/docs/code-quality/c26166.md
@@ -10,6 +10,8 @@ ms.assetid: a3d21838-07da-40f6-8d2e-1ada72765af2
 
 > Possibly failing to acquire or to hold lock '*lock*' in function '*func*'.
 
+## Remarks
+
 Warning C26166 resembles warning [C26116](../code-quality/c26116.md) except that the confidence level is lower. For example, the function may contain annotation errors.
 
 ## Example

--- a/docs/code-quality/c26167.md
+++ b/docs/code-quality/c26167.md
@@ -1,10 +1,9 @@
 ---
+title: "Warning C26167"
 description: "Learn more about: Warning C26167"
-title: Warning C26167
 ms.date: 11/04/2016
 f1_keywords: ["C26167"]
 helpviewer_keywords: ["C26167"]
-ms.assetid: 5a3d767f-31fa-45e0-8c9b-1aa776acaa45
 ---
 # Warning C26167
 

--- a/docs/code-quality/c26167.md
+++ b/docs/code-quality/c26167.md
@@ -10,6 +10,8 @@ ms.assetid: 5a3d767f-31fa-45e0-8c9b-1aa776acaa45
 
 > Possibly releasing unheld lock '*lock*' in function '*func*'.
 
+## Remarks
+
 Warning C26167 resembles warning [C26117](../code-quality/c26117.md) except that the confidence level is lower. For example, the function may contain annotation errors.
 
 ## Examples


### PR DESCRIPTION
C26116, C26132, and C26133 are skipped to prevent potential merge conflicts with #5591 and #5714. A separate PR will be issued once those are merged.

This is batch 119 that structures error/warning references. See #5465 for more information.