### PR TITLE
Set CMake code block language to `txt` as a fallback

### DIFF
--- a/docs/build/cmake-presets-vs.md
+++ b/docs/build/cmake-presets-vs.md
@@ -443,7 +443,7 @@ Instead, enable and disable AddressSanitizer by setting the required compiler an
 
 You can add the following sample to *`CMakeLists.txt`* to enable or disable AddressSanitizer for a target:
 
-```cmd
+```txt
 option(ASAN_ENABLED "Build this target with AddressSanitizer" ON)
 
 if(ASAN_ENABLED)

--- a/docs/build/cmake-projects-in-visual-studio.md
+++ b/docs/build/cmake-projects-in-visual-studio.md
@@ -148,7 +148,7 @@ When you build for Windows using the MSVC compiler, CMake projects have support 
 
 When you build for Windows with the MSVC compiler, CMake projects have support for Edit and Continue. Add the following code to your *`CMakeLists.txt`* file to enable Edit and Continue.
 
-```
+```txt
 if(MSVC)
   target_compile_options(<target> PUBLIC "/ZI")
   target_link_options(<target> PUBLIC "/INCREMENTAL")


### PR DESCRIPTION
Since code block language `cmake` is not supported in this repository (https://github.com/MicrosoftDocs/cpp-docs/pull/5808#pullrequestreview-3286050201), we have mainly 3 options:

1. Keep it empty
    - No syntax highlighting
    - Might be seen as "missing" or "incomplete"
1. Put `txt`
    - No syntax highlighting
    - Matches the `.txt` extension of `CMakeLists.txt`
    - Could be mistaken as a normal text file/output rather than CMake
1. Put some other language
    - Potentially plausible syntax highlighting
    - Might be confusing or misleading

Overall, I am in favor of option 2.