### PR TITLE
Fix padding size comment in struct S3

### DIFF
--- a/docs/cpp/align-cpp.md
+++ b/docs/cpp/align-cpp.md
@@ -100,7 +100,7 @@ struct S3 {
    struct S1 s1;   // S3 inherits cache alignment requirement
                   // from S1 declaration
    int a;         // a is now cache aligned because of s1
-                  // 28 bytes of trailing padding
+                  // 16 bytes of trailing padding
 };
 ```
 


### PR DESCRIPTION
Updated the comment to reflect the correct padding size for struct S3.