### PR TITLE
Enhance localtime_s documentation on compatibility

### DIFF
--- a/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
+++ b/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
@@ -72,7 +72,8 @@ Each of the structure fields is of type **`int`**, as shown in the following tab
 
 **`_gmtime64_s`**, which uses the **`__time64_t`** structure, allows dates to be expressed up through 23:59:59, December 31, 3000, UTC; whereas **`gmtime32_s`** only represent dates through 23:59:59 January 18, 2038, UTC. Midnight, January 1, 1970, is the lower bound of the date range for both these functions.
 
-The Microsoft-specific **`gmtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any of the required headers.
+The Microsoft-specific **`gmtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including **`<time.h>`**.
+
 
 **`gmtime_s`** is an inline function that evaluates to **`_gmtime64_s`** and **`time_t`** is equivalent to **`__time64_t`**. If you need to force the compiler to interpret **`time_t`** as the old 32-bit **`time_t`**, you can define `_USE_32BIT_TIME_T`. `_USE_32BIT_TIME_T` causes **`gmtime_s`** to be inlined as **`_gmtime32_s`**. We don't recommend `_USE_32BIT_TIME_T`, because your application may fail after January 18, 2038, and because it isn't allowed on 64-bit platforms.
 

--- a/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
+++ b/docs/c-runtime-library/reference/gmtime-s-gmtime32-s-gmtime64-s.md
@@ -72,6 +72,8 @@ Each of the structure fields is of type **`int`**, as shown in the following tab
 
 **`_gmtime64_s`**, which uses the **`__time64_t`** structure, allows dates to be expressed up through 23:59:59, December 31, 3000, UTC; whereas **`gmtime32_s`** only represent dates through 23:59:59 January 18, 2038, UTC. Midnight, January 1, 1970, is the lower bound of the date range for both these functions.
 
+The Microsoft-specific **`gmtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any of the required headers.
+
 **`gmtime_s`** is an inline function that evaluates to **`_gmtime64_s`** and **`time_t`** is equivalent to **`__time64_t`**. If you need to force the compiler to interpret **`time_t`** as the old 32-bit **`time_t`**, you can define `_USE_32BIT_TIME_T`. `_USE_32BIT_TIME_T` causes **`gmtime_s`** to be inlined as **`_gmtime32_s`**. We don't recommend `_USE_32BIT_TIME_T`, because your application may fail after January 18, 2038, and because it isn't allowed on 64-bit platforms.
 
 By default, this function's global state is scoped to the application. To change this behavior, see [Global state in the CRT](../global-state.md).

--- a/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
+++ b/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
@@ -59,10 +59,10 @@ The **`localtime_s`** function converts a time stored as a [`time_t`](../standar
 
 **`localtime_s`** corrects for the local time zone if the user first sets the global environment variable **`TZ`**. When **`TZ`** is set, three other environment variables (**`_timezone`**, **`_daylight`**, and **`_tzname`**) are automatically set as well. If the **`TZ`** variable isn't set, **`localtime_s`** attempts to use the time zone information specified in the Date/Time application in Control Panel. If this information can't be obtained, PST8PDT, which signifies the Pacific time zone, is used by default. See [`_tzset`](tzset.md) for a description of these variables. **`TZ`** is a Microsoft extension and not part of the ANSI standard definition of **`localtime`**.
 
-The Microsoft-specific **`localtime_s`** is not compatible with the C standard version due to differences in its signature. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any relevant headers.
-
 > [!NOTE]
 > The target environment should try to determine whether daylight saving time is in effect.
+
+The Microsoft-specific **`localtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any of the required headers.
 
 **`_localtime64_s`**, which uses the **`__time64_t`** structure, allows dates to be expressed up through 23:59:59, January 18, 3001, coordinated universal time (UTC), whereas **`_localtime32_s`** represents dates through 23:59:59 January 18, 2038, UTC.
 

--- a/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
+++ b/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
@@ -62,7 +62,7 @@ The **`localtime_s`** function converts a time stored as a [`time_t`](../standar
 > [!NOTE]
 > The target environment should try to determine whether daylight saving time is in effect.
 
-The Microsoft-specific **`localtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any of the required headers.
+The Microsoft-specific **`localtime_s`** has a different signature than the C standard version. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including **`<time.h>`**.
 
 **`_localtime64_s`**, which uses the **`__time64_t`** structure, allows dates to be expressed up through 23:59:59, January 18, 3001, coordinated universal time (UTC), whereas **`_localtime32_s`** represents dates through 23:59:59 January 18, 2038, UTC.
 

--- a/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
+++ b/docs/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s.md
@@ -59,6 +59,8 @@ The **`localtime_s`** function converts a time stored as a [`time_t`](../standar
 
 **`localtime_s`** corrects for the local time zone if the user first sets the global environment variable **`TZ`**. When **`TZ`** is set, three other environment variables (**`_timezone`**, **`_daylight`**, and **`_tzname`**) are automatically set as well. If the **`TZ`** variable isn't set, **`localtime_s`** attempts to use the time zone information specified in the Date/Time application in Control Panel. If this information can't be obtained, PST8PDT, which signifies the Pacific time zone, is used by default. See [`_tzset`](tzset.md) for a description of these variables. **`TZ`** is a Microsoft extension and not part of the ANSI standard definition of **`localtime`**.
 
+The Microsoft-specific **`localtime_s`** is not compatible with the C standard version due to differences in its signature. To enable the standard-conforming variant, define **`_CRT_USE_CONFORMING_ANNEX_K_TIME`** to a nonzero value before including any relevant headers.
+
 > [!NOTE]
 > The target environment should try to determine whether daylight saving time is in effect.
 


### PR DESCRIPTION
Clarified compatibility issues of localtime_s with C standard and provided guidance for enabling the standard-conforming variant.