### PR TITLE
Add/change some code block languages to `cmake`

### DIFF
--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -443,7 +443,7 @@ Instead, enable and disable AddressSanitizer by setting the required compiler an
 
 You can add the following sample to *`CMakeLists.txt`* to enable or disable AddressSanitizer for a target:
 
-```cmd
+```cmake
 option(ASAN_ENABLED "Build this target with AddressSanitizer" ON)
 
 if(ASAN_ENABLED)

--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -148,7 +148,7 @@ When you build for Windows using the MSVC compiler, CMake projects have support 
 
 When you build for Windows with the MSVC compiler, CMake projects have support for Edit and Continue. Add the following code to your *`CMakeLists.txt`* file to enable Edit and Continue.
 
-```
+```cmake
 if(MSVC)
   target_compile_options(<target> PUBLIC "/ZI")
   target_link_options(<target> PUBLIC "/INCREMENTAL")

--- a/docs/build/reference/profile-performance-tools-profiler.md
+++ b/docs/build/reference/profile-performance-tools-profiler.md
@@ -51,7 +51,7 @@ Because a **CMake** project doesn't have the usual **Property Pages** support, t
 
 1. Add the code below. For more information, see the CMake [`set_target_properties`](https://cmake.org/cmake/help/latest/command/set_target_properties.html) documentation.
 
-   ```txt
+   ```cmake
    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/PROFILE")
    ```
 


### PR DESCRIPTION
Use `cmake` as the code block language for clarity and syntax highlighting as seen on [this page](https://github.com/MicrosoftDocs/vcpkg-docs/blob/2c4d444297b0892c9303b6d4d698821dce165086/vcpkg/users/platforms/windows.md):

<img width="912" height="335" alt="image" src="https://github.com/user-attachments/assets/dbfdb98f-05c7-43f2-a5bb-d83116205df2" />
