### PR TITLE
Invert section wording about headers to match content

### DIFF
--- a/docs/cpp/header-files-cpp.md
+++ b/docs/cpp/header-files-cpp.md
@@ -94,7 +94,7 @@ namespace N
 #endif /* MY_CLASS_H */
 ```
 
-## What to put in a header file
+## What to avoid in a header file
 
 Because a header file might potentially be included by multiple files, it cannot contain definitions that might produce multiple definitions of the same name. The following are not allowed, or are considered very bad practice:
 


### PR DESCRIPTION
The section heading for ["What to put in a header file"](https://learn.microsoft.com/en-us/cpp/cpp/header-files-cpp?view=msvc-170#what-to-put-in-a-header-file) is misleading because all of its content is actually about what to _avoid_ placing in a header file.  It can especially be a problem for people skimming through who immediately jump to the bullet-list which, again, are things _not_ to be included in a header.

This PR clarifies the section heading by changing it from "What to put in a header file" to "What to avoid in a header file".