### PR TITLE
Elide trailing colon in headings

### DIFF
--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -30,7 +30,7 @@ In a CMake project, build configurations are stored in a *`CMakeSettings.json`* 
 
 When you choose a configuration, it's added to the *`CMakeSettings.json`* file in the project's root folder. You can then use it to build your project. For information about the configuration properties, see [CMakeSettings reference](cmakesettings-reference.md).
 
-## Linux predefined build configurations:
+## Linux predefined build configurations
 
 ```json
 {

--- a/docs/build/cmake-predefined-configuration-reference.md
+++ b/docs/build/cmake-predefined-configuration-reference.md
@@ -1,6 +1,6 @@
 ---
-description: "Learn more about: CMake predefined build configurations"
 title: "CMake predefined configuration reference"
+description: "Learn more about: CMake predefined build configurations"
 ms.description: "Visual Studio provides several predefined build configurations for CMake projects on Linux, Windows, ARM, and IoT."
 ms.date: 08/03/2021
 helpviewer_keywords: ["CMake redefined configurations"]

--- a/docs/c-runtime-library/reference/strdate-s-wstrdate-s.md
+++ b/docs/c-runtime-library/reference/strdate-s-wstrdate-s.md
@@ -1,14 +1,13 @@
 ---
 title: "_strdate_s, _wstrdate_s"
 description: "_strdate_s and _wstrdate_s are secure CRT versions of the _strdate and _wstrdate functions that put the current date in a buffer."
-ms.date: "4/2/2020"
+ms.date: 4/2/2020
 api_name: ["_strdate_s", "_wstrdate_s", "_o__strdate_s", "_o__wstrdate_s"]
 api_location: ["msvcrt.dll", "msvcr80.dll", "msvcr90.dll", "msvcr100.dll", "msvcr100_clr0400.dll", "msvcr110.dll", "msvcr110_clr0400.dll", "msvcr120.dll", "msvcr120_clr0400.dll", "ucrtbase.dll", "api-ms-win-crt-time-l1-1-0.dll"]
 api_type: ["DLLExport"]
 topic_type: ["apiref"]
 f1_keywords: ["_strdate_s", "wstrdate_s", "_wstrdate_s", "strdate_s", "_tstrdate_s"]
 helpviewer_keywords: ["dates, copying", "tstrdate_s function", "wstrdate_s function", "_tstrdate_s function", "strdate_s function", "copying dates", "_strdate_s function", "_wstrdate_s function"]
-ms.assetid: d41d8ea9-e5ce-40d4-864e-1ac29b455991
 ---
 # `_strdate_s`, `_wstrdate_s`
 

--- a/docs/c-runtime-library/reference/strdate-s-wstrdate-s.md
+++ b/docs/c-runtime-library/reference/strdate-s-wstrdate-s.md
@@ -76,7 +76,7 @@ The debug library versions of these functions first fill the buffer with 0xFE. T
 
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).
 
-### Generic-text routine mapping:
+### Generic-text routine mapping
 
 | TCHAR.H routine | `_UNICODE` and `_MBCS` not defined | `_MBCS` defined | `_UNICODE` defined |
 |---|---|---|---|

--- a/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
+++ b/docs/code-quality/using-the-cpp-core-guidelines-checkers.md
@@ -39,7 +39,7 @@ To enable more Core Check rules, open the dropdown list and choose which rule se
 
 A subset of C++ Core Check rules is included in the Microsoft Native Recommended rule set. It's the ruleset that runs by default when Microsoft code analysis is enabled.
 
-### To enable code analysis on your project:
+### To enable code analysis on your project
 
 1. Open the  **Property Pages** dialog for your project.
 

--- a/docs/dotnet/how-to-sink-windows-forms-events-from-native-cpp-classes.md
+++ b/docs/dotnet/how-to-sink-windows-forms-events-from-native-cpp-classes.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: How to: Sink Windows Forms Events from Native C++ Classes"
 title: "How to: Sink Windows Forms Events from Native C++ Classes"
+description: "Learn more about: How to: Sink Windows Forms Events from Native C++ Classes"
+ms.date: 11/04/2016
 ms.custom: "get-started-article"
-ms.date: "11/04/2016"
 helpviewer_keywords: ["event handling, managed/native interop", "event handling, sinking .NET in C++", "event handling, .NET/native interop", "event handling, Windows Forms in C++"]
-ms.assetid: 6e30ddee-d058-4c8d-9956-2a43d86f19d5
 ---
 # How to: Sink Windows Forms Events from Native C++ Classes
 

--- a/docs/dotnet/how-to-sink-windows-forms-events-from-native-cpp-classes.md
+++ b/docs/dotnet/how-to-sink-windows-forms-events-from-native-cpp-classes.md
@@ -20,7 +20,7 @@ This sample continues the work you did in [How to: Do DDX/DDV Data Binding with 
 
 Now, you will associate your MFC control (`m_MyControl`) with a managed event handler delegate called `OnClick` for the managed <xref:System.Windows.Forms.Control.Click> event.
 
-### To attach the OnClick event handler:
+### To attach the OnClick event handler
 
 1. Add the following code to the implementation of BOOL CMFC01Dlg::OnInitDialog:
 

--- a/docs/ide/adding-a-generic-cpp-class.md
+++ b/docs/ide/adding-a-generic-cpp-class.md
@@ -1,11 +1,10 @@
 ---
-description: "Learn more about: Add a generic C++ class"
 title: "Add a generic C++ class"
-ms.date: "11/09/2018"
+description: "Learn more about: Add a generic C++ class"
+ms.date: 11/09/2018
+ms.topic: how-to
 f1_keywords: ["vc.codewiz.classes.adding.generic", "vc.codewiz.class.generic"]
 helpviewer_keywords: ["Visual C++, classes", "generic classes, adding", "generic classes", "generic C++ class wizard [C++]"]
-ms.assetid: e95a5a14-dbed-4edc-8551-344fe48613cb
-ms.topic: how-to
 ---
 # Add a generic C++ class
 

--- a/docs/ide/adding-a-generic-cpp-class.md
+++ b/docs/ide/adding-a-generic-cpp-class.md
@@ -13,7 +13,7 @@ You can add a generic C++ class by using **Class View**. A generic C++ class is 
 
 ::: moniker range="msvc-140"
 
-## To add a generic C++ class to a project:
+## To add a generic C++ class to a project
 
 1. In **Class View**, right-click the project to which you want to add the new class, choose **Add**, and then choose **Class**.
 

--- a/docs/standard-library/indirect-array-class.md
+++ b/docs/standard-library/indirect-array-class.md
@@ -20,7 +20,7 @@ You construct an `indirect_array<Type>` object only by writing an expression of 
 
 The sequence consists of [`xa.size`](../standard-library/valarray-class.md#size) elements, where element `I` becomes the index `xa[I]` within `va`.
 
-## Example:
+## Example
 
 ```cpp
 // indirect_array.cpp

