### PR TITLE
revised `isfinite`, `_finite`, and `_finitef` documentation

### DIFF
--- a/docs/c-runtime-library/reference/finite-finitef.md
+++ b/docs/c-runtime-library/reference/finite-finitef.md
@@ -42,11 +42,15 @@ The floating-point value to test.
 
 ## Return value
 
-The `isfinite` macro and the `_finite` and `_finitef` functions return a non-zero value if *`x`* is a normal, subnormal, or signed zero (`±0`) finite value. They return 0 if the argument is infinite or a NaN. The C++ inline template function `isfinite` behaves the same way, but returns **`true`** or **`false`**.
+The `isfinite` macro and the `_finite` and `_finitef` functions return a non-zero value if *`x`* is a normal, subnormal, or signed zero (`±0`) finite value. They return 0 if the argument is infinite or Not a Number (NaN). The C++ inline template function `isfinite` behaves the same way but returns **`true`** or **`false`**.
 
 ## Remarks
 
-`isfinite` is a macro when compiled as C, and an inline template function when compiled as C++. The `_finite` and `_finitef` functions are Microsoft-specific. The `_finitef` function is only available when compiled for x64, ARM, or ARM64 platforms.
+`_finite` and `_finitef` are Microsoft-specific.
+
+`isfinite` is a macro when compiled as C, and an inline template function when compiled as C++.
+
+`_finitef` is only available when compiling for the x64, ARM, ARM64, or ARM64EC platforms.
 
 ## Requirements
 

--- a/docs/c-runtime-library/reference/finite-finitef.md
+++ b/docs/c-runtime-library/reference/finite-finitef.md
@@ -42,18 +42,19 @@ The floating-point value to test.
 
 ## Return value
 
-The `isfinite` macro and the `_finite` and `_finitef` functions return a non-zero value if *`x`* is either a normal or subnormal finite value. They return 0 if the argument is infinite or a NaN. The C++ inline template function `isfinite` behaves the same way, but returns **`true`** or **`false`**.
+The `isfinite` macro and the `_finite` and `_finitef` functions return a non-zero value if *`x`* is a normal, subnormal, or signed zero (`±0`) finite value. They return 0 if the argument is infinite or a NaN. The C++ inline template function `isfinite` behaves the same way, but returns **`true`** or **`false`**.
 
 ## Remarks
 
-`isfinite` is a macro when compiled as C, and an inline template function when compiled as C++. The `_finite` and `_finitef` functions are Microsoft-specific. The `_finitef` function is only available when compiled for x86, ARM, or ARM64 platforms.
+`isfinite` is a macro when compiled as C, and an inline template function when compiled as C++. The `_finite` and `_finitef` functions are Microsoft-specific. The `_finitef` function is only available when compiled for x64, ARM, or ARM64 platforms.
 
 ## Requirements
 
 | Function | Required header (C) | Required header (C++) |
 |---|---|---|
-| `_finite` | \<float.h> or \<math.h> | \<float.h>, \<math.h>, \<cfloat>, or \<cmath> |
-| `isfinite`, `_finitef` | \<math.h> | \<math.h> or \<cmath> |
+| `isfinite` | `<math.h>` | `<math.h>` or `<cmath>` |
+| `_finite` | `<float.h>` | `<float.h>` or `<cfloat>` |
+| `_finitef` | `<math.h>` | `<math.h>` or `<cmath>` |
 
 For more compatibility information, see [Compatibility](../compatibility.md).
 


### PR DESCRIPTION
this corrects some information of the `isfinite`, `_finite`, and `_finitef` reference page: the current page lists `<math.h>` and `<cmath>` as valid headers for `_finite` even though the current UCRT declares it only through `<float.h>` and `<cfloat>`. its remarks section also name x86 instead of x64 as a supported `_finitef` target, while the UCRT implementation disagrees. the return value section benignly omitted signed zeros. this revision addresses the C and C++ header requirements, and makes it evident that normal numbers, subnormal numbers, and **both signed zeros** are finite.