--- a/docs/standard-library/indirect-array-class.md
+++ b/docs/standard-library/indirect-array-class.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: indirect_array class"
 title: "indirect_array class"
+description: "Learn more about: indirect_array class"
 ms.date: 01/12/2022
 f1_keywords: ["valarray/std::indirect_array"]
 helpviewer_keywords: ["indirect_array class"]
-ms.assetid: 10e1eaea-ba5a-405c-a25e-7bdd3eee7fc7
 ---
 # `indirect_array` class
 

--- a/docs/windows/windows-desktop-wizard.md
+++ b/docs/windows/windows-desktop-wizard.md
@@ -58,7 +58,7 @@ Defines the support and options for the application, depending on its type.
 |**Precompiled header**|Specifies that the static library project uses a pre-compiled header.|
 |**Security Development Lifecycle (SDL) checks**|For more information about SDL, see [Microsoft Security Development Lifecycle (SDL)  Process Guidance](../build/reference/sdl-enable-additional-security-checks.md)|
 
-## Add common headers for:
+## Add common headers for
 
 Add support for one of the libraries supplied in Visual C++.
 

--- a/docs/windows/windows-desktop-wizard.md
+++ b/docs/windows/windows-desktop-wizard.md
@@ -1,10 +1,9 @@
 ---
-description: "Learn more about: Windows Desktop Wizard"
 title: "Windows Desktop Wizard"
-ms.date: "03/29/2019"
+description: "Learn more about: Windows Desktop Wizard"
+ms.date: 03/29/2019
 f1_keywords: ["vc.appwiz.win32.overview", "vc.appwiz.win32.appset"]
 helpviewer_keywords: ["Windows Desktop Wizard", "Win32 Project Wizard"]
-ms.assetid: 5d7b3a5e-8461-479a-969a-67b7883725b9
 ---
 # Windows Desktop Wizard
 

--- a/styleguide/voice-tone.md
+++ b/styleguide/voice-tone.md
@@ -19,14 +19,14 @@ like when you don't follow our guidelines. Here are the details on what we recom
 
 ## Use a conversational tone
 
-### Appropriate style:
+### Appropriate style
 
 We want our documentation to have a conversational tone. Hopefully, you'll feel as though you're
 having a conversation with the author as you read any of our tutorials or explanations.
 For you, the experience ought to be informal, conversational, and informative. Readers should
 feel as though they're listening to the author explain the concepts to them.
 
-### Inappropriate style:
+### Inappropriate style
 
 One might see the contrast between a conversational style, and the style one finds with
 more academic treatments of technical subjects. Those resources are useful, but the authors
@@ -39,14 +39,14 @@ is a more academic style. You can see the difference immediately.
 
 ## Write in second person
 
-### Appropriate style:
+### Appropriate style
 
 Write your articles as though you're speaking directly to the reader. Use the second person
 often as you write (as I just have in these two sentences). Second person doesn't always mean
 using the word 'you'. Write directly to the reader. Write imperative sentences. Tell your
 reader what you want them to learn.
 
-### Inappropriate style:
+### Inappropriate style
 
 An author could also choose to write in third person. In that model, an author must find some
 pronoun or noun to use when referring to the reader. A reader might often find this third


### PR DESCRIPTION
Headings should not have trailing colons. Commit https://github.com/MicrosoftDocs/cpp-docs/commit/e4a205eaaba1ba2401ab96cae01a4f26f1cd41dc gave me the inspiration for this PR